### PR TITLE
Networking: make distinction between request id and metadata id

### DIFF
--- a/examples/chatgpt/src/app.rs
+++ b/examples/chatgpt/src/app.rs
@@ -8,7 +8,6 @@ live_design!{
     import makepad_widgets::button::Button;
     import makepad_widgets::desktop_window::DesktopWindow;
     import makepad_widgets::label::Label;
-    import makepad_widgets::frame::Image;
     import makepad_widgets::text_input::TextInput;
     
     App = {{App}} {
@@ -74,7 +73,7 @@ impl App{
     // The response will be received and processed by AppMain's handle_event.
     fn send_message(cx: &mut Cx, message: String) {
         let completion_url = format!("{}/chat/completions", OPENAI_BASE_URL);
-        let request_id = LiveId::from_str("SendChatMessage");
+        let request_id = live_id!(SendChatMessage);
         let mut request = HttpRequest::new(completion_url, HttpMethod::POST);
         
         request.set_header("Content-Type".to_string(), "application/json".to_string());

--- a/examples/chatgpt/src/app.rs
+++ b/examples/chatgpt/src/app.rs
@@ -99,7 +99,7 @@ impl AppMain for App{
             match &event.response{
                 NetworkResponse::HttpResponse(response)=>{
                     let label = self.ui.get_label(id!(message_label));
-                    match event.id {
+                    match event.request_id {
                          live_id!(SendChatMessage) => {
                             if response.status_code == 200 {
                                 let chat_response = response.get_json_body::<ChatResponse>().unwrap();

--- a/examples/chatgpt/src/app.rs
+++ b/examples/chatgpt/src/app.rs
@@ -112,11 +112,12 @@ impl AppMain for App{
                         _ => (),
                     }
                 }
-                e=>{
+                NetworkResponse::HttpRequestError(error)=>{
                     let label = self.ui.get_label(id!(message_label));
-                    label.set_label(&format!("Failed to connect with OpenAI {:?}", e));
+                    label.set_label(&format!("Failed to connect with OpenAI {:?}", error));
                     label.redraw(cx);
                 }
+                _ => ()
             }
         }
 

--- a/examples/chatgpt/src/lib.rs
+++ b/examples/chatgpt/src/lib.rs
@@ -4,7 +4,6 @@ pub use makepad_widgets::makepad_platform;
 pub use makepad_widgets::makepad_draw;
 pub use makepad_widgets::makepad_micro_serde;
 pub use makepad_widgets::makepad_live_id;
-pub use makepad_platform::network;
 pub use makepad_platform::makepad_error_log;
 
 pub mod app;

--- a/examples/sdxl/src/lib.rs
+++ b/examples/sdxl/src/lib.rs
@@ -4,7 +4,6 @@ pub use makepad_widgets::makepad_platform;
 pub use makepad_widgets::makepad_draw;
 pub use makepad_widgets::makepad_micro_serde;
 pub use makepad_widgets::makepad_live_id;
-pub use makepad_platform::network;
 pub use makepad_platform::makepad_error_log;
 
 pub mod app;

--- a/libs/wasm_bridge/derive/src/derive_wasm_bridge.rs
+++ b/libs/wasm_bridge/derive/src/derive_wasm_bridge.rs
@@ -74,7 +74,7 @@ pub fn derive_from_wasm_impl(input: TokenStream) -> TokenStream {
             tb.add("{");
             
             tb.add("    fn type_name()->&'static str{").string(&name).add("}");
-            tb.add("    fn live_id()->LiveId{LiveId::from_str_with_lut(").string(&name).add(").unwrap()}");
+            tb.add("    fn live_id()->LiveId{LiveId::from_str_with_lut(").string(&name).add(")}");
              
             tb.add("    fn from_wasm_inner(self ,out:&mut FromWasmMsg){");
             tb.add("        match self {");

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -72,10 +72,10 @@ pub enum CxOsOp {
     StartDragging(Vec<DragItem>),
     UpdateMenu(Menu),
     ShowClipboardActions(String),
-    HttpRequest{id:LiveId, request:HttpRequest},
-    WebSocketOpen{id: LiveId, request:HttpRequest},
-    WebSocketSendString{id: LiveId, data:String},
-    WebSocketSendBinary{id: LiveId, data:Vec<u8>},
+    HttpRequest{request_id: LiveId, request:HttpRequest},
+    WebSocketOpen{request_id: LiveId, request:HttpRequest},
+    WebSocketSendString{request_id: LiveId, data:String},
+    WebSocketSendBinary{request_id: LiveId, data:Vec<u8>},
 }
 
 impl Cx { 
@@ -391,20 +391,20 @@ impl Cx {
         &self.spawner
     }
 
-    pub fn http_request(&mut self, id:LiveId, request: HttpRequest) {
-        self.platform_ops.push(CxOsOp::HttpRequest{id, request});
+    pub fn http_request(&mut self, request_id: LiveId, request: HttpRequest) {
+        self.platform_ops.push(CxOsOp::HttpRequest{request_id, request});
     }
            
-    pub fn web_socket_open(&mut self, id:LiveId, request: HttpRequest) {
+    pub fn web_socket_open(&mut self, request_id: LiveId, request: HttpRequest) {
         self.platform_ops.push(CxOsOp::WebSocketOpen{
             request,
-            id,
+            request_id,
         });
     }
     
-    pub fn web_socket_send_binary(&mut self, id: LiveId, data: Vec<u8>) {
+    pub fn web_socket_send_binary(&mut self, request_id: LiveId, data: Vec<u8>) {
         self.platform_ops.push(CxOsOp::WebSocketSendBinary{
-            id,
+            request_id,
             data,
         });
     }

--- a/platform/src/event/network.rs
+++ b/platform/src/event/network.rs
@@ -7,8 +7,7 @@ use crate::event::Event;
 
 #[derive(Clone, Debug)]
 pub struct NetworkResponseEvent {
-    // TODO rename to request_id
-    pub id: LiveId,
+    pub request_id: LiveId,
     pub response: NetworkResponse,
 }
 

--- a/platform/src/event/network.rs
+++ b/platform/src/event/network.rs
@@ -7,6 +7,7 @@ use crate::event::Event;
 
 #[derive(Clone, Debug)]
 pub struct NetworkResponseEvent {
+    // TODO rename to request_id
     pub id: LiveId,
     pub response: NetworkResponse,
 }
@@ -72,7 +73,7 @@ impl Default for NetworkResponseChannel {
 
 #[derive(PartialEq, Debug)]
 pub struct HttpRequest {
-    pub request_id: LiveId,
+    pub metadata_id: LiveId,
     pub url: String,
     pub method: HttpMethod,
     pub headers: BTreeMap<String, Vec<String>>,
@@ -82,7 +83,7 @@ pub struct HttpRequest {
 impl HttpRequest { 
     pub fn new(url: String, method: HttpMethod) -> Self {
         HttpRequest {
-            request_id: LiveId(0),
+            metadata_id: LiveId(0),
             url,
             method,
             headers: BTreeMap::new(),
@@ -90,8 +91,8 @@ impl HttpRequest {
         }
     }
     
-    pub fn set_request_id(&mut self, id: LiveId){
-        self.request_id = id;
+    pub fn set_metadata_id(&mut self, id: LiveId){
+        self.metadata_id = id;
     }
     
     pub fn set_header(&mut self, name: String, value: String) {
@@ -124,16 +125,16 @@ impl HttpRequest {
 
 #[derive(Debug, Clone)]
 pub struct HttpResponse {
-    pub request_id: LiveId,
+    pub metadata_id: LiveId,
     pub status_code: u16,
     pub headers: BTreeMap<String, Vec<String>>,
     pub body: Option<Vec<u8>>,
 }
 
 impl HttpResponse {
-    pub fn new(request_id:LiveId, status_code: u16, string_headers: String, body: Option<Vec<u8>>) -> Self {
+    pub fn new(metadata_id: LiveId, status_code: u16, string_headers: String, body: Option<Vec<u8>>) -> Self {
         HttpResponse {
-            request_id,
+            metadata_id,
             status_code,
             headers: HttpResponse::parse_headers(string_headers),
             body

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -34,7 +34,6 @@ mod gpu_info;
 mod geometry;
 mod debug;
 mod component_map;
-pub mod network;
 
 pub mod audio_stream;
 

--- a/platform/src/os/apple/cocoa_app_nw.rs
+++ b/platform/src/os/apple/cocoa_app_nw.rs
@@ -84,7 +84,7 @@ impl CocoaApp {
     }
     
     
-    pub fn web_socket_open(&mut self, id: LiveId, request: HttpRequest, networking_sender: Sender<NetworkResponseEvent>) {
+    pub fn web_socket_open(&mut self, request_id: LiveId, request: HttpRequest, networking_sender: Sender<NetworkResponseEvent>) {
         
         unsafe {
             //self.lazy_init_ns_url_session();
@@ -94,13 +94,13 @@ impl CocoaApp {
             let data_task: ObjcId = msg_send![session, webSocketTaskWithRequest: ns_request];
             let web_socket_delegate_instance: ObjcId = msg_send![get_cocoa_class_global().web_socket_delegate, new];
             
-            unsafe fn set_message_receive_handler(data_task2: Arc<ObjcId>, id: LiveId, networking_sender: Sender<NetworkResponseEvent>) {
+            unsafe fn set_message_receive_handler(data_task2: Arc<ObjcId>, request_id: LiveId, networking_sender: Sender<NetworkResponseEvent>) {
                 let data_task = data_task2.clone();
                 let handler = objc_block!(move | message: ObjcId, error: ObjcId | {
                     if error != ptr::null_mut() {
                         let error_str: String = nsstring_to_string(msg_send![error, localizedDescription]);
                         let message = NetworkResponseEvent {
-                            id,
+                            request_id,
                             response: NetworkResponse::WebSocketError(error_str)
                         };
                         networking_sender.send(message).unwrap();
@@ -113,7 +113,7 @@ impl CocoaApp {
                         let length: usize = msg_send![data, length];
                         let data_bytes: &[u8] = std::slice::from_raw_parts(bytes, length);
                         let message = NetworkResponseEvent {
-                            id,
+                            request_id,
                             response: NetworkResponse::WebSocketBinary(data_bytes.to_vec())
                         };
                         networking_sender.send(message).unwrap();
@@ -121,17 +121,17 @@ impl CocoaApp {
                     else { // string
                         let string: ObjcId = msg_send![message, string];
                          let message = NetworkResponseEvent {
-                            id,
+                            request_id,
                             response: NetworkResponse::WebSocketString(nsstring_to_string(string))
                         };
                         networking_sender.send(message).unwrap();
                     }
-                    set_message_receive_handler(data_task.clone(), id, networking_sender.clone())
+                    set_message_receive_handler(data_task.clone(), request_id, networking_sender.clone())
                 });
                 let () = msg_send![*Arc::as_ptr(&data_task2), receiveMessageWithCompletionHandler: handler];
             }
             let () = msg_send![data_task, setDelegate: web_socket_delegate_instance];
-            set_message_receive_handler(Arc::new(data_task), id, networking_sender);
+            set_message_receive_handler(Arc::new(data_task), request_id, networking_sender);
             let () = msg_send![data_task, resume];
         }
     }
@@ -145,7 +145,7 @@ impl CocoaApp {
                 if error != ptr::null_mut() {
                     let error_str: String = nsstring_to_string(msg_send![error, localizedDescription]);
                     let message = NetworkResponseEvent {
-                        id: request_id,
+                        request_id,
                         response: NetworkResponse::HttpRequestError(error_str)
                     };
                     networking_sender.send(message).unwrap();
@@ -176,7 +176,7 @@ impl CocoaApp {
                 }
                 
                 let message = NetworkResponseEvent {
-                    id: request_id,
+                    request_id,
                     response: NetworkResponse::HttpResponse(response)
                 };
                 networking_sender.send(message).unwrap();

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -413,19 +413,19 @@ impl Cx {
                 CxOsOp::UpdateMenu(menu) => {
                     cocoa_app.update_app_menu(&menu, &self.command_settings)
                 },
-                CxOsOp::HttpRequest{id, request} => {
-                    cocoa_app.make_http_request(id, request, self.os.network_response.sender.clone());
+                CxOsOp::HttpRequest{request_id, request} => {
+                    cocoa_app.make_http_request(request_id, request, self.os.network_response.sender.clone());
                 },
                 CxOsOp::ShowClipboardActions(_request) => {
                     crate::log!("Show clipboard actions not supported yet");
                 }
-                CxOsOp::WebSocketOpen{id, request}=>{
-                    cocoa_app.web_socket_open(id, request, self.os.network_response.sender.clone());
+                CxOsOp::WebSocketOpen{request_id, request}=>{
+                    cocoa_app.web_socket_open(request_id, request, self.os.network_response.sender.clone());
                 }
-                CxOsOp::WebSocketSendBinary{id:_, data:_}=>{
+                CxOsOp::WebSocketSendBinary{request_id:_, data:_}=>{
                     todo!()
                 }
-                CxOsOp::WebSocketSendString{id:_, data:_}=>{
+                CxOsOp::WebSocketSendString{request_id:_, data:_}=>{
                     todo!()
                 }
             }

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -352,12 +352,12 @@ impl Cx {
         self.after_every_event(&to_java);
     }
 
-    pub fn from_java_on_http_response(&mut self, id: u64, status_code: u16, headers: String, body: Vec<u8>, to_java: AndroidToJava) {
+    pub fn from_java_on_http_response(&mut self, request_id: u64, metadata_id: u64, status_code: u16, headers: String, body: Vec<u8>, to_java: AndroidToJava) {
         let e = Event::NetworkResponses(vec![
             NetworkResponseEvent{
-                id: LiveId(id),
+                id: LiveId(request_id),
                 response: NetworkResponse::HttpResponse(HttpResponse::new(
-                    LiveId(0),
+                    LiveId(metadata_id),
                     status_code,
                     headers,
                     Some(body)
@@ -368,10 +368,10 @@ impl Cx {
         self.after_every_event(&to_java);
     }
 
-    pub fn from_java_on_http_request_error(&mut self, id: u64, error: String, to_java: AndroidToJava) {
+    pub fn from_java_on_http_request_error(&mut self, request_id: u64, _metadata_id: u64, error: String, to_java: AndroidToJava) {
         let e = Event::NetworkResponses(vec![
             NetworkResponseEvent{
-                id: LiveId(id),
+                id: LiveId(request_id),
                 response: NetworkResponse::HttpRequestError(error)
             }
         ]);

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -355,7 +355,7 @@ impl Cx {
     pub fn from_java_on_http_response(&mut self, request_id: u64, metadata_id: u64, status_code: u16, headers: String, body: Vec<u8>, to_java: AndroidToJava) {
         let e = Event::NetworkResponses(vec![
             NetworkResponseEvent{
-                id: LiveId(request_id),
+                request_id: LiveId(request_id),
                 response: NetworkResponse::HttpResponse(HttpResponse::new(
                     LiveId(metadata_id),
                     status_code,
@@ -371,7 +371,7 @@ impl Cx {
     pub fn from_java_on_http_request_error(&mut self, request_id: u64, _metadata_id: u64, error: String, to_java: AndroidToJava) {
         let e = Event::NetworkResponses(vec![
             NetworkResponseEvent{
-                id: LiveId(request_id),
+                request_id: LiveId(request_id),
                 response: NetworkResponse::HttpRequestError(error)
             }
         ]);

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -519,8 +519,8 @@ impl Cx {
                 CxOsOp::ShowClipboardActions(selected) => {
                     to_java.show_clipboard_actions(selected.as_str());
                 },
-                CxOsOp::HttpRequest{id, request} => {
-                    to_java.http_request(id, request)
+                CxOsOp::HttpRequest{request_id, request} => {
+                    to_java.http_request(request_id, request)
                 },
                 _ => ()
             }

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -302,16 +302,16 @@ impl Cx {
                 },
                 CxOsOp::UpdateMenu(_menu) => {
                 },
-                CxOsOp::HttpRequest{id:_, request:_} => {
+                CxOsOp::HttpRequest{request_id:_, request:_} => {
                     todo!()
                 },
-                CxOsOp::WebSocketOpen{id:_, request:_}=>{
+                CxOsOp::WebSocketOpen{request_id:_, request:_}=>{
                     todo!()
                 }
-                CxOsOp::WebSocketSendBinary{id:_, data:_}=>{
+                CxOsOp::WebSocketSendBinary{request_id:_, data:_}=>{
                     todo!()
                 }
-                CxOsOp::WebSocketSendString{id:_, data:_}=>{
+                CxOsOp::WebSocketSendString{request_id:_, data:_}=>{
                     todo!()
                 }
             }

--- a/platform/src/os/web/from_wasm.rs
+++ b/platform/src/os/web/from_wasm.rs
@@ -110,8 +110,8 @@ pub struct FromWasmHideTextIME {
 
 #[derive(FromWasm)]
 pub struct FromWasmWebSocketOpen {
-    pub id_lo: u32,
-    pub id_hi: u32,
+    pub request_id_lo: u32,
+    pub request_id_hi: u32,
     pub url: String,
     pub method: String,
     pub headers: String,
@@ -120,15 +120,15 @@ pub struct FromWasmWebSocketOpen {
 
 #[derive(FromWasm)]
 pub struct FromWasmWebSocketSendBinary{
-    pub id_lo: u32,
-    pub id_hi: u32,
+    pub request_id_lo: u32,
+    pub request_id_hi: u32,
     pub data: WasmDataU8
 }
 
 #[derive(FromWasm)]
 pub struct FromWasmWebSocketSendString{
-    pub id_lo: u32,
-    pub id_hi: u32,
+    pub request_id_lo: u32,
+    pub request_id_hi: u32,
     pub data: String
 }
 
@@ -154,8 +154,10 @@ pub struct FromWasmCreateThread {
 
 #[derive(FromWasm)]
 pub struct FromWasmHTTPRequest {
-    pub id_lo: u32,
-    pub id_hi: u32,
+    pub request_id_lo: u32,
+    pub request_id_hi: u32,
+    pub metadata_id_lo: u32,
+    pub metadata_id_hi: u32,
     pub url: String,
     pub method: String,
     pub headers: String,

--- a/platform/src/os/web/to_wasm.rs
+++ b/platform/src/os/web/to_wasm.rs
@@ -602,8 +602,10 @@ pub struct ToWasmAppLostFocus {}
 
 #[derive(ToWasm)]
 pub struct ToWasmHTTPResponse {
-    pub id_lo: u32,
-    pub id_hi: u32,
+    pub request_id_lo: u32,
+    pub request_id_hi: u32,
+    pub metadata_id_hi: u32,
+    pub metadata_id_lo: u32,
     pub status: u32,
     pub headers: String,
     pub body: WasmDataU8
@@ -611,57 +613,57 @@ pub struct ToWasmHTTPResponse {
 
 #[derive(ToWasm)]
 pub struct ToWasmHttpRequestError {
-    pub id_lo: u32,
-    pub id_hi: u32,
+    pub request_id_lo: u32,
+    pub request_id_hi: u32,
     pub error: String
 }
 
 #[derive(ToWasm)]
 pub struct ToWasmHttpResponseProgress {
-    pub id_lo: u32,
-    pub id_hi: u32,
+    pub request_id_lo: u32,
+    pub request_id_hi: u32,
     pub loaded: u32,
     pub total: u32
 }
 
 #[derive(ToWasm)]
 pub struct ToWasmHttpUploadProgress {
-    pub id_lo: u32,
-    pub id_hi: u32,
+    pub request_id_lo: u32,
+    pub request_id_hi: u32,
     pub loaded: u32,
     pub total: u32
 }
 
 #[derive(ToWasm)]
 pub struct ToWasmWebSocketClose {
-    pub id_lo: u32,
-    pub id_hi: u32,
+    pub request_id_lo: u32,
+    pub request_id_hi: u32,
 }
 
 #[derive(ToWasm)]
 pub struct ToWasmWebSocketOpen {
-    pub id_lo: u32,
-    pub id_hi: u32,
+    pub request_id_lo: u32,
+    pub request_id_hi: u32,
 }
 
 #[derive(ToWasm)]
 pub struct ToWasmWebSocketError {
-    pub id_lo: u32,
-    pub id_hi: u32,
+    pub request_id_lo: u32,
+    pub request_id_hi: u32,
     pub error: String
 }
 
 #[derive(ToWasm)]
 pub struct ToWasmWebSocketString {
-    pub id_lo: u32,
-    pub id_hi: u32,
+    pub request_id_lo: u32,
+    pub request_id_hi: u32,
     pub data: String
 }
 
 #[derive(ToWasm)]
 pub struct ToWasmWebSocketBinary {
-    pub id_lo: u32,
-    pub id_hi: u32,
+    pub request_id_lo: u32,
+    pub request_id_hi: u32,
     pub data: WasmDataU8
 }
 

--- a/platform/src/os/web/web.js
+++ b/platform/src/os/web/web.js
@@ -513,8 +513,8 @@ export class WasmWebBrowser extends WasmBridge {
             let responseEvent = event.target;
 
             this.to_wasm.ToWasmHTTPResponse({
-                id_lo: args.id_lo,
-                id_hi: args.id_hi,
+                request_id_lo: args.request_id_lo,
+                request_id_hi: args.request_id_hi,
                 status: responseEvent.status,
                 body: responseEvent.response,
                 headers: responseEvent.getAllResponseHeaders()
@@ -529,8 +529,8 @@ export class WasmWebBrowser extends WasmBridge {
             }
 
             this.to_wasm.ToWasmHttpRequestError({
-                id_lo: args.id_lo,
-                id_hi: args.id_hi,
+                request_id_lo: args.request_id_lo,
+                request_id_hi: args.request_id_hi,
                 error: errorMessage,
             });
             this.do_wasm_pump();
@@ -538,8 +538,8 @@ export class WasmWebBrowser extends WasmBridge {
 
         req.addEventListener("timeout", event => {
             this.to_wasm.ToWasmHttpRequestError({
-                id_lo: args.id_lo,
-                id_hi: args.id_hi,
+                request_id_lo: args.request_id_lo,
+                request_id_hi: args.request_id_hi,
                 error: "The HTTP request timed out.",
             });
             this.do_wasm_pump();
@@ -547,8 +547,8 @@ export class WasmWebBrowser extends WasmBridge {
 
         req.addEventListener("abort", event => {
             this.to_wasm.ToWasmHttpRequestError({
-                id_lo: args.id_lo,
-                id_hi: args.id_hi,
+                request_id_lo: args.request_id_lo,
+                request_id_hi: args.request_id_hi,
                 error: "The HTTP request was aborted.",
             });
             this.do_wasm_pump();
@@ -558,8 +558,8 @@ export class WasmWebBrowser extends WasmBridge {
             console.log("progress", event);
             if (event.lengthComputable) {
                 this.to_wasm.ToWasmHttpResponseProgress({
-                    id_lo: args.id_lo,
-                    id_hi: args.id_hi,
+                    request_id_lo: args.request_id_lo,
+                    request_id_hi: args.request_id_hi,
                     loaded: event.loaded,
                     total: event.total,
                 });
@@ -570,8 +570,8 @@ export class WasmWebBrowser extends WasmBridge {
         req.upload.addEventListener("progress", (event) => {
             if (event.lengthComputable) {
                 this.to_wasm.ToWasmHttpUploadProgress({
-                    id_lo: args.id_lo,
-                    id_hi: args.id_hi,
+                    request_id_lo: args.request_id_lo,
+                    request_id_hi: args.request_id_hi,
                     loaded: event.loaded,
                     total: event.total,
                 });

--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -220,9 +220,9 @@ impl Cx {
                 live_id!(ToWasmHTTPResponse) => {
                     let tw = ToWasmHTTPResponse::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.id_lo, tw.id_hi),
+                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::HttpResponse(HttpResponse::new(
-                            LiveId(0),
+                            LiveId::from_lo_hi(tw.metadata_id_lo, tw.metadata_id_hi),
                             tw.status as u16,
                             tw.headers,
                             Some(tw.body.into_vec_u8())
@@ -233,7 +233,7 @@ impl Cx {
                 live_id!(ToWasmHttpRequestError) => {
                     let tw = ToWasmHttpRequestError::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.id_lo, tw.id_hi),
+                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::HttpRequestError(tw.error)
                     });
                 }
@@ -241,7 +241,7 @@ impl Cx {
                 live_id!(ToWasmHttpResponseProgress) => {
                     let tw = ToWasmHttpResponseProgress::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.id_lo, tw.id_hi),
+                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::HttpProgress{loaded:tw.loaded, total:tw.total}
                     });
                 }
@@ -249,7 +249,7 @@ impl Cx {
                 live_id!(ToWasmHttpUploadProgress) => {
                     let tw = ToWasmHttpUploadProgress::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.id_lo, tw.id_hi),
+                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::HttpProgress{loaded:tw.loaded, total:tw.total}
                     });
                 }
@@ -257,7 +257,7 @@ impl Cx {
                 live_id!(ToWasmWebSocketClose) => {
                     let tw = ToWasmWebSocketClose::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.id_lo, tw.id_hi),
+                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::WebSocketClose
                     });
                 }
@@ -265,7 +265,7 @@ impl Cx {
                 live_id!(ToWasmWebSocketOpen) => {
                     let tw = ToWasmWebSocketOpen::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.id_lo, tw.id_hi),
+                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::WebSocketOpen
                     });
                 }
@@ -273,21 +273,21 @@ impl Cx {
                 live_id!(ToWasmWebSocketError) => {
                     let tw = ToWasmWebSocketError::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.id_lo, tw.id_hi),
+                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::WebSocketError(tw.error)
                     });
                 }
                 live_id!(ToWasmWebSocketString) => {
                     let tw = ToWasmWebSocketString::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.id_lo, tw.id_hi),
+                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::WebSocketString(tw.data)
                     });
                 }
                 live_id!(ToWasmWebSocketBinary) => {
                     let tw = ToWasmWebSocketBinary::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.id_lo, tw.id_hi),
+                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::WebSocketBinary(tw.data.into_vec_u8())
                     });
                 }
@@ -324,6 +324,10 @@ impl Cx {
                 self.webgl_compile_shaders();
             }
             self.handle_repaint();
+        }
+
+        if network_responses.len() != 0 {
+            self.call_event_handler(&Event::NetworkResponses(network_responses));
         }
         
         self.handle_platform_ops();
@@ -428,39 +432,41 @@ impl Cx {
                 }
                 CxOsOp::UpdateMenu(_menu) => {
                 },
-                CxOsOp::HttpRequest{id, request} => {
+                CxOsOp::HttpRequest{request_id, request} => {
                     let headers = request.get_headers_string();
                     self.os.from_wasm(FromWasmHTTPRequest {
-                        id_lo: id.lo(),
-                        id_hi: id.hi(),
+                        request_id_lo: request_id.lo(),
+                        request_id_hi: request_id.hi(),
+                        metadata_id_lo: request.metadata_id.lo(),
+                        metadata_id_hi: request.metadata_id.hi(),
                         url: request.url,
                         method: request.method.to_string().into(),
                         headers: headers,
                         body: WasmDataU8::from_vec_u8(request.body.unwrap_or(Vec::new())),
                     });
                 },
-                CxOsOp::WebSocketOpen{id, request}=>{
+                CxOsOp::WebSocketOpen{request_id, request}=>{
                     let headers = request.get_headers_string();
                     self.os.from_wasm(FromWasmWebSocketOpen {
                         url: request.url,
                         method: request.method.to_string().into(),
                         headers: headers,
                         body: WasmDataU8::from_vec_u8(request.body.unwrap_or(Vec::new())),
-                        id_lo: id.lo(),
-                        id_hi: id.hi(),
+                        request_id_lo: request_id.lo(),
+                        request_id_hi: request_id.hi(),
                     });
                 }
-                CxOsOp::WebSocketSendBinary{id, data}=>{
+                CxOsOp::WebSocketSendBinary{request_id, data}=>{
                     self.os.from_wasm(FromWasmWebSocketSendBinary {
-                        id_lo: id.lo(),
-                        id_hi: id.hi(),
+                        request_id_lo: request_id.lo(),
+                        request_id_hi: request_id.hi(),
                         data: WasmDataU8::from_vec_u8(data)
                     });
                 }
-                CxOsOp::WebSocketSendString{id, data}=>{
+                CxOsOp::WebSocketSendString{request_id, data}=>{
                     self.os.from_wasm(FromWasmWebSocketSendString {
-                        id_lo: id.lo(),
-                        id_hi: id.hi(),
+                        request_id_lo: request_id.lo(),
+                        request_id_hi: request_id.hi(),
                         data
                     });
                 }

--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -220,7 +220,7 @@ impl Cx {
                 live_id!(ToWasmHTTPResponse) => {
                     let tw = ToWasmHTTPResponse::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
+                        request_id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::HttpResponse(HttpResponse::new(
                             LiveId::from_lo_hi(tw.metadata_id_lo, tw.metadata_id_hi),
                             tw.status as u16,
@@ -233,7 +233,7 @@ impl Cx {
                 live_id!(ToWasmHttpRequestError) => {
                     let tw = ToWasmHttpRequestError::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
+                        request_id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::HttpRequestError(tw.error)
                     });
                 }
@@ -241,7 +241,7 @@ impl Cx {
                 live_id!(ToWasmHttpResponseProgress) => {
                     let tw = ToWasmHttpResponseProgress::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
+                        request_id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::HttpProgress{loaded:tw.loaded, total:tw.total}
                     });
                 }
@@ -249,7 +249,7 @@ impl Cx {
                 live_id!(ToWasmHttpUploadProgress) => {
                     let tw = ToWasmHttpUploadProgress::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
+                        request_id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::HttpProgress{loaded:tw.loaded, total:tw.total}
                     });
                 }
@@ -257,7 +257,7 @@ impl Cx {
                 live_id!(ToWasmWebSocketClose) => {
                     let tw = ToWasmWebSocketClose::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
+                        request_id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::WebSocketClose
                     });
                 }
@@ -265,7 +265,7 @@ impl Cx {
                 live_id!(ToWasmWebSocketOpen) => {
                     let tw = ToWasmWebSocketOpen::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
+                        request_id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::WebSocketOpen
                     });
                 }
@@ -273,21 +273,21 @@ impl Cx {
                 live_id!(ToWasmWebSocketError) => {
                     let tw = ToWasmWebSocketError::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
+                        request_id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::WebSocketError(tw.error)
                     });
                 }
                 live_id!(ToWasmWebSocketString) => {
                     let tw = ToWasmWebSocketString::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
+                        request_id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::WebSocketString(tw.data)
                     });
                 }
                 live_id!(ToWasmWebSocketBinary) => {
                     let tw = ToWasmWebSocketBinary::read_to_wasm(&mut to_wasm);
                     network_responses.push(NetworkResponseEvent{
-                        id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
+                        request_id: LiveId::from_lo_hi(tw.request_id_lo, tw.request_id_hi),
                         response: NetworkResponse::WebSocketBinary(tw.data.into_vec_u8())
                     });
                 }

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -301,16 +301,16 @@ impl Cx {
                 },
                 CxOsOp::UpdateMenu(_menu) => {
                 },
-                CxOsOp::HttpRequest{id:_, request:_} => {
+                CxOsOp::HttpRequest{request_id:_, request:_} => {
                     todo!()
                 },
-                CxOsOp::WebSocketOpen{id:_, request:_,}=>{
+                CxOsOp::WebSocketOpen{request_id:_, request:_,}=>{
                     todo!()
                 }
-                CxOsOp::WebSocketSendBinary{id:_, data:_}=>{
+                CxOsOp::WebSocketSendBinary{request_id:_, data:_}=>{
                     todo!()
                 }
-                CxOsOp::WebSocketSendString{id:_, data:_}=>{
+                CxOsOp::WebSocketSendString{request_id:_, data:_}=>{
                     todo!()
                 }
             }

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/Makepad.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/Makepad.java
@@ -17,7 +17,7 @@ public class Makepad {
         void showClipboardActions(String selected);
         void copyToClipboard(String selected);
         void pasteFromClipboard();
-        void requestHttp(long id, String url, String method, String headers, byte[] body);
+        void requestHttp(long requestId, long metadataId, String url, String method, String headers, byte[] body);
     }
 
     static {
@@ -43,6 +43,6 @@ public class Makepad {
     static native void onCopyToClipboard(long cx, Callback callback);
     static native void onPasteFromClipboard(long cx, String content, Callback callback);
     static native void onCutToClipboard(long cx, Callback callback);
-    static native void onHttpResponse(long cx, long id, int statusCode, String headers, byte[] body, Callback callback);
-    static native void onHttpRequestError(long cx, long id, String error, Callback callback);
+    static native void onHttpResponse(long cx, long requestId, long metadataId, int statusCode, String headers, byte[] body, Callback callback);
+    static native void onHttpRequestError(long cx, long requestId, long metadataId, String error, Callback callback);
 }

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -337,20 +337,20 @@ Makepad.Callback{
         }
     }
 
-    public void requestHttp(long id, String url, String method, String headers, byte[] body) {
+    public void requestHttp(long requestId, long metadataId, String url, String method, String headers, byte[] body) {
         try {
             MakepadNetwork network = new MakepadNetwork();
 
             CompletableFuture<HttpResponse> future = network.performHttpRequest(url, method, headers, body);
 
             future.thenAccept(response -> {
-                runOnUiThread(() -> Makepad.onHttpResponse(mCx, id, response.getStatusCode(), response.getHeaders(), response.getBody(), (Makepad.Callback) mView.getContext()));
+                runOnUiThread(() -> Makepad.onHttpResponse(mCx, requestId, metadataId, response.getStatusCode(), response.getHeaders(), response.getBody(), (Makepad.Callback) mView.getContext()));
             }).exceptionally(ex -> {
-                runOnUiThread(() -> Makepad.onHttpRequestError(mCx, id, ex.toString(), (Makepad.Callback) mView.getContext()));
+                runOnUiThread(() -> Makepad.onHttpRequestError(mCx, requestId, metadataId, ex.toString(), (Makepad.Callback) mView.getContext()));
                 return null;
             });
         } catch (Exception e) {
-            Makepad.onHttpRequestError(mCx, id, e.toString(), (Makepad.Callback) mView.getContext());
+            Makepad.onHttpRequestError(mCx, requestId, metadataId, e.toString(), (Makepad.Callback) mView.getContext());
         }
     }
 


### PR DESCRIPTION
Changes

* Renames `event.id` to `event.request_id`, to make it clear
* Responses now renames their `id` field to `metadata_id`
* Adds support in android, wasm and mac to carry on the metadata information for all the API commands/events

Pending

* ErrorResponses and other secondary events are not exposing yet the `metadata_id`. Everything it is in place to add this capability but it is not part of this PR