### PR TITLE
draw/vector: don't eagerly decode/allocate all font glyphs on parse.

### DIFF
--- a/draw/vector/src/font/font.rs
+++ b/draw/vector/src/font/font.rs
@@ -9,6 +9,6 @@ pub struct TTFFont {
     pub descender: f64,
     pub line_gap: f64,
     pub bounds: Rectangle,
-    pub glyphs: Vec<Glyph>,
+    pub cached_decoded_glyphs: Vec<Option<Box<Glyph>>>,
 }
 


### PR DESCRIPTION
Before the "Go Noto" megafont started being used, the load time and RAM usage were negligible.

However, when you get close to the 64k glyph limit (imposed by TrueType/OpenType), as megafonts like "Go Noto" do, you can easily end up spending half a second and allocating 300 MiB, just to hold all the `Glyph`s.

Main thing I'm unsure here is whether interior mutability should be used to reduce `&mut`s.