### PR TITLE
Fix broken checkboxes in Android

### DIFF
--- a/platform/shader_compiler/src/generate.rs
+++ b/platform/shader_compiler/src/generate.rs
@@ -331,7 +331,9 @@ impl<'a> BlockGenerator<'a> {
             }
 
             if self.backend_writer.enum_is_float(){
-                write!(self.string, "if(abs(").unwrap();
+                write!(self.string, "if((sign(").unwrap();
+                self.generate_expr(expr);
+                write!(self.string, ") * ").unwrap();
                 self.generate_expr(expr);
                 write!(self.string, " - {}.0)<0.5)", match_item.enum_value.get().unwrap()).unwrap();
             }


### PR DESCRIPTION
The solution was to replace the usage of `abs` in shaders code, as suggested here:

https://stackoverflow.com/questions/13335507/glsl-abs-broken