### PR TITLE
Performance view widget

### DIFF
--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -4,7 +4,6 @@ use {
         collections::{
             HashMap,
             HashSet,
-            VecDeque,
         },
         any::{Any, TypeId},
         rc::Rc,
@@ -21,6 +20,7 @@ use {
         draw_matrix::CxDrawMatrixPool,
         os::{CxOs},
         debug::Debug,
+        performance_stats::PerformanceStats,
         event::{
             DrawEvent,
             CxFingers,
@@ -110,7 +110,7 @@ pub struct Cx {
     pub(crate) executor: Option<Executor>,
     pub(crate) spawner: Spawner,
 
-    pub performance: PerformanceStats,
+    pub performance_stats: PerformanceStats,
 }
 
 #[derive(Clone)]
@@ -156,25 +156,6 @@ pub enum OsType {
 pub struct XrCapabilities {
     pub ar_supported: bool,
     pub vr_supported: bool,
-}
-
-pub struct FrameStats {
-    pub occurred_at: f64,
-    pub time_spent: f64
-}
-
-pub struct PerformanceStats {
-    pub last_frame_time: Option<f64>,
-    pub frame_times: VecDeque<FrameStats>
-}
-
-impl Default for PerformanceStats {
-    fn default() -> Self {
-        Self {
-            last_frame_time: None,
-            frame_times: VecDeque::with_capacity(100000),
-        }
-    }
 }
 
 impl OsType {
@@ -279,7 +260,7 @@ impl Cx {
             spawner,
 
             self_ref: None,
-            performance: Default::default(),
+            performance_stats: Default::default(),
         }
     }
 }

--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -4,6 +4,7 @@ use {
         collections::{
             HashMap,
             HashSet,
+            VecDeque,
         },
         any::{Any, TypeId},
         rc::Rc,
@@ -108,6 +109,8 @@ pub struct Cx {
     #[allow(dead_code)]
     pub(crate) executor: Option<Executor>,
     pub(crate) spawner: Spawner,
+
+    pub performance: PerformanceStats,
 }
 
 #[derive(Clone)]
@@ -153,6 +156,25 @@ pub enum OsType {
 pub struct XrCapabilities {
     pub ar_supported: bool,
     pub vr_supported: bool,
+}
+
+pub struct FrameStats {
+    pub occurred_at: f64,
+    pub time_spent: f64
+}
+
+pub struct PerformanceStats {
+    pub last_frame_time: Option<f64>,
+    pub frame_times: VecDeque<FrameStats>
+}
+
+impl Default for PerformanceStats {
+    fn default() -> Self {
+        Self {
+            last_frame_time: None,
+            frame_times: VecDeque::with_capacity(100000),
+        }
+    }
 }
 
 impl OsType {
@@ -256,7 +278,8 @@ impl Cx {
             executor: Some(executor),
             spawner,
 
-            self_ref: None
+            self_ref: None,
+            performance: Default::default(),
         }
     }
 }

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -36,6 +36,7 @@ mod gpu_info;
 mod geometry;
 mod debug;
 mod component_map;
+mod performance_stats;
 
 pub mod audio_stream;
 

--- a/platform/src/os/cx_shared.rs
+++ b/platform/src/os/cx_shared.rs
@@ -168,26 +168,7 @@ impl Cx {
         let mut set = HashSet::default();
         std::mem::swap(&mut set, &mut self.new_next_frames);
 
-        if let Some(previous_time) = self.performance.last_frame_time {
-            if self.performance.frame_times.len() >= 100000 {
-                self.performance.frame_times.pop_back();
-                // if let Some(d) = discarded {
-                //     if time - d.occurred_at < 1. {
-                //         log!("Discarding non-used data {} {}", time, d.occurred_at);
-                //     }
-                // }
-            }
-            self.performance.frame_times.push_front(crate::cx::FrameStats{
-                occurred_at: time,
-                time_spent: time - previous_time
-            });
-
-            if time - previous_time > 0.05 {
-                log!("Frame took {} seconds", time - previous_time);
-            }
-        };
-        self.performance.last_frame_time = Some(time);
-
+        self.performance_stats.process_frame_data(time);
 
         self.call_event_handler(&Event::NextFrame(NextFrameEvent {set, time: time, frame: self.repaint_id}));
     }

--- a/platform/src/os/cx_shared.rs
+++ b/platform/src/os/cx_shared.rs
@@ -167,6 +167,28 @@ impl Cx {
     pub (crate) fn call_next_frame_event(&mut self, time: f64) {
         let mut set = HashSet::default();
         std::mem::swap(&mut set, &mut self.new_next_frames);
+
+        if let Some(previous_time) = self.performance.last_frame_time {
+            if self.performance.frame_times.len() >= 100000 {
+                self.performance.frame_times.pop_back();
+                // if let Some(d) = discarded {
+                //     if time - d.occurred_at < 1. {
+                //         log!("Discarding non-used data {} {}", time, d.occurred_at);
+                //     }
+                // }
+            }
+            self.performance.frame_times.push_front(crate::cx::FrameStats{
+                occurred_at: time,
+                time_spent: time - previous_time
+            });
+
+            if time - previous_time > 0.05 {
+                log!("Frame took {} seconds", time - previous_time);
+            }
+        };
+        self.performance.last_frame_time = Some(time);
+
+
         self.call_event_handler(&Event::NextFrame(NextFrameEvent {set, time: time, frame: self.repaint_id}));
     }
 }

--- a/platform/src/performance_stats.rs
+++ b/platform/src/performance_stats.rs
@@ -1,0 +1,63 @@
+use std::collections::VecDeque;
+
+#[derive(Debug)]
+pub struct FrameStats {
+    pub occurred_at: f64,
+    pub time_spent: f64
+}
+
+pub struct PerformanceStats {
+    pub last_frame_time: Option<f64>,
+    pub max_frame_times: VecDeque<FrameStats>,
+    //pub frame_times: VecDeque<FrameStats>
+}
+
+impl Default for PerformanceStats {
+    fn default() -> Self {
+        Self {
+            last_frame_time: None,
+            max_frame_times: VecDeque::with_capacity(100),
+            //frame_times: VecDeque::with_capacity(100000),
+        }
+    }
+}
+
+impl PerformanceStats {
+    pub fn process_frame_data(&mut self, time: f64) {
+        if let Some(previous_time) = self.last_frame_time {
+            // if self.frame_times.len() >= 100000 {
+            //     self.frame_times.pop_back();
+            // }
+            // self.frame_times.push_front(FrameStats{
+            //     occurred_at: time,
+            //     time_spent: time - previous_time
+            // });
+
+            if self.max_frame_times.len() == 0 {
+                self.max_frame_times.push_front(FrameStats{
+                    occurred_at: time,
+                    time_spent: time - previous_time
+                });
+                return
+            }
+
+            let current_period = (time * 10.0) as i64;
+            let data_data_period = (self.max_frame_times[0].occurred_at * 10.0) as i64;
+            if current_period == data_data_period {
+                if self.max_frame_times[0].time_spent < time - previous_time {
+                    self.max_frame_times[0].time_spent = time - previous_time;
+                }
+            } else {
+                if self.max_frame_times.len() >= 100 {
+                    self.max_frame_times.pop_back();
+                }
+
+                self.max_frame_times.push_front(FrameStats{
+                    occurred_at: time,
+                    time_spent: time - previous_time
+                });
+            }
+        };
+        self.last_frame_time = Some(time);
+    }
+}

--- a/platform/src/performance_stats.rs
+++ b/platform/src/performance_stats.rs
@@ -9,7 +9,6 @@ pub struct FrameStats {
 pub struct PerformanceStats {
     pub last_frame_time: Option<f64>,
     pub max_frame_times: VecDeque<FrameStats>,
-    //pub frame_times: VecDeque<FrameStats>
 }
 
 impl Default for PerformanceStats {
@@ -17,7 +16,6 @@ impl Default for PerformanceStats {
         Self {
             last_frame_time: None,
             max_frame_times: VecDeque::with_capacity(100),
-            //frame_times: VecDeque::with_capacity(100000),
         }
     }
 }
@@ -25,14 +23,6 @@ impl Default for PerformanceStats {
 impl PerformanceStats {
     pub fn process_frame_data(&mut self, time: f64) {
         if let Some(previous_time) = self.last_frame_time {
-            // if self.frame_times.len() >= 100000 {
-            //     self.frame_times.pop_back();
-            // }
-            // self.frame_times.push_front(FrameStats{
-            //     occurred_at: time,
-            //     time_spent: time - previous_time
-            // });
-
             if self.max_frame_times.len() == 0 {
                 self.max_frame_times.push_front(FrameStats{
                     occurred_at: time,

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -46,6 +46,7 @@ pub mod slides_view;
 pub mod color_picker;
 
 pub mod debug_view;
+pub mod performance_view;
 pub mod nav_control;
 
 pub mod view;
@@ -107,6 +108,7 @@ pub fn live_design(cx: &mut Cx) {
     makepad_draw::live_design(cx);
     crate::page_flip::live_design(cx);
     crate::debug_view::live_design(cx);
+    crate::performance_view::live_design(cx);
     crate::fold_header::live_design(cx);
     crate::splitter::live_design(cx);
     crate::base::live_design(cx);

--- a/widgets/src/performance_view.rs
+++ b/widgets/src/performance_view.rs
@@ -1,12 +1,9 @@
-use crate::{
-    widget::*,
-    makepad_draw::*,
-    view::*,
-    label::*
-};
+use std::collections::VecDeque;
 
-live_design!{
-    import makepad_draw::shader::std::*;  
+use crate::{label::*, makepad_draw::*, view::*, widget::*};
+
+live_design! {
+    import makepad_draw::shader::std::*;
     import makepad_widgets::label::LabelBase;
     import makepad_widgets::view::ViewBase;
 
@@ -15,43 +12,40 @@ live_design!{
         font: {path: dep("crate://makepad-widgets/resources/GoNotoKurrent-Regular.ttf")}
     }
 
-    PerformanceView = {{PerformanceView}} {  
-        width: 160,
-        height: 90,
+    PerformanceView = {{PerformanceView}} {
+        width: 300,
+        height: 65,
 
-        abs_pos: vec2(20, 40),
+        abs_pos: vec2(0, 20),
 
         show_bg: true,
         draw_bg: {
-            color: #f00
+            color: vec4(0.8, 0.8, 0.8, 0.8)
         }
 
         <ViewBase> {
+            margin: 5,
             visible: true
-            flow: Down
+            flow: Right
             width: Fill,
             height: Fill,
 
-            margin: 10,
 
             <LabelBase> {
+                width: Fit
+                align: {x: 0., y: 1.}
                 draw_text: {
-                    text_style: <REGULAR_TEXT>{},
+                    text_style: <REGULAR_TEXT>{font_size: 8},
                     color: #111
                 }
-                text: "Frame time"
+                text: "Frame time (max in last second)"
             }
-            <LabelBase> {
-                draw_text: {
-                    text_style: <REGULAR_TEXT>{},
-                    color: #111
-                }
-                text: "(max in last second)"
-            }
+            <View> { width: Fill, height: Fit }
             frame_time = <LabelBase> {
-                align: {x: 1}
+                width: Fit
+                align: {x: 1., y: 1}
                 draw_text: {
-                    text_style: <REGULAR_TEXT>{font_size: 16},
+                    text_style: <REGULAR_TEXT>{font_size: 8},
                     color: #111
                 }
                 text: "-"
@@ -60,11 +54,22 @@ live_design!{
     }
 }
 
+const BAR_WIDTH: f64 = 3.;
+
 #[derive(Live)]
 pub struct PerformanceView {
-    #[deref] view: View,
-    #[rust] next_frame: NextFrame,
-    #[rust] next_refresh_at: f64,
+    #[deref]
+    view: View,
+    #[rust]
+    next_frame: NextFrame,
+    #[rust]
+    next_refresh_at: f64,
+    #[live]
+    draw_graph: DrawColor,
+    #[live]
+    draw_bar: DrawColor,
+    #[rust]
+    frame_time_data: VecDeque<i64>,
 }
 
 impl LiveHook for PerformanceView {
@@ -81,6 +86,8 @@ impl LiveHook for PerformanceView {
 impl Widget for PerformanceView {
     fn redraw(&mut self, cx: &mut Cx) {
         self.view.redraw(cx);
+        self.draw_graph.redraw(cx);
+        self.draw_bar.redraw(cx);
     }
 
     fn walk(&mut self, cx: &mut Cx) -> Walk {
@@ -92,7 +99,9 @@ impl Widget for PerformanceView {
     }
 
     fn draw_walk_widget(&mut self, cx: &mut Cx2d, walk: Walk) -> WidgetDraw {
-        self.view.draw_walk_widget(cx, walk)
+        let _ = self.view.draw_walk_widget(cx, walk);
+        let _ = self.draw_walk(cx, walk);
+        WidgetDraw::done()
     }
 }
 
@@ -101,31 +110,88 @@ impl PerformanceView {
         if let Some(ne) = self.next_frame.is_event(event) {
             if self.next_refresh_at < ne.time {
                 self.next_refresh_at = ne.time + 0.5;
-                
+
                 if cx.performance_stats.max_frame_times.len() > 0 {
                     // Data is stored in 100ms buckets, so we take the max of the last 10 buckets
                     let last_sec_data = cx.performance_stats.max_frame_times.iter().take(10);
-                    let time = (last_sec_data.max_by(|a, b|
-                        a.time_spent.partial_cmp(&b.time_spent).unwrap()
-                    ).unwrap().time_spent * 1000.0) as i64;
+                    let time = (last_sec_data
+                        .max_by(|a, b| a.time_spent.partial_cmp(&b.time_spent).unwrap())
+                        .unwrap()
+                        .time_spent
+                        * 1000.0) as i64;
 
-                    self.label(id!(frame_time)).set_text(&format!("{} ms", time));
-                    
-                    let color = match time {
-                        0..=16 => vec4(0.4, 1.0, 0.4, 1.0),
-                        17..=33 => vec4(0.9, 0.9, 0.4, 1.0),
-                        _ => vec4(1.0, 0.2, 0.2, 1.0)
-                    };
-                    self.view.apply_over(cx, live!{
-                        draw_bg: {
-                            color: (color)
-                        }
-                    });
+                    // Update the frame time data array
+                    let frames_shown_count: usize =
+                        (self.walk(cx).width.fixed_or_zero() / BAR_WIDTH) as usize;
+                    self.frame_time_data.push_back(time);
+                    while self.frame_time_data.len() >= frames_shown_count {
+                        self.frame_time_data.pop_front();
+                    }
+
+                    self.label(id!(frame_time))
+                        .set_text(&format!("{} ms", time));
+
                     self.redraw(cx);
                 }
             }
 
             self.next_frame = cx.new_next_frame();
         }
+    }
+
+    pub fn draw_walk(&mut self, cx: &mut Cx2d, walk: Walk) {
+        // Draw graph
+        let color_increment_lines = vec4(0.5, 0.5, 0.5, 1.);
+        let color_ok = vec4(0.4, 1.0, 0.4, 1.0);
+        let color_warning = vec4(0.9, 0.9, 0.4, 1.0);
+        let color_fatal = vec4(1.0, 0.2, 0.2, 1.0);
+
+        let graph_width = self.walk(cx).width.fixed_or_zero();
+        let graph_height = self.walk(cx).height.fixed_or_zero();
+        const MS_INCREMENTS: i64 = 16;
+
+        self.draw_graph.begin(cx, walk, Layout::default());
+
+        // draw increment lines
+        for i in 0..(graph_height as i64 / MS_INCREMENTS) {
+            self.draw_bar.color = color_increment_lines;
+            let rect = Rect {
+                pos: DVec2 {
+                    x: 0.,
+                    // + 1 to compensate the bar height
+                    y: -(i * MS_INCREMENTS - graph_height as i64) as f64,
+                },
+                size: DVec2 {
+                    x: graph_width,
+                    y: 1.,
+                },
+            };
+            self.draw_bar.draw_abs(cx, rect);
+        }
+
+        // graphing frame time data
+        let frame_time_data_clone = &self.frame_time_data.clone();
+        for (i, &time) in frame_time_data_clone.iter().enumerate() {
+            self.draw_bar.color = match time {
+                t if t < MS_INCREMENTS => color_ok,
+                t if t >= MS_INCREMENTS && t < MS_INCREMENTS * 2 => color_warning,
+                _ => color_fatal,
+            };
+
+            let rect = Rect {
+                pos: DVec2 {
+                    x: i as f64 * BAR_WIDTH,
+                    y: graph_height,
+                },
+                size: DVec2 {
+                    x: BAR_WIDTH,
+                    // Negative so it draws to the positive side of the y axis.
+                    y: -(time as f64) - 1.,
+                },
+            };
+            self.draw_bar.draw_abs(cx, rect);
+        }
+
+        self.draw_graph.end(cx);
     }
 }

--- a/widgets/src/performance_view.rs
+++ b/widgets/src/performance_view.rs
@@ -30,7 +30,6 @@ live_design! {
             width: Fill,
             height: Fill,
 
-
             <LabelBase> {
                 width: Fit
                 align: {x: 0., y: 1.}
@@ -40,7 +39,9 @@ live_design! {
                 }
                 text: "Frame time (max in last second)"
             }
+
             <View> { width: Fill, height: Fit }
+
             frame_time = <LabelBase> {
                 width: Fit
                 align: {x: 1., y: 1}
@@ -140,7 +141,6 @@ impl PerformanceView {
     }
 
     pub fn draw_walk(&mut self, cx: &mut Cx2d, walk: Walk) {
-        // Draw graph
         let color_increment_lines = vec4(0.5, 0.5, 0.5, 1.);
         let color_ok = vec4(0.4, 1.0, 0.4, 1.0);
         let color_warning = vec4(0.9, 0.9, 0.4, 1.0);
@@ -158,6 +158,7 @@ impl PerformanceView {
             let rect = Rect {
                 pos: DVec2 {
                     x: 0.,
+                    // Negative so it draws to the positive side of the y axis.
                     y: -(i * MS_INCREMENTS - graph_height as i64) as f64,
                 },
                 size: DVec2 {

--- a/widgets/src/performance_view.rs
+++ b/widgets/src/performance_view.rs
@@ -103,8 +103,8 @@ impl PerformanceView {
                 let prev_refresh_in = self.next_refresh_in;
                 self.next_refresh_in = ne.time + 0.5;
                 
-                if cx.performance.frame_times.len() > 0 {
-                    let last_sec_data = cx.performance.frame_times.iter().filter_map(|f|
+                if cx.performance_stats.frame_times.len() > 0 {
+                    let last_sec_data = cx.performance_stats.frame_times.iter().filter_map(|f|
                         if f.occurred_at >= prev_refresh_in - 0.5 {
                             Some((f.time_spent * 1000.) as u32)
                         } else {

--- a/widgets/src/performance_view.rs
+++ b/widgets/src/performance_view.rs
@@ -1,0 +1,135 @@
+use crate::{
+    widget::*,
+    makepad_draw::*,
+    view::*,
+    label::*
+};
+
+live_design!{
+    import makepad_draw::shader::std::*;  
+    import makepad_widgets::label::LabelBase;
+    import makepad_widgets::view::ViewBase;
+
+    REGULAR_TEXT = {
+        font_size: 10,
+        font: {path: dep("crate://makepad-widgets/resources/GoNotoKurrent-Regular.ttf")}
+    }
+
+    PerformanceView = {{PerformanceView}} {  
+        width: 160,
+        height: 90,
+
+        abs_pos: vec2(20, 40),
+
+        show_bg: true,
+        draw_bg: {
+            color: #f00
+        }
+
+        <ViewBase> {
+            visible: true
+            flow: Down
+            width: Fill,
+            height: Fill,
+
+            margin: 10,
+
+            <LabelBase> {
+                draw_text: {
+                    text_style: <REGULAR_TEXT>{},
+                    color: #111
+                }
+                text: "Frame time"
+            }
+            <LabelBase> {
+                draw_text: {
+                    text_style: <REGULAR_TEXT>{},
+                    color: #111
+                }
+                text: "(max in last second)"
+            }
+            frame_time = <LabelBase> {
+                align: {x: 1}
+                draw_text: {
+                    text_style: <REGULAR_TEXT>{font_size: 16},
+                    color: #111
+                }
+                text: "-"
+            }
+        }
+    }
+}
+
+#[derive(Live)]
+pub struct PerformanceView {
+    #[deref] view: View,
+    #[rust] next_frame: NextFrame,
+    #[rust] next_refresh_in: f64,
+}
+
+impl LiveHook for PerformanceView {
+    fn before_live_design(cx: &mut Cx) {
+        register_widget!(cx, PerformanceView);
+    }
+
+    fn after_new_from_doc(&mut self, cx: &mut Cx) {
+        self.next_frame = cx.new_next_frame();
+        self.next_refresh_in = 2.0;
+    }
+}
+
+impl Widget for PerformanceView {
+    fn redraw(&mut self, cx: &mut Cx) {
+        self.view.redraw(cx);
+    }
+
+    fn walk(&mut self, cx: &mut Cx) -> Walk {
+        self.view.walk(cx)
+    }
+
+    fn find_widgets(&mut self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet) {
+        self.view.find_widgets(path, cached, results);
+    }
+
+    fn draw_walk_widget(&mut self, cx: &mut Cx2d, walk: Walk) -> WidgetDraw {
+        self.view.draw_walk_widget(cx, walk)
+    }
+}
+
+impl PerformanceView {
+    pub fn handle_widget(&mut self, cx: &mut Cx, event: &Event) {
+        if let Some(ne) = self.next_frame.is_event(event) {
+            if self.next_refresh_in < ne.time {
+                let prev_refresh_in = self.next_refresh_in;
+                self.next_refresh_in = ne.time + 0.5;
+                
+                if cx.performance.frame_times.len() > 0 {
+                    let last_sec_data = cx.performance.frame_times.iter().filter_map(|f|
+                        if f.occurred_at >= prev_refresh_in - 0.5 {
+                            Some((f.time_spent * 1000.) as u32)
+                        } else {
+                            None
+                        }
+                    ).collect::<Vec<u32>>();
+
+                    let fps = last_sec_data.iter().max().unwrap();
+                    self.label(id!(frame_time)).set_text(&format!("{} ms", fps));
+                    
+                    let color = match fps {
+                        0..=16 => vec4(0.4, 1.0, 0.4, 1.0),
+                        17..=33 => vec4(0.9, 0.9, 0.4, 1.0),
+                        _ => vec4(1.0, 0.2, 0.2, 1.0)
+                    };
+                    self.view.apply_over(cx, live!{
+                        draw_bg: {
+                            color: (color)
+                        }
+                    });
+                    self.redraw(cx);
+                }
+            }
+
+            self.next_frame = cx.new_next_frame();
+        }
+    }
+}

--- a/widgets/src/performance_view.rs
+++ b/widgets/src/performance_view.rs
@@ -158,7 +158,6 @@ impl PerformanceView {
             let rect = Rect {
                 pos: DVec2 {
                     x: 0.,
-                    // + 1 to compensate the bar height
                     y: -(i * MS_INCREMENTS - graph_height as i64) as f64,
                 },
                 size: DVec2 {

--- a/widgets/src/performance_view.rs
+++ b/widgets/src/performance_view.rs
@@ -18,11 +18,12 @@ live_design! {
         data_increments: 16.
         bar_width: 3.
         graph_label: ""
-        data_y_subfix: ""
+        data_y_suffix: ""
 
         width: 300,
         height: 65,
 
+        margin: 30,
         abs_pos: vec2(0, 0)
 
         show_bg: true,
@@ -68,9 +69,8 @@ live_design! {
         abs_pos: vec2(0, 0)
 
         graph = <PerformanceLiveGraph> {
-            abs_pos: vec2(0, 20)
             graph_label: "Frame time (max in last second)"
-            data_y_subfix: "ms"
+            data_y_suffix: "ms"
         }
 
     }
@@ -156,7 +156,7 @@ pub struct PerformanceLiveGraph {
     #[live]
     data_increments: i64,
     #[live]
-    data_y_subfix: String,
+    data_y_suffix: String,
     #[live]
     graph_label: String,
 }
@@ -204,7 +204,7 @@ impl PerformanceLiveGraph {
         }
 
         self.label(id!(current_y_entry))
-            .set_text(&format!("{}{}", y_entry, self.data_y_subfix));
+            .set_text(&format!("{}{}", y_entry, self.data_y_suffix));
 
         self.redraw(cx);
     }

--- a/widgets/src/performance_view.rs
+++ b/widgets/src/performance_view.rs
@@ -1,5 +1,7 @@
 use std::collections::VecDeque;
 
+use makepad_derive_widget::WidgetRef;
+
 use crate::{label::*, makepad_draw::*, view::*, widget::*};
 
 live_design! {
@@ -12,37 +14,42 @@ live_design! {
         font: {path: dep("crate://makepad-widgets/resources/GoNotoKurrent-Regular.ttf")}
     }
 
-    PerformanceView = {{PerformanceView}} {
+    PerformanceLiveGraph = {{PerformanceLiveGraph}} {
+        data_increments: 16.
+        bar_width: 3.
+        graph_label: ""
+        data_y_subfix: ""
+
         width: 300,
         height: 65,
 
-        abs_pos: vec2(0, 20),
+        abs_pos: vec2(0, 0)
 
         show_bg: true,
         draw_bg: {
             color: vec4(0.8, 0.8, 0.8, 0.8)
         }
 
-        <ViewBase> {
+        view = <ViewBase> {
             margin: 5,
             visible: true
             flow: Right
             width: Fill,
             height: Fill,
 
-            <LabelBase> {
+            graph_label = <LabelBase> {
                 width: Fit
                 align: {x: 0., y: 1.}
                 draw_text: {
                     text_style: <REGULAR_TEXT>{font_size: 8},
                     color: #111
                 }
-                text: "Frame time (max in last second)"
+                text: ""
             }
 
             <ViewBase> { width: Fill, height: Fit }
 
-            frame_time = <LabelBase> {
+            current_y_entry = <LabelBase> {
                 width: Fit
                 align: {x: 1., y: 1}
                 draw_text: {
@@ -53,9 +60,21 @@ live_design! {
             }
         }
     }
-}
 
-const BAR_WIDTH: f64 = 3.;
+    PerformanceView = {{PerformanceView}} {
+        width: Fit,
+        height: Fit,
+
+        abs_pos: vec2(0, 0)
+
+        graph = <PerformanceLiveGraph> {
+            abs_pos: vec2(0, 20)
+            graph_label: "Frame time (max in last second)"
+            data_y_subfix: "ms"
+        }
+
+    }
+}
 
 #[derive(Live)]
 pub struct PerformanceView {
@@ -65,12 +84,6 @@ pub struct PerformanceView {
     next_frame: NextFrame,
     #[rust]
     next_refresh_at: f64,
-    #[live]
-    draw_graph: DrawColor,
-    #[live]
-    draw_bar: DrawColor,
-    #[rust]
-    frame_time_data: VecDeque<i64>,
 }
 
 impl LiveHook for PerformanceView {
@@ -85,6 +98,81 @@ impl LiveHook for PerformanceView {
 }
 
 impl Widget for PerformanceView {
+    fn redraw(&mut self, cx: &mut Cx) {
+        self.view.redraw(cx);
+    }
+
+    fn find_widgets(&mut self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet) {
+        self.view.find_widgets(path, cached, results);
+    }
+
+    fn walk(&mut self, cx: &mut Cx) -> Walk {
+        self.view.walk(cx)
+    }
+
+    fn draw_walk_widget(&mut self, cx: &mut Cx2d, walk: Walk) -> WidgetDraw {
+        let _ = self.view.draw_walk_widget(cx, walk);
+        WidgetDraw::done()
+    }
+}
+
+impl PerformanceView {
+    pub fn handle_widget(&mut self, cx: &mut Cx, event: &Event) {
+        if let Some(ne) = self.next_frame.is_event(event) {
+            if self.next_refresh_at < ne.time {
+                self.next_refresh_at = ne.time + 0.5;
+
+                if cx.performance_stats.max_frame_times.len() > 0 {
+                    // Data is stored in 100ms buckets, so we take the max of the last 10 buckets
+                    let last_sec_data = cx.performance_stats.max_frame_times.iter().take(10);
+                    let time = (last_sec_data
+                        .max_by(|a, b| a.time_spent.partial_cmp(&b.time_spent).unwrap())
+                        .unwrap()
+                        .time_spent
+                        * 1000.) as i64;
+
+                    self.performance_live_graph(id!(graph))
+                        .add_y_entry(cx, time);
+                }
+            }
+
+            self.next_frame = cx.new_next_frame();
+        }
+    }
+}
+
+#[derive(Live)]
+pub struct PerformanceLiveGraph {
+    #[deref]
+    view: View,
+    #[live]
+    draw_graph: DrawColor,
+    #[live]
+    draw_bar: DrawColor,
+    #[rust]
+    data: VecDeque<i64>,
+    #[live]
+    bar_width: f64,
+    #[live]
+    data_increments: i64,
+    #[live]
+    data_y_subfix: String,
+    #[live]
+    graph_label: String,
+}
+
+impl LiveHook for PerformanceLiveGraph {
+    fn before_live_design(cx: &mut Cx) {
+        register_widget!(cx, PerformanceLiveGraph);
+    }
+
+    fn after_new_from_doc(&mut self, _cx: &mut Cx) {
+        self.label(id!(graph_label))
+            .set_text(&format!("{}", self.graph_label));
+    }
+}
+
+impl Widget for PerformanceLiveGraph {
     fn redraw(&mut self, cx: &mut Cx) {
         self.view.redraw(cx);
         self.draw_graph.redraw(cx);
@@ -106,38 +194,19 @@ impl Widget for PerformanceView {
     }
 }
 
-impl PerformanceView {
-    pub fn handle_widget(&mut self, cx: &mut Cx, event: &Event) {
-        if let Some(ne) = self.next_frame.is_event(event) {
-            if self.next_refresh_at < ne.time {
-                self.next_refresh_at = ne.time + 0.5;
-
-                if cx.performance_stats.max_frame_times.len() > 0 {
-                    // Data is stored in 100ms buckets, so we take the max of the last 10 buckets
-                    let last_sec_data = cx.performance_stats.max_frame_times.iter().take(10);
-                    let time = (last_sec_data
-                        .max_by(|a, b| a.time_spent.partial_cmp(&b.time_spent).unwrap())
-                        .unwrap()
-                        .time_spent
-                        * 1000.0) as i64;
-
-                    // Update the frame time data array
-                    let frames_shown_count: usize =
-                        (self.walk(cx).width.fixed_or_zero() / BAR_WIDTH) as usize;
-                    self.frame_time_data.push_back(time);
-                    while self.frame_time_data.len() >= frames_shown_count {
-                        self.frame_time_data.pop_front();
-                    }
-
-                    self.label(id!(frame_time))
-                        .set_text(&format!("{} ms", time));
-
-                    self.redraw(cx);
-                }
-            }
-
-            self.next_frame = cx.new_next_frame();
+impl PerformanceLiveGraph {
+    pub fn add_y_entry(&mut self, cx: &mut Cx, y_entry: i64) {
+        let frames_shown_count: usize =
+            (self.walk(cx).width.fixed_or_zero() / self.bar_width) as usize;
+        self.data.push_back(y_entry);
+        while self.data.len() >= frames_shown_count {
+            self.data.pop_front();
         }
+
+        self.label(id!(current_y_entry))
+            .set_text(&format!("{}{}", y_entry, self.data_y_subfix));
+
+        self.redraw(cx);
     }
 
     pub fn draw_walk(&mut self, cx: &mut Cx2d, walk: Walk) {
@@ -148,50 +217,66 @@ impl PerformanceView {
 
         let graph_width = self.walk(cx).width.fixed_or_zero();
         let graph_height = self.walk(cx).height.fixed_or_zero();
-        const MS_INCREMENTS: i64 = 16;
+        let graph_zero_baseline = graph_height - 20.;
+
+        self.label(id!(graph_label))
+            .set_text(&format!("{}", self.graph_label));
 
         self.draw_graph.begin(cx, walk, Layout::default());
 
         // draw increment lines
-        for i in 0..(graph_height as i64 / MS_INCREMENTS) {
-            self.draw_bar.color = color_increment_lines;
-            let rect = Rect {
-                pos: DVec2 {
-                    x: 0.,
-                    // Negative so it draws to the positive side of the y axis.
-                    y: -(i * MS_INCREMENTS - graph_height as i64) as f64,
-                },
-                size: DVec2 {
-                    x: graph_width,
-                    y: 1.,
-                },
-            };
-            self.draw_bar.draw_abs(cx, rect);
+        if self.data_increments > 0 {
+            for i in 0..(graph_height as i64 / self.data_increments) {
+                self.draw_bar.color = color_increment_lines;
+                let rect = Rect {
+                    pos: DVec2 {
+                        x: 0.,
+                        // Negative so it draws to the positive side of the y axis.
+                        y: -(i * self.data_increments - graph_zero_baseline as i64) as f64,
+                    },
+                    size: DVec2 {
+                        x: graph_width,
+                        y: 1.,
+                    },
+                };
+                self.draw_bar.draw_rel(cx, rect);
+            }
         }
 
-        // graphing frame time data
-        let frame_time_data_clone = &self.frame_time_data.clone();
-        for (i, &time) in frame_time_data_clone.iter().enumerate() {
-            self.draw_bar.color = match time {
-                t if t < MS_INCREMENTS => color_ok,
-                t if t >= MS_INCREMENTS && t < MS_INCREMENTS * 2 => color_warning,
+        // graphing data
+        for (i, &y_entry) in self.data.iter().enumerate() {
+            self.draw_bar.color = match y_entry {
+                t if t < self.data_increments => color_ok,
+                t if t >= self.data_increments && t < self.data_increments * 2 => color_warning,
                 _ => color_fatal,
             };
 
             let rect = Rect {
                 pos: DVec2 {
-                    x: i as f64 * BAR_WIDTH,
-                    y: graph_height,
+                    x: i as f64 * self.bar_width,
+                    y: graph_zero_baseline,
                 },
                 size: DVec2 {
-                    x: BAR_WIDTH,
+                    x: self.bar_width,
                     // Negative so it draws to the positive side of the y axis.
-                    y: -(time as f64) - 1.,
+                    y: -(y_entry as f64) - 1.,
                 },
             };
-            self.draw_bar.draw_abs(cx, rect);
+
+            self.draw_bar.draw_rel(cx, rect);
         }
 
         self.draw_graph.end(cx);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, WidgetRef)]
+pub struct PerformanceLiveGraphRef(WidgetRef);
+
+impl PerformanceLiveGraphRef {
+    pub fn add_y_entry(&mut self, cx: &mut Cx, y_entry: i64) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.add_y_entry(cx, y_entry);
+        }
     }
 }

--- a/widgets/src/performance_view.rs
+++ b/widgets/src/performance_view.rs
@@ -40,7 +40,7 @@ live_design! {
                 text: "Frame time (max in last second)"
             }
 
-            <View> { width: Fill, height: Fit }
+            <ViewBase> { width: Fill, height: Fit }
 
             frame_time = <LabelBase> {
                 width: Fit

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -1,6 +1,7 @@
 use crate::{
     makepad_derive_widget::*,
     debug_view::DebugView,
+    performance_view::PerformanceView,
     makepad_draw::*,
     nav_control::NavControl,
     button::*,
@@ -22,6 +23,7 @@ pub struct Window {
     #[live] cursor_draw_list: DrawList2d,
     #[live] draw_cursor: DrawQuad,
     #[live] debug_view: DebugView,
+    #[live] performance_view: PerformanceView,
     #[live] nav_control: NavControl,
     #[live] window: WindowHandle,
     #[live] stdin_size: DrawColor,
@@ -30,6 +32,7 @@ pub struct Window {
     #[live] pass: Pass,
     #[rust(Texture::new(cx))] depth_texture: Texture,
     #[live] hide_caption_on_fullscreen: bool, 
+    #[live] show_performance_view: bool,
     #[deref] view: View,
     // #[rust(WindowMenu::new(cx))] _window_menu: WindowMenu,
     /*#[rust(Menu::main(vec![
@@ -117,8 +120,11 @@ pub enum WindowAction {
 
 impl Window {
     pub fn handle_event_with(&mut self, cx: &mut Cx, event: &Event, dispatch_action: &mut dyn FnMut(&mut Cx, WindowAction)) {
-        
         self.debug_view.handle_event(cx, event);
+        if self.show_performance_view {
+            self.performance_view.handle_widget(cx, event);
+        }
+
         self.nav_control.handle_event(cx, event, self.main_draw_list.draw_list_id());
         self.overlay.handle_event(cx, event);
         if self.demo_next_frame.is_event(event).is_some(){
@@ -277,7 +283,11 @@ impl Window {
             self.stdin_size.color = encode_size(size.y);
             self.stdin_size.draw_abs(cx, Rect{pos:dvec2(1.0/df,0.0),size:dvec2(1.0/df,1.0/df)});
         }
-        
+
+        if self.show_performance_view {
+            self.performance_view.draw_widget(cx);
+        }
+
         cx.end_pass_sized_turtle();
         
         self.main_draw_list.end(cx);


### PR DESCRIPTION
This is the initial implementation for an in-app Performance View widget.

Usage:

```
App = {{App}} {
        ui: <Window> {
            window: {position: vec2(0, 0), inner_size:...},
            pass: {clear_color: #2A}
            
            // Add this line!
            show_performance_view: true,

            body = {
                ...
            }
        }
    }
```

<img width="369" alt="image" src="https://github.com/makepad/makepad/assets/487140/33fcda3a-ea63-4aaa-9bb2-d59e5b593f30">
