### PR TITLE
Reuse dx11 buffers

### DIFF
--- a/libs/windows/src/Windows/mod.rs
+++ b/libs/windows/src/Windows/mod.rs
@@ -1797,8 +1797,11 @@ impl ::core::fmt::Debug for D3D11_BUFFER_DESC {
 }
 
 pub const D3D11_USAGE_DEFAULT: D3D11_USAGE = D3D11_USAGE(0i32);
+pub const D3D11_USAGE_DYNAMIC: D3D11_USAGE = D3D11_USAGE(2i32);
 
 pub const D3D11_BIND_CONSTANT_BUFFER: D3D11_BIND_FLAG = D3D11_BIND_FLAG(4u32);
+
+pub const D3D11_CPU_ACCESS_WRITE: D3D11_CPU_ACCESS_FLAG = D3D11_CPU_ACCESS_FLAG(0x10000u32);
 
 #[derive(PartialEq, Eq)]#[repr(transparent)]pub struct D3D11_CPU_ACCESS_FLAG(pub u32);
 impl ::core::marker::Copy for D3D11_CPU_ACCESS_FLAG {}
@@ -7524,6 +7527,8 @@ impl ::core::fmt::Debug for D3D11_TEX3D_RTV {
         f.debug_struct("D3D11_TEX3D_RTV").field("MipSlice", &self.MipSlice).field("FirstWSlice", &self.FirstWSlice).field("WSize", &self.WSize).finish()
     }
 }
+
+pub const D3D11_MAP_WRITE_DISCARD: D3D11_MAP = D3D11_MAP(4i32);
 
 #[derive(PartialEq, Eq)]#[repr(transparent)]pub struct D3D11_MAP(pub i32);
 impl ::core::marker::Copy for D3D11_MAP {}


### PR DESCRIPTION
The current implementation calls DX11 CreateBuffer every frame. This stresses the gpu and makes heap use go haywire after just a few seconds on the sample ironfish application:
![old](https://github.com/makepad/makepad/assets/6618140/fd83dc4c-e3d5-4ffb-9372-1e86407c55d8)

This PR is a very simple addition to reuse the buffers. I suspect this might be something already planned, since there was a last_size variable already.
![new](https://github.com/makepad/makepad/assets/6618140/2abde5a5-6ed2-45f9-8e85-909ce7688334)
