### PR TITLE
Extract image widget

### DIFF
--- a/draw/image_formats/src/image.rs
+++ b/draw/image_formats/src/image.rs
@@ -1,7 +1,7 @@
 // image_formats::image
 // by Desmond Germans, 2019
 
-#[derive(Default)] 
+#[derive(Default, Clone)] 
 pub struct ImageBuffer {
     pub width: usize,
     pub height: usize,

--- a/draw/image_formats/src/lib.rs
+++ b/draw/image_formats/src/lib.rs
@@ -2,10 +2,9 @@
 // image_formats
 // by Desmond Germans, 2019
 
-mod image;
-pub use image::*;
-
+pub mod image;
 pub mod bmp;
 pub mod png;
 pub mod jpeg;
 
+pub use image::*;

--- a/examples/ironfish/src/app_desktop.rs
+++ b/examples/ironfish/src/app_desktop.rs
@@ -5,6 +5,7 @@ live_design!{
     import makepad_widgets::frame::*;
     import makepad_draw::shader::std::*;
     
+    import makepad_widgets::image::Image;
     import makepad_widgets::scroll_bars::ScrollBars;
     import makepad_widgets::label::Label;
     import makepad_widgets::link_label::LinkLabel;
@@ -1846,10 +1847,11 @@ live_design!{
                 }
                 
                 <Image> {
-                    image: dep("crate://self/resources/tinrs.png"),
+                    source: dep("crate://self/resources/tinrs.png"),
                     walk: {width: (1000 * 0.175), height: (175 * 0.175), margin: 0}
                     layout: {padding: 0}
                 }
+
             }
             
             <FillerV> {}

--- a/examples/ironfish/src/app_mobile.rs
+++ b/examples/ironfish/src/app_mobile.rs
@@ -5,6 +5,7 @@ live_design!{
     import makepad_widgets::frame::*;
     import makepad_draw::shader::std::*;
     
+    import makepad_widgets::image::Image;
     import makepad_widgets::label::Label;
     import makepad_widgets::drop_down::DropDown;
     import makepad_widgets::button::Button;
@@ -601,7 +602,7 @@ live_design!{
             <FillerX> {}
 
             <Image> {
-                image: dep("crate://self/resources/tinrs_mobile.png"),
+                source: dep("crate://self/resources/tinrs_mobile.png"),
                 walk: {width: (178 * 0.175), height: (121 * 0.175), margin: { top: 0.0, right: 0.0, bottom: 0.0, left: 10.0 } }
                 layout: {padding: 0}
             }

--- a/examples/news_feed/src/app.rs
+++ b/examples/news_feed/src/app.rs
@@ -8,6 +8,7 @@ live_design!{
     import makepad_widgets::desktop_window::DesktopWindow;
     import makepad_widgets::label::Label;
     import makepad_widgets::frame::*;
+    import makepad_widgets::image::Image;
     import makepad_widgets::slider::Slider;
     import makepad_widgets::text_input::TextInput;
     import makepad_widgets::drop_down::DropDown;
@@ -186,7 +187,7 @@ live_design!{
                 walk: {width: Fit, height: Fit, margin: {top: 7.5}}
                 layout: {flow: Down, padding: 0.0}
                 profile_img = <Image> {
-                    image: (IMG_PROFILE_A)
+                    source: (IMG_PROFILE_A)
                     draw_bg: {
                         fn pixel(self) -> vec4 {
                             let sdf = Sdf2d::viewport(self.pos * self.rect_size);
@@ -197,7 +198,7 @@ live_design!{
                             return sdf.result
                         }
                     }
-                    image_scale: 0.65
+                    scale_factor: 0.65
                     walk: {margin: 0}
                     layout: {padding: 0}
                 }
@@ -243,8 +244,7 @@ live_design!{
         layout: {flow: Down, padding: 0.0, spacing: 0.0}
         
         hero = <Image> {
-            image: (IMG_A),
-            //image_scale: 1.0,
+            source: (IMG_A),
             walk: {margin: 0, width:Fill, height:250}
             layout: {padding: 0}
         }

--- a/examples/news_feed/src/app.rs
+++ b/examples/news_feed/src/app.rs
@@ -189,6 +189,7 @@ live_design!{
                 profile_img = <Image> {
                     source: (IMG_PROFILE_A)
                     draw_bg: {
+                        scale: 0.65
                         fn pixel(self) -> vec4 {
                             let sdf = Sdf2d::viewport(self.pos * self.rect_size);
                             let c = self.rect_size * 0.5;
@@ -198,7 +199,6 @@ live_design!{
                             return sdf.result
                         }
                     }
-                    scale_factor: 0.65
                     walk: {margin: 0}
                     layout: {padding: 0}
                 }

--- a/examples/simple/src/app.rs
+++ b/examples/simple/src/app.rs
@@ -12,7 +12,8 @@ live_design!{
     import makepad_widgets::button::Button;
     import makepad_widgets::desktop_window::DesktopWindow;
     import makepad_widgets::label::Label;
-    import makepad_widgets::frame::Image;
+    import makepad_widgets::image::Image;
+    import makepad_widgets::frame::Frame;
     import makepad_widgets::text_input::TextInput;
     
     // The `{{App}}` syntax is used to inherit a DSL object from a Rust struct. This tells the
@@ -92,7 +93,7 @@ live_design!{
             }
             input1 = <TextInput> {
                 walk: {width: 100, height: 30},
-                label: "Click to count"
+                text: "Click to count"
             }
             
             // A label to display the counter.

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -11,7 +11,7 @@ metadata.makepad-auto-version = "wxHZD_56sR__1P12uohe4SoyRR8="
 
 [dependencies]
 makepad-futures = { path = "../libs/futures" }
-
+makepad-image-formats = { path = "../draw/image_formats", version = "0.3.0"}
 makepad-shader-compiler = { path = "./shader_compiler", version = "0.3.0" }
 
 [target.wasm32-unknown-unknown.dependencies]

--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -11,7 +11,6 @@ use {
         cell::RefCell,
     },
     crate::{
-        image::ImageBuffer,
         makepad_live_compiler::{
             LiveRegistry
         },

--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -11,6 +11,7 @@ use {
         cell::RefCell,
     },
     crate::{
+        image::ImageBuffer,
         makepad_live_compiler::{
             LiveRegistry
         },
@@ -126,6 +127,8 @@ pub struct Cx {
     #[allow(dead_code)]
     pub(crate) executor: Option<Executor>,
     pub(crate) spawner: Spawner,
+
+    pub image_cache: HashMap<String, ImageBuffer>
 }
 
 #[derive(Clone)]
@@ -277,6 +280,8 @@ impl Cx {
             executor: Some(executor),
             spawner,
             
+            image_cache: HashMap::new(),
+
             self_ref: None
         }
     }

--- a/platform/src/id_pool.rs
+++ b/platform/src/id_pool.rs
@@ -29,7 +29,7 @@ impl<T> DerefMut for IdPoolItem<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {&mut self.item}
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PoolId {
     pub id: usize,
     pub generation: u64,

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -61,6 +61,7 @@ pub use {
     makepad_shader_compiler::makepad_live_compiler,
     makepad_shader_compiler::makepad_live_id,
     makepad_shader_compiler::makepad_error_log,
+    makepad_image_formats::image,
     makepad_derive_live::*,
     makepad_error_log::*,
     makepad_math::*,

--- a/platform/src/os/linux/gl_sys.rs
+++ b/platform/src/os/linux/gl_sys.rs
@@ -48,6 +48,9 @@ pub const VERTEX_SHADER: types::GLenum = 0x8B31;
 pub const FRAGMENT_SHADER: types::GLenum = 0x8B30;
 pub const TEXTURE_MIN_FILTER: types::GLenum = 0x2801;
 pub const LINEAR: types::GLenum = 0x2601;
+pub const LINEAR_MIPMAP_LINEAR: types::GLenum = 0x2703;
+pub const TEXTURE_BASE_LEVEL: types::GLenum = 0x813C;
+pub const TEXTURE_MAX_LEVEL: types::GLenum = 0x813D;
 pub const TEXTURE_MAG_FILTER: types::GLenum = 0x2800;
 pub const RGBA: types::GLenum = 0x1908;
 pub const UNSIGNED_BYTE: types::GLenum = 0x1401;
@@ -114,6 +117,7 @@ pub const PROGRAM_BINARY_LENGTH: types::GLenum = 0x8741;
 #[inline] pub unsafe fn DeleteBuffers(n: types::GLsizei, buffers: *const types::GLuint) -> () { mem::transmute::<_, extern "system" fn(types::GLsizei, *const types::GLuint) -> ()>(storage::DeleteBuffers.f)(n, buffers) }
 #[inline] pub unsafe fn DeleteFramebuffers(n: types::GLsizei, framebuffers: *const types::GLuint) -> () { mem::transmute::<_, extern "system" fn(types::GLsizei, *const types::GLuint) -> ()>(storage::DeleteFramebuffers.f)(n, framebuffers) }
 #[inline] pub unsafe fn DeleteVertexArrays(n: types::GLsizei, arrays: *const types::GLuint) -> () { mem::transmute::<_, extern "system" fn(types::GLsizei, *const types::GLuint) -> ()>(storage::DeleteVertexArrays.f)(n, arrays) }
+#[inline] pub unsafe fn GenerateMipmap(target: types::GLenum) -> () { mem::transmute::<_, extern "system" fn(types::GLenum) -> ()>( storage::GenerateMipmap.f)(target)}
 
 mod storage {
     use super::FnPtr;
@@ -173,6 +177,7 @@ mod storage {
     pub static mut DeleteBuffers: FnPtr = FnPtr::default();
     pub static mut DeleteFramebuffers: FnPtr = FnPtr::default();
     pub static mut DeleteVertexArrays: FnPtr = FnPtr::default();
+    pub static mut GenerateMipmap: FnPtr = FnPtr::default();
 }
 
 pub unsafe fn load_with<F>(mut loadfn: F) where F: FnMut(&'static str) -> *const raw::c_void {
@@ -231,7 +236,8 @@ pub unsafe fn load_with<F>(mut loadfn: F) where F: FnMut(&'static str) -> *const
     storage::DeleteRenderbuffers = FnPtr::new(metaloadfn(&mut loadfn, "glDeleteRenderbuffers", &["glDeleteRenderbuffersEXT"]));
     storage::DeleteBuffers = FnPtr::new(metaloadfn(&mut loadfn, "glDeleteBuffers", &["glDeleteBuffersARB"]));
     storage::DeleteFramebuffers = FnPtr::new(metaloadfn(&mut loadfn, "glDeleteFramebuffers", &["glDeleteFramebuffersEXT"]));
-    storage::DeleteVertexArrays = FnPtr::new(metaloadfn(&mut loadfn, "glDeleteVertexArrays", &["glDeleteVertexArraysAPPLE", "glDeleteVertexArraysOES"]))
+    storage::DeleteVertexArrays = FnPtr::new(metaloadfn(&mut loadfn, "glDeleteVertexArrays", &["glDeleteVertexArraysAPPLE", "glDeleteVertexArraysOES"]));
+    storage::GenerateMipmap = FnPtr::new(metaloadfn(&mut loadfn, "glGenerateMipmap", &[]));
 }
 
 #[inline(never)]

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -817,8 +817,7 @@ impl CxOsTexture {
         }
         unsafe {
             gl_sys::BindTexture(gl_sys::TEXTURE_2D, self.gl_texture.unwrap());
-            gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MIN_FILTER, gl_sys::NEAREST as i32);
-            gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MAG_FILTER, gl_sys::NEAREST as i32);
+            gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MIN_FILTER, gl_sys::LINEAR_MIPMAP_LINEAR as i32);            gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MAG_FILTER, gl_sys::NEAREST as i32);
             gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_WRAP_S, gl_sys::CLAMP_TO_EDGE as i32);
             gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_WRAP_T, gl_sys::CLAMP_TO_EDGE as i32);
             gl_sys::TexImage2D(
@@ -832,6 +831,9 @@ impl CxOsTexture {
                 gl_sys::UNSIGNED_BYTE,
                 image_u32.as_ptr() as *const _
             );
+            gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_BASE_LEVEL, 0);
+            gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MAX_LEVEL, 3);
+            gl_sys::GenerateMipmap(gl_sys::TEXTURE_2D);  
             gl_sys::BindTexture(gl_sys::TEXTURE_2D, 0);
         }
     }

--- a/platform/src/texture.rs
+++ b/platform/src/texture.rs
@@ -20,6 +20,7 @@ use {
 };
 
 
+#[derive(Clone)]
 pub struct Texture(PoolId);
 
 #[derive(Clone, Debug, PartialEq, Copy)]

--- a/widgets/src/frame.rs
+++ b/widgets/src/frame.rs
@@ -492,18 +492,6 @@ pub struct FrameRef(WidgetRef);
 pub struct FrameSet(WidgetSet);
 
 impl FrameRef {
-    /*
-    pub fn handle_event(&self, cx: &mut Cx, event: &Event) -> WidgetActions {
-        self.0.handle_widget_event(cx, event)
-    }
-    
-    pub fn draw(&self, cx: &mut Cx2d,) -> WidgetDraw {
-        if let Some(mut inner) = self.inner_mut() {
-            return inner.draw(cx)
-        }
-        WidgetDraw::done()
-    }*/
-    
     pub fn set_visible(&self, visible: bool) {
         if let Some(mut inner) = self.borrow_mut() {
             inner.visible = visible

--- a/widgets/src/frame.rs
+++ b/widgets/src/frame.rs
@@ -4,7 +4,7 @@ use {
         makepad_derive_widget::*,
         makepad_draw::*,
         widget::*,
-        widget_with_image::*,
+        image_loading_widget::*,
         scroll_bars::ScrollBars,
     },
 };
@@ -403,7 +403,7 @@ struct FrameTextureCache {
     color_texture: Texture,
 }
 
-impl WidgetWithImage for Frame {
+impl ImageLoadingWidget for Frame {
     fn image_filename(&self) -> &LiveDependency {
         &self.image
     }
@@ -428,7 +428,7 @@ impl LiveHook for Frame {
             }
         }
 
-        self.after_apply_for_widget_with_image(cx, from, index, nodes);
+        self.after_apply_for_image_loading_widget(cx, from, index, nodes);
 
         if let Some(image_texture) = &mut self.image_texture {
             if self.image_scale != 0.0 {

--- a/widgets/src/frame.rs
+++ b/widgets/src/frame.rs
@@ -2,10 +2,9 @@ use {
     std::collections::hash_map::HashMap,
     crate::{
         makepad_derive_widget::*,
-        makepad_image_formats::jpeg,
-        makepad_image_formats::png,
         makepad_draw::*,
         widget::*,
+        widget_with_image::*,
         scroll_bars::ScrollBars,
     },
 };
@@ -298,6 +297,23 @@ live_design!{
             return Pal::premul(self.get_color())
         }
     }}
+
+    // Legacy Image widget that is being replaced with the new Image widget
+    ImageFrame = <Frame> {show_bg: true, draw_bg: {
+        texture image: texture2d
+        instance image_scale: vec2(1.0, 1.0)
+        instance image_pan: vec2(0.0, 0.0)
+        fn get_color(self) -> vec4 {
+            return sample2d(self.image, self.pos * self.image_scale + self.image_pan).xyzw;
+        }
+
+        fn pixel(self) -> vec4 {
+            return Pal::premul(self.get_color())
+        }
+
+        shape: Solid,
+        fill: Image
+    }}
     
     CachedFrame = <Frame> {
         has_view: true,
@@ -387,12 +403,22 @@ struct FrameTextureCache {
     color_texture: Texture,
 }
 
+impl WidgetWithImage for Frame {
+    fn image_filename(&self) -> &LiveDependency {
+        &self.image
+    }
+
+    fn texture(&mut self) -> &mut Option<Texture> {
+        &mut self.image_texture
+    }
+}
+
 impl LiveHook for Frame {
     fn before_live_design(cx: &mut Cx) {
         register_widget!(cx, Frame)
     }
     
-    fn after_apply(&mut self, cx: &mut Cx, _from: ApplyFrom, index: usize, nodes: &[LiveNode]) {
+    fn after_apply(&mut self, cx: &mut Cx, from: ApplyFrom, index: usize, nodes: &[LiveNode]) {
         if self.has_view && self.view.is_none() {
             self.view = Some(View::new(cx));
         }
@@ -401,58 +427,18 @@ impl LiveHook for Frame {
                 self.scroll_bars_obj = Some(Box::new(ScrollBars::new_from_ptr(cx, self.scroll_bars)));
             }
         }
-        // lets load the image resource
-        let image_path = self.image.as_str();
-        if image_path.len()>0 {
-            let mut image_buffer = None;
-            match cx.get_dependency(image_path) {
-                Ok(data) => {
-                    if image_path.ends_with(".jpg") {
-                        match jpeg::decode(data) {
-                            Ok(image) => {
-                                if self.image_scale != 0.0 {
-                                    self.walk = Walk::fixed_size(DVec2 {x: image.width as f64 * self.image_scale, y: image.height as f64 * self.image_scale});
-                                }
-                                image_buffer = Some(image);
-                            }
-                            Err(err) => {
-                                cx.apply_image_decoding_failed(live_error_origin!(), index, nodes, image_path, &err);
-                            }
-                        }
+
+        self.after_apply_for_widget_with_image(cx, from, index, nodes);
+
+        if let Some(image_texture) = &mut self.image_texture {
+            if self.image_scale != 0.0 {
+                let texture_desc = image_texture.get_desc(cx);
+                self.walk = Walk::fixed_size(
+                    DVec2 {
+                        x: texture_desc.width.unwrap() as f64 * self.image_scale,
+                        y: texture_desc.height.unwrap() as f64 * self.image_scale
                     }
-                    else if image_path.ends_with(".png") {
-                        match png::decode(data) {
-                            Ok(image) => {
-                                if self.image_scale != 0.0 {
-                                    self.walk = Walk::fixed_size(DVec2 {x: image.width as f64 * self.image_scale, y: image.height as f64 * self.image_scale});
-                                }
-                                image_buffer = Some(image);
-                            }
-                            Err(err) => {
-                                cx.apply_image_decoding_failed(live_error_origin!(), index, nodes, image_path, &err);
-                            }
-                        }
-                    }
-                    else {
-                        cx.apply_image_type_not_supported(live_error_origin!(), index, nodes, image_path);
-                    }
-                }
-                Err(err) => {
-                    cx.apply_resource_not_loaded(live_error_origin!(), index, nodes, image_path, &err);
-                }
-            }
-            if let Some(mut image_buffer) = image_buffer.take() {
-                if self.image_texture.is_none() {
-                    self.image_texture = Some(Texture::new(cx));
-                }
-                if let Some(image_texture) = &mut self.image_texture {
-                    image_texture.set_desc(cx, TextureDesc {
-                        format: TextureFormat::ImageBGRA,
-                        width: Some(image_buffer.width),
-                        height: Some(image_buffer.height),
-                    });
-                    image_texture.swap_image_u32(cx, &mut image_buffer.data);
-                }
+                );
             }
         }
     }

--- a/widgets/src/frame.rs
+++ b/widgets/src/frame.rs
@@ -299,24 +299,6 @@ live_design!{
         }
     }}
     
-    Image = <Frame> {show_bg: true, draw_bg: {
-        texture image: texture2d
-        instance image_scale: vec2(1.0, 1.0)
-        instance image_pan: vec2(0.0, 0.0)
-        uniform image_alpha: 1.0
-        fn get_color(self) -> vec4 {
-            return sample2d(self.image, self.pos * self.image_scale + self.image_pan).xyzw;
-        }
-        
-        fn pixel(self) -> vec4 {
-            let color = self.get_color();
-            return Pal::premul(vec4(color.xyz, color.w*self.image_alpha))
-        }
-        
-        shape: Solid,
-        fill: Image
-    }}
-    
     CachedFrame = <Frame> {
         has_view: true,
         use_cache: true,

--- a/widgets/src/frame.rs
+++ b/widgets/src/frame.rs
@@ -743,10 +743,6 @@ impl Frame {
         self.area
     }
     
-    pub fn draw(&mut self, cx: &mut Cx2d,) -> WidgetDraw {
-        self.draw_walk(cx, self.get_walk())
-    }
-    
     pub fn walk_from_previous_size(&self, walk: Walk) -> Walk {
         let view_size = self.view_size.unwrap_or(DVec2::default());
         Walk {

--- a/widgets/src/frame.rs
+++ b/widgets/src/frame.rs
@@ -408,8 +408,12 @@ impl ImageLoadingWidget for Frame {
         &self.image
     }
 
-    fn texture(&mut self) -> &mut Option<Texture> {
-        &mut self.image_texture
+    fn get_texture(&self) -> &Option<Texture> {
+        &self.image_texture
+    }
+
+    fn set_texture(&mut self, texture: Option<Texture>) {
+        self.image_texture = texture;
     }
 }
 

--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -13,8 +13,8 @@ live_design!{
     
     Image = {{Image}} {
         walk:{
-            width:Fit
-            height:Fit
+            width: Fit
+            height: Fit
         }
         layout: {
             // This is important to avoid clipping the image, specially when it is rotated.

--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -57,7 +57,7 @@ live_design!{
                 let original_pos = rotate_2d_from_center(current_pos, self.rotation, self.rect_size);
 
                 // Scale the current position by the scale factor
-                let scaled_pos = (original_pos - vec2(0.5, 0.5)) / self.scale + vec2(0.5, 0.5);
+                let scaled_pos = original_pos / self.scale;
 
                 // Take pixel color from the original image
                 let color = sample2d(self.image, scaled_pos).xyzw;
@@ -71,21 +71,20 @@ live_design!{
 
                 // Debug
                 // let line_width = 0.01;
-                // if self.pos.x < line_width || self.pos.x > (1. + rot_expansion.x - line_width) || self.pos.y < line_width || self.pos.y > (1. + rot_expansion.y - line_width) {
+                // if self.pos.x < line_width || self.pos.x > (self.scale + rot_expansion.x - line_width) || self.pos.y < line_width || self.pos.y > (self.scale + rot_expansion.y - line_width) {
                 //     return #c86;
                 // }
 
                 let sdf = Sdf2d::viewport(self.pos * self.rect_size);
 
-                let translation_offset = vec2(self.rect_size.x * rot_expansion.x / 2.0, self.rect_size.y * rot_expansion.y / 2.0);
+                let translation_offset = vec2(self.rect_size.x * rot_expansion.x / 2.0, self.rect_size.y * self.scale * rot_expansion.y / 2.0);
                 sdf.translate(translation_offset.x, translation_offset.y);
 
                 let center = self.rect_size * 0.5;
                 sdf.rotate(self.rotation, center.x, center.y);
 
                 let scaled_size = self.rect_size * self.scale;
-                let offset = (self.rect_size - scaled_size) * 0.5;
-                sdf.box(offset.x, offset.y, scaled_size.x, scaled_size.y, 1);
+                sdf.box(0.0, 0.0, scaled_size.x, scaled_size.y, 1);
 
                 sdf.fill_premul(Pal::premul(self.get_color(rot_expansion / 2.0)));
                 return sdf.result
@@ -98,11 +97,11 @@ live_design!{
                     self.rect_pos.y - self.rect_size.y * rot_expansion.y / 2.0
                 );
 
-                let expanded_size = vec2(self.rect_size.x * (1.0 + rot_expansion.x), self.rect_size.y * (1.0 + rot_expansion.y));
+                let expanded_size = vec2(self.rect_size.x * (self.scale + rot_expansion.x), self.rect_size.y * (self.scale + rot_expansion.y));
                 let clipped: vec2 = clamp(
                     self.geom_pos * expanded_size + adjusted_pos,
                     self.draw_clip.xy,
-                    vec2(self.draw_clip.zw.x * (1.0 + rot_expansion.x), self.draw_clip.zw.y * (1.0 + rot_expansion.y))
+                    self.draw_clip.zw
                 );
 
                 self.pos = (clipped - adjusted_pos) / self.rect_size;

--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -1,9 +1,8 @@
 use {
     crate::{
-        makepad_image_formats::jpeg,
-        makepad_image_formats::png,
         makepad_draw::*,
-        widget::*
+        widget::*,
+        widget_with_image::*
     }
 };
 
@@ -127,68 +126,25 @@ pub struct Image {
     #[live] source: LiveDependency,
     #[live] texture: Option<Texture>,
     #[live] scale: f64,
-} 
+}
+
+impl WidgetWithImage for Image {
+    fn image_filename(&self) -> &LiveDependency {
+        &self.source
+    }
+
+    fn texture(&mut self) -> &mut Option<Texture> {
+        &mut self.texture
+    }
+}
 
 impl LiveHook for Image {
     fn before_live_design(cx: &mut Cx) {
         register_widget!(cx, Image)
     }
-    
-    fn after_apply(&mut self, cx: &mut Cx, _from: ApplyFrom, index: usize, nodes: &[LiveNode]) {
-        // lets load the image resource
-        let image_path = self.source.as_str();
-        if image_path.len()>0 {
-            let mut image_buffer = None;
-            match cx.get_dependency(image_path) {
-                Ok(data) => {
-                    if image_path.ends_with(".jpg") {
-                        match jpeg::decode(data) {
-                            Ok(image) => {
-                                if self.scale != 0.0 {
-                                    self.walk = Walk::fixed_size(DVec2 {x: image.width as f64 * self.scale, y: image.height as f64 * self.scale});
-                                }
-                                image_buffer = Some(image);
-                            }
-                            Err(err) => {
-                                cx.apply_image_decoding_failed(live_error_origin!(), index, nodes, image_path, &err);
-                            }
-                        }
-                    }
-                    else if image_path.ends_with(".png") {
-                        match png::decode(data) {
-                            Ok(image) => {
-                                if self.scale != 0.0 {
-                                    self.walk = Walk::fixed_size(DVec2 {x: image.width as f64 * self.scale, y: image.height as f64 * self.scale});
-                                }
-                                image_buffer = Some(image);
-                            }
-                            Err(err) => {
-                                cx.apply_image_decoding_failed(live_error_origin!(), index, nodes, image_path, &err);
-                            }
-                        }
-                    }
-                    else {
-                        cx.apply_image_type_not_supported(live_error_origin!(), index, nodes, image_path);
-                    }
-                }
-                Err(err) => {
-                    cx.apply_resource_not_loaded(live_error_origin!(), index, nodes, image_path, &err);
-                }
-            }
-            if let Some(mut image_buffer) = image_buffer.take() {
-                if self.texture.is_none() {
-                    self.texture = Some(Texture::new(cx));
-                }
-                if let Some(texture) = &mut self.texture {
-                    texture.set_desc(cx, TextureDesc {
-                        format: TextureFormat::ImageBGRA,
-                        width: Some(image_buffer.width),
-                        height: Some(image_buffer.height),
-                    });
-                    texture.swap_image_u32(cx, &mut image_buffer.data);
-                }
-            }
-        }
+
+    fn after_apply(&mut self, cx: &mut Cx, from: ApplyFrom, index: usize, nodes: &[LiveNode]) {
+        self.after_apply_for_widget_with_image(cx, from, index, nodes);
     }
 }
 

--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -51,7 +51,9 @@ live_design!{
                 return rotated + vec2(0.5, 0.5);
             }
 
-            fn get_color(self, rot_padding: vec2) -> vec4 {
+            fn get_color(self) -> vec4 {
+                let rot_padding = rotation_vertex_expansion(self.rotation, self.rect_size.x, self.rect_size.y) / 2.0;
+
                 // Current position is a traslated one, so let's get the original position
                 let current_pos = self.pos.xy - rot_padding;
                 let original_pos = rotate_2d_from_center(current_pos, self.rotation, self.rect_size);
@@ -86,7 +88,7 @@ live_design!{
                 let scaled_size = self.rect_size * self.scale;
                 sdf.box(0.0, 0.0, scaled_size.x, scaled_size.y, 1);
 
-                sdf.fill_premul(Pal::premul(self.get_color(rot_expansion / 2.0)));
+                sdf.fill_premul(Pal::premul(self.get_color()));
                 return sdf.result
             }
 

--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -24,13 +24,13 @@ live_design!{
         draw_bg: {
             texture image: texture2d
 
-            instance angle: 0.0
-            instance fade_factor: 1.0
-            instance scale_factor: 1.0
+            instance rotation: 0.0
+            instance opacity: 1.0
+            instance scale: 1.0
 
-            fn rotation_vertex_expansion(angle: float, w: float, h: float) -> vec2 {
-                let horizontal_expansion = (abs(cos(angle)) * w + abs(sin(angle)) * h) / w - 1.0;
-                let vertical_expansion = (abs(sin(angle)) * w + abs(cos(angle)) * h) / h - 1.0;
+            fn rotation_vertex_expansion(rotation: float, w: float, h: float) -> vec2 {
+                let horizontal_expansion = (abs(cos(rotation)) * w + abs(sin(rotation)) * h) / w - 1.0;
+                let vertical_expansion = (abs(sin(rotation)) * w + abs(cos(rotation)) * h) / h - 1.0;
 
                 return vec2(horizontal_expansion, vertical_expansion);
             }
@@ -54,20 +54,20 @@ live_design!{
             fn get_color(self, rot_padding: vec2) -> vec4 {
                 // Current position is a traslated one, so let's get the original position
                 let current_pos = self.pos.xy - rot_padding;
-                let original_pos = rotate_2d_from_center(current_pos, self.angle, self.rect_size);
+                let original_pos = rotate_2d_from_center(current_pos, self.rotation, self.rect_size);
 
                 // Scale the current position by the scale factor
-                let scaled_pos = (original_pos - vec2(0.5, 0.5)) / self.scale_factor + vec2(0.5, 0.5);
+                let scaled_pos = (original_pos - vec2(0.5, 0.5)) / self.scale + vec2(0.5, 0.5);
 
                 // Take pixel color from the original image
                 let color = sample2d(self.image, scaled_pos).xyzw;
 
-                let faded_color = color * vec4(1.0, 1.0, 1.0, self.fade_factor);
+                let faded_color = color * vec4(1.0, 1.0, 1.0, self.opacity);
                 return faded_color;
             }
 
             fn pixel(self) -> vec4 {
-                let rot_expansion = rotation_vertex_expansion(self.angle, self.rect_size.x, self.rect_size.y);
+                let rot_expansion = rotation_vertex_expansion(self.rotation, self.rect_size.x, self.rect_size.y);
 
                 // Debug
                 // let line_width = 0.01;
@@ -81,9 +81,9 @@ live_design!{
                 sdf.translate(translation_offset.x, translation_offset.y);
 
                 let center = self.rect_size * 0.5;
-                sdf.rotate(self.angle, center.x, center.y);
+                sdf.rotate(self.rotation, center.x, center.y);
 
-                let scaled_size = self.rect_size * self.scale_factor;
+                let scaled_size = self.rect_size * self.scale;
                 let offset = (self.rect_size - scaled_size) * 0.5;
                 sdf.box(offset.x, offset.y, scaled_size.x, scaled_size.y, 1);
 
@@ -92,7 +92,7 @@ live_design!{
             }
 
             fn vertex(self) -> vec4 {
-                let rot_expansion = rotation_vertex_expansion(self.angle, self.rect_size.x, self.rect_size.y);
+                let rot_expansion = rotation_vertex_expansion(self.rotation, self.rect_size.x, self.rect_size.y);
                 let adjusted_pos = vec2(
                     self.rect_pos.x - self.rect_size.x * rot_expansion.x / 2.0,
                     self.rect_pos.y - self.rect_size.y * rot_expansion.y / 2.0

--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         makepad_draw::*,
         widget::*,
-        widget_with_image::*
+        image_loading_widget::*
     }
 };
 
@@ -128,7 +128,7 @@ pub struct Image {
     #[live] scale: f64,
 }
 
-impl WidgetWithImage for Image {
+impl ImageLoadingWidget for Image {
     fn image_filename(&self) -> &LiveDependency {
         &self.source
     }
@@ -144,7 +144,7 @@ impl LiveHook for Image {
     }
 
     fn after_apply(&mut self, cx: &mut Cx, from: ApplyFrom, index: usize, nodes: &[LiveNode]) {
-        self.after_apply_for_widget_with_image(cx, from, index, nodes);
+        self.after_apply_for_image_loading_widget(cx, from, index, nodes);
     }
 }
 

--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -1,15 +1,9 @@
-use {
-    crate::{
-        makepad_draw::*,
-        widget::*,
-        image_loading_widget::*
-    }
-};
+use crate::{image_loading_widget::*, makepad_draw::*, widget::*};
 
-live_design!{
+live_design! {
     import makepad_draw::shader::std::*;
     import makepad_widgets::theme::*;
-    
+
     Image = {{Image}} {
         walk:{
             width: Fit
@@ -111,7 +105,7 @@ live_design!{
                     self.view_transform * vec4(clipped.x, clipped.y, self.draw_depth + self.draw_zbias, 1.)
                 ));
             }
-            
+
             shape: Solid,
             fill: Image
         }
@@ -120,13 +114,19 @@ live_design!{
 
 #[derive(Live)]
 pub struct Image {
-    #[live] walk: Walk,
-    #[live] layout: Layout,
-    #[live] draw_bg: DrawColor,
-    
-    #[live] source: LiveDependency,
-    #[live] texture: Option<Texture>,
-    #[live] scale: f64,
+    #[live]
+    walk: Walk,
+    #[live]
+    layout: Layout,
+    #[live]
+    draw_bg: DrawColor,
+
+    #[live]
+    source: LiveDependency,
+    #[live]
+    texture: Option<Texture>,
+    #[live]
+    scale: f64,
 }
 
 impl ImageLoadingWidget for Image {
@@ -134,8 +134,12 @@ impl ImageLoadingWidget for Image {
         &self.source
     }
 
-    fn texture(&mut self) -> &mut Option<Texture> {
-        &mut self.texture
+    fn get_texture(&self) -> &Option<Texture> {
+        &self.texture
+    }
+
+    fn set_texture(&mut self, texture: Option<Texture>) {
+        self.texture = texture;
     }
 }
 
@@ -150,14 +154,14 @@ impl LiveHook for Image {
 }
 
 impl Widget for Image {
-    fn redraw(&mut self, cx:&mut Cx) {
+    fn redraw(&mut self, cx: &mut Cx) {
         self.draw_bg.redraw(cx)
     }
-    
-    fn get_walk(&self)->Walk {
+
+    fn get_walk(&self) -> Walk {
         self.walk
     }
-    
+
     fn draw_walk_widget(&mut self, cx: &mut Cx2d, walk: Walk) -> WidgetDraw {
         self.draw_walk(cx, walk)
     }

--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -1,0 +1,135 @@
+use {
+    crate::{
+        makepad_derive_widget::*,
+        makepad_image_formats::jpeg,
+        makepad_image_formats::png,
+        makepad_draw::*,
+        widget::*
+    }
+};
+
+live_design!{
+    import makepad_draw::shader::std::*;
+    import makepad_widgets::theme::*;
+    
+    Image = {{Image}} {
+        walk:{
+            width:Fit
+            height:Fit
+        }
+        draw_bg: {
+            texture image: texture2d
+            instance scale: vec2(1.0, 1.0)
+            fn get_color(self) -> vec4 {
+                return sample2d(self.image, self.pos * self.scale).xyzw;
+            }
+            
+            fn pixel(self) -> vec4 {
+                return Pal::premul(self.get_color())
+            }
+            
+            shape: Solid,
+            fill: Image
+        }
+    }
+}
+
+#[derive(Live)]
+pub struct Image {
+    #[live] walk: Walk,
+    #[live] layout: Layout,
+    #[live] draw_bg: DrawColor,
+    
+    #[live] source: LiveDependency,
+    #[live] texture: Option<Texture>,
+    #[live] scale: f64,
+} 
+
+impl LiveHook for Image {
+    fn before_live_design(cx: &mut Cx) {
+        register_widget!(cx, Image)
+    }
+    
+    fn after_apply(&mut self, cx: &mut Cx, _from: ApplyFrom, index: usize, nodes: &[LiveNode]) {
+        // lets load the image resource
+        let image_path = self.source.as_str();
+        if image_path.len()>0 {
+            let mut image_buffer = None;
+            match cx.get_dependency(image_path) {
+                Ok(data) => {
+                    if image_path.ends_with(".jpg") {
+                        match jpeg::decode(data) {
+                            Ok(image) => {
+                                if self.scale != 0.0 {
+                                    self.walk = Walk::fixed_size(DVec2 {x: image.width as f64 * self.scale, y: image.height as f64 * self.scale});
+                                }
+                                image_buffer = Some(image);
+                            }
+                            Err(err) => {
+                                cx.apply_image_decoding_failed(live_error_origin!(), index, nodes, image_path, &err);
+                            }
+                        }
+                    }
+                    else if image_path.ends_with(".png") {
+                        match png::decode(data) {
+                            Ok(image) => {
+                                if self.scale != 0.0 {
+                                    self.walk = Walk::fixed_size(DVec2 {x: image.width as f64 * self.scale, y: image.height as f64 * self.scale});
+                                }
+                                image_buffer = Some(image);
+                            }
+                            Err(err) => {
+                                cx.apply_image_decoding_failed(live_error_origin!(), index, nodes, image_path, &err);
+                            }
+                        }
+                    }
+                    else {
+                        cx.apply_image_type_not_supported(live_error_origin!(), index, nodes, image_path);
+                    }
+                }
+                Err(err) => {
+                    cx.apply_resource_not_loaded(live_error_origin!(), index, nodes, image_path, &err);
+                }
+            }
+            if let Some(mut image_buffer) = image_buffer.take() {
+                if self.texture.is_none() {
+                    self.texture = Some(Texture::new(cx));
+                }
+                if let Some(texture) = &mut self.texture {
+                    texture.set_desc(cx, TextureDesc {
+                        format: TextureFormat::ImageBGRA,
+                        width: Some(image_buffer.width),
+                        height: Some(image_buffer.height),
+                    });
+                    texture.swap_image_u32(cx, &mut image_buffer.data);
+                }
+            }
+        }
+    }
+}
+
+impl Widget for Image {
+    fn redraw(&mut self, cx:&mut Cx) {
+        self.draw_bg.redraw(cx)
+    }
+    
+    fn get_walk(&self)->Walk {
+        self.walk
+    }
+    
+    fn draw_walk_widget(&mut self, cx: &mut Cx2d, walk:Walk) -> WidgetDraw {
+        self.draw_walk(cx, walk)
+    }
+}
+
+impl Image {
+    pub fn draw_walk(&mut self, cx: &mut Cx2d, walk:Walk) -> WidgetDraw {        
+        if let Some(image_texture) = &self.texture {
+            self.draw_bg.draw_vars.set_texture(0, image_texture);
+        }
+        self.draw_bg.begin(cx, walk, self.layout);
+        self.draw_bg.end(cx);
+
+        WidgetDraw::done()
+    }
+}

--- a/widgets/src/image_loading_widget.rs
+++ b/widgets/src/image_loading_widget.rs
@@ -5,11 +5,11 @@ use {
     }
 };
 
-pub trait WidgetWithImage {
+pub trait ImageLoadingWidget {
     fn image_filename(&self) -> &LiveDependency;
     fn texture(&mut self) -> &mut Option<Texture>;
 
-    fn after_apply_for_widget_with_image(&mut self, cx: &mut Cx, _from: ApplyFrom, index: usize, nodes: &[LiveNode]) {
+    fn after_apply_for_image_loading_widget(&mut self, cx: &mut Cx, _from: ApplyFrom, index: usize, nodes: &[LiveNode]) {
         let filename = self.image_filename();
         let image_path = filename.as_str();
         if image_path.len()>0 {

--- a/widgets/src/image_loading_widget.rs
+++ b/widgets/src/image_loading_widget.rs
@@ -1,87 +1,95 @@
-use {
-    crate::{
-        makepad_image_formats::*,
-        makepad_draw::*,
-    }
-};
+use crate::{makepad_draw::*, makepad_image_formats::*};
 
 pub trait ImageLoadingWidget {
     fn image_filename(&self) -> &LiveDependency;
-    fn texture(&mut self) -> &mut Option<Texture>;
+    fn get_texture(&self) -> &Option<Texture>;
+    fn set_texture(&mut self, texture: Option<Texture>);
 
-    fn after_apply_for_image_loading_widget(&mut self, cx: &mut Cx, _from: ApplyFrom, index: usize, nodes: &[LiveNode]) {
-        if self.texture().is_none() {
-            let filename = self.image_filename();
-            let image_path = filename.as_str();
+    fn after_apply_for_image_loading_widget(
+        &mut self,
+        cx: &mut Cx,
+        _from: ApplyFrom,
+        index: usize,
+        nodes: &[LiveNode],
+    ) {
+        if self.get_texture().is_none() {
+            self.create_texture_from_image(cx, index, nodes);
+        }
+    }
 
-            let buffer = {
-                if image_path.len() > 0 {
-                    if let Some(buffer) = cx.image_cache.get(image_path) {
-                        Some(buffer.clone())
-                    } else {
-                        if let Some(buffer) =
-                            Self::load_image_dependency(cx, image_path, index, nodes)
-                        {
-                            cx.image_cache
-                                .insert(image_path.to_string(), buffer.clone());
-                            Some(buffer)
-                        } else {
-                            None
-                        }
-                    }
-                } else {
-                    None
+    fn create_texture_from_image(&mut self, cx: &mut Cx, index: usize, nodes: &[LiveNode]) {
+        let binding = self.image_filename().clone();
+        let image_path = binding.as_str();
+
+        if image_path.len() > 0 {
+            if let Some(cached_texture) = cx.image_cache.get(image_path) {
+                self.set_texture(Some(cached_texture.clone()));
+            } else {
+                let texture = Texture::new(cx);
+
+                if let Some(mut buffer) = Self::load_image_dependency(cx, image_path, index, nodes)
+                {
+                    texture.set_desc(
+                        cx,
+                        TextureDesc {
+                            format: TextureFormat::ImageBGRA,
+                            width: Some(buffer.width),
+                            height: Some(buffer.height),
+                        },
+                    );
+                    texture.swap_image_u32(cx, &mut buffer.data);
                 }
-            };
 
-            if let Some(mut buffer) = buffer {
-                self.create_texture_from_image(cx, &mut buffer);
+                self.set_texture(Some(texture.clone()));
+
+                cx.image_cache.put(image_path, texture);
             }
         }
     }
 
-    fn create_texture_from_image(&mut self, cx: &mut Cx, image_buffer: &mut ImageBuffer) {
-        if self.texture().is_none() {
-            let texture = self.texture();
-            *texture = Some(Texture::new(cx));
-        }
-        if let Some(texture) = &mut self.texture() {
-            texture.set_desc(cx, TextureDesc {
-                format: TextureFormat::ImageBGRA,
-                width: Some(image_buffer.width),
-                height: Some(image_buffer.height),
-            });
-            texture.swap_image_u32(cx, &mut image_buffer.data);
-        }
-    }
-
-    fn load_image_dependency(cx: &mut Cx, image_path: &str, index: usize, nodes: &[LiveNode]) -> Option<ImageBuffer> {
+    fn load_image_dependency(
+        cx: &mut Cx,
+        image_path: &str,
+        index: usize,
+        nodes: &[LiveNode],
+    ) -> Option<ImageBuffer> {
         match cx.get_dependency(image_path) {
             Ok(data) => {
                 if image_path.ends_with(".jpg") {
                     match jpeg::decode(data) {
-                        Ok(image) => {
-                            Some(image)
-                        }
+                        Ok(image) => Some(image),
                         Err(err) => {
-                            cx.apply_image_decoding_failed(live_error_origin!(), index, nodes, image_path, &err);
+                            cx.apply_image_decoding_failed(
+                                live_error_origin!(),
+                                index,
+                                nodes,
+                                image_path,
+                                &err,
+                            );
                             None
                         }
                     }
-                }
-                else if image_path.ends_with(".png") {
+                } else if image_path.ends_with(".png") {
                     match png::decode(data) {
-                        Ok(image) => {
-                            Some(image)
-                        }
+                        Ok(image) => Some(image),
                         Err(err) => {
-                            cx.apply_image_decoding_failed(live_error_origin!(), index, nodes, image_path, &err);
+                            cx.apply_image_decoding_failed(
+                                live_error_origin!(),
+                                index,
+                                nodes,
+                                image_path,
+                                &err,
+                            );
                             None
                         }
                     }
-                }
-                else {
-                    cx.apply_image_type_not_supported(live_error_origin!(), index, nodes, image_path);
+                } else {
+                    cx.apply_image_type_not_supported(
+                        live_error_origin!(),
+                        index,
+                        nodes,
+                        image_path,
+                    );
                     None
                 }
             }

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -54,6 +54,7 @@ pub mod widget;
 pub mod data_binding;
 
 mod theme;
+mod widget_with_image;
 
 pub use crate::{
     data_binding::{DataBindingStore, DataBindingMap},

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -60,6 +60,7 @@ pub use crate::{
     data_binding::{DataBindingStore, DataBindingMap},
     button::*,
     frame::*,
+    image::*,
     label::*,
     slider::*,
     check_box::*,

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -54,7 +54,7 @@ pub mod widget;
 pub mod data_binding;
 
 mod theme;
-mod widget_with_image;
+mod image_loading_widget;
 
 pub use crate::{
     data_binding::{DataBindingStore, DataBindingMap},

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -8,6 +8,7 @@ pub use makepad_derive_widget::*;
 
 pub mod button;
 pub mod label;
+pub mod image;
 pub mod link_label;
 pub mod drop_down;
 pub mod popup_menu;
@@ -100,6 +101,7 @@ pub fn live_design(cx: &mut Cx) {
     crate::slider::live_design(cx);
     crate::label::live_design(cx);
     crate::nav_control::live_design(cx);
+    crate::image::live_design(cx);
     crate::frame::live_design(cx);
     crate::fold_button::live_design(cx);
     crate::text_input::live_design(cx);

--- a/widgets/src/widget_with_image.rs
+++ b/widgets/src/widget_with_image.rs
@@ -1,0 +1,74 @@
+use {
+    crate::{
+        makepad_image_formats::*,
+        makepad_draw::*,
+    }
+};
+
+pub trait WidgetWithImage {
+    fn image_filename(&self) -> &LiveDependency;
+    fn texture(&mut self) -> &mut Option<Texture>;
+
+    fn after_apply_for_widget_with_image(&mut self, cx: &mut Cx, _from: ApplyFrom, index: usize, nodes: &[LiveNode]) {
+        let filename = self.image_filename();
+        let image_path = filename.as_str();
+        if image_path.len()>0 {
+            let mut image_buffer = Self::load_image_dependency(cx, image_path, index, nodes);
+            if let Some(mut image_buffer) = image_buffer.take() {
+                self.create_texture_from_image(cx, &mut image_buffer);
+            }
+        }
+    }
+
+    fn create_texture_from_image(&mut self, cx: &mut Cx, image_buffer: &mut ImageBuffer) {
+        if self.texture().is_none() {
+            let texture = self.texture();
+            *texture = Some(Texture::new(cx));
+        }
+        if let Some(texture) = &mut self.texture() {
+            texture.set_desc(cx, TextureDesc {
+                format: TextureFormat::ImageBGRA,
+                width: Some(image_buffer.width),
+                height: Some(image_buffer.height),
+            });
+            texture.swap_image_u32(cx, &mut image_buffer.data);
+        }
+    }
+
+    fn load_image_dependency(cx: &mut Cx, image_path: &str, index: usize, nodes: &[LiveNode]) -> Option<ImageBuffer> {
+        match cx.get_dependency(image_path) {
+            Ok(data) => {
+                if image_path.ends_with(".jpg") {
+                    match jpeg::decode(data) {
+                        Ok(image) => {
+                            Some(image)
+                        }
+                        Err(err) => {
+                            cx.apply_image_decoding_failed(live_error_origin!(), index, nodes, image_path, &err);
+                            None
+                        }
+                    }
+                }
+                else if image_path.ends_with(".png") {
+                    match png::decode(data) {
+                        Ok(image) => {
+                            Some(image)
+                        }
+                        Err(err) => {
+                            cx.apply_image_decoding_failed(live_error_origin!(), index, nodes, image_path, &err);
+                            None
+                        }
+                    }
+                }
+                else {
+                    cx.apply_image_type_not_supported(live_error_origin!(), index, nodes, image_path);
+                    None
+                }
+            }
+            Err(err) => {
+                cx.apply_resource_not_loaded(live_error_origin!(), index, nodes, image_path, &err);
+                None
+            }
+        }
+    }
+}


### PR DESCRIPTION
Extract a new `Image` widget based in the existing one that was implemented into `Frame` code.
It adds the some common transformations: rotation, opacity & scaling.

The legacy one is renamed to `ImageFrame` until we decide what it is the best way to refactor `Frame`.

Examples:

```
            // New Image widget
            img1 = <Image> {
                source: dep("crate://self/resources/tinrs.png")
                walk: {width: 100, height: 30},
                draw_bg: {
                    rotation: 1.0,
                    scale: 0.3,
                    opacity: 0.3,
                }
            }

            // Legacy way
            frm1 = <ImageFrame> {
                image: dep("crate://self/resources/tinrs.png")
                image_scale: 0.3,
                walk: {width: 100, height: 30},
            }
        }
```