### PR TITLE
Fix a bug in the char map parser

### DIFF
--- a/render/vector/ttf_parser/src/lib.rs
+++ b/render/vector/ttf_parser/src/lib.rs
@@ -642,10 +642,11 @@ fn parse_char_code_to_glyph_index_map_format_4(bytes: &[u8]) -> Result<Vec<usize
             let mut id = if id_range_offset == 0 {
                 code
             } else {
-                let id_range_bytes = &id_range_offset_bytes[(seg_index * 2 + id_range_offset)..];
+                let id_range_bytes = &id_range_offset_bytes[(seg_index * 2)..];
                 let mut reader = Reader::new(id_range_bytes);
-                reader.skip((code - start_code) as usize)?;
-                reader.read_u16()?
+                reader.skip(id_range_offset + (code - start_code) as usize * 2)?;
+                let id = reader.read_u16()?;
+                id
             } as usize;
             if id != 0 {
                 id = (id + id_delta) % 65536;

--- a/render/vector/ttf_parser/tests/test.rs
+++ b/render/vector/ttf_parser/tests/test.rs
@@ -4,12 +4,15 @@ use std::path::Path;
 
 #[test]
 fn main() {
-    for entry in fs::read_dir(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../resources")).unwrap() {
+    for entry in fs::read_dir(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../resources")).unwrap() {
         let path = entry.unwrap().path();
         if path.extension().unwrap() != "ttf" {
             continue;
         }
         println!("{}", path.file_stem().unwrap().to_str().unwrap());
-        ttf_parser::parse_ttf(&fs::read(path).unwrap()).unwrap();
+        let font = ttf_parser::parse_ttf(&fs::read(path).unwrap()).unwrap();
+        for char_code in 0..font.char_code_to_glyph_index_map.len() {
+            assert!(font.char_code_to_glyph_index_map[char_code] <= font.glyphs.len());
+        }
     }
 }


### PR DESCRIPTION
We were using a wrong offset into the id_offset_array, which in turn
caused us to compute incorrect glyph indices.

This commit also fixes a bug in the tests for the ttf parser.