### PR TITLE
Prevent warnings if the target is not Android

### DIFF
--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -139,17 +139,6 @@ pub struct AndroidParams {
     pub cache_path: String,
 }
 
-pub struct AndroidInitParams {
-    pub cache_path: String,
-    pub density: f64,
-}
-
-impl AndroidInitParams {
-    pub fn extract_android_params(&self) -> AndroidParams {
-        AndroidParams{cache_path: self.cache_path.clone()}
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct WebParams {
     pub protocol: String,

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -39,6 +39,17 @@ extern "C" {
     fn eglGetProcAddress(procname: *const c_char) -> *mut c_void;
 }
 
+pub struct AndroidInitParams {
+    pub cache_path: String,
+    pub density: f64,
+}
+
+impl AndroidInitParams {
+    pub fn extract_android_params(&self) -> AndroidParams {
+        AndroidParams{cache_path: self.cache_path.clone()}
+    }
+}
+
 impl Cx {
     
     /// Called when EGL is initialized.


### PR DESCRIPTION
Fixes the following warning (it shows up when android is not the target)

```
warning: struct `AndroidInitParams` is never constructed
   --> /Users/jorgebejar/Projects/makepad/platform/src/cx.rs:142:12
    |
142 | pub struct AndroidInitParams {
    |            ^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: associated function `extract_android_params` is never used
   --> /Users/jorgebejar/Projects/makepad/platform/src/cx.rs:148:12
    |
148 |     pub fn extract_android_params(&self) -> AndroidParams {
    |            ^^^^^^^^^^^^^^^^^^^^^^
```