### PR TITLE
Update Cargo.toml's from Rust edition 2018 to Rust edition 2021.

### DIFF
--- a/audio_graph/Cargo.toml
+++ b/audio_graph/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-audio-graph" 
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad audio graph"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/audio_graph/audio_widgets/Cargo.toml
+++ b/audio_graph/audio_widgets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-audio-widgets" 
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad audio widgets"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/draw/Cargo.toml
+++ b/draw/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-draw"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad 2d drawing API"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/draw/vector/Cargo.toml
+++ b/draw/vector/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-vector"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad vector api"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/draw/vector/bender/arena/Cargo.toml
+++ b/draw/vector/bender/arena/Cargo.toml
@@ -2,6 +2,6 @@
 name = "bender_arena"
 version = "0.1.0"
 authors = ["Eddy Bruel <ejpbruel@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]

--- a/draw/vector/bender/clipper/Cargo.toml
+++ b/draw/vector/bender/clipper/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bender_clipper"
 version = "0.1.0"
 authors = ["Eddy Bruel <ejpbruel@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bender_arena = { path = "../arena" }

--- a/draw/vector/bender/filler/Cargo.toml
+++ b/draw/vector/bender/filler/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bender_filler"
 version = "0.1.0"
 authors = ["Eddy Bruel <ejpbruel@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bender_clipper = { path = "../clipper" }

--- a/draw/vector/bender/geometry/Cargo.toml
+++ b/draw/vector/bender/geometry/Cargo.toml
@@ -2,4 +2,4 @@
 name = "bender_geometry"
 version = "0.1.0"
 authors = ["Eddy Bruel <ejpbruel@gmail.com>"]
-edition = "2018"
+edition = "2021"

--- a/draw/vector/bender/internal_iter/Cargo.toml
+++ b/draw/vector/bender/internal_iter/Cargo.toml
@@ -2,6 +2,6 @@
 name = "bender_internal_iter"
 version = "0.1.0"
 authors = ["Eddy Bruel <ejpbruel@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]

--- a/draw/vector/bender/offsetter/Cargo.toml
+++ b/draw/vector/bender/offsetter/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bender_offsetter"
 version = "0.1.0"
 authors = ["Eddy Bruel <ejpbruel@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bender_geometry = { path = "../geometry" }

--- a/draw/vector/bender/stroker/Cargo.toml
+++ b/draw/vector/bender/stroker/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bender_stroker"
 version = "0.1.0"
 authors = ["Eddy Bruel <ejpbruel@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bender_filler = { path = "../filler" }

--- a/draw/vector/bender/tessellator/Cargo.toml
+++ b/draw/vector/bender/tessellator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bender_tessellator"
 version = "0.1.0"
 authors = ["Eddy Bruel <ejpbruel@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bender_arena = { path = "../arena" }

--- a/draw/vector/bender/viewer/Cargo.toml
+++ b/draw/vector/bender/viewer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bender_viewer"
 version = "0.1.0"
 authors = ["Eddy Bruel <ejpbruel@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bender_clipper = { path = "../clipper" }

--- a/examples/chatgpt/Cargo.toml
+++ b/examples/chatgpt/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-example-chatgpt"
 version = "0.1.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad simple example"
 license = "MIT OR Apache-2.0"
 metadata.makepad-auto-version = "5POKajmZt90sjG2MIw5C9dizbBo="

--- a/examples/comfyui/Cargo.toml
+++ b/examples/comfyui/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-example-comfyui"
 version = "0.1.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad comfyUI example"
 license = "MIT OR Apache-2.0"
 metadata.makepad-auto-version = "5POKajmZt90sjG2MIw5C9dizbBo="

--- a/examples/fractal_zoom/Cargo.toml
+++ b/examples/fractal_zoom/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-example-fractal-zoom"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad fractal zoom example"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/examples/ironfish/Cargo.toml
+++ b/examples/ironfish/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-example-ironfish"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad ironfish example"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/examples/ironfish/synth_ironfish/Cargo.toml
+++ b/examples/ironfish/synth_ironfish/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-synth-ironfish"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad ironfish example"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/examples/news_feed/Cargo.toml
+++ b/examples/news_feed/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-example-news-feed"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad news feed example"
 license = "MIT OR Apache-2.0"
 metadata.makepad-auto-version = "5POKajmZt90sjG2MIw5C9dizbBo="

--- a/examples/numbers/Cargo.toml
+++ b/examples/numbers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-example-numbers"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad numbers example"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-example-simple"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad simple example"
 license = "MIT OR Apache-2.0"
 metadata.makepad-auto-version = "5POKajmZt90sjG2MIw5C9dizbBo="

--- a/examples/widgets/Cargo.toml
+++ b/examples/widgets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-example-widgets"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad widgets example"
 license = "MIT OR Apache-2.0"
 metadata.makepad-auto-version = "5POKajmZt90sjG2MIw5C9dizbBo="

--- a/libs/base64/Cargo.toml
+++ b/libs/base64/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-base64"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad base64"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/libs/digest/Cargo.toml
+++ b/libs/digest/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-digest"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad digest functions"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/libs/error_log/Cargo.toml
+++ b/libs/error_log/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-error-log"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad error logging"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/libs/live_id/Cargo.toml
+++ b/libs/live_id/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-live-id"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad live id symbol interning"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/libs/live_id/id_macros/Cargo.toml
+++ b/libs/live_id/id_macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-live-id-macros"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad live id macros"
 license = "MIT OR Apache-2.0"
 metadata.makepad-auto-version = "MLcfsINqytU6m4AZitT4ipHt0MY="

--- a/libs/math/Cargo.toml
+++ b/libs/math/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-math"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad math functions"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/libs/micro_proc_macro/Cargo.toml
+++ b/libs/micro_proc_macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-micro-proc-macro"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad micro proc macro util lib"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/libs/micro_serde/Cargo.toml
+++ b/libs/micro_serde/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-micro-serde"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad micro replacement for serde"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/libs/micro_serde/derive/Cargo.toml
+++ b/libs/micro_serde/derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-micro-serde-derive"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad micro serde derive macro"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/libs/micro_serde/example/Cargo.toml
+++ b/libs/micro_serde/example/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "microserde_example"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [workspace]
 

--- a/libs/miniz/Cargo.toml
+++ b/libs/miniz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-miniz"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad fork of miniz-oxide with no deps"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/libs/networking/Cargo.toml
+++ b/libs/networking/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-networking"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Cross platform networking with TLS support"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/libs/rust_tokenizer/Cargo.toml
+++ b/libs/rust_tokenizer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-rust-tokenizer"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad rust tokenizer"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/libs/toml_parser/Cargo.toml
+++ b/libs/toml_parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-toml-parser"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad TOML parser"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/libs/wasm_bridge/Cargo.toml
+++ b/libs/wasm_bridge/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-wasm-bridge"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad wasm bridge"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/libs/wasm_bridge/derive/Cargo.toml
+++ b/libs/wasm_bridge/derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-derive-wasm-bridge"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad wasm bridge derive macros"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/libs/wasm_bridge/test/Cargo.toml
+++ b/libs/wasm_bridge/test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-wasm-bridge-test"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad wasm bridge test"
 license = "MIT OR Apache-2.0"
 metadata.makepad-auto-version = "Ifw4P7taDKkpQl4r5uw1BLMHXNs="

--- a/libs/windows/Cargo.toml
+++ b/libs/windows/Cargo.toml
@@ -10,7 +10,7 @@
 # See Cargo.toml.orig for the original contents.
 
 [package]
-edition = "2018"
+edition = "2021"
 rust-version = "1.64"
 name = "makepad-windows" 
 version = "0.3.0"

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-platform"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad platform layer"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/platform/derive_live/Cargo.toml
+++ b/platform/derive_live/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-derive-live"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad platform live DSL derive macros"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/platform/live_compiler/Cargo.toml
+++ b/platform/live_compiler/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-live-compiler"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad platform live DSL compiler"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/platform/live_tokenizer/Cargo.toml
+++ b/platform/live_tokenizer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-live-tokenizer"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad platform live DSL tokenizer"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/platform/shader_compiler/Cargo.toml
+++ b/platform/shader_compiler/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-shader-compiler"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad platform shader compiler"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/platform/src/app_main.rs
+++ b/platform/src/app_main.rs
@@ -19,7 +19,7 @@ macro_rules!app_main {
                 if let Event::LiveEdit = event{
                     app.borrow_mut().update_main(cx);
                 }
-                <AppMain>::handle_event(app.borrow_mut().as_mut().unwrap(), cx, event);
+                <dyn AppMain>::handle_event(app.borrow_mut().as_mut().unwrap(), cx, event);
             }))));
             live_design(&mut *cx.borrow_mut());
             cx.borrow_mut().init_cx_os();

--- a/studio/Cargo.toml
+++ b/studio/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-studio"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad studio"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/studio/file_protocol/Cargo.toml
+++ b/studio/file_protocol/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-file-protocol"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad file protocol"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/studio/file_server/Cargo.toml
+++ b/studio/file_server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-file-server"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad file server"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/tools/auto_version/Cargo.toml
+++ b/tools/auto_version/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-auto-version"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad crate auto versioning"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/tools/brotli_check/Cargo.toml
+++ b/tools/brotli_check/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "brotli_check"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 brotli = "3.3"

--- a/tools/cargo_makepad/Cargo.toml
+++ b/tools/cargo_makepad/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-makepad"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad cargo extension"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/tools/file_router/Cargo.toml
+++ b/tools/file_router/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-file-router"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad file router"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/tools/video_mixer/Cargo.toml
+++ b/tools/video_mixer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-video-mixer"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad video mixer"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/tools/wasm_strip/Cargo.toml
+++ b/tools/wasm_strip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm_strip"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]

--- a/tools/web_server/Cargo.toml
+++ b/tools/web_server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-web-server"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad web server"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/tools/web_server/http/Cargo.toml
+++ b/tools/web_server/http/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-http"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad http utils"
 license = "MIT OR Apache-2.0"
 metadata.makepad-auto-version = "BefUyZMzPI0UEwpCL-pa9dV13mc="

--- a/tools/windows_strip/Cargo.toml
+++ b/tools/windows_strip/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-windows-strip"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad windows library strip"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/widgets/Cargo.toml
+++ b/widgets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-widgets"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad widgets"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"

--- a/widgets/derive_widget/Cargo.toml
+++ b/widgets/derive_widget/Cargo.toml
@@ -2,7 +2,7 @@
 name = "makepad-derive-widget"
 version = "0.3.0"
 authors = ["Makepad <info@makepad.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Makepad widget derive macros"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/makepad/makepad/"


### PR DESCRIPTION
- Change the keyword '2018' to '2021'
- Add mandatory 'dyn' to trait