### PR TITLE
Android basic clipboard functionality for keyboard shortcuts

### DIFF
--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -71,8 +71,6 @@ pub enum CxOsOp {
     StartDragging(DraggedItem),
     UpdateMenu(Menu),
     ShowClipboardActions(String),
-    CopyToClipboard(String),
-    PasteFromClipboard(),
 }
 
 impl Cx { 
@@ -131,14 +129,6 @@ impl Cx {
 
     pub fn show_clipboard_actions(&mut self, selected: String) {
         self.platform_ops.push(CxOsOp::ShowClipboardActions(selected));
-    }
-
-    pub fn copy_to_clipboard(&mut self, selected: String) {
-        self.platform_ops.push(CxOsOp::CopyToClipboard(selected));
-    }
-    
-    pub fn paste_from_clipboard(&mut self) {
-        self.platform_ops.push(CxOsOp::PasteFromClipboard());
     }
 
     pub fn start_dragging(&mut self, dragged_item: DraggedItem) {

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -70,7 +70,9 @@ pub enum CxOsOp {
     StopTimer(u64),
     StartDragging(DraggedItem),
     UpdateMenu(Menu),
-    ShowClipboardActions(String)
+    ShowClipboardActions(String),
+    CopyToClipboard(String),
+    PasteFromClipboard(),
 }
 
 impl Cx { 
@@ -130,7 +132,15 @@ impl Cx {
     pub fn show_clipboard_actions(&mut self, selected: String) {
         self.platform_ops.push(CxOsOp::ShowClipboardActions(selected));
     }
+
+    pub fn copy_to_clipboard(&mut self, selected: String) {
+        self.platform_ops.push(CxOsOp::CopyToClipboard(selected));
+    }
     
+    pub fn paste_from_clipboard(&mut self) {
+        self.platform_ops.push(CxOsOp::PasteFromClipboard());
+    }
+
     pub fn start_dragging(&mut self, dragged_item: DraggedItem) {
         self.platform_ops.iter().for_each( | p | {
             if let CxOsOp::StartDragging(_) = p {

--- a/platform/src/event/event.rs
+++ b/platform/src/event/event.rs
@@ -61,7 +61,7 @@ pub enum Event {
     KeyUp(KeyEvent),
     TextInput(TextInputEvent),
     TextCopy(TextCopyEvent),
-    TextCut,
+    TextCut(TextCutEvent),
     
     Drag(DragEvent),
     Drop(DropEvent),
@@ -88,7 +88,7 @@ pub enum Hit{
     Trigger(TriggerHitEvent),
     TextInput(TextInputEvent),
     TextCopy(TextCopyEvent),
-    TextCut,
+    TextCut(TextCutEvent),
     
     FingerScroll(FingerScrollEvent),
     FingerDown(FingerDownEvent),

--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -617,9 +617,9 @@ impl Event {
                     return Hit::TextCopy(tc.clone());
                 }
             },
-            Event::TextCut => {
+            Event::TextCut(tc) => {
                 if cx.keyboard.has_key_focus(area) {
-                    return Hit::TextCut;
+                    return Hit::TextCut(tc.clone());
                 }
             },
             Event::Scroll(e) => {

--- a/platform/src/event/keyboard.rs
+++ b/platform/src/event/keyboard.rs
@@ -112,6 +112,11 @@ pub struct TextCopyEvent {
     pub response: Rc<RefCell<Option<String>>>
 }
 
+#[derive(Clone, Debug)]
+pub struct TextCutEvent {
+    pub response: Rc<RefCell<Option<String>>>
+}
+
 impl Default for KeyCode {
     fn default() -> Self {KeyCode::Unknown}
 }

--- a/platform/src/os/apple/cocoa_app.rs
+++ b/platform/src/os/apple/cocoa_app.rs
@@ -40,6 +40,7 @@ use {
             KeyEvent,
             TextInputEvent,
             TextCopyEvent,
+            TextCutEvent,
             TimerEvent,
             //Signal,
             //SignalEvent,
@@ -397,11 +398,25 @@ impl CocoaApp {
                                 })
                             );
                         },
-                        KeyCode::KeyX | KeyCode::KeyC => if modifiers.logo || modifiers.control {
-                            // cut or copy.
+                        KeyCode::KeyC => if modifiers.logo || modifiers.control {
                             let response = Rc::new(RefCell::new(None));
                             self.do_callback(
                                 CocoaEvent::TextCopy(TextCopyEvent {
+                                    response: response.clone()
+                                })
+                            );
+                            let response = response.borrow();
+                            if let Some(response) = response.as_ref(){
+                                let nsstring = str_to_nsstring(&response);
+                                let array: ObjcId = msg_send![class!(NSArray), arrayWithObject: NSStringPboardType];
+                                let () = msg_send![self.pasteboard, declareTypes: array owner: nil];
+                                let () = msg_send![self.pasteboard, setString: nsstring forType: NSStringPboardType];
+                            }
+                        },
+                        KeyCode::KeyX => if modifiers.logo || modifiers.control {
+                            let response = Rc::new(RefCell::new(None));
+                            self.do_callback(
+                                CocoaEvent::TextCut(TextCutEvent {
                                     response: response.clone()
                                 })
                             );

--- a/platform/src/os/apple/cocoa_event.rs
+++ b/platform/src/os/apple/cocoa_event.rs
@@ -16,6 +16,7 @@ use {
             DragEvent,
             DropEvent,
             TextCopyEvent,
+            TextCutEvent,
             TimerEvent,
         },
     }
@@ -45,6 +46,7 @@ pub enum CocoaEvent {
     KeyDown(KeyEvent),
     KeyUp(KeyEvent),
     TextCopy(TextCopyEvent),
+    TextCut(TextCutEvent),
     Timer(TimerEvent),
     MenuCommand(MenuCommand),
 }

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -281,6 +281,9 @@ impl Cx {
             CocoaEvent::TextCopy(e) => {
                 self.call_event_handler(&Event::TextCopy(e))
             }
+            CocoaEvent::TextCut(e) => {
+                self.call_event_handler(&Event::TextCut(e))
+            }
             CocoaEvent::Timer(e) => {
                 self.call_event_handler(&Event::Timer(e))
             }

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -491,12 +491,6 @@ impl Cx {
                 CxOsOp::ShowClipboardActions(selected) => {
                     to_java.show_clipboard_actions(selected.as_str());
                 },
-                CxOsOp::CopyToClipboard(selected) => {
-                    to_java.copy_to_clipboard(selected.as_str());
-                },
-                CxOsOp::PasteFromClipboard() => {
-                    to_java.paste_from_clipboard();
-                },
                 _ => ()
             }
         }  

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -25,6 +25,7 @@ use {
             TimerEvent,
             TextInputEvent,
             TextCopyEvent,
+            TextCutEvent,
             KeyEvent,
             KeyModifiers,
             KeyCode,
@@ -226,7 +227,6 @@ impl Cx {
                     }
                 );
                 self.call_event_handler(&e);
-                self.after_every_event(&to_java);
             }
             None => {
                 let key_code = android_to_makepad_key_code(key_code_val);
@@ -241,11 +241,36 @@ impl Cx {
                         let input = ch.unwrap().to_string();
                         e = Event::TextInput(
                             TextInputEvent {
-                                input: input,
+                                input,
                                 replace_last: false,
                                 was_paste: false,
                             }
-                        )
+                        );
+                        self.call_event_handler(&e);
+                    } else if is_shortcut {
+                        if key_code == KeyCode::KeyC {  
+                            let response = Rc::new(RefCell::new(None));
+                            e = Event::TextCopy(TextCopyEvent {
+                                response: response.clone()
+                            });
+                            self.call_event_handler(&e);
+                            let response = response.borrow();
+                            if let Some(response) = response.as_ref(){
+                                to_java.copy_to_clipboard(response);
+                            }
+                        } else if key_code == KeyCode::KeyX {
+                            let response = Rc::new(RefCell::new(None));
+                            let e = Event::TextCut(TextCutEvent {
+                                response: response.clone()
+                            });
+                            self.call_event_handler(&e);
+                            let response = response.borrow();
+                            if let Some(response) = response.as_ref(){
+                                to_java.copy_to_clipboard(response);
+                            }
+                        } else if key_code == KeyCode::KeyV {  
+                            to_java.paste_from_clipboard();
+                        }
                     } else {
                         e = Event::KeyDown(
                             KeyEvent {
@@ -254,9 +279,9 @@ impl Cx {
                                 modifiers: KeyModifiers {shift, control, alt, ..Default::default()},
                                 time: self.os.time_now()
                             }
-                        )
+                        );
+                        self.call_event_handler(&e);
                     }
-                    self.call_event_handler(&e);
                     self.after_every_event(&to_java);
                 }
             }
@@ -302,15 +327,6 @@ impl Cx {
         self.after_every_event(&to_java);
     }
 
-    pub fn from_java_on_copy_to_clipboard(&mut self, to_java: AndroidToJava) {
-        let response = Rc::new(RefCell::new(None));
-        let e = Event::TextCopy(TextCopyEvent {
-            response: response.clone()
-        });
-        self.call_event_handler(&e);
-        self.after_every_event(&to_java);
-    }
-
     pub fn from_java_on_paste_from_clipboard(&mut self, content: Option<String>, to_java: AndroidToJava) {
         if let Some(text) = content {
             let e = Event::TextInput(
@@ -326,7 +342,11 @@ impl Cx {
     }
 
     pub fn from_java_on_cut_to_clipboard(&mut self, to_java: AndroidToJava) {
-        let e = Event::TextCut;
+        let e = Event::TextCut(
+            TextCutEvent {
+                response: Rc::new(RefCell::new(None))
+            }
+        );
         self.call_event_handler(&e);
         self.after_every_event(&to_java);
     }

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -302,7 +302,7 @@ impl Cx {
         self.after_every_event(&to_java);
     }
 
-    pub fn from_java_copy_to_clipboard(&mut self, to_java: AndroidToJava) {
+    pub fn from_java_on_copy_to_clipboard(&mut self, to_java: AndroidToJava) {
         let response = Rc::new(RefCell::new(None));
         let e = Event::TextCopy(TextCopyEvent {
             response: response.clone()
@@ -311,19 +311,21 @@ impl Cx {
         self.after_every_event(&to_java);
     }
 
-    pub fn from_java_paste_from_clipboard(&mut self, content: String, to_java: AndroidToJava) {
-        let e = Event::TextInput(
-            TextInputEvent {
-                input: content,
-                replace_last: false,
-                was_paste: true,
-            }
-        );
-        self.call_event_handler(&e);
-        self.after_every_event(&to_java);
+    pub fn from_java_on_paste_from_clipboard(&mut self, content: Option<String>, to_java: AndroidToJava) {
+        if let Some(text) = content {
+            let e = Event::TextInput(
+                TextInputEvent {
+                    input: text,
+                    replace_last: false,
+                    was_paste: true,
+                }
+            );
+            self.call_event_handler(&e);
+            self.after_every_event(&to_java);
+        }
     }
 
-    pub fn from_java_cut_to_clipboard(&mut self, to_java: AndroidToJava) {
+    pub fn from_java_on_cut_to_clipboard(&mut self, to_java: AndroidToJava) {
         let e = Event::TextCut;
         self.call_event_handler(&e);
         self.after_every_event(&to_java);
@@ -468,6 +470,12 @@ impl Cx {
                 },
                 CxOsOp::ShowClipboardActions(selected) => {
                     to_java.show_clipboard_actions(selected.as_str());
+                },
+                CxOsOp::CopyToClipboard(selected) => {
+                    to_java.copy_to_clipboard(selected.as_str());
+                },
+                CxOsOp::PasteFromClipboard() => {
+                    to_java.paste_from_clipboard();
                 },
                 _ => ()
             }

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -156,6 +156,38 @@ impl<'a> AndroidToJava<'a> {
         }
     }
     
+    pub fn copy_to_clipboard(&self, selected: &str) {
+        unsafe {
+            let class = ((**self.env).GetObjectClass.unwrap())(self.env, self.callback);
+            let name = CString::new("copyToClipboard").unwrap();
+            let signature = CString::new("(Ljava/lang/String;)V").unwrap();
+            let selected = CString::new(selected).unwrap();
+            let selected = ((**self.env).NewStringUTF.unwrap())(self.env, selected.as_ptr());
+            let method_id = ((**self.env).GetMethodID.unwrap())(
+                self.env,
+                class,
+                name.as_ptr(),
+                signature.as_ptr(),
+            );
+            ((**self.env).CallVoidMethod.unwrap())(self.env, self.callback, method_id, selected);
+        }
+    }
+
+    pub fn paste_from_clipboard(&self) {
+        unsafe {
+            let class = ((**self.env).GetObjectClass.unwrap())(self.env, self.callback);
+
+            let name = CString::new("pasteFromClipboard").unwrap();
+            let signature = CString::new("()V").unwrap();
+            let method_id = ((**self.env).GetMethodID.unwrap())(
+                self.env,
+                class,
+                name.as_ptr(),
+                signature.as_ptr(),
+            );
+            ((**self.env).CallVoidMethod.unwrap())(self.env, self.callback, method_id);
+        }
+    }
     
     /// reads an asset
     ///
@@ -595,13 +627,13 @@ pub unsafe extern "C" fn Java_dev_makepad_android_Makepad_onResizeTextIME(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_dev_makepad_android_Makepad_copyToClipboard(
+pub unsafe extern "C" fn Java_dev_makepad_android_Makepad_onCopyToClipboard(
     env: *mut JNIEnv,
     _: jclass,
     cx: jlong,
     callback: jobject,
 ) {
-    (*(cx as *mut Cx)).from_java_copy_to_clipboard(
+    (*(cx as *mut Cx)).from_java_on_copy_to_clipboard(
         AndroidToJava {
             env,
             callback,
@@ -611,15 +643,21 @@ pub unsafe extern "C" fn Java_dev_makepad_android_Makepad_copyToClipboard(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_dev_makepad_android_Makepad_pasteFromClipboard(
+pub unsafe extern "C" fn Java_dev_makepad_android_Makepad_onPasteFromClipboard(
     env: *mut JNIEnv,
     _: jclass,
     cx: jlong,
     content: jstring,
     callback: jobject,
 ) {
-    (*(cx as *mut Cx)).from_java_paste_from_clipboard(
-        jstring_to_string(env, content),
+    let string_content = if content == std::ptr::null_mut() {
+        None
+    } else {
+        Some(jstring_to_string(env, content))
+    };
+
+    (*(cx as *mut Cx)).from_java_on_paste_from_clipboard(
+        string_content,
         AndroidToJava {
             env,
             callback,
@@ -629,13 +667,13 @@ pub unsafe extern "C" fn Java_dev_makepad_android_Makepad_pasteFromClipboard(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_dev_makepad_android_Makepad_cutToClipboard(
+pub unsafe extern "C" fn Java_dev_makepad_android_Makepad_onCutToClipboard(
     env: *mut JNIEnv,
     _: jclass,
     cx: jlong,
     callback: jobject,
 ) {
-    (*(cx as *mut Cx)).from_java_cut_to_clipboard(
+    (*(cx as *mut Cx)).from_java_on_cut_to_clipboard(
         AndroidToJava {
             env,
             callback,

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -627,22 +627,6 @@ pub unsafe extern "C" fn Java_dev_makepad_android_Makepad_onResizeTextIME(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_dev_makepad_android_Makepad_onCopyToClipboard(
-    env: *mut JNIEnv,
-    _: jclass,
-    cx: jlong,
-    callback: jobject,
-) {
-    (*(cx as *mut Cx)).from_java_on_copy_to_clipboard(
-        AndroidToJava {
-            env,
-            callback,
-            phantom: PhantomData,
-        },
-    );
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn Java_dev_makepad_android_Makepad_onPasteFromClipboard(
     env: *mut JNIEnv,
     _: jclass,

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -176,6 +176,9 @@ impl Cx {
             XlibEvent::TextCopy(e) => {
                 self.call_event_handler(&Event::TextCopy(e))
             }
+            XlibEvent::TextCut(e) => {
+                self.call_event_handler(&Event::TextCut(e))
+            }
             XlibEvent::Timer(e) => {
                 //println!("TIMER! {:?}", std::time::Instant::now());
                 if e.timer_id == 0{

--- a/platform/src/os/linux/x11/xlib_app.rs
+++ b/platform/src/os/linux/x11/xlib_app.rs
@@ -830,7 +830,6 @@ impl XlibApp {
         // store the text on the clipboard
         self.clipboard = text.clone();
         // lets set the owner
-        println!("Set selection owner");
         x11_sys::XSetSelectionOwner(
             self.display,
             self.atoms.clipboard,

--- a/platform/src/os/linux/x11/xlib_app.rs
+++ b/platform/src/os/linux/x11/xlib_app.rs
@@ -18,6 +18,7 @@ use {
         event::*,
         cursor::MouseCursor,
         os::cx_native::EventFlow,
+        x11::x11_sys::XEvent
     },
 };
 
@@ -441,24 +442,24 @@ impl XlibApp {
                                         ]);
                                         */
                                     }
-                                    KeyCode::KeyX | KeyCode::KeyC => {
+                                    KeyCode::KeyC => {
                                         let response = Rc::new(RefCell::new(None));
                                         self.do_callback(XlibEvent::TextCopy(TextCopyEvent {
                                             response: response.clone()
                                         }));
                                         let response = response.borrow();
                                         if let Some(response) = response.as_ref() {
-                                            // store the text on the clipboard
-                                            self.clipboard = response.clone();
-                                            // lets set the owner
-                                            println!("Set selection owner");
-                                            x11_sys::XSetSelectionOwner(
-                                                self.display,
-                                                self.atoms.clipboard,
-                                                window.window.unwrap(),
-                                                event.xkey.time
-                                            );
-                                            x11_sys::XFlush(self.display);
+                                            self.copy_to_clipboard(response, &window, &event);
+                                        }
+                                    }
+                                    KeyCode::KeyX => {
+                                        let response = Rc::new(RefCell::new(None));
+                                        self.do_callback(XlibEvent::TextCut(TextCutEvent {
+                                            response: response.clone()
+                                        }));
+                                        let response = response.borrow();
+                                        if let Some(response) = response.as_ref() {
+                                            self.copy_to_clipboard(response, &window, &event);
                                         }
                                     }
                                     _ => ()
@@ -823,6 +824,20 @@ impl XlibApp {
             x11_sys::XK_Up => KeyCode::ArrowUp,
             _ => KeyCode::Unknown,
         }
+    }
+
+    unsafe fn copy_to_clipboard(&mut self, text: &String, window: &XlibWindow, event: &XEvent) {
+        // store the text on the clipboard
+        self.clipboard = text.clone();
+        // lets set the owner
+        println!("Set selection owner");
+        x11_sys::XSetSelectionOwner(
+            self.display,
+            self.atoms.clipboard,
+            window.window.unwrap(),
+            event.xkey.time
+        );
+        x11_sys::XFlush(self.display);
     }
 }
 

--- a/platform/src/os/linux/x11/xlib_event.rs
+++ b/platform/src/os/linux/x11/xlib_event.rs
@@ -14,6 +14,7 @@ use {
             DragEvent,
             DropEvent,
             TextCopyEvent,
+            TextCutEvent,
             TimerEvent,
         },
     }
@@ -41,5 +42,6 @@ pub enum XlibEvent {
     KeyDown(KeyEvent),
     KeyUp(KeyEvent),
     TextCopy(TextCopyEvent),
+    TextCut(TextCutEvent),
     Timer(TimerEvent),
 }

--- a/platform/src/os/windows/win32_event.rs
+++ b/platform/src/os/windows/win32_event.rs
@@ -15,6 +15,7 @@ use {
             DragEvent,
             DropEvent,
             TextCopyEvent,
+            TextCutEvent,
             TimerEvent,
         },
     }
@@ -44,6 +45,7 @@ pub enum Win32Event {
     KeyDown(KeyEvent),
     KeyUp(KeyEvent),
     TextCopy(TextCopyEvent),
+    TextCut(TextCutEvent),
     Timer(TimerEvent),
     Signal,
 }

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -509,7 +509,7 @@ impl Win32Window {
                             );
                             let response = response.borrow();
                             if let Some(response) = response.as_ref() {
-                                copy_to_cliboard(response);
+                                Self::copy_to_clipboard(response);
                             }
                         },
                         KeyCode::KeyX => {
@@ -521,7 +521,7 @@ impl Win32Window {
                             );
                             let response = response.borrow();
                             if let Some(response) = response.as_ref() {
-                                copy_to_cliboard(response);
+                                Self::copy_to_clipboard(response);
                             }
                         }
                         _ => ()
@@ -613,7 +613,7 @@ impl Win32Window {
         //run_catch_panic(-1, || callback_inner(window, msg, wparam, lparam))
     }
 
-    unsafe fn copy_to_clipboard(text: &String) {
+    fn copy_to_clipboard(text: &String) {
         // plug it into the windows clipboard
         // make utf16 dta
         if OpenClipboard(None) == TRUE {

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -176,6 +176,9 @@ impl Cx {
             Win32Event::TextCopy(e) => {
                 self.call_event_handler(&Event::TextCopy(e))
             }
+            Win32Event::TextCut(e) => {
+                self.call_event_handler(&Event::TextCut(e))
+            }
             Win32Event::Timer(e) => {
                 self.call_event_handler(&Event::Timer(e))
             }

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/Makepad.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/Makepad.java
@@ -15,6 +15,8 @@ public class Makepad {
         void showTextIME();
         void hideTextIME();
         void showClipboardActions(String selected);
+        void copyToClipboard(String selected);
+        void pasteFromClipboard();
     }
 
     static {
@@ -36,7 +38,7 @@ public class Makepad {
     static native void onMidiDeviceOpened(long cx, String name, Object midi_device, Callback callback);
     static native void onHideTextIME(long cx, Callback callback);
     static native void onResizeTextIME(long cx, int ime_height, Callback callback);
-    static native void copyToClipboard(long cx, Callback callback);
-    static native void pasteFromClipboard(long cx, String content, Callback callback);
-    static native void cutToClipboard(long cx, Callback callback);
+    static native void onCopyToClipboard(long cx, Callback callback);
+    static native void onPasteFromClipboard(long cx, String content, Callback callback);
+    static native void onCutToClipboard(long cx, Callback callback);
 }

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -261,6 +261,31 @@ Makepad.Callback{
         mView.showContextMenu();
     }
 
+    public void copyToClipboard(String selected) {
+        mSelectedContent = selected;
+        ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+        ClipData clip = ClipData.newPlainText("Makepad", mSelectedContent);
+        clipboard.setPrimaryClip(clip);
+    }
+
+    public void pasteFromClipboard(){
+        ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+        try{
+            String text;
+            if (clipboard.hasPrimaryClip()) {
+                ClipData.Item cb_item = clipboard.getPrimaryClip().getItemAt(0);
+                text = cb_item.getText().toString();
+            } else {
+                text = null;
+            }
+            Makepad.onPasteFromClipboard(mCx, text, (Makepad.Callback)mView.getContext());
+        }
+        catch(Exception e){
+            Log.e("Makepad", "exception: " + e.getMessage());
+            Log.e("Makepad", "exception: " + e.toString());
+        }
+    }
+
     @Override
     public void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo) {
         super.onCreateContextMenu(menu, v, menuInfo);
@@ -303,7 +328,7 @@ Makepad.Callback{
 
                 // Will emit the internal Makepad TextCopy event, just in case
                 // widget developers want to do something else
-                Makepad.copyToClipboard(mCx, (Makepad.Callback)mView.getContext());
+                Makepad.onCopyToClipboard(mCx, (Makepad.Callback)mView.getContext());
                 return true;
             case R.id.menu_paste:
                 if (clipboard.hasPrimaryClip()) {
@@ -311,7 +336,7 @@ Makepad.Callback{
                     String text = cb_item.getText().toString();
 
                     // Will emit TextInput event with the was_paste flag in true
-                    Makepad.pasteFromClipboard(mCx, text, (Makepad.Callback)mView.getContext());
+                    Makepad.onPasteFromClipboard(mCx, text, (Makepad.Callback)mView.getContext());
                 }
                 return true;
             case R.id.menu_cut:
@@ -319,7 +344,7 @@ Makepad.Callback{
                 clipboard.setPrimaryClip(clip);
 
                 // Will emit TextCut event so Makepad widgets can strip the selected content
-                Makepad.cutToClipboard(mCx, (Makepad.Callback)mView.getContext());
+                Makepad.onCutToClipboard(mCx, (Makepad.Callback)mView.getContext());
                 return true;
             default:
                 return super.onContextItemSelected(item);

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -257,33 +257,18 @@ Makepad.Callback{
     }
 
     public void showClipboardActions(String selected) {
-        mSelectedContent = selected;
+        mSelectedText = selected;
         mView.showContextMenu();
     }
 
     public void copyToClipboard(String selected) {
-        mSelectedContent = selected;
-        ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
-        ClipData clip = ClipData.newPlainText("Makepad", mSelectedContent);
-        clipboard.setPrimaryClip(clip);
+        mSelectedText = selected;
+        copySelectedTextToClipboard();
     }
 
     public void pasteFromClipboard(){
-        ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
-        try{
-            String text;
-            if (clipboard.hasPrimaryClip()) {
-                ClipData.Item cb_item = clipboard.getPrimaryClip().getItemAt(0);
-                text = cb_item.getText().toString();
-            } else {
-                text = null;
-            }
-            Makepad.onPasteFromClipboard(mCx, text, (Makepad.Callback)mView.getContext());
-        }
-        catch(Exception e){
-            Log.e("Makepad", "exception: " + e.getMessage());
-            Log.e("Makepad", "exception: " + e.toString());
-        }
+        String text = getTextFromClipboard();
+        Makepad.onPasteFromClipboard(mCx, text, (Makepad.Callback)mView.getContext());
     }
 
     @Override
@@ -295,7 +280,7 @@ Makepad.Callback{
 
         MenuItem copyItem = menu.findItem(R.id.menu_copy);
         MenuItem cutItem = menu.findItem(R.id.menu_cut);
-        if (mSelectedContent == null || mSelectedContent.isEmpty()) {
+        if (mSelectedText == null || mSelectedText.isEmpty()) {
             copyItem.setVisible(false);
             cutItem.setVisible(false);
         } else {
@@ -323,31 +308,48 @@ Makepad.Callback{
         ClipData clip;
         switch (item.getItemId()) {
             case R.id.menu_copy:
-                clip = ClipData.newPlainText("Makepad", mSelectedContent);
-                clipboard.setPrimaryClip(clip);
-
-                // Will emit the internal Makepad TextCopy event, just in case
-                // widget developers want to do something else
-                Makepad.onCopyToClipboard(mCx, (Makepad.Callback)mView.getContext());
+                copySelectedTextToClipboard();
                 return true;
-            case R.id.menu_paste:
-                if (clipboard.hasPrimaryClip()) {
-                    ClipData.Item cb_item = clipboard.getPrimaryClip().getItemAt(0);
-                    String text = cb_item.getText().toString();
 
-                    // Will emit TextInput event with the was_paste flag in true
-                    Makepad.onPasteFromClipboard(mCx, text, (Makepad.Callback)mView.getContext());
-                }
-                return true;
             case R.id.menu_cut:
-                clip = ClipData.newPlainText("Makepad", mSelectedContent);
-                clipboard.setPrimaryClip(clip);
-
-                // Will emit TextCut event so Makepad widgets can strip the selected content
+                copySelectedTextToClipboard();
                 Makepad.onCutToClipboard(mCx, (Makepad.Callback)mView.getContext());
                 return true;
+
+            case R.id.menu_paste:
+                String text = getTextFromClipboard();
+                Makepad.onPasteFromClipboard(mCx, text, (Makepad.Callback)mView.getContext());
+                return true;
+                
             default:
                 return super.onContextItemSelected(item);
+        }
+    }
+
+    private void copySelectedTextToClipboard() {
+        ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+        ClipData clip = ClipData.newPlainText("Makepad", mSelectedText);
+        clipboard.setPrimaryClip(clip);
+    }
+        
+    private String getTextFromClipboard() {
+        ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+        try{
+            String text;
+            if (clipboard.hasPrimaryClip()) {
+                ClipData.Item cb_item = clipboard.getPrimaryClip().getItemAt(0);
+                text = cb_item.getText().toString();
+            } else {
+                text = null;
+            }
+
+            return text;
+        }
+        catch(Exception e){
+            Log.e("Makepad", "exception: " + e.getMessage());
+            Log.e("Makepad", "exception: " + e.toString());
+
+            return null;
         }
     }
 
@@ -355,5 +357,5 @@ Makepad.Callback{
     HashMap<Long, Runnable> mRunnables;
     MakepadSurfaceView mView;
     long mCx;
-    String mSelectedContent;
+    String mSelectedText;
 }

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -495,11 +495,12 @@ impl TextInput {
             }
             Hit::TextCopy(ce) => {
                 self.undo_id += 1;
-                *ce.response.borrow_mut() = Some(self.selected_text())
+                *ce.response.borrow_mut() = Some(self.selected_text());
             }
-            Hit::TextCut => {
+            Hit::TextCut(tc) => {
                 self.undo_id += 1;
                 if self.cursor_head != self.cursor_tail {
+                    *tc.response.borrow_mut() = Some(self.selected_text());
                     self.create_undo(UndoGroup::Cut(self.undo_id));
                     self.change(cx, "", dispatch_action);
                 }
@@ -534,20 +535,6 @@ impl TextInput {
                     self.cursor_tail = 0;
                     self.cursor_head = self.text.chars().count();
                     self.draw_bg.redraw(cx);
-                }
-                KeyCode::KeyX if ke.modifiers.logo || ke.modifiers.control => {
-                    self.undo_id += 1;
-                    if self.cursor_head != self.cursor_tail {
-                        cx.copy_to_clipboard(self.selected_text());
-                        self.create_undo(UndoGroup::Cut(self.undo_id));
-                        self.change(cx, "", dispatch_action);
-                    }
-                }
-                KeyCode::KeyC if ke.modifiers.logo || ke.modifiers.control => {
-                    cx.copy_to_clipboard(self.selected_text());
-                }
-                KeyCode::KeyV if ke.modifiers.logo || ke.modifiers.control => {
-                    cx.paste_from_clipboard();
                 }
                 KeyCode::ArrowLeft => {
                     self.undo_id += 1;

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -538,9 +538,16 @@ impl TextInput {
                 KeyCode::KeyX if ke.modifiers.logo || ke.modifiers.control => {
                     self.undo_id += 1;
                     if self.cursor_head != self.cursor_tail {
+                        cx.copy_to_clipboard(self.selected_text());
                         self.create_undo(UndoGroup::Cut(self.undo_id));
                         self.change(cx, "", dispatch_action);
                     }
+                }
+                KeyCode::KeyC if ke.modifiers.logo || ke.modifiers.control => {
+                    cx.copy_to_clipboard(self.selected_text());
+                }
+                KeyCode::KeyV if ke.modifiers.logo || ke.modifiers.control => {
+                    cx.paste_from_clipboard();
                 }
                 KeyCode::ArrowLeft => {
                     self.undo_id += 1;


### PR DESCRIPTION
- Adds Copy, Cut, and Paste functionality for physical keyboard shortcuts
- Some minor renaming for clipboard functions coming from java
- Moves Cut shortcut handling to the platform layer in all platforms

TODO

- [x] Needs #167 in order to work.
- [x] Add clipboard functionality for physical keyboards
- [x] Move shortcut handling to platform layer
    - [x] Android
    - [x] macOS
    - [x] Windows
    - [x] x11 (direct doesn't have the clipboard impl yet)