### PR TITLE
Fix failing doc.rs by adding target metadata

### DIFF
--- a/widgets/Cargo.toml
+++ b/widgets/Cargo.toml
@@ -16,3 +16,5 @@ makepad-derive-widget = {path = "./derive_widget", version="0.3.0"}
 [features]
 nightly = ["makepad-draw-2d/nightly"]
 
+[package.metadata.docs.rs]
+default-target = "x86_64-apple-darwin"


### PR DESCRIPTION
Looking at the [failed build log](https://docs.rs/crate/makepad-widgets/0.3.0/builds/653283), it is trying to build for linux. Based on https://docs.rs/about/metadata I added the metadata to tell it to build for MacOS.

I kept it minimal. I also couldn't test that it works. If you have different opinions on the exact values of the metadata or what not, feel free to close. Just figured a PR doing the minimum was better than an issue or an overly complicated change.