### PR TITLE
Cross-platform `Swapchain` management for reliable cross-process texture sharing.

### DIFF
--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -1,10 +1,7 @@
 use {
     std::{
         rc::Rc,
-        cell::{
-            Cell,
-            RefCell,
-        },
+        cell::RefCell,
     },
     makepad_objc_sys::{
         msg_send,
@@ -147,7 +144,7 @@ impl Cx {
         let metal_cx: Rc<RefCell<MetalCx >> = Rc::new(RefCell::new(MetalCx::new()));
 
         // store device object ID for double buffering
-        cx.borrow_mut().os.metal_device = Cell::new(Some(metal_cx.borrow().device));
+        cx.borrow_mut().os.metal_device = Some(metal_cx.borrow().device);
 
         //let cx = Rc::new(RefCell::new(self));
         if std::env::args().find(|v| v == "--stdin-loop").is_some(){
@@ -579,5 +576,5 @@ pub struct CxOs {
     pub (crate) draw_calls_done: usize,
     pub (crate) network_response: NetworkResponseChannel,
     pub (crate) decoding: CxAppleDecoding,
-    pub metal_device: Cell<Option<ObjcId>>,
+    pub metal_device: Option<ObjcId>,
 }

--- a/platform/src/os/apple/macos/macos_stdin.rs
+++ b/platform/src/os/apple/macos/macos_stdin.rs
@@ -28,7 +28,7 @@ use {
                 fetch_xpc_service_texture,
             },
             metal::{MetalCx, DrawPassMode},
-            cx_stdin::{HostToStdin, StdinToHost},
+            cx_stdin::{HostToStdin, StdinToHost, Swapchain, PresentableImageId},
         },
         pass::{CxPassParent, PassClearColor, CxPassColorTexture},
         cx_api::CxOsOp,
@@ -38,20 +38,19 @@ use {
 
 impl Cx {
     
-    pub (crate) fn stdin_send_draw_complete(buf:u32){
-
-        // get the current present index
-        //let mut index = present_index.lock().unwrap();
-        //log!("frame {} ready, sending message to host",index);
+    pub (crate) fn stdin_send_draw_complete(presented_image_id: PresentableImageId) {
+        //log!("image {} presented, sending message to host", presented_image_id.as_u64());
 
         // send message
-        let _ = io::stdout().write_all(StdinToHost::DrawCompleteAndFlip(buf as usize).to_json().as_bytes());
-
-        // flip swapchain
-        //*index = 1 - *index;
+        let _ = io::stdout().write_all(StdinToHost::DrawCompleteAndFlip(presented_image_id).to_json().as_bytes());
     }
     
-    pub (crate) fn stdin_handle_repaint(&mut self, metal_cx: &mut MetalCx, texture:Texture, time:f32, swapchain_front:u32) {
+    pub (crate) fn stdin_handle_repaint(
+        &mut self,
+        metal_cx: &mut MetalCx,
+        swapchain: &Swapchain<Option<Texture>>,
+        time: f32,
+    ) {
         let mut passes_todo = Vec::new();
         self.compute_pass_repaint_order(&mut passes_todo);
         self.repaint_id += 1;
@@ -59,26 +58,20 @@ impl Cx {
             self.passes[*pass_id].set_time(time as f32);
             match self.passes[*pass_id].parent.clone() {
                 CxPassParent::Window(_) => {
+                    let [current_image] = &swapchain.presentable_images;
+                    if let Some(texture) = &current_image.image {
+                        let window = &mut self.windows[CxWindowPool::id_zero()];
+                        let pass = &mut self.passes[window.main_pass_id.unwrap()];
+                        pass.color_textures = vec![CxPassColorTexture {
+                            clear_color: PassClearColor::ClearWith(pass.clear_color),
+                            texture_id: texture.texture_id(),
+                        }];
 
-                    // make sure rendering is done onto the right texture
-                    //if let Some(swapchain) = self.os.swapchain.as_ref() {
-                        //let present_index = *self.os.present_index.lock().unwrap();
-                    let texture_id = texture.texture_id();//swapchain[present_index].texture_id();
-                    let window = &mut self.windows[CxWindowPool::id_zero()];
-                    let pass = &mut self.passes[window.main_pass_id.unwrap()];
-                    pass.color_textures = vec![CxPassColorTexture {
-                        clear_color: PassClearColor::ClearWith(pass.clear_color),
-                        texture_id,
-                    }];
-                    //}
-                    //else {
-                   //     log!("wanting to paint, but there is no swapchain yet");
-                    //}
-                                
-                    // render to swapchain
-                    self.draw_pass(*pass_id, metal_cx, DrawPassMode::StdinMain(swapchain_front));
+                        // render to swapchain
+                        self.draw_pass(*pass_id, metal_cx, DrawPassMode::StdinMain(current_image.id));
 
-                    // and then wait for GPU, which calls stdin_send_draw_complete when its done
+                        // and then wait for GPU, which calls stdin_send_draw_complete when its done
+                    }
                 }
                 CxPassParent::Pass(_) => {
                     self.draw_pass(*pass_id, metal_cx, DrawPassMode::Texture);
@@ -94,7 +87,8 @@ impl Cx {
         let _ = io::stdout().write_all(StdinToHost::ReadyToStart.to_json().as_bytes());
         let service_proxy = xpc_service_proxy();
         let mut reader = BufReader::new(std::io::stdin());
-        let mut window_size = None;
+
+        let mut swapchain = None;
         
         self.call_event_handler(&Event::Construct);
         
@@ -146,52 +140,41 @@ impl Cx {
                             self.call_event_handler(&Event::Scroll(e.into()))
                         }
                         HostToStdin::WindowSize(ws) => {
+                            self.redraw_all();
 
-                            // update the swapchain resources
-                            
+                            let new_swapchain = ws.swapchain.images_map(|_, _| None);
+                            let swapchain = swapchain.insert(new_swapchain);
 
-                            // and reset present index
-                            //*self.os.present_index.lock().unwrap() = 0;
-
-                            // and window size might have changed
-                            if window_size != Some(ws) {
-                                window_size = Some(ws);
-                                self.redraw_all();
-
-                                let window = &mut self.windows[CxWindowPool::id_zero()];
-                                window.window_geom = WindowGeom {
-                                    dpi_factor: ws.dpi_factor,
-                                    inner_size: dvec2(ws.width, ws.height),
-                                    ..Default::default()
-                                };
-                                self.stdin_handle_platform_ops(metal_cx);
-                            }
+                            let window = &mut self.windows[CxWindowPool::id_zero()];
+                            window.window_geom = WindowGeom {
+                                dpi_factor: ws.dpi_factor,
+                                inner_size: dvec2(swapchain.width as f64, swapchain.height as f64) / ws.dpi_factor,
+                                ..Default::default()
+                            };
+                            self.stdin_handle_platform_ops(metal_cx);
                         }
-                        HostToStdin::Tick {frame: _, buffer_id: _, time} => if let Some(ws) = window_size {
-                            
-                            let (tx_fb, rx_fb) = std::sync::mpsc::channel::<RcObjcId> ();
+                        HostToStdin::Tick {frame: _, buffer_id: _, time} => if let Some(swapchain) = &mut swapchain {
+                            let [presentable_image] = &swapchain.presentable_images;
                             
                             // lets fetch the framebuffers
-                            fetch_xpc_service_texture(service_proxy.as_id(),ws.swapchain_handle,0,Box::new({
-                                let tx_fb = tx_fb.clone();
-                                move |objcid,_uid| {
-                                    let _ = tx_fb.send(objcid);
+                            if presentable_image.image.is_none() {
+                                let (tx_fb, rx_fb) = std::sync::mpsc::channel::<RcObjcId> ();
+                                fetch_xpc_service_texture(
+                                    service_proxy.as_id(),
+                                    presentable_image.id,
+                                    move |objcid| { let _ = tx_fb.send(objcid); },
+                                );
+                                if let Ok(fb) = rx_fb.recv_timeout(std::time::Duration::from_millis(1)) {
+                                    let texture = Texture::new(self);
+                                    if self.textures[texture.texture_id()].os.update_from_shared_handle(
+                                        metal_cx,
+                                        swapchain,
+                                        fb.as_id(),
+                                    ) {
+                                        let [presentable_image] = &mut swapchain.presentable_images;
+                                        presentable_image.image = Some(texture);
+                                    }
                                 }
-                            })); 
-                            let mut tex = None;
-                            while let Ok(fb) = rx_fb.recv(){
-                                let texture = Texture::new(self);
-                                let cxtexture = &mut self.textures[texture.texture_id()];
-                                if !cxtexture.os.update_from_shared_handle(
-                                    metal_cx,
-                                    fb.as_id(),
-                                    (ws.width * ws.dpi_factor) as u64 ,
-                                    (ws.height * ws.dpi_factor) as u64,
-                                ){
-                                    break;
-                                }
-                                tex = Some(texture);
-                                break
                             }
 
                             // check signals
@@ -216,8 +199,9 @@ impl Cx {
                                 self.mtl_compile_shaders(metal_cx);
                             }
 
-                            if tex.is_some(){
-                                self.stdin_handle_repaint(metal_cx, tex.unwrap(), time as f32, ws.swapchain_front);
+                            let [presentable_image] = &swapchain.presentable_images;
+                            if presentable_image.image.is_some() {
+                                self.stdin_handle_repaint(metal_cx, swapchain, time as f32);
                             }
                         }
                     }

--- a/platform/src/os/apple/metal_xpc.m
+++ b/platform/src/os/apple/metal_xpc.m
@@ -1,22 +1,23 @@
 #import <Foundation/Foundation.h>
+#include <stdint.h>
 
 @protocol MetalXPCProtocol
--(void)fetchTexture:(NSUInteger)index uid:(NSUInteger)uid with:(void (^)(NSObject*, NSUInteger))completion;
--(void)storeTexture:(NSUInteger)index obj:(NSObject*)obj uid:(NSUInteger)uid with:(void (^)())completion;;
+-(void)fetchTexture:(uint64_t)presentable_image_id_u64 _padding:(uint64_t)_padding with:(void (^)(NSObject*, /*padding*/uint64_t))completion;
+-(void)storeTexture:(uint64_t)presentable_image_id_u64 obj:(NSObject*)obj _padding:(uint64_t)_padding with:(void (^)())completion;
 @end
 
-Protocol* define_xpc_service_protocol(void){
+Protocol* define_xpc_service_protocol(void) {
     return @protocol(MetalXPCProtocol);
 }
 
-NSObject* get_fetch_texture_completion_block(void(^block)(NSObject*, NSUInteger)){
-    return Block_copy(^(NSObject * texture, NSUInteger uid){
-        block(texture, uid); 
+NSObject* hackily_heapify_block2_obj_u64(void(^block)(NSObject*, /*padding*/uint64_t)){
+    return Block_copy(^(NSObject *texture, uint64_t _padding) {
+        block(texture, _padding);
     });
 }
 
-NSObject* get_store_completion_block(void(^block)()){
-    return Block_copy(^(){
+NSObject* hackily_heapify_block0(void(^block)()) {
+    return Block_copy(^() {
         block();
     });
 }

--- a/platform/src/os/linux/dma_buf.rs
+++ b/platform/src/os/linux/dma_buf.rs
@@ -1,0 +1,202 @@
+//! # Linux cross-process DMA-BUF-based image ("texture") sharing
+//!
+//! An [`Image<FD>`] primarily contains [DMA-BUF] (`FD`-typed) file descriptor(s)
+//! (within each [`ImagePlane<FD>`], which also tracks its buffer's "2D slice"),
+//! and the ["DRM format"] ([`DrmFormat`]) describing the image's texel encoding,
+//! all combined into a conveniently (de)serializable form (as long as `FD` is).
+//!
+//! ---
+//!
+//! Under EGL, this allows sharing an OpenGL texture across processes, e.g.:
+//! * A creates an `EGLImage` from some OpenGL texture (or another resource)
+//! * A exports its `EGLImage` using [`EGL_MESA_image_dma_buf_export`]
+//! * A passes to B its [DMA-BUF] file descriptor(s) and ["DRM format"] metadata
+//! * B imports it as an `EGLImage` using [`EGL_EXT_image_dma_buf_import`]
+//! * B exposes its `EGLImage` as an OpenGL texture using [`glEGLImageTargetTexture2DOES`]
+//!
+//! [DMA-BUF]: https://docs.kernel.org/driver-api/dma-buf.html
+//! ["DRM format"]: https://docs.kernel.org/gpu/drm-kms.html#drm-format-handling
+//! [`EGL_MESA_image_dma_buf_export`]: https://registry.khronos.org/EGL/extensions/MESA/EGL_MESA_image_dma_buf_export.txt
+//! [`EGL_EXT_image_dma_buf_import`]: https://registry.khronos.org/EGL/extensions/EXT/EGL_EXT_image_dma_buf_import.txt
+//! [`glEGLImageTargetTexture2DOES`]: https://registry.khronos.org/OpenGL/extensions/OES/OES_EGL_image.txt
+
+use crate::makepad_micro_serde::*;
+
+use std::os::{self, fd::AsRawFd as _};
+
+#[derive(Debug, PartialEq, SerBin, DeBin, SerJson, DeJson)]
+pub struct Image<FD>
+    // HACK(eddyb) hint `{Ser,De}{Bin,Json}` derivers to add their own bounds.
+    where FD: Sized
+{
+    pub drm_format: DrmFormat,
+    // FIXME(eddyb) support 2-4 planes (not needed for RGBA, so most likely only
+    // relevant to YUV video decode streams - or certain forms of compression).
+    pub planes: ImagePlane<FD>,
+}
+
+impl<FD> Image<FD> {
+    pub fn planes_map<FD2>(self, f: impl Fn(ImagePlane<FD>) -> ImagePlane<FD2>) -> Image<FD2> {
+        let Image { drm_format, planes: plane0 } = self;
+        Image { drm_format, planes: f(plane0) }
+    }
+    pub fn planes_ref_map<FD2>(&self, f: impl Fn(&ImagePlane<FD>) -> ImagePlane<FD2>) -> Image<FD2> {
+        let Image { drm_format, planes: ref plane0 } = *self;
+        Image { drm_format, planes: f(plane0) }
+    }
+}
+
+impl<FD> Copy for Image<FD> where ImagePlane<FD>: Copy {}
+impl<FD> Clone for Image<FD> where ImagePlane<FD>: Clone {
+    fn clone(&self) -> Self {
+        self.planes_ref_map(|plane| plane.clone())
+    }
+}
+
+impl Image<os::fd::OwnedFd> {
+    pub fn as_remote(&self) -> Image<RemoteFd> {
+        self.planes_ref_map(|plane| plane.as_remote())
+    }
+}
+
+/// In the Linux DRM+KMS system (i.e. kernel-side GPU drivers), a "DRM format"
+/// is an image format (i.e. a specific byte-level encoding of texel data)
+/// that framebuffers (or more generally "surfaces" / "images") could use,
+/// provided that all the GPUs involved support the specific format used.
+///
+/// See also <https://docs.kernel.org/gpu/drm-kms.html#drm-format-handling>.
+#[derive(Copy, Clone, Debug, PartialEq, SerBin, DeBin, SerJson, DeJson)]
+pub struct DrmFormat {
+    /// FourCC code for a "DRM format", i.e. one of the `DRM_FORMAT_*` values
+    /// defined in `drm/drm_fourcc.h`, and the main aspect of a "DRM format"
+    /// that userspace needs to care about (e.g. RGB vs YUV, bit width, etc.).
+    ///
+    /// For example, non-HDR RGBA surfaces will almost always use the format
+    /// `DRM_FORMAT_ABGR8888` (with FourCC `"AB24"`, i.e. `0x34324241`), and:
+    /// - "A" can be replaced with "X" (disabling the alpha channel)
+    /// - "AB" can be reversed, to get "BA" (ABGR -> BGRA)
+    /// - "B" can be replaced with "R" (ABGR -> ARGB)
+    /// - "AR" can be reversed, to get "RA" (ARGB -> RGBA)
+    /// - "24" can be replaced with "30" or "48" (increasing bits per channel)
+    ///
+    /// Some formats also require multiple "planes" (i.e. independent buffers),
+    /// and while that's commonly for YUV formats, planar RGBA also exists.
+    pub fourcc: u32,
+
+    /// Each "DRM format" may be further "modified" with additional features,
+    /// describing how memory is accessed by GPU texture units (e.g. "tiling"),
+    /// and optionally requiring additional "planes" for compression purposes.
+    ///
+    /// To userspace, the modifiers are almost always opaque and merely need to
+    /// be passed from an image exporter to an image importer, to correctly
+    /// interpret the GPU memory in the same way on both sides.
+    pub modifiers: u64,
+}
+
+#[derive(Debug, PartialEq, SerBin, DeBin, SerJson, DeJson)]
+pub struct ImagePlane<FD>
+    // HACK(eddyb) hint `{Ser,De}{Bin,Json}` derivers to add their own bounds.
+    where FD: Sized
+{
+    /// Linux DMA-BUF file descriptor, representing a generic GPU buffer object.
+    ///
+    /// See also <https://docs.kernel.org/driver-api/dma-buf.html>.
+    pub dma_buf_fd: FD,
+
+    /// This plane's starting position (in bytes), in the DMA-BUF buffer.
+    pub offset: u32,
+
+    /// This plane's stride (aka "pitch") for texel rows, in the DMA-BUF buffer.
+    pub stride: u32,
+}
+
+impl<FD> ImagePlane<FD> {
+    pub fn fd_as_ref(&self) -> ImagePlane<&FD> {
+        let ImagePlane { ref dma_buf_fd, offset, stride } = *self;
+        ImagePlane { dma_buf_fd, offset, stride }
+    }
+    pub fn fd_map<FD2>(self, f: impl FnOnce(FD) -> FD2) -> ImagePlane<FD2> {
+        let ImagePlane { dma_buf_fd, offset, stride } = self;
+        ImagePlane { dma_buf_fd: f(dma_buf_fd), offset, stride }
+    }
+}
+
+impl Copy for ImagePlane<RemoteFd> {}
+impl Clone for ImagePlane<RemoteFd> {
+    fn clone(&self) -> Self {
+        self.fd_as_ref().fd_map(|&fd| fd)
+    }
+}
+
+impl Clone for ImagePlane<os::fd::OwnedFd> {
+    fn clone(&self) -> Self {
+        self.fd_as_ref().fd_map(|fd| fd.try_clone().unwrap())
+    }
+}
+
+impl ImagePlane<os::fd::OwnedFd> {
+    pub fn as_remote(&self) -> ImagePlane<RemoteFd> {
+        self.fd_as_ref().fd_map(|fd| RemoteFd {
+            remote_pid: std::process::id(),
+            remote_fd: fd.as_raw_fd(),
+        })
+    }
+}
+
+// HACK(eddyb) to avoid needing an UNIX domain socket, we pass file descriptors
+// to child processes via `pidfd_getfd` (see also `linux_x11_stdin::pid_fd`).
+#[derive(Copy, Clone, Debug, PartialEq, SerBin, DeBin, SerJson, DeJson)]
+pub struct RemoteFd {
+    pub remote_pid: u32,
+    pub remote_fd: i32,
+}
+
+/// Linux pidfd (file-descriptor-based API for "process handles") wrapper.
+///
+/// `PidFd` is used here specifically for its ability to clone any file descriptors
+/// from a remote process, similar to opening `/proc/$REMOTE_PID/fd/$REMOTE_FD`,
+/// but without all the caveats and failure modes around special file descriptors.
+//
+// FIXME(eddyb) `std::os::linux::process::PidFd` should be used/wrapped instead,
+// but for now it's still unstable, and it also lacks `pidfd_getfd` functionality,
+// as its main purpose appears to be creating a pidfd from `std::process::Command`.
+#[allow(non_camel_case_types, non_upper_case_globals)]
+pub(super) mod pid_fd {
+    use std::{
+        ffi::{c_int, c_long, c_uint},
+        io,
+        os::{self, fd::{AsRawFd as _, FromRawFd as _}},
+    };
+
+    pub(crate) type pid_t = c_int;
+
+    extern "C" { fn syscall(num: c_long, ...) -> c_long; }
+    const SYS_pidfd_open: c_long = 434;
+    const SYS_pidfd_getfd: c_long = 438;
+
+    pub(crate) struct PidFd(os::fd::OwnedFd);
+    impl PidFd {
+        pub fn from_remote_pid(remote_pid: pid_t) -> Result<PidFd, io::Error> {
+            unsafe {
+                let flags: c_uint = 0;
+                let pid_fd = syscall(SYS_pidfd_open, remote_pid, flags);
+                if pid_fd == -1 {
+                    Err(io::Error::last_os_error())
+                } else {
+                    Ok(PidFd(os::fd::OwnedFd::from_raw_fd(pid_fd as os::fd::RawFd)))
+                }
+            }
+        }
+        pub fn clone_remote_fd(&self, remote_fd: os::fd::RawFd) -> Result<os::fd::OwnedFd, io::Error> {
+            unsafe {
+                let flags: c_uint = 0;
+                let cloned_fd = syscall(SYS_pidfd_getfd, self.0.as_raw_fd(), remote_fd, flags);
+                if cloned_fd == -1 {
+                    Err(io::Error::last_os_error())
+                } else {
+                    Ok(os::fd::OwnedFd::from_raw_fd(cloned_fd as os::fd::RawFd))
+                }
+            }
+        }
+    }
+}

--- a/platform/src/os/linux/mod.rs
+++ b/platform/src/os/linux/mod.rs
@@ -11,6 +11,9 @@ pub mod libc_sys;
 pub mod opengl;
 
 #[cfg(not(target_os="android"))]
+pub mod dma_buf;
+
+#[cfg(not(target_os="android"))]
 pub mod alsa_sys;
 #[cfg(not(target_os="android"))]
 pub mod linux_media;

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -21,7 +21,6 @@ use {
         cx::{Cx, OsType,LinuxWindowParams}, 
         gpu_info::GpuPerformance,
         os::cx_native::EventFlow,
-        Texture,
     }
 };
 
@@ -351,12 +350,9 @@ impl CxOsApi for Cx {
 
 #[derive(Default)]
 pub struct CxOs {
-    pub (crate) media: CxLinuxMedia,
+    pub(crate) media: CxLinuxMedia,
 
     // HACK(eddyb) generalize this to EGL, properly.
-    pub opengl_cx: Option<OpenglCx>,
-
-    pub swapchain: Option<[Texture; 2]>,
-    pub present_index: usize,
+    pub(super) opengl_cx: Option<OpenglCx>,
 }
 

--- a/platform/src/os/linux/x11/linux_x11_stdin.rs
+++ b/platform/src/os/linux/x11/linux_x11_stdin.rs
@@ -16,7 +16,7 @@ use {
         texture::Texture,
         live_traits::LiveNew,
         thread::Signal,
-        os::cx_stdin::{HostToStdin, StdinToHost},
+        os::cx_stdin::{HostToStdin, StdinToHost, Swapchain},
         pass::{CxPassParent, PassClearColor, CxPassColorTexture},
         cx_api::CxOsOp,
         cx::Cx,
@@ -26,7 +26,11 @@ use {
 
 impl Cx {
     
-    pub (crate) fn stdin_handle_repaint(&mut self) {
+    pub (crate) fn stdin_handle_repaint(
+        &mut self,
+        swapchain: Option<&Swapchain<Texture>>,
+        present_index: &mut usize,
+    ) {
         self.os.opengl_cx.as_ref().unwrap().make_current();
         let mut passes_todo = Vec::new();
         self.compute_pass_repaint_order(&mut passes_todo);
@@ -34,20 +38,28 @@ impl Cx {
         for pass_id in &passes_todo {
             match self.passes[*pass_id].parent.clone() {
                 CxPassParent::Window(_) => {
-                    if self.os.swapchain.is_some() {
+                    if let Some(swapchain) = swapchain {
+                        // HACK(eddyb) retry loop in case we have broken images.
+                        for _ in 0..swapchain.presentable_images.len() {
+                            let current_image = &swapchain.presentable_images[*present_index];
+                            *present_index = (*present_index + 1) % swapchain.presentable_images.len();
 
-                        // render to swapchain
-                        let texture_id = self.os.swapchain.as_ref().unwrap()[self.os.present_index].texture_id();
-                        self.draw_pass_to_texture(*pass_id, texture_id);
+                            if self.textures[current_image.image.texture_id()].os.gl_texture.is_none() {
+                                // FIXME(eddyb) ask the server for a new swapchain.
+                                continue;
+                            }
 
-                        // wait for GPU to finish rendering
-                        unsafe { gl_sys::Finish(); }
+                            // render to swapchain
+                            self.draw_pass_to_texture(*pass_id, current_image.image.texture_id());
 
-                        // inform host that frame is ready
-                        let _ = io::stdout().write_all(StdinToHost::DrawCompleteAndFlip(self.os.present_index).to_json().as_bytes());
+                            // wait for GPU to finish rendering
+                            unsafe { gl_sys::Finish(); }
 
-                        // flip to next one
-                        self.os.present_index = 1 - self.os.present_index;
+                            // inform host that frame is ready
+                            let _ = io::stdout().write_all(StdinToHost::DrawCompleteAndFlip(current_image.id).to_json().as_bytes());
+
+                            break;
+                        }
                     }
                 }
                 CxPassParent::Pass(_) => {
@@ -65,8 +77,10 @@ impl Cx {
         let _ = io::stdout().write_all(StdinToHost::ReadyToStart.to_json().as_bytes());
 
         let mut reader = BufReader::new(std::io::stdin());
-        let mut window_size = None;
-        
+
+        let mut swapchain = None;
+        let mut present_index = 0;
+
         self.call_event_handler(&Event::Construct);
         
         loop {
@@ -117,11 +131,9 @@ impl Cx {
                             self.call_event_handler(&Event::Scroll(e.into()))
                         }
                         HostToStdin::WindowSize(ws) => {
-                            if window_size != Some(ws) {
+                            self.redraw_all();
 
-                                let dma_buf_image0 = ws.swapchain_handles[0];
-                                let dma_buf_image1 = ws.swapchain_handles[1];
-
+                            let new_swapchain = ws.swapchain.images_map(|_, dma_buf_image| {
                                 // HACK(eddyb) we get the host process's ID, and
                                 // a file descriptor *in that process* - normally
                                 // it'd need to be passed to this process via some
@@ -132,68 +144,54 @@ impl Cx {
                                 // so for now this requires `pidfd` (Linux 5.6+),
                                 // but could be reworked to use UNIX domain sockets
                                 // (with `SCM_RIGHTS` messages) instead, long-term.
+                                use crate::os::linux::dma_buf::pid_fd;
 
-                                let dma_buf_image0 = dma_buf_image0.planes_ref_map(|plane| plane.fd_map(|fd| {
+                                let dma_buf_image = dma_buf_image.planes_map(|plane| plane.fd_map(|fd| {
                                     // FIXME(eddyb) reuse `PidFd`s as the host PID
                                     // will never change (unless it can do client
                                     // handover, or there's "worker processes").
                                     pid_fd::PidFd::from_remote_pid(fd.remote_pid as pid_fd::pid_t)
                                         .and_then(|pid_fd| pid_fd.clone_remote_fd(fd.remote_fd))
                                 }));
-                                let dma_buf_image1 = dma_buf_image1.planes_ref_map(|plane| plane.fd_map(|fd| {
-                                    pid_fd::PidFd::from_remote_pid(fd.remote_pid as pid_fd::pid_t)
-                                        .and_then(|pid_fd| pid_fd.clone_remote_fd(fd.remote_fd))
-                                }));
 
-                                let new_textures = [Texture::new(self),Texture::new(self),];
+                                // FIXME(eddyb) is this necessary or could they be reused?
+                                let new_texture = Texture::new(self);
 
-                                if let Err(err) = &dma_buf_image0.planes.dma_buf_fd {
+                                if let Err(err) = &dma_buf_image.planes.dma_buf_fd {
                                     error!("failed to pidfd_getfd the DMA-BUF fd: {err:?}");
                                     if err.kind() == io::ErrorKind::Unsupported {
                                         error!("pidfd_getfd syscall requires at least Linux 5.6")
                                     }
                                 } else {
-                                    let dma_buf_image = dma_buf_image0.planes_map(|plane| plane.fd_map(Result::unwrap));
+                                    let dma_buf_image = dma_buf_image.planes_map(|plane| plane.fd_map(Result::unwrap));
 
                                     // update texture
-                                    let cxtexture = &mut self.textures[new_textures[0].texture_id()];
-                                    cxtexture.os.update_from_shared_dma_buf_image(
-                                        self.os.opengl_cx.as_ref().unwrap(),
-                                        &dma_buf_image,
-                                    );
-                                }
-                                if let Err(err) = &dma_buf_image1.planes.dma_buf_fd {
-                                    error!("failed to pidfd_getfd the DMA-BUF fd: {err:?}");
-                                    if err.kind() == io::ErrorKind::Unsupported {
-                                        error!("pidfd_getfd syscall requires at least Linux 5.6")
-                                    }
-                                } else {
-                                    let dma_buf_image = dma_buf_image1.planes_map(|plane| plane.fd_map(Result::unwrap));
-
-                                    // update texture
-                                    let cxtexture = &mut self.textures[new_textures[1].texture_id()];
-                                    cxtexture.os.update_from_shared_dma_buf_image(
-                                        self.os.opengl_cx.as_ref().unwrap(),
-                                        &dma_buf_image,
-                                    );
+                                    self.textures[new_texture.texture_id()]
+                                        .os.update_from_shared_dma_buf_image(
+                                            self.os.opengl_cx.as_ref().unwrap(),
+                                            &ws.swapchain,
+                                            &dma_buf_image,
+                                        );
                                 }
 
-                                self.os.swapchain = Some(new_textures);
+                                new_texture
+                            });
+                            let swapchain = swapchain.insert(new_swapchain);
 
-                                window_size = Some(ws);
-                                self.redraw_all();
+                            // reset present_index
+                            present_index = 0;
 
-                                let window = &mut self.windows[CxWindowPool::id_zero()];
-                                window.window_geom = WindowGeom {
-                                    dpi_factor: ws.dpi_factor,
-                                    inner_size: dvec2(ws.width, ws.height),
-                                    ..Default::default()
-                                };
-                                self.stdin_handle_platform_ops();
-                            }
+                            let window = &mut self.windows[CxWindowPool::id_zero()];
+                            window.window_geom = WindowGeom {
+                                dpi_factor: ws.dpi_factor,
+                                inner_size: dvec2(swapchain.width as f64, swapchain.height as f64) / ws.dpi_factor,
+                                ..Default::default()
+                            };
+
+                            self.stdin_handle_platform_ops(Some(swapchain), present_index);
                         }
 
-                        HostToStdin::Tick {frame: _, time, buffer_id: _} => if let Some(_ws) = window_size {
+                        HostToStdin::Tick {frame: _, time, buffer_id: _} => if swapchain.is_some() {
 
                             // poll the service for updates
                             // check signals
@@ -219,7 +217,7 @@ impl Cx {
                             }
                             
                             // we need to make this shared texture handle into a true metal one
-                            self.stdin_handle_repaint();
+                            self.stdin_handle_repaint(swapchain.as_ref(), &mut present_index);
                         }
                     }
                     Err(err) => { // we should output a log string
@@ -228,12 +226,16 @@ impl Cx {
                 }
             }
             // we should poll our runloop
-            self.stdin_handle_platform_ops();
+            self.stdin_handle_platform_ops(swapchain.as_ref(), present_index);
         }
     }
     
     
-    fn stdin_handle_platform_ops(&mut self) {
+    fn stdin_handle_platform_ops(
+        &mut self,
+        swapchain: Option<&Swapchain<Texture>>,
+        present_index: usize,
+    ) {
         while let Some(op) = self.platform_ops.pop() {
             match op {
                 CxOsOp::CreateWindow(window_id) => {
@@ -244,12 +246,11 @@ impl Cx {
                     window.is_created = true;
                     // lets set up our render pass target
                     let pass = &mut self.passes[window.main_pass_id.unwrap()];
-                    if self.os.swapchain.is_some() {
-                        let texture_id = self.os.swapchain.as_ref().unwrap()[self.os.present_index].texture_id();
+                    if let Some(swapchain) = swapchain {
                         pass.color_textures = vec![CxPassColorTexture {
                             clear_color: PassClearColor::ClearWith(vec4(1.0,1.0,0.0,1.0)),
                             //clear_color: PassClearColor::ClearWith(pass.clear_color),
-                            texture_id,
+                            texture_id: swapchain.presentable_images[present_index].image.texture_id(),
                         }];
                     }
                 },
@@ -278,54 +279,4 @@ impl Cx {
         }
     }
     
-}
-
-/// Linux pidfd (file-descriptor-based API for "process handles") wrapper.
-///
-/// `PidFd` is used here specifically for its ability to clone any file descriptors
-/// from a remote process, similar to opening `/proc/$REMOTE_PID/fd/$REMOTE_FD`,
-/// but without all the caveats and failure modes around special file descriptors.
-//
-// FIXME(eddyb) `std::os::linux::process::PidFd` should be used/wrapped instead,
-// but for now it's still unstable, and it also lacks `pidfd_getfd` functionality,
-// as its main purpose appears to be creating a pidfd from `std::process::Command`.
-#[allow(non_camel_case_types, non_upper_case_globals)]
-mod pid_fd {
-    use std::{
-        ffi::{c_int, c_long, c_uint},
-        io,
-        os::{self, fd::{AsRawFd as _, FromRawFd as _}},
-    };
-
-    pub(super) type pid_t = c_int;
-
-    extern "C" { fn syscall(num: c_long, ...) -> c_long; }
-    const SYS_pidfd_open: c_long = 434;
-    const SYS_pidfd_getfd: c_long = 438;
-
-    pub(super) struct PidFd(os::fd::OwnedFd);
-    impl PidFd {
-        pub fn from_remote_pid(remote_pid: pid_t) -> Result<PidFd, io::Error> {
-            unsafe {
-                let flags: c_uint = 0;
-                let pid_fd = syscall(SYS_pidfd_open, remote_pid, flags);
-                if pid_fd == -1 {
-                    Err(io::Error::last_os_error())
-                } else {
-                    Ok(PidFd(os::fd::OwnedFd::from_raw_fd(pid_fd as os::fd::RawFd)))
-                }
-            }
-        }
-        pub fn clone_remote_fd(&self, remote_fd: os::fd::RawFd) -> Result<os::fd::OwnedFd, io::Error> {
-            unsafe {
-                let flags: c_uint = 0;
-                let cloned_fd = syscall(SYS_pidfd_getfd, self.0.as_raw_fd(), remote_fd, flags);
-                if cloned_fd == -1 {
-                    Err(io::Error::last_os_error())
-                } else {
-                    Ok(os::fd::OwnedFd::from_raw_fd(cloned_fd as os::fd::RawFd))
-                }
-            }
-        }
-    }
 }

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -1,7 +1,7 @@
 use {
     std::{
         rc::Rc,
-        cell::{Cell,RefCell},
+        cell::RefCell,
     },
     crate::{
         makepad_live_id::*,
@@ -22,8 +22,6 @@ use {
         cx_api::{CxOsApi, CxOsOp},
         window::CxWindowPool,
         windows::Win32::Graphics::Direct3D11::ID3D11Device,
-        Texture,
-        windows::Win32::Foundation::HANDLE,
     }
 };
 
@@ -37,7 +35,7 @@ impl Cx {
         let d3d11_cx = Rc::new(RefCell::new(D3d11Cx::new()));
 
         // hack: store ID3D11Device in CxOs, so texture-related operations become possible on the makepad/studio side, yet don't completely destroy the code there
-        cx.borrow_mut().os.d3d11_device = Cell::new(Some(d3d11_cx.borrow().device.clone()));
+        cx.borrow_mut().os.d3d11_device = Some(d3d11_cx.borrow().device.clone());
 
         for arg in std::env::args() {
             if arg == "--stdin-loop" {
@@ -375,10 +373,7 @@ impl CxOsApi for Cx {
 #[derive(Default)]
 pub struct CxOs {
     pub (crate) media: CxWindowsMedia,
-    pub d3d11_device: Cell<Option<ID3D11Device>>,
-    pub (crate) swapchain: Option<[Texture; 2]>,
-    pub (crate) swapchain_handles: [HANDLE; 2],
-    pub (crate) present_index: usize,
+    pub (crate) d3d11_device: Option<ID3D11Device>,
     pub (crate) decoding: CxWindowsDecoding,
-    pub (crate) new_frame_being_rendered: bool,
+    pub (crate) new_frame_being_rendered: Option<crate::cx_stdin::PresentableImageId>,
 }

--- a/platform/src/texture.rs
+++ b/platform/src/texture.rs
@@ -68,7 +68,7 @@ pub enum TextureFormat {
     RenderBGRA,
     RenderBGRAf16,
     RenderBGRAf32,
-    SharedBGRA(u64),
+    SharedBGRA(crate::cx_stdin::PresentableImageId),
     //    ImageBGRAf32,
     //    ImageRf32,
     //    ImageRGf32,

--- a/studio/src/build_manager/build_manager.rs
+++ b/studio/src/build_manager/build_manager.rs
@@ -49,9 +49,9 @@ pub struct ActiveBuild {
     pub process: BuildProcess,
     pub run_view_id: LiveId,
     pub cmd_id: Option<BuildCmdId>,
-    pub swapchain: [Texture; 2],
-    pub mac_resize_id: usize,
-    pub present_index: Cell<usize>,
+    pub swapchain: Option<cx_stdin::Swapchain<Texture>>,
+    pub last_presented_id: Cell<Option<cx_stdin::PresentableImageId>>,
+    pub last_presented_backup_for_resizing: Texture,
 }
 
 #[derive(Clone, Debug, Default, Eq, Hash, Copy, PartialEq, FromLiveId)]

--- a/studio/src/build_manager/run_list.rs
+++ b/studio/src/build_manager/run_list.rs
@@ -258,14 +258,14 @@ impl BuildManager {
             if active.builds.get(&build_id).is_none() {
                 let index = active.builds.len();
                 active.builds.insert(build_id, ActiveBuild {
-                    mac_resize_id: 0,
                     item_id,
                     log_index: format!("[{}]", index),
                     process: process.clone(),
                     run_view_id,
                     cmd_id: Some(client.send_cmd(BuildCmd::Run(process.clone(), studio_http))),
-                    swapchain: [Texture::new(cx),Texture::new(cx),],
-                    present_index: Cell::new(0),
+                    swapchain: None,
+                    last_presented_id: Cell::new(None),
+                    last_presented_backup_for_resizing: Texture::new(cx),
                 });
             }
             if process.target.runs_in_studio(){

--- a/studio/src/build_manager/run_view.rs
+++ b/studio/src/build_manager/run_view.rs
@@ -58,7 +58,7 @@ pub struct RunView {
     #[animator] animator: Animator,
     #[live] draw_app: DrawQuad,
     #[live] frame_delta: f64,
-    #[rust] last_size: (usize, usize),
+    #[rust] last_size: (u32, u32),
     #[rust] tick: NextFrame,
     #[rust] timer: Timer,
     #[rust(100usize)] redraw_countdown: usize,
@@ -182,17 +182,21 @@ impl RunView {
                 self.last_size = Default::default();
                 self.redraw(cx);
             }
-            StdinToHost::DrawCompleteAndFlip(present_index) => {
-                for v in manager.active.builds.values_mut() {
-                    if v.run_view_id == run_view_id {
-                        if !self.started{
-                            self.started = true;
-                            self.animator_play(cx, id!(started.on));
+            &StdinToHost::DrawCompleteAndFlip(drawn_presentable_id) => {
+                if let Some(v) = manager.active.builds.values_mut().find(|v| v.run_view_id == run_view_id) {
+                    // Only allow presenting images in the current host swapchain
+                    // (and look them up by their unique IDs), to avoid using
+                    // different textures than the ones the client just drew to.
+                    if let Some(swapchain) = &v.swapchain {
+                        if let Some(pi) = swapchain.presentable_images.iter().find(|pi| pi.id == drawn_presentable_id) {
+                            if !self.started{
+                                self.started = true;
+                                self.animator_play(cx, id!(started.on));
+                            }
+                            self.redraw_countdown = 20;
+                            v.last_presented_id.set(Some(pi.id));
+                            self.draw_app.set_texture(0, &pi.image);
                         }
-                        self.redraw_countdown = 20;
-                        v.present_index.set(*present_index);
-                        self.draw_app.set_texture(0, &v.swapchain[*present_index]);
-                        v.mac_resize_id = 1 - present_index;
                     }
                 }
             }
@@ -211,112 +215,53 @@ impl RunView {
         let walk = if let Some(walk) = self.draw_state.get() {walk}else {panic!()};
         let rect = cx.walk_turtle(walk).dpi_snap(dpi_factor);
         // lets pixelsnap rect in position and size
-        
-        for v in manager.active.builds.values_mut() {
-            if v.run_view_id == run_view_id {
-                
-                // update texture size and indicate new size to client if needed
-                let new_size = ((rect.size.x * dpi_factor) as usize, (rect.size.y * dpi_factor) as usize);
-                if new_size != self.last_size {
-                    self.last_size = new_size;
-                    self.redraw_countdown = 20;
-                    // update descriptors for swapchain textures
-                    let ids = [run_view_id.0 & 0x0000FFFFFFFFFFFF, run_view_id.0 | 0x0001000000000000];
-                    let descs = [TextureDesc {
-                        format: TextureFormat::SharedBGRA(ids[0]),
-                        width: Some(new_size.0.max(1)),
-                        height: Some(new_size.1.max(1)),
-                    }, TextureDesc {
-                        format: TextureFormat::SharedBGRA(ids[1]),
-                        width: Some(new_size.0.max(1)),
-                        height: Some(new_size.1.max(1)),
-                    }];
-                    
-                    // make sure the actual shared texture resources exist, and get their handles                   
-                    #[cfg(target_os = "windows")] {
-                        v.swapchain[0].set_desc(cx, descs[0]);
-                        v.swapchain[1].set_desc(cx, descs[1]);
-                        
-                        let mut handles = [0u64, 0u64];
-                        
-                        let d3d11_device = cx.cx.os.d3d11_device.replace(None).unwrap();
-                        
-                        let cxtexture = &mut cx.textures[v.swapchain[0].texture_id()];
-                        cxtexture.os.update_shared_texture(&d3d11_device, new_size.0 as u32, new_size.1 as u32);
-                        handles[0] = cxtexture.os.shared_handle.0 as u64;
-                        
-                        let cxtexture = &mut cx.textures[v.swapchain[1].texture_id()];
-                        cxtexture.os.update_shared_texture(&d3d11_device, new_size.0 as u32, new_size.1 as u32);
-                        handles[1] = cxtexture.os.shared_handle.0 as u64;
-                        
-                        cx.cx.os.d3d11_device.replace(Some(d3d11_device));
-                        manager.send_host_to_stdin(run_view_id, HostToStdin::WindowSize(StdinWindowSize {
-                            width: rect.size.x,
-                            height: rect.size.y,
-                            dpi_factor: dpi_factor,
-                            swapchain_handles: handles,
-                        }));
-                    };
-                    
-                    #[cfg(target_os = "macos")] {
-                        // macos alternates resizes with doublebuffering NOT frames
-                        let id = v.mac_resize_id;
-                        v.swapchain[id].set_desc(cx, descs[id]);
-                        let metal_device = cx.cx.os.metal_device.replace(None).unwrap();
-                        // ok so we have to alternate which buffer we resize
-                        let cxtexture = &mut cx.textures[v.swapchain[id].texture_id()];
-                        cxtexture.os.update_shared_texture(metal_device, &descs[id]);
-                        
-                        cx.cx.os.metal_device.replace(Some(metal_device));
-                        // for macos, pass the hashmap indices to the client, so they can find the right texture in XPC
-                        // send size update to client
-                        let swapchain_front = v.mac_resize_id as u32;
-                        manager.send_host_to_stdin(run_view_id, HostToStdin::WindowSize(StdinWindowSize {
-                            width: rect.size.x,
-                            height: rect.size.y,
-                            dpi_factor: dpi_factor,
-                            swapchain_handle: ids[id],
-                            swapchain_front
-                        }));
-                    };
-                    
-                    #[cfg(target_os = "linux")]
-                    {
-                        v.swapchain[0].set_desc(cx, descs[0]);
-                        v.swapchain[1].set_desc(cx, descs[1]);
-                        
-                        // HACK(eddyb) normally this would be triggered later,
-                        // but we need it *before* `get_shared_texture_dma_buf_image`.
-                        {
-                            // FIXME(eddyb) there should probably be an unified EGL `OpenglCx`.
-                            let cxtexture = &mut cx.cx.textures[v.swapchain[0].texture_id()];
-                            #[cfg(not(any(linux_direct, target_os = "android")))]
-                            cxtexture.os.update_shared_texture(cx.cx.os.opengl_cx.as_ref().unwrap(), &descs[0]);
-                            
-                            let cxtexture = &mut cx.cx.textures[v.swapchain[1].texture_id()];
-                            #[cfg(not(any(linux_direct, target_os = "android")))]
-                            cxtexture.os.update_shared_texture(cx.cx.os.opengl_cx.as_ref().unwrap(), &descs[1]);
+
+        if let Some(v) = manager.active.builds.values_mut().find(|v| v.run_view_id == run_view_id) {
+            let new_size = (
+                ((rect.size.x * dpi_factor) as u32).max(1),
+                ((rect.size.y * dpi_factor) as u32).max(1),
+            );
+            if new_size != self.last_size {
+                self.last_size = new_size;
+                self.redraw_countdown = 20;
+
+                // `Texture`s can be reused, but all `PresentableImageId`s must
+                // be regenerated, to tell apart swapchains when e.g. resizing
+                // constantly, so textures keep getting created and replaced.
+                if let Some(swapchain) = &mut v.swapchain {
+                    for pi in &mut swapchain.presentable_images {
+                        // Keep intact the most recently presented swapchain entry,
+                        // so that its pre-resize texture isn't lost during resizing,
+                        // and is only replaced *after* the client finishes a redraw.
+                        if Some(pi.id) == v.last_presented_id.get() {
+                            std::mem::swap(&mut pi.image, &mut v.last_presented_backup_for_resizing);
                         }
-                        
-                        let handles = [
-                            cx.get_shared_texture_dma_buf_image(&v.swapchain[0]),
-                            cx.get_shared_texture_dma_buf_image(&v.swapchain[1]),
-                        ];
-                        
-                        manager.send_host_to_stdin(run_view_id, HostToStdin::WindowSize(StdinWindowSize {
-                            width: rect.size.x,
-                            height: rect.size.y,
-                            dpi_factor: dpi_factor,
-                            swapchain_handles: handles,
-                        }));
-                    };
-                    
+
+                        pi.id = cx_stdin::PresentableImageId::alloc();
+                    }
                 }
-                
-                // make sure it's going to present the right texture
-                
-                
-                break
+                let swapchain = v.swapchain.get_or_insert_with(|| {
+                    Swapchain::new(0, 0).images_map(|_, ()| Texture::new(cx))
+                });
+
+                // Resize the swapchain and prepare its images for sharing.
+                (swapchain.width, swapchain.height) = new_size;
+                let shared_swapchain = swapchain.images_as_ref().images_map(|id, texture| {
+                    texture.set_desc(cx, TextureDesc {
+                        format: TextureFormat::SharedBGRA(id),
+                        width: Some(swapchain.width as usize),
+                        height: Some(swapchain.height as usize),
+                    });
+                    cx.get_shared_presentable_image_os_handle(&texture)
+                });
+
+                // Inform the client about the new swapchain it *should* use
+                // (using older swapchains isn't an error, but the draw calls
+                // will either be noops, or write to orphaned GPU memory ranges).
+                manager.send_host_to_stdin(run_view_id, HostToStdin::WindowSize(StdinWindowSize {
+                    dpi_factor: dpi_factor,
+                    swapchain: shared_swapchain,
+                }));
             }
         }
         


### PR DESCRIPTION
See most of the API additions to `os::cx_stdin` in `makepad-platform`, I tried to document as much as I could (also, the Linux DMA-BUF support data types are in a better place now).

As far as cross-platform unification goes, `run_view`'s changes are probably the most significant, and especially the `RunView::draw` method (which used to contain a lot of similar-but-different platform-specific minutiae).