### PR TITLE
Android keyboard fixes

### DIFF
--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -214,11 +214,11 @@ impl Cx {
                             }))
                         } 
                         else {
+                            self.text_ime_was_dismissed();
                             self.call_event_handler(&Event::VirtualKeyboard(VirtualKeyboardEvent::DidHide {
                                 time: self.os.time_now()
                             }))
                         }
-                        //self.panning_adjust_for_text_ime(keyboard_height);
                     }
                     FromJavaMessage::HttpResponse {request_id, metadata_id, status_code, headers, body} => {
                         let e = Event::NetworkResponses(vec![
@@ -376,16 +376,7 @@ impl Cx {
         });
     }
     
-    /*
-    pub fn from_java_on_resize_text_ime(&mut self, ime_height: i32) {
-        let dt = crate::profile_start();
-        self.os.keyboard_visible = true;
-        self.panning_adjust_for_text_ime(ime_height);
-        self.redraw_all();
-        self.after_every_event(&to_java);
-        crate::profile_end!(dt);
-    }
-    
+    /*    
     pub fn from_java_on_paste_from_clipboard(&mut self, content: Option<String>, to_java: AndroidToJava) {
         if let Some(text) = content {
             let e = Event::TextInput(
@@ -509,27 +500,7 @@ impl Cx {
         
         
     }
-    /*
-    fn panning_adjust_for_text_ime(&mut self, android_ime_height: u32) {
-        self.os.keyboard_visible = true;
-        
-        let screen_height = (self.os.display_size.y / self.os.dpi_factor) as i32;
-        let vertical_offset = self.os.keyboard_trigger_position.y as i32;
-        let ime_height = (android_ime_height as f64 / self.os.dpi_factor) as i32;
-        
-        // Make sure there is some room between the software keyword and the text input or widget that triggered
-        // the TextIME event
-        let vertical_space = ime_height / 3;
-        
-        let should_be_panned = vertical_offset > screen_height - ime_height;
-        if should_be_panned {
-            let panning_offset = vertical_offset - (screen_height - ime_height) + vertical_space;
-            self.os.keyboard_panning_offset = (panning_offset as f64 * self.os.dpi_factor) as i32;
-        } else {
-            self.os.keyboard_panning_offset = 0;
-        }
-    }*/
-    
+
     fn handle_platform_ops(&mut self) -> EventFlow {
         while let Some(op) = self.platform_ops.pop() {
             match op {

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -186,15 +186,21 @@ impl Cx {
                             }
                         }
                     }
-                    FromJavaMessage::KeyUp {keycode: _} => {
-                        /*match keycode {
-                            KeyCode::LeftShift | KeyCode::RightShift => self.keymods.shift = false,
-                            KeyCode::LeftControl | KeyCode::RightControl => self.keymods.ctrl = false,
-                            KeyCode::LeftAlt | KeyCode::RightAlt => self.keymods.alt = false,
-                            KeyCode::LeftSuper | KeyCode::RightSuper => self.keymods.logo = false,
-                            _ => {}
-                        }
-                        self.event_handler.key_up_event(keycode, self.keymods);*/
+                    FromJavaMessage::KeyUp {keycode, meta_state} => {
+                        let makepad_keycode = android_to_makepad_key_code(keycode);
+                        let control = meta_state & ANDROID_META_CTRL_MASK != 0;
+                        let alt = meta_state & ANDROID_META_ALT_MASK != 0;
+                        let shift = meta_state & ANDROID_META_SHIFT_MASK != 0;
+
+                        let e = Event::KeyUp(
+                            KeyEvent {
+                                key_code: makepad_keycode,
+                                is_repeat: false,
+                                modifiers: KeyModifiers {shift, control, alt, ..Default::default()},
+                                time: self.os.time_now()
+                            }
+                        );
+                        self.call_event_handler(&e);
                     }
                     FromJavaMessage::ResizeTextIME {keyboard_height, is_open} => {
                         let keyboard_height = (keyboard_height as f64) / self.os.dpi_factor;

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -55,6 +55,7 @@ pub enum FromJavaMessage {
     },
     KeyUp {
         keycode: u32,
+        meta_state: u32,
     },
     ResizeTextIME {
         keyboard_height: u32,
@@ -277,8 +278,12 @@ extern "C" fn Java_dev_makepad_android_MakepadNative_surfaceOnKeyUp(
     _: *mut jni_sys::JNIEnv,
     _: jni_sys::jobject,
     keycode: jni_sys::jint,
+    meta_state: jni_sys::jint,
 ) {
-    send_from_java_message(FromJavaMessage::KeyUp { keycode: keycode as u32});
+    send_from_java_message(FromJavaMessage::KeyUp {
+        keycode: keycode as u32,
+        meta_state: meta_state as u32,
+    });
 }
 
 #[no_mangle]

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -137,7 +137,8 @@ class MakepadSurface
         }
 
         if (event.getAction() == KeyEvent.ACTION_UP && keyCode != 0) {
-            MakepadNative.surfaceOnKeyUp(keyCode);
+            int metaState = event.getMetaState();
+            MakepadNative.surfaceOnKeyUp(keyCode, metaState);
         }
         
         if (event.getAction() == KeyEvent.ACTION_UP || event.getAction() == KeyEvent.ACTION_MULTIPLE) {

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
@@ -18,7 +18,7 @@ public class MakepadNative {
     public static native void surfaceOnTouch(MotionEvent event);
     public native static void surfaceOnSurfaceChanged(Surface surface, int width, int height);
     public native static void surfaceOnKeyDown(int keycode, int meta_state);
-    public native static void surfaceOnKeyUp(int keycode);
+    public native static void surfaceOnKeyUp(int keycode, int meta_state);
     public native static void surfaceOnCharacter(int character);
     public native static void surfaceOnResizeTextIME(int keyboard_height, boolean is_open);
 


### PR DESCRIPTION
* KeyUp event is working now
* Fixes an issue when the user closes the keyboard using the dismiss button (without taping outside of the text input)