### PR TITLE
ToUISender/FromUIReceiver<T>: Data race allowed on T

### DIFF
--- a/platform/src/thread.rs
+++ b/platform/src/thread.rs
@@ -61,7 +61,7 @@ impl<T> Clone for ToUISender<T> {
     }
 }
 
-unsafe impl<T> Send for ToUISender<T> {}
+unsafe impl<T: Send> Send for ToUISender<T> {}
 
 impl<T> Default for ToUIReceiver<T> {
     fn default() -> Self {
@@ -124,7 +124,7 @@ pub struct FromUISender<T> {
     sender: Sender<T>,
 }
 
-unsafe impl<T> Send for FromUIReceiver<T> {}
+unsafe impl<T: Send> Send for FromUIReceiver<T> {}
 
 impl<T> Default for FromUISender<T> {
     fn default() -> Self {


### PR DESCRIPTION
Hi,
I found a memory-safety/soundness issue in this crate while scanning Rust code for potential vulnerabilities. This PR contains a fix for the issue.

# Issue Description
`ToUISender<T>` unconditionally implements Sync. This allows users to create data races on `T: !Sync`. Such data races can lead to undefined behavior.
https://github.com/makepad/makepad/blob/65b16bda9f148670128ba64f5a4811f7c477be17/platform/src/thread.rs#L64

same
https://github.com/makepad/makepad/blob/65b16bda9f148670128ba64f5a4811f7c477be17/platform/src/thread.rs#L127