### PR TITLE
Fixed an issue where the "hover out" message could not be triggered when the mouse moved out of the window.

### DIFF
--- a/platform/src/event/event.rs
+++ b/platform/src/event/event.rs
@@ -51,6 +51,7 @@ pub enum Event {
     MouseDown(MouseDownEvent),
     MouseMove(MouseMoveEvent),
     MouseUp(MouseUpEvent),
+    MouseLeave(MouseLeaveEvent),
     TouchUpdate(TouchUpdateEvent),
     Scroll(ScrollEvent), // this is the MouseWheel / touch scroll event sent by the OS
     

--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -70,6 +70,15 @@ pub struct MouseUpEvent {
 }
 
 #[derive(Clone, Debug)]
+pub struct MouseLeaveEvent {
+    pub abs: DVec2,
+    pub window_id: WindowId,
+    pub modifiers: KeyModifiers,
+    pub time: f64,
+    pub handled: Cell<Area>,
+}
+
+#[derive(Clone, Debug)]
 pub struct ScrollEvent {
     pub window_id: WindowId,
     pub scroll: DVec2,

--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -1024,6 +1024,29 @@ impl Event {
                     return event
                 }
             },
+            Event::MouseLeave(e) => {
+                if cx.fingers.test_sweep_lock(options.sweep_area) {
+                    return Hit::Nothing;
+                }
+                let device = DigitDevice::Mouse { button: 0 };
+                let digit_id = live_id!(mouse).into();
+                let rect = area.get_clipped_rect(&cx);
+                let hover_last = cx.fingers.get_hover_area(digit_id);
+                let handled_area = e.handled.get();
+                
+                let fhe = FingerHoverEvent {
+                    window_id: e.window_id,
+                    abs: e.abs,
+                    digit_id,
+                    device,
+                    modifiers: e.modifiers.clone(),
+                    time: e.time,
+                    rect,
+                };
+                if hover_last == area {
+                    return Hit::FingerHoverOut(fhe);
+                }
+            },
             _ => ()
         };
         Hit::Nothing

--- a/platform/src/os/windows/win32_event.rs
+++ b/platform/src/os/windows/win32_event.rs
@@ -5,6 +5,7 @@ use {
             MouseDownEvent,
             MouseUpEvent,
             MouseMoveEvent,
+            MouseLeaveEvent,
             ScrollEvent,
             WindowGeomChangeEvent,
             WindowDragQueryEvent,
@@ -33,6 +34,7 @@ pub enum Win32Event {
     MouseDown(MouseDownEvent),
     MouseUp(MouseUpEvent),
     MouseMove(MouseMoveEvent),
+    MouseLeave(MouseLeaveEvent),
     Scroll(ScrollEvent),
     
     WindowDragQuery(WindowDragQueryEvent),

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -501,7 +501,7 @@ impl Win32Window {
                     return LRESULT(0)
                 }
                 window.track_mouse_event = false;
-                window.send_mouse_move(
+                window.send_mouse_leave(
                     window.last_mouse_pos,
                     Self::get_key_modifiers()
                 );
@@ -1030,6 +1030,17 @@ impl Win32Window {
     pub fn send_mouse_move(&mut self, pos: DVec2, modifiers: KeyModifiers) {
         self.last_mouse_pos = pos;
         self.do_callback(Win32Event::MouseMove(MouseMoveEvent {
+            window_id: self.window_id,
+            abs: pos,
+            modifiers: modifiers,
+            time: self.time_now(),
+            handled: Cell::new(Area::Empty),
+        }));
+    }
+
+    pub fn send_mouse_leave(&mut self, pos: DVec2, modifiers: KeyModifiers) {
+        self.last_mouse_pos = pos;
+        self.do_callback(Win32Event::MouseLeave(MouseLeaveEvent {
             window_id: self.window_id,
             abs: pos,
             modifiers: modifiers,

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -163,6 +163,11 @@ impl Cx {
                 self.fingers.mouse_up(button);
                 self.fingers.cycle_hover_area(live_id!(mouse).into());
             }
+            Win32Event::MouseLeave(e) => {
+                self.call_event_handler(&Event::MouseLeave(e.into()));
+                self.fingers.cycle_hover_area(live_id!(mouse).into());
+                self.fingers.switch_captures();
+            }
             Win32Event::Scroll(e) => {
                 self.call_event_handler(&Event::Scroll(e.into()))
             }


### PR DESCRIPTION
When the mouse moved in and out of the window, I found that the mouse icon was not displayed properly.