### PR TITLE
Improve android assets compilation

### DIFF
--- a/tools/cargo_makepad/src/android/compile.rs
+++ b/tools/cargo_makepad/src/android/compile.rs
@@ -269,32 +269,14 @@ pub fn build(sdk_dir: &Path, host_os: HostOs, args: &[String]) -> Result<BuildRe
         cp_all(&resources_path, &dst_dir, false) ?;
     }
 
-    // TODO - This is copying all from /icons but we should discuss which folders we
-    // want to support, or if we want to copy recursively from /resources
-    for (name, resources_path) in dependencies.iter() {
-        if resources_path.join("icons").is_dir() {
-            let dst_dir = out_dir.join(format!("assets/makepad/{name}/resources/icons"));
-            mkdir(&dst_dir) ?;
-            cp_all(&resources_path.join("icons"), &dst_dir, false) ?;
-        }
-    }
-
     let mut assets_to_add: Vec<String> = Vec::new();
     for (name, _resources_path) in dependencies.iter() {
         let dst_dir = out_dir.join(format!("assets/makepad/{name}/resources"));
         let assets = ls(&dst_dir) ?;
 
-        for a in &assets {
-            assets_to_add.push(format!("assets/makepad/{name}/resources/{a}"));
-        }
-
-        // TODO Check this!
-        if dst_dir.join("icons").is_dir() {
-            let icon_assets = ls(&dst_dir.join("icons")) ?;
-
-            for a in &icon_assets {
-                assets_to_add.push(format!("assets/makepad/{name}/resources/icons/{a}"));
-            }
+        for path in &assets {
+            let path = path.display();
+            assets_to_add.push(format!("assets/makepad/{name}/resources/{path}"));
         }
     }
 

--- a/tools/cargo_makepad/src/android/mod.rs
+++ b/tools/cargo_makepad/src/android/mod.rs
@@ -36,7 +36,6 @@ impl HostOs {
 }
 
 pub fn handle_android(mut args: &[String]) -> Result<(), String> {
-    
     #[allow(unused)]
     let mut host_os = HostOs::Unsupported;
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))] let mut host_os = HostOs::WindowsX64;
@@ -44,6 +43,8 @@ pub fn handle_android(mut args: &[String]) -> Result<(), String> {
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))] let mut host_os = HostOs::MacosAarch64;
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))] let mut host_os = HostOs::LinuxX64;
     let mut sdk_path = None;
+    let mut package_name = None;
+    let mut app_label = None;
     // pull out options
     for i in 0..args.len() {
         let v = &args[i];
@@ -52,6 +53,12 @@ pub fn handle_android(mut args: &[String]) -> Result<(), String> {
         }
         else if let Some(opt) = v.strip_prefix("--sdk-path=") {
             sdk_path = Some(opt.to_string());
+        }
+        else if let Some(opt) = v.strip_prefix("--package-name=") {
+            package_name = Some(opt.to_string());
+        }
+        else if let Some(opt) = v.strip_prefix("--app-label=") {
+            app_label = Some(opt.to_string());
         }
         else {
             args = &args[i..];
@@ -64,8 +71,6 @@ pub fn handle_android(mut args: &[String]) -> Result<(), String> {
     
     let cwd = std::env::current_dir().unwrap();
     let sdk_dir = cwd.join(&sdk_path.unwrap());
-    // 
-    
     
     match args[0].as_ref() {
         "rustup-toolchain-install"=>{
@@ -102,13 +107,13 @@ pub fn handle_android(mut args: &[String]) -> Result<(), String> {
             compile::base_apk(&sdk_dir, host_os, &args[1..])
         }*/
         "build" =>{
-            if let Err(e) = compile::build(&sdk_dir, host_os, &args[1..]){
+            if let Err(e) = compile::build(&sdk_dir, host_os, package_name, app_label, &args[1..]){
                 return Err(e)
             }
             Ok(())
         }
         "run" =>{
-            compile::run(&sdk_dir, host_os, &args[1..])
+            compile::run(&sdk_dir, host_os, package_name, app_label, &args[1..])
         }
         _ => Err(format!("{} is not a valid command or option", args[0]))
     }

--- a/tools/cargo_makepad/src/main.rs
+++ b/tools/cargo_makepad/src/main.rs
@@ -71,5 +71,3 @@ fn main() {
         _=> show_help("not implemented yet")
     }
 }
-
-

--- a/tools/cargo_makepad/src/main.rs
+++ b/tools/cargo_makepad/src/main.rs
@@ -43,19 +43,23 @@ fn show_help(err: &str){
     }
 
 fn main() {
-   
-    /*let test_args = "cargo makepad android expand-sdk";
-    let args:Vec<String> = test_args.split(" ").map(|s| s.to_string()).collect();
-    let args = &args[2..];*/
     let args:Vec<String> = std::env::args().collect();
     println!("{:?}", args);
-    if args.len()<3{
+
+    // Skip the first argument if it's the binary path or 'cargo'
+    let args = if args.len() > 1 && (args[0].ends_with("cargo-makepad") || args[0] == "cargo") {
+        // If it's 'cargo makepad', then skip the second argument as well
+        if args.len() > 2 && args[1] == "makepad" {
+            args[2..].to_vec()
+        } else {
+            args[1..].to_vec()
+        }
+    } else {
+        args
+    };
+
+    if args.len() <= 1 {
         return show_help("not enough arguments");
-    }
-    let args = &args[2..];
-   
-    if args.len() == 0{
-        return show_help("");
     }
     match args[0].as_ref(){
         "android" => if let Err(e) = handle_android(&args[1..]){

--- a/tools/cargo_makepad/src/shell.rs
+++ b/tools/cargo_makepad/src/shell.rs
@@ -124,3 +124,41 @@ pub fn cp(source_path: &Path, dest_path: &Path, exec: bool) -> Result<(), String
     Ok(())
 }
 
+pub fn cp_all(source_dir: &Path, dest_dir: &Path, exec: bool) -> Result<(), String> {
+    if !source_dir.is_dir() {
+        return Err(format!("{:?} is not a directory", source_dir));
+    }
+
+    mkdir(dest_dir) ?;
+
+    for entry in fs::read_dir(source_dir).map_err(|_e| format!("Unable to read source directory {:?}", source_dir))? {
+        let entry = entry.map_err(|_e| format!("Unable to process directory entry"))?;
+        let source_path = entry.path();
+        if source_path.is_file() {
+            let dest_path = dest_dir.join(source_path.file_name()
+                .ok_or_else(|| format!("Unable to get filename for {:?}", source_path))?);
+
+            cp(&source_path, &dest_path, exec)?;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn ls(dir: &Path) -> Result<Vec<String>, String> {
+    let mut result = Vec::new();
+    for entry in fs::read_dir(dir).map_err(|_e| format!("Unable to read source directory {:?}", dir))? {
+        let entry = entry.map_err(|_e| format!("Unable to process directory entry"))?;
+        let source_path = entry.path();
+        if source_path.is_file() {
+            let file_name = source_path.file_name()
+                .ok_or_else(|| format!("Unable to get filename for {:?}", source_path))?.to_str();
+
+            if !file_name.unwrap().starts_with('.') {
+                result.push(file_name.unwrap().to_string());
+            }
+        }
+    }
+
+    Ok(result)
+}

--- a/tools/cargo_makepad/src/shell.rs
+++ b/tools/cargo_makepad/src/shell.rs
@@ -1,5 +1,5 @@
 use std::{
-    path::{Path},
+    path::{Path, PathBuf},
     fs::File,
     io::{Write,Read},
     fs,
@@ -125,6 +125,11 @@ pub fn cp(source_path: &Path, dest_path: &Path, exec: bool) -> Result<(), String
 }
 
 pub fn cp_all(source_dir: &Path, dest_dir: &Path, exec: bool) -> Result<(), String> {
+    cp_all_recursive(source_dir, dest_dir, exec)?;
+    Ok(())
+}
+
+fn cp_all_recursive(source_dir: &Path, dest_dir: &Path, exec: bool) -> Result<(), String> {
     if !source_dir.is_dir() {
         return Err(format!("{:?} is not a directory", source_dir));
     }
@@ -139,26 +144,43 @@ pub fn cp_all(source_dir: &Path, dest_dir: &Path, exec: bool) -> Result<(), Stri
                 .ok_or_else(|| format!("Unable to get filename for {:?}", source_path))?);
 
             cp(&source_path, &dest_path, exec)?;
+        } else if source_path.is_dir() {
+            let dest_path = dest_dir.join(source_path.file_name()
+                    .ok_or_else(|| format!("Unable to get folder name for {:?}", source_path))?);
+
+            cp_all_recursive(&source_path, &dest_path, exec)?;
         }
     }
 
     Ok(())
 }
 
-pub fn ls(dir: &Path) -> Result<Vec<String>, String> {
+pub fn ls(dir: &Path) -> Result<Vec<PathBuf>, String> {
     let mut result = Vec::new();
+    ls_recursive(dir, dir, &mut result)?;
+    Ok(result)
+}
+
+fn ls_recursive(dir: &Path, prefix: &Path, result: &mut Vec<PathBuf>) -> Result<(), String> {
     for entry in fs::read_dir(dir).map_err(|_e| format!("Unable to read source directory {:?}", dir))? {
         let entry = entry.map_err(|_e| format!("Unable to process directory entry"))?;
         let source_path = entry.path();
         if source_path.is_file() {
-            let file_name = source_path.file_name()
-                .ok_or_else(|| format!("Unable to get filename for {:?}", source_path))?.to_str();
+            let file_name = source_path
+                .file_name()
+                .ok_or_else(|| format!("Unable to get filename"))?
+                .to_str()
+                .ok_or_else(|| format!( "Unable to convert filename to str"))?;
 
-            if !file_name.unwrap().starts_with('.') {
-                result.push(file_name.unwrap().to_string());
+            if !file_name.starts_with('.') {
+                let result_path = source_path.strip_prefix(prefix)
+                    .map_err(|_e| format!("Unable to strip prefix"))?;
+                result.push(result_path.to_path_buf());
             }
+        } else if source_path.is_dir() {
+            ls_recursive(&source_path, prefix, result)?;
         }
     }
 
-    Ok(result)
+    Ok(())
 }


### PR DESCRIPTION
This PR removes the need to hardcode assets filenames in the compile script.
Also, it makes possible to build projects defined in separate repositories, since all hardcoded references are gone.

Changes
- [x] Bundle resources found in cargo dependencies (makepad libraries, community-created widgets, etc)
- [x] Bundle local resources (`/resources` folder in host app project)
- [x] Files found in `/resources` are copies recursively.
- [x] `android/compile.rs` build code split in several functions 
- [x] Make sure `cargo-makepad` and `cargo makepad` invokations works indistinctly. 