### PR TITLE
Remove duplicate entry in the toml file

### DIFF
--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -23,9 +23,6 @@ makepad-draw-derive = { path = "./draw_derive", version = "0.1" }
 [target.aarch64-apple-darwin.dependencies]
 makepad-objc-sys = { path = "./bind/objc-sys", version = "0.2" }
 
-[target.aarch64-apple-darwin.dependencies]
-makepad-objc-sys = { path = "./bind/objc-sys", version = "0.2" }
-
 [target.x86_64-apple-darwin.dependencies]
 makepad-objc-sys = { path = "./bind/objc-sys", version = "0.2" }
 


### PR DESCRIPTION
Fixes this error for macos:

```
~/c/makepad (master)> cargo run -p makepad --release
error: failed to parse manifest at `/Users/bjorn/code/makepad/render/Cargo.toml`

Caused by:
  could not parse input as TOML

Caused by:
  redefinition of table `target.aarch64-apple-darwin.dependencies` for key `target.aarch64-apple-darwin.dependencies` at line 26 column 1
```
