### PR TITLE
Implement path

### DIFF
--- a/render/path/Cargo.toml
+++ b/render/path/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "path"
+version = "0.1.0"
+authors = ["Eddy Bruel <ejpbruel@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+geometry = { path = "../geometry" }
+internal_iter = { path = "../internal_iter" }

--- a/render/path/src/lib.rs
+++ b/render/path/src/lib.rs
@@ -1,0 +1,14 @@
+pub mod line_path;
+pub mod path;
+
+mod line_path_command;
+mod line_path_iterator;
+mod path_command;
+mod path_iterator;
+
+pub use self::line_path::LinePath;
+pub use self::line_path_command::LinePathCommand;
+pub use self::line_path_iterator::LinePathIterator;
+pub use self::path::Path;
+pub use self::path_command::PathCommand;
+pub use self::path_iterator::PathIterator;

--- a/render/path/src/line_path.rs
+++ b/render/path/src/line_path.rs
@@ -1,0 +1,135 @@
+use crate::LinePathCommand;
+use geometry::{Point, Transform, Transformation};
+use internal_iter::{
+    ExtendFromInternalIterator, FromInternalIterator, InternalIterator, IntoInternalIterator,
+};
+use std::iter::Cloned;
+use std::slice::Iter;
+
+/// A sequence of commands that defines a set of contours, each of which consists of a sequence of
+/// line segments. Each contour is either open or closed.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct LinePath {
+    verbs: Vec<Verb>,
+    points: Vec<Point>,
+}
+
+impl LinePath {
+    /// Creates a new empty line path.
+    pub fn new() -> LinePath {
+        LinePath::default()
+    }
+
+    /// Returns a slice of the points that make up `self`.
+    pub fn points(&self) -> &[Point] {
+        &self.points
+    }
+
+    /// Returns an iterator over the commands that make up `self`.
+    pub fn commands(&self) -> Commands {
+        Commands {
+            verbs: self.verbs.iter().cloned(),
+            points: self.points.iter().cloned(),
+        }
+    }
+
+    /// Returns a mutable slice of the points that make up `self`.
+    pub fn points_mut(&mut self) -> &mut [Point] {
+        &mut self.points
+    }
+
+    /// Adds a new contour, starting at the given point.
+    pub fn move_to(&mut self, p: Point) {
+        self.verbs.push(Verb::MoveTo);
+        self.points.push(p);
+    }
+
+    /// Adds a line segment to the current contour, starting at the current point.
+    pub fn line_to(&mut self, p: Point) {
+        self.verbs.push(Verb::LineTo);
+        self.points.push(p);
+    }
+
+    /// Closes the current contour.
+    pub fn close(&mut self) {
+        self.verbs.push(Verb::Close);
+    }
+
+    /// Clears `self`.
+    pub fn clear(&mut self) {
+        self.verbs.clear();
+        self.points.clear();
+    }
+}
+
+impl ExtendFromInternalIterator<LinePathCommand> for LinePath {
+    fn extend_from_internal_iter<I>(&mut self, internal_iter: I)
+    where
+        I: IntoInternalIterator<Item = LinePathCommand>,
+    {
+        internal_iter.into_internal_iter().for_each(&mut |command| {
+            match command {
+                LinePathCommand::MoveTo(p) => self.move_to(p),
+                LinePathCommand::LineTo(p) => self.line_to(p),
+                LinePathCommand::Close => self.close(),
+            }
+            true
+        });
+    }
+}
+
+impl FromInternalIterator<LinePathCommand> for LinePath {
+    fn from_internal_iter<I>(internal_iter: I) -> Self
+    where
+        I: IntoInternalIterator<Item = LinePathCommand>,
+    {
+        let mut path = LinePath::new();
+        path.extend_from_internal_iter(internal_iter);
+        path
+    }
+}
+
+impl Transform for LinePath {
+    fn transform<T>(mut self, t: &T) -> LinePath
+    where
+        T: Transformation,
+    {
+        self.transform_mut(t);
+        self
+    }
+
+    fn transform_mut<T>(&mut self, t: &T)
+    where
+        T: Transformation,
+    {
+        for point in self.points_mut() {
+            point.transform_mut(t);
+        }
+    }
+}
+
+/// An iterator over the commands that make up a line path.
+#[derive(Clone, Debug)]
+pub struct Commands<'a> {
+    verbs: Cloned<Iter<'a, Verb>>,
+    points: Cloned<Iter<'a, Point>>,
+}
+
+impl<'a> Iterator for Commands<'a> {
+    type Item = LinePathCommand;
+
+    fn next(&mut self) -> Option<LinePathCommand> {
+        self.verbs.next().map(|verb| match verb {
+            Verb::MoveTo => LinePathCommand::MoveTo(self.points.next().unwrap()),
+            Verb::LineTo => LinePathCommand::LineTo(self.points.next().unwrap()),
+            Verb::Close => LinePathCommand::Close,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+enum Verb {
+    MoveTo,
+    LineTo,
+    Close,
+}

--- a/render/path/src/line_path_command.rs
+++ b/render/path/src/line_path_command.rs
@@ -1,0 +1,29 @@
+use geometry::{Point, Transform, Transformation};
+
+/// A command in a line path
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LinePathCommand {
+    MoveTo(Point),
+    LineTo(Point),
+    Close,
+}
+
+impl Transform for LinePathCommand {
+    fn transform<T>(self, t: &T) -> LinePathCommand
+    where
+        T: Transformation,
+    {
+        match self {
+            LinePathCommand::MoveTo(p) => LinePathCommand::MoveTo(p.transform(t)),
+            LinePathCommand::LineTo(p) => LinePathCommand::LineTo(p.transform(t)),
+            LinePathCommand::Close => LinePathCommand::Close,
+        }
+    }
+
+    fn transform_mut<T>(&mut self, t: &T)
+    where
+        T: Transformation,
+    {
+        *self = self.transform(t);
+    }
+}

--- a/render/path/src/line_path_iterator.rs
+++ b/render/path/src/line_path_iterator.rs
@@ -1,0 +1,7 @@
+use crate::LinePathCommand;
+use internal_iter::InternalIterator;
+
+/// An extension trait for iterators over line path commands.
+pub trait LinePathIterator: InternalIterator<Item = LinePathCommand> {}
+
+impl<I> LinePathIterator for I where I: InternalIterator<Item = LinePathCommand> {}

--- a/render/path/src/path.rs
+++ b/render/path/src/path.rs
@@ -1,0 +1,147 @@
+use crate::PathCommand;
+use geometry::{Point, Transform, Transformation};
+use internal_iter::{
+    ExtendFromInternalIterator, FromInternalIterator, InternalIterator, IntoInternalIterator,
+};
+use std::iter::Cloned;
+use std::slice::Iter;
+
+/// A sequence of commands that defines a set of contours, each of which is either open or closed,
+/// and consists of a sequence of curve segments.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Path {
+    verbs: Vec<Verb>,
+    points: Vec<Point>,
+}
+
+impl Path {
+    /// Creates a new empty path.
+    pub fn new() -> Path {
+        Path::default()
+    }
+
+    /// Returns a slice of the points that make up `self`.
+    pub fn points(&self) -> &[Point] {
+        &self.points
+    }
+
+    /// Returns an iterator over the commands that make up `self`.
+    pub fn commands(&self) -> Commands {
+        Commands {
+            verbs: self.verbs.iter().cloned(),
+            points: self.points.iter().cloned(),
+        }
+    }
+
+    /// Returns a mutable slice of the points that make up `self`.
+    pub fn points_mut(&mut self) -> &mut [Point] {
+        &mut self.points
+    }
+
+    /// Adds a new contour, starting at the given point.
+    pub fn move_to(&mut self, p: Point) {
+        self.verbs.push(Verb::MoveTo);
+        self.points.push(p);
+    }
+
+    /// Adds a line segment to the current contour, starting at the current point.
+    pub fn line_to(&mut self, p: Point) {
+        self.verbs.push(Verb::LineTo);
+        self.points.push(p);
+    }
+
+    // Adds a quadratic Bezier curve segment to the current contour, starting at the current point.
+    pub fn quadratic_to(&mut self, p1: Point, p: Point) {
+        self.verbs.push(Verb::QuadraticTo);
+        self.points.push(p1);
+        self.points.push(p);
+    }
+
+    /// Closes the current contour.
+    pub fn close(&mut self) {
+        self.verbs.push(Verb::Close);
+    }
+
+    /// Clears `self`.
+    pub fn clear(&mut self) {
+        self.verbs.clear();
+        self.points.clear();
+    }
+}
+
+impl ExtendFromInternalIterator<PathCommand> for Path {
+    fn extend_from_internal_iter<I>(&mut self, internal_iter: I)
+    where
+        I: IntoInternalIterator<Item = PathCommand>,
+    {
+        internal_iter.into_internal_iter().for_each(&mut |command| {
+            match command {
+                PathCommand::MoveTo(p) => self.move_to(p),
+                PathCommand::LineTo(p) => self.line_to(p),
+                PathCommand::QuadraticTo(p1, p) => self.quadratic_to(p1, p),
+                PathCommand::Close => self.close(),
+            }
+            true
+        });
+    }
+}
+
+impl FromInternalIterator<PathCommand> for Path {
+    fn from_internal_iter<I>(internal_iter: I) -> Self
+    where
+        I: IntoInternalIterator<Item = PathCommand>,
+    {
+        let mut path = Path::new();
+        path.extend_from_internal_iter(internal_iter);
+        path
+    }
+}
+
+impl Transform for Path {
+    fn transform<T>(mut self, t: &T) -> Path
+    where
+        T: Transformation,
+    {
+        self.transform_mut(t);
+        self
+    }
+
+    fn transform_mut<T>(&mut self, t: &T)
+    where
+        T: Transformation,
+    {
+        for point in self.points_mut() {
+            point.transform_mut(t);
+        }
+    }
+}
+
+/// An iterator over the commands that make up a path.
+#[derive(Clone, Debug)]
+pub struct Commands<'a> {
+    verbs: Cloned<Iter<'a, Verb>>,
+    points: Cloned<Iter<'a, Point>>,
+}
+
+impl<'a> Iterator for Commands<'a> {
+    type Item = PathCommand;
+
+    fn next(&mut self) -> Option<PathCommand> {
+        self.verbs.next().map(|verb| match verb {
+            Verb::MoveTo => PathCommand::MoveTo(self.points.next().unwrap()),
+            Verb::LineTo => PathCommand::LineTo(self.points.next().unwrap()),
+            Verb::QuadraticTo => {
+                PathCommand::QuadraticTo(self.points.next().unwrap(), self.points.next().unwrap())
+            }
+            Verb::Close => PathCommand::Close,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+enum Verb {
+    MoveTo,
+    LineTo,
+    QuadraticTo,
+    Close,
+}

--- a/render/path/src/path_command.rs
+++ b/render/path/src/path_command.rs
@@ -1,0 +1,33 @@
+use geometry::{Point, Transform, Transformation};
+
+/// A command in a path
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PathCommand {
+    MoveTo(Point),
+    LineTo(Point),
+    QuadraticTo(Point, Point),
+    Close,
+}
+
+impl Transform for PathCommand {
+    fn transform<T>(self, t: &T) -> PathCommand
+    where
+        T: Transformation,
+    {
+        match self {
+            PathCommand::MoveTo(p) => PathCommand::MoveTo(p.transform(t)),
+            PathCommand::LineTo(p) => PathCommand::LineTo(p.transform(t)),
+            PathCommand::QuadraticTo(p1, p) => {
+                PathCommand::QuadraticTo(p1.transform(t), p.transform(t))
+            }
+            PathCommand::Close => PathCommand::Close,
+        }
+    }
+
+    fn transform_mut<T>(&mut self, t: &T)
+    where
+        T: Transformation,
+    {
+        *self = self.transform(t);
+    }
+}

--- a/render/path/src/path_iterator.rs
+++ b/render/path/src/path_iterator.rs
@@ -1,0 +1,68 @@
+use crate::{LinePathCommand, PathCommand};
+use geometry::QuadraticSegment;
+use internal_iter::InternalIterator;
+
+/// An extension trait for iterators over path commands.
+pub trait PathIterator: InternalIterator<Item = PathCommand> {
+    /// Returns an iterator over line path commands that approximate `self` with tolerance
+    /// `epsilon`.
+    fn linearize(self, epsilon: f32) -> Linearize<Self>
+    where
+        Self: Sized,
+    {
+        Linearize {
+            path: self,
+            epsilon,
+        }
+    }
+}
+
+impl<I> PathIterator for I where I: InternalIterator<Item = PathCommand> {}
+
+/// An iterator over line path commands that approximate `self` with tolerance `epsilon`.
+#[derive(Clone, Debug)]
+pub struct Linearize<P> {
+    path: P,
+    epsilon: f32,
+}
+
+impl<P> InternalIterator for Linearize<P>
+where
+    P: PathIterator,
+{
+    type Item = LinePathCommand;
+
+    fn for_each<F>(self, f: &mut F) -> bool
+    where
+        F: FnMut(LinePathCommand) -> bool,
+    {
+        let mut initial_point = None;
+        let mut current_point = None;
+        self.path.for_each({
+            let epsilon = self.epsilon;
+            &mut move |command| match command {
+                PathCommand::MoveTo(p) => {
+                    initial_point = Some(p);
+                    current_point = Some(p);
+                    f(LinePathCommand::MoveTo(p))
+                }
+                PathCommand::LineTo(p) => {
+                    current_point = Some(p);
+                    f(LinePathCommand::LineTo(p))
+                }
+                PathCommand::QuadraticTo(p1, p) => {
+                    QuadraticSegment::new(current_point.unwrap(), p1, p)
+                        .linearize(epsilon)
+                        .for_each(&mut |p| {
+                            current_point = Some(p);
+                            f(LinePathCommand::LineTo(p))
+                        })
+                }
+                PathCommand::Close => {
+                    current_point = initial_point;
+                    f(LinePathCommand::Close)
+                }
+            }
+        })
+    }
+}


### PR DESCRIPTION
Implement the path library. This library contains utilities to represent paths. A path is a set of one or more contours, each of which consists of one or more curve segments. The contents of a paths are described by a sequence of path commands.

In addition to an efficient representation for paths, this library contains utilities for iterating over the commands in a path, and linearizing paths in a lazy fashion (that is, without allocating any intermediate vectors) using internal iterators.