### PR TITLE
microserde: parse tuple types in structures

### DIFF
--- a/render/microserde/derive/src/derive_bin.rs
+++ b/render/microserde/derive/src/derive_bin.rs
@@ -114,7 +114,7 @@ pub fn derive_de_bin_impl(input: TokenStream) -> TokenStream {
             if let Some(types) = types{
                 tb.add("(");
                 for _ in 0..types.len(){
-                     tb.add("DeBin :: de_bin ( o , d ) ?");
+                     tb.add("DeBin :: de_bin ( o , d ) ? ,");
                 }
                 tb.add(")");
             }

--- a/render/microserde/derive/src/derive_json.rs
+++ b/render/microserde/derive/src/derive_json.rs
@@ -161,7 +161,7 @@ pub fn derive_de_json_impl(input: TokenStream) -> TokenStream {
                 }
                 tb.add(") ;");
                 tb.add("s . block_close ( i ) ? ;");
-                tb.add("std :: result :: Result :: Ok ( r ) ;");
+                tb.add("std :: result :: Result :: Ok ( r )");
             }
             else if let Some(fields) = parser.eat_all_struct_fields(){ 
                 tb.add("s . curly_open ( i ) ? ;");

--- a/render/microserde/derive/src/derive_ron.rs
+++ b/render/microserde/derive/src/derive_ron.rs
@@ -156,7 +156,7 @@ pub fn derive_de_ron_impl(input: TokenStream) -> TokenStream {
                 }
                 tb.add(") ;");
                 tb.add("s . paren_close ( i ) ? ;");
-                tb.add("std :: result :: Result :: Ok ( r ) ;");
+                tb.add("std :: result :: Result :: Ok ( r ) ");
             }
             else if let Some(fields) = parser.eat_all_struct_fields(){ 
                 tb.add("s . paren_open ( i ) ? ;");

--- a/render/microserde/derive/src/macro_lib.rs
+++ b/render/microserde/derive/src/macro_lib.rs
@@ -476,6 +476,15 @@ impl TokenParser {
             tb.add("]");
             return Some(tb.end())
         }
+        else if self.open_paren(){ // tuple type
+            tb.add("(");
+            while !self.eat_eot(){
+                tb.stream(self.eat_type());
+                self.eat_punct(',');
+            }
+            tb.add(")");
+            return Some(tb.end());
+        }
         else if let Some(ty) = self.eat_any_ident() {
             tb.ident(&ty);
             tb.stream(self.eat_generic());

--- a/render/microserde/derive/src/macro_lib.rs
+++ b/render/microserde/derive/src/macro_lib.rs
@@ -448,6 +448,7 @@ impl TokenParser {
         if self.open_paren(){
             let mut ret = Vec::new();
             while !self.eat_eot(){
+                self.eat_ident("pub");
                 if let Some(tt) = self.eat_type(){
                     ret.push(tt);
                     self.eat_punct(',');

--- a/render/microserde/example/src/main.rs
+++ b/render/microserde/example/src/main.rs
@@ -16,7 +16,11 @@ struct MyStruct<T> where T: Clone {
     j: String,
     k: [u32;2],
     l: (u64, u32, u16, u8),
+    m: MyAnomStruct,
 } 
+
+#[derive(SerBin, DeBin, SerJson, DeJson, SerRon, DeRon, PartialEq)]
+struct MyAnomStruct(f32, pub f64);
 
 #[derive(SerBin, DeBin, SerJson, DeJson, SerRon, DeRon, PartialEq)]
 enum MyEnum<T> where T: Clone {
@@ -42,6 +46,7 @@ fn main() {
         j: "Hello".to_string(),
         k: [10,11],
         l: (1, 2, 3, 4),
+        m: MyAnomStruct(2.0,3.0),
     };
     let bin = x.serialize_bin();
     println!("Bin len: {}", bin.len());

--- a/render/microserde/example/src/main.rs
+++ b/render/microserde/example/src/main.rs
@@ -14,7 +14,8 @@ struct MyStruct<T> where T: Clone {
     h: MyEnum<T>,
     i: MyEnum<T>,
     j: String,
-    k: [u32;2]
+    k: [u32;2],
+    l: (u64, u32, u16, u8),
 } 
 
 #[derive(SerBin, DeBin, SerJson, DeJson, SerRon, DeRon, PartialEq)]
@@ -39,7 +40,8 @@ fn main() {
         h: MyEnum::Four {z: None, w: 8},
         i: MyEnum::Four {z: Some(9), w: 8},
         j: "Hello".to_string(),
-        k: [10,11]
+        k: [10,11],
+        l: (1, 2, 3, 4),
     };
     let bin = x.serialize_bin();
     println!("Bin len: {}", bin.len());


### PR DESCRIPTION
Tuple are valid types for a structures and enums in Rust. The current
implmentation only parses arrays. We extend the use of `eat_type` to
look for parenthesis '(' and parse it as a tuple. The implementatio has
been tested by extended the example case to include a tuple.

Feel free to ignore the pull request and reimplement this. I don't have a deep insight into proc macros and your implementation to ensure error conditions are okay. I am happy to also work on it more given some feedback on the change.