### PR TITLE
Set correct dpi_factor in Android

### DIFF
--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -134,10 +134,20 @@ pub struct CxRef(pub (crate) Rc<RefCell<Cx>>);
 pub struct CxDependency {
     pub data: Option<Result<Vec<u8>, String >>
 }
-
 #[derive(Clone, Debug)]
 pub struct AndroidParams {
     pub cache_path: String,
+}
+
+pub struct AndroidInitParams {
+    pub cache_path: String,
+    pub density: f64,
+}
+
+impl AndroidInitParams {
+    pub fn extract_android_params(&self) -> AndroidParams {
+        AndroidParams{cache_path: self.cache_path.clone()}
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -27,7 +27,7 @@ use {
         },
         window::CxWindowPool,
         pass::CxPassParent,
-        cx::{Cx, OsType, AndroidParams},
+        cx::{Cx, OsType, AndroidInitParams},
         gpu_info::GpuPerformance,
         os::cx_native::EventFlow,
         pass::{PassClearColor, PassClearDepth, PassId},
@@ -42,11 +42,12 @@ extern "C" {
 impl Cx {
     
     /// Called when EGL is initialized.
-    pub fn from_java_on_init(&mut self, params: AndroidParams, to_java: AndroidToJava) {
+    pub fn from_java_on_init(&mut self, params: AndroidInitParams, to_java: AndroidToJava) {
         // lets load dependencies here.
         self.android_load_dependencies(&to_java);
         
-        self.os_type = OsType::Android(params);
+        self.os_type = OsType::Android(params.extract_android_params());
+        self.os.dpi_factor = params.density;
         self.gpu_info.performance = GpuPerformance::Tier1;
         self.call_event_handler(&Event::Construct);
     } 

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -2,13 +2,13 @@
 
 use {
     self::super::{
-        jni_sys::{jclass, jsize, jint, jlong, jstring, jobject, JNIEnv, JNI_ABORT},
+        jni_sys::{jclass, jsize, jint, jlong, jstring, jfloat, jobject, JNIEnv, JNI_ABORT},
     },
     crate::{
         area::Area,
         makepad_math::*,
         event::*,
-        cx::{Cx, AndroidParams},
+        cx::{Cx, AndroidInitParams},
     },
     std::{
         cell::Cell,
@@ -247,23 +247,20 @@ unsafe fn java_byte_array_to_vec(env: *mut JNIEnv, byte_array: jobject) -> Vec<u
     out_bytes
 }
 
-
-pub struct AndroidInitParams {
-    pub cache_path: String,
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn Java_dev_makepad_android_Makepad_onInit(
     env: *mut JNIEnv,
     _: jclass,
     cx: jlong,
     cache_path: jstring,
+    density: jfloat,
     callback: jobject,
 ) {
     crate::makepad_error_log::init_panic_hook();
     (*(cx as *mut Cx)).from_java_on_init(
-        AndroidParams {
+        AndroidInitParams {
             cache_path: jstring_to_string(env, cache_path),
+            density: density as f64,
         },
         AndroidToJava {
             env,

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/Makepad.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/Makepad.java
@@ -23,7 +23,7 @@ public class Makepad {
     static native void onResume(long cx, Callback callback);
     static native long onNewGL(long cx, Callback callback);
     static native void onFreeGL(long cx, Callback callback);
-    static native void onInit(long cx, String cache_path, Callback callback);
+    static native void onInit(long cx, String cache_path, float dentify, Callback callback);
     static native void onResize(long cx, int width, int height, Callback callback);
     static native void onDraw(long cx, Callback callback);
     static native void onTouch(long cx, MotionEvent event, Callback callback);

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -54,11 +54,10 @@ Makepad.Callback{
         mHandler = new Handler(Looper.getMainLooper());
         mRunnables = new HashMap<Long, Runnable>();
 
-        String apk_path = this.getCacheDir().getAbsolutePath();
         String cache_path = this.getCacheDir().getAbsolutePath();
+        float density = getResources().getDisplayMetrics().density;
 
-        Makepad.onInit(mCx, cache_path, this);
-        //Makepad.onNewGL(mCx, this);
+        Makepad.onInit(mCx, cache_path, density, this);
     }
 
     @Override


### PR DESCRIPTION
Retrieves the [density value](https://developer.android.com/reference/android/util/DisplayMetrics#density) on application initialization, and set this value as the dpi_factor to be used in all calculations.