### PR TITLE
Bug fixes to better enable third-party devs

### DIFF
--- a/component/src/frame_registry.rs
+++ b/component/src/frame_registry.rs
@@ -25,6 +25,8 @@ pub trait FrameComponent: LiveApply {
     fn type_id(&self) -> TypeId;
 }
 
+generate_ref_cast_api!(FrameComponent);
+
 #[derive(Clone)]
 pub struct FrameActionItem {
     pub id: LiveId,

--- a/render/src/live_prims.rs
+++ b/render/src/live_prims.rs
@@ -14,7 +14,14 @@ pub use {
 #[macro_export]
 macro_rules!get_component {
     ( $ comp_id: expr, $ ty: ty, $ frame: expr) => {
-        $ frame.get_component( $ comp_id).map_or(None, | v | v.cast_mut::< $ ty>())
+        $ frame.components.get( $ comp_id).map_or(None, | v | v.cast::< $ ty>())
+    }
+}
+
+#[macro_export]
+macro_rules!get_component_mut {
+    ( $ comp_id: expr, $ ty: ty, $ frame: expr) => {
+        $ frame.components.get_mut( $ comp_id).map_or(None, | v | v.cast_mut::< $ ty>())
     }
 }
 

--- a/studio/src/design_editor/inline_cache.rs
+++ b/studio/src/design_editor/inline_cache.rs
@@ -187,9 +187,13 @@ impl InlineCache {
         }
         let range = self.live_register_range.unwrap();
         
-        let path = if let Some(prefix) = path.strip_prefix("/Users/admin/makepad/edit_repo/sub_repo") {prefix}
-        else {
-            path
+        let working_dir = std::env::current_dir().unwrap();
+        let working_dir = working_dir.as_os_str().to_str().unwrap();
+        let path = if let Some(prefix) = path.strip_prefix(working_dir){
+            prefix
+        }
+        else{
+           path 
         };
         //println!("{}", &path.strip_prefix("/Users/admin/makepad/edit_repo/").unwrap());
         let file_id = if let Some(file_id) = live_registry.path_str_to_file_id(path) {file_id}


### PR DESCRIPTION
Issue:

1) Running "cargo run --bin makepad_studio" had some hard-coded expectations about the directory it would exist in. 

2) File editing always looks for a live-code macro even in files that don't have that at all, causing a panic.

3) No way to retrieve solid components types to then edit parameters due to absence of downcasting on the trait object.

Fixes:

1) Retrieve the os working dir for the app and strip the prefix for files using that instead of hardcoded.

2) Added a check to see if the file has a live-code macro before running the live edit logic

3) Use the macro to generate a downcast for FrameComponent trait object, and modified the get_component macro to appropriately reflect changes.

Result:

These fixes let third party devs run the studio application to play with the app as expected and allows the modification of component props in code outside of the component, by being able to operate on the component directly.