### PR TITLE
Video Player API Improvements

### DIFF
--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -78,7 +78,7 @@ pub enum CxOsOp {
     PrepareVideoPlayback(LiveId, VideoSource, u32, bool, bool),
     PauseVideoPlayback(LiveId),
     ResumeVideoPlayback(LiveId),
-    EndVideoPlayback(LiveId),
+    CleanupVideoPlaybackResources(LiveId),
     UpdateVideoSurfaceTexture(LiveId),
 }
 
@@ -446,8 +446,8 @@ impl Cx {
         self.platform_ops.push(CxOsOp::ResumeVideoPlayback(video_id));
     }
 
-    pub fn end_video_playback(&mut self, video_id: LiveId) {
-        self.platform_ops.push(CxOsOp::EndVideoPlayback(video_id));
+    pub fn cleanup_video_playback_resources(&mut self, video_id: LiveId) {
+        self.platform_ops.push(CxOsOp::CleanupVideoPlaybackResources(video_id));
     }
 
     pub fn println_resources(&self){

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -78,6 +78,8 @@ pub enum CxOsOp {
     PrepareVideoPlayback(LiveId, VideoSource, u32, bool, bool),
     PauseVideoPlayback(LiveId),
     ResumeVideoPlayback(LiveId),
+    MuteVideoPlayback(LiveId),
+    UnmuteVideoPlayback(LiveId),
     CleanupVideoPlaybackResources(LiveId),
     UpdateVideoSurfaceTexture(LiveId),
 }
@@ -444,6 +446,14 @@ impl Cx {
 
     pub fn resume_video_playback(&mut self, video_id: LiveId) {
         self.platform_ops.push(CxOsOp::ResumeVideoPlayback(video_id));
+    }
+
+    pub fn mute_video_playback(&mut self, video_id: LiveId) {
+        self.platform_ops.push(CxOsOp::MuteVideoPlayback(video_id));
+    }
+
+    pub fn unmute_video_playback(&mut self, video_id: LiveId) {
+        self.platform_ops.push(CxOsOp::UnmuteVideoPlayback(video_id));
     }
 
     pub fn cleanup_video_playback_resources(&mut self, video_id: LiveId) {

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -75,7 +75,7 @@ pub enum CxOsOp {
 
     HttpRequest{request_id: LiveId, request:HttpRequest},
 
-    PrepareVideoPlayback(LiveId, VideoSource, u32, bool, bool, bool),
+    PrepareVideoPlayback(LiveId, VideoSource, u32, bool, bool),
     PauseVideoPlayback(LiveId),
     ResumeVideoPlayback(LiveId),
     EndVideoPlayback(LiveId),
@@ -434,8 +434,8 @@ impl Cx {
         });
     }
 */
-    pub fn prepare_video_playback(&mut self, video_id: LiveId, source: VideoSource, external_texture_id: u32, autoplay: bool, should_loop: bool, pause_on_first_frame: bool) {
-        self.platform_ops.push(CxOsOp::PrepareVideoPlayback(video_id, source, external_texture_id, autoplay, should_loop, pause_on_first_frame));
+    pub fn prepare_video_playback(&mut self, video_id: LiveId, source: VideoSource, external_texture_id: u32, autoplay: bool, should_loop: bool) {
+        self.platform_ops.push(CxOsOp::PrepareVideoPlayback(video_id, source, external_texture_id, autoplay, should_loop));
     }
 
     pub fn pause_video_playback(&mut self, video_id: LiveId) {

--- a/platform/src/event/event.rs
+++ b/platform/src/event/event.rs
@@ -80,6 +80,7 @@ pub enum Event {
     VideoPlaybackPrepared(VideoPlaybackPreparedEvent),
     VideoTextureUpdated(VideoTextureUpdatedEvent),
     VideoPlaybackCompleted(VideoPlaybackCompletedEvent),
+    VideoPlaybackResourcesReleased(VideoPlaybackResourcesReleasedEvent),
     VideoDecodingError(VideoDecodingErrorEvent),
     TextureHandleReady(TextureHandleReadyEvent),
  
@@ -142,10 +143,11 @@ impl Event{
             41=>"VideoTextureUpdated",
             42=>"VideoPlaybackCompleted",
             43=>"VideoDecodingError",
+            44=>"VideoPlaybackResourcesReleased",
              
             #[cfg(target_arch = "wasm32")]
-            44=>"ToWasmMsg",
-            45=>"MouseLeave",
+            45=>"ToWasmMsg",
+            46=>"MouseLeave",
             _=>panic!()
         }
     }
@@ -204,11 +206,12 @@ impl Event{
             Self::VideoTextureUpdated(_)=>41,
             Self::VideoPlaybackCompleted(_)=>42,
             Self::VideoDecodingError(_)=>43,
-            Self::TextureHandleReady(_)=>44,
-            Self::MouseLeave(_)=>45,
+            Self::VideoPlaybackResourcesReleased(_)=>44,
+            Self::TextureHandleReady(_)=>45,
+            Self::MouseLeave(_)=>46,
                                      
             #[cfg(target_arch = "wasm32")]
-            Self::ToWasmMsg(_)=>46,
+            Self::ToWasmMsg(_)=>47,
         }
     }
 }

--- a/platform/src/event/video_playback.rs
+++ b/platform/src/event/video_playback.rs
@@ -29,6 +29,11 @@ pub struct VideoPlaybackCompletedEvent {
 }
 
 #[derive(Clone, Debug)]
+pub struct VideoPlaybackResourcesReleasedEvent {
+    pub video_id: LiveId
+}
+
+#[derive(Clone, Debug)]
 pub struct VideoDecodingErrorEvent {
     pub video_id: LiveId,
     pub error: String,

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -314,7 +314,7 @@ impl Cx {
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
-                CxOsOp::EndVideoPlayback(_) => todo!(),
+                CxOsOp::CleanupVideoPlaybackResources(_) => todo!(),
                 CxOsOp::UpdateVideoSurfaceTexture(_) => todo!(),
             }
         }

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -311,7 +311,7 @@ impl Cx {
                 CxOsOp::ShowClipboardActions(_request) => {
                     crate::log!("Show clipboard actions not supported yet");
                 }
-                CxOsOp::PrepareVideoPlayback(_, _, _, _, _, _) => todo!(),
+                CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
                 CxOsOp::EndVideoPlayback(_) => todo!(),

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -314,6 +314,8 @@ impl Cx {
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
+                CxOsOp::MuteVideoPlayback(_) => todo!(),
+                CxOsOp::UnmuteVideoPlayback(_) => todo!(),
                 CxOsOp::CleanupVideoPlaybackResources(_) => todo!(),
                 CxOsOp::UpdateVideoSurfaceTexture(_) => todo!(),
             }

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -528,7 +528,7 @@ impl Cx {
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
-                CxOsOp::EndVideoPlayback(_) => todo!(),
+                CxOsOp::CleanupVideoPlaybackResources(_) => todo!(),
                 CxOsOp::UpdateVideoSurfaceTexture(_) => todo!(),
             }
         }

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -528,6 +528,8 @@ impl Cx {
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
+                CxOsOp::MuteVideoPlayback(_) => todo!(),
+                CxOsOp::UnmuteVideoPlayback(_) => todo!(),
                 CxOsOp::CleanupVideoPlaybackResources(_) => todo!(),
                 CxOsOp::UpdateVideoSurfaceTexture(_) => todo!(),
             }

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -525,7 +525,7 @@ impl Cx {
                 CxOsOp::WebSocketSendString {request_id: _, data: _} => {
                     todo!()
                 }*/
-                CxOsOp::PrepareVideoPlayback(_, _, _, _, _, _) => todo!(),
+                CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
                 CxOsOp::EndVideoPlayback(_) => todo!(),

--- a/platform/src/os/apple/tvos/tvos.rs
+++ b/platform/src/os/apple/tvos/tvos.rs
@@ -262,10 +262,11 @@ impl Cx {
                 CxOsOp::ShowClipboardActions(_request) => {
                     crate::log!("Show clipboard actions not supported yet");
                 }
-                CxOsOp::InitializeVideoDecoding(_, _,) => todo!(),
-                CxOsOp::DecodeNextVideoChunk(_, _) => todo!(),
-                CxOsOp::FetchNextVideoFrames(_, _) => todo!(),
-                CxOsOp::CleanupVideoDecoding(_) => todo!(),
+                CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
+                CxOsOp::PauseVideoPlayback(_) => todo!(),
+                CxOsOp::ResumeVideoPlayback(_) => todo!(),
+                CxOsOp::EndVideoPlayback(_) => todo!(),
+                CxOsOp::UpdateVideoSurfaceTexture(_) => todo!(),
             }
         }
     }

--- a/platform/src/os/apple/tvos/tvos.rs
+++ b/platform/src/os/apple/tvos/tvos.rs
@@ -265,6 +265,8 @@ impl Cx {
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
+                CxOsOp::MuteVideoPlayback(_) => todo!(),
+                CxOsOp::UnmuteVideoPlayback(_) => todo!(),
                 CxOsOp::CleanupVideoPlaybackResources(_) => todo!(),
                 CxOsOp::UpdateVideoSurfaceTexture(_) => todo!(),
             }

--- a/platform/src/os/apple/tvos/tvos.rs
+++ b/platform/src/os/apple/tvos/tvos.rs
@@ -265,7 +265,7 @@ impl Cx {
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
-                CxOsOp::EndVideoPlayback(_) => todo!(),
+                CxOsOp::CleanupVideoPlaybackResources(_) => todo!(),
                 CxOsOp::UpdateVideoSurfaceTexture(_) => todo!(),
             }
         }

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -687,10 +687,10 @@ impl Cx {
                 CxOsOp::HttpRequest {request_id, request} => {
                     unsafe {android_jni::to_java_http_request(request_id, request);}
                 },
-                CxOsOp::PrepareVideoPlayback(video_id, source, external_texture_id, autoplay, should_loop, pause_on_first_frame) => {
+                CxOsOp::PrepareVideoPlayback(video_id, source, external_texture_id, autoplay, should_loop) => {
                     unsafe {
                         let env = attach_jni_env();
-                        android_jni::to_java_prepare_video_playback(env, video_id, source, external_texture_id, autoplay, should_loop, pause_on_first_frame);
+                        android_jni::to_java_prepare_video_playback(env, video_id, source, external_texture_id, autoplay, should_loop);
                     }
                 },
                 CxOsOp::PauseVideoPlayback(video_id) => {

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -46,6 +46,7 @@ use {
             VideoTextureUpdatedEvent,
             VideoDecodingErrorEvent,
             VideoPlaybackCompletedEvent,
+            VideoPlaybackResourcesReleasedEvent,
             HttpRequest,
             HttpMethod,
         },
@@ -310,7 +311,16 @@ impl Cx {
                             }
                         );
                         self.call_event_handler(&e);
-                    }
+                    },
+                    FromJavaMessage::VideoPlayerReleased {video_id} => {
+                        self.os.video_surfaces.remove(&LiveId(video_id));
+                        let e = Event::VideoPlaybackResourcesReleased(
+                            VideoPlaybackResourcesReleasedEvent {
+                                video_id: LiveId(video_id)
+                            }
+                        );
+                        self.call_event_handler(&e);
+                    },
                     FromJavaMessage::VideoDecodingError {video_id, error} => {
                         let e = Event::VideoDecodingError(
                             VideoDecodingErrorEvent {

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -715,10 +715,10 @@ impl Cx {
                         android_jni::to_java_resume_video_playback(env, video_id);
                     }
                 },
-                CxOsOp::EndVideoPlayback(video_id) => {
+                CxOsOp::CleanupVideoPlaybackResources(video_id) => {
                     unsafe {
                         let env = attach_jni_env();
-                        android_jni::to_java_end_video_playback(env, video_id);
+                        android_jni::to_java_cleanup_video_playback_resources(env, video_id);
                     }
                 },
                 _ => ()

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -715,6 +715,18 @@ impl Cx {
                         android_jni::to_java_resume_video_playback(env, video_id);
                     }
                 },
+                CxOsOp::MuteVideoPlayback(video_id) => {
+                    unsafe {
+                        let env = attach_jni_env();
+                        android_jni::to_java_mute_video_playback(env, video_id);
+                    }
+                },
+                CxOsOp::UnmuteVideoPlayback(video_id) => {
+                    unsafe {
+                        let env = attach_jni_env();
+                        android_jni::to_java_unmute_video_playback(env, video_id);
+                    }
+                },
                 CxOsOp::CleanupVideoPlaybackResources(video_id) => {
                     unsafe {
                         let env = attach_jni_env();

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -750,11 +750,11 @@ pub unsafe fn to_java_resume_video_playback(env: *mut jni_sys::JNIEnv, video_id:
     );
 }    
 
-pub unsafe fn to_java_end_video_playback(env: *mut jni_sys::JNIEnv, video_id: LiveId) {
+pub unsafe fn to_java_cleanup_video_playback_resources(env: *mut jni_sys::JNIEnv, video_id: LiveId) {
     ndk_utils::call_void_method!(
         env,
         ACTIVITY,
-        "endVideoPlayback",
+        "cleanupVideoPlaybackResources",
         "(J)V",
         video_id
     );

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -738,7 +738,7 @@ pub unsafe fn to_java_pause_video_playback(env: *mut jni_sys::JNIEnv, video_id: 
         "(J)V",
         video_id
     );
-}    
+}
 
 pub unsafe fn to_java_resume_video_playback(env: *mut jni_sys::JNIEnv, video_id: LiveId) {
     ndk_utils::call_void_method!(
@@ -748,7 +748,27 @@ pub unsafe fn to_java_resume_video_playback(env: *mut jni_sys::JNIEnv, video_id:
         "(J)V",
         video_id
     );
-}    
+}
+
+pub unsafe fn to_java_mute_video_playback(env: *mut jni_sys::JNIEnv, video_id: LiveId) {
+    ndk_utils::call_void_method!(
+        env,
+        ACTIVITY,
+        "muteVideoPlayback",
+        "(J)V",
+        video_id
+    );
+}
+
+pub unsafe fn to_java_unmute_video_playback(env: *mut jni_sys::JNIEnv, video_id: LiveId) {
+    ndk_utils::call_void_method!(
+        env,
+        ACTIVITY,
+        "unmuteVideoPlayback",
+        "(J)V",
+        video_id
+    );
+}
 
 pub unsafe fn to_java_cleanup_video_playback_resources(env: *mut jni_sys::JNIEnv, video_id: LiveId) {
     ndk_utils::call_void_method!(

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -662,7 +662,7 @@ pub fn to_java_open_all_midi_devices(delay: jni_sys::jlong) {
     }  
 }
 
-pub unsafe fn to_java_prepare_video_playback(env: *mut jni_sys::JNIEnv, video_id: LiveId, source: VideoSource, external_texture_handle: u32, autoplay: bool, should_loop: bool, pause_on_first_frame: bool) {
+pub unsafe fn to_java_prepare_video_playback(env: *mut jni_sys::JNIEnv, video_id: LiveId, source: VideoSource, external_texture_handle: u32, autoplay: bool, should_loop: bool) {
     let video_source = match source {
         VideoSource::InMemory(data) => {
             let source = &*data;
@@ -689,13 +689,12 @@ pub unsafe fn to_java_prepare_video_playback(env: *mut jni_sys::JNIEnv, video_id
         env,
         ACTIVITY,
         "prepareVideoPlayback",
-        "(JLjava/lang/Object;IZZZ)V",
+        "(JLjava/lang/Object;IZZ)V",
         video_id.get_value() as jni_sys::jlong,
         video_source,
         external_texture_handle as jni_sys::jint,
         autoplay as jni_sys::jboolean as std::ffi::c_uint,
-        should_loop as jni_sys::jboolean as std::ffi::c_uint,
-        pause_on_first_frame as jni_sys::jboolean as std::ffi::c_uint
+        should_loop as jni_sys::jboolean as std::ffi::c_uint
     );
 }
 

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -100,6 +100,9 @@ pub enum FromJavaMessage {
     VideoPlaybackCompleted {
         video_id: u64,
     },
+    VideoPlayerReleased {
+        video_id: u64,
+    },
     VideoDecodingError {
         video_id: u64,
         error: String,
@@ -456,6 +459,18 @@ pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onVideoPlaybackC
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onVideoPlayerReleased(
+    _env: *mut jni_sys::JNIEnv,
+    _: jni_sys::jobject,
+    video_id: jni_sys::jlong,
+) {
+    send_from_java_message(FromJavaMessage::VideoPlayerReleased {
+        video_id: video_id as u64,
+    });
+}
+
+
+#[no_mangle]
 pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onVideoDecodingError(
     env: *mut jni_sys::JNIEnv,
     _: jni_sys::jobject,
@@ -710,6 +725,8 @@ pub unsafe fn to_java_update_tex_image(env: *mut jni_sys::JNIEnv, video_decoder_
     );
 
     let updated = (**env).CallBooleanMethod.unwrap()(env, video_decoder_ref, mid_update_tex_image);
+    (**env).DeleteLocalRef.unwrap()(env, class);
+
     updated != 0
 }
 

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -195,14 +195,16 @@ impl Cx {
                         if cxtexture.format.is_vec(){
                             cxtexture.update_vec_texture();
                         } else if cxtexture.format.is_video() {
-                            cxtexture.update_video_texture();
-                            let e = Event::TextureHandleReady(
-                                TextureHandleReadyEvent {
-                                    texture_id,
-                                    handle: cxtexture.os.gl_texture.unwrap()
-                                }
-                            );
-                            to_dispatch.push(e);
+                            let is_initial_setup = cxtexture.setup_video_texture();
+                            if is_initial_setup {
+                                let e = Event::TextureHandleReady(
+                                    TextureHandleReadyEvent {
+                                        texture_id,
+                                        handle: cxtexture.os.gl_texture.unwrap()
+                                    }
+                                );
+                                to_dispatch.push(e);
+                            }
                         }
                     }
                     for i in 0..sh.mapping.textures.len() {
@@ -984,7 +986,7 @@ impl CxTexture {
         }
     }
 
-    pub fn update_video_texture(&mut self) {
+    pub fn setup_video_texture(&mut self) -> bool {
         while unsafe { gl_sys::GetError() } != 0 {}
 
         if self.alloc_video(){
@@ -1010,7 +1012,9 @@ impl CxTexture {
 
                 assert_eq!(gl_sys::GetError(), 0, "UPDATE VIDEO TEXTURE ERROR {}", self.os.gl_texture.unwrap());
             }
+            return true;
         }
+        false
     }
     
     pub fn update_render_target(&mut self, width: usize, height: usize) {

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -324,7 +324,7 @@ impl Cx {
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
-                CxOsOp::EndVideoPlayback(_) => todo!(),
+                CxOsOp::CleanupVideoPlaybackResources(_) => todo!(),
                 CxOsOp::UpdateVideoSurfaceTexture(_) => todo!(),
             }
         }

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -321,7 +321,7 @@ impl Cx {
                 CxOsOp::HttpRequest{request_id:_, request:_} => {
                     todo!()
                 },
-                CxOsOp::PrepareVideoPlayback(_, _, _, _, _, _) => todo!(),
+                CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
                 CxOsOp::EndVideoPlayback(_) => todo!(),

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -324,6 +324,8 @@ impl Cx {
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
+                CxOsOp::MuteVideoPlayback(_) => todo!(),
+                CxOsOp::UnmuteVideoPlayback(_) => todo!(),
                 CxOsOp::CleanupVideoPlaybackResources(_) => todo!(),
                 CxOsOp::UpdateVideoSurfaceTexture(_) => todo!(),
             }

--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -494,7 +494,7 @@ impl Cx {
                         data
                     });
                 },*/
-                CxOsOp::PrepareVideoPlayback(_, _, _, _, _, _) => todo!(),
+                CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
                 CxOsOp::EndVideoPlayback(_) => todo!(),

--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -497,7 +497,7 @@ impl Cx {
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
-                CxOsOp::EndVideoPlayback(_) => todo!(),
+                CxOsOp::CleanupVideoPlaybackResources(_) => todo!(),
                 CxOsOp::UpdateVideoSurfaceTexture(_) => todo!(),
             }
         }

--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -497,6 +497,8 @@ impl Cx {
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
+                CxOsOp::MuteVideoPlayback(_) => todo!(),
+                CxOsOp::UnmuteVideoPlayback(_) => todo!(),
                 CxOsOp::CleanupVideoPlaybackResources(_) => todo!(),
                 CxOsOp::UpdateVideoSurfaceTexture(_) => todo!(),
             }

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -367,7 +367,7 @@ impl Cx {
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
-                CxOsOp::EndVideoPlayback(_) => todo!(),
+                CxOsOp::CleanupVideoPlaybackResources(_) => todo!(),
                 CxOsOp::UpdateVideoSurfaceTexture(_) => todo!(),
             }
         }

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -367,6 +367,8 @@ impl Cx {
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
+                CxOsOp::MuteVideoPlayback(_) => todo!(),
+                CxOsOp::UnmuteVideoPlayback(_) => todo!(),
                 CxOsOp::CleanupVideoPlaybackResources(_) => todo!(),
                 CxOsOp::UpdateVideoSurfaceTexture(_) => todo!(),
             }

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -364,7 +364,7 @@ impl Cx {
                 CxOsOp::HttpRequest {request_id: _, request: _} => {
                     //todo!()
                 },
-                CxOsOp::PrepareVideoPlayback(_, _, _, _, _, _) => todo!(),
+                CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
                 CxOsOp::EndVideoPlayback(_) => todo!(),

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -504,13 +504,12 @@ MidiManager.OnDeviceOpenedListener{
         }
     }
 
-    public void prepareVideoPlayback(long videoId, Object source, int externalTextureHandle, boolean autoplay, boolean shouldLoop, boolean pauseFirstFrame) {
+    public void prepareVideoPlayback(long videoId, Object source, int externalTextureHandle, boolean autoplay, boolean shouldLoop) {
         VideoPlayer VideoPlayer = new VideoPlayer(this, videoId);
         VideoPlayer.setSource(source);
         VideoPlayer.setExternalTextureHandle(externalTextureHandle);
         VideoPlayer.setAutoplay(autoplay);
         VideoPlayer.setShouldLoop(shouldLoop);
-        VideoPlayer.setPauseFirstFrame(pauseFirstFrame);
         VideoPlayerRunnable runnable = new VideoPlayerRunnable(VideoPlayer);
 
         mVideoPlayerRunnables.put(videoId, runnable);

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -530,10 +530,10 @@ MidiManager.OnDeviceOpenedListener{
         }
     }
 
-    public void endVideoPlayback(long videoId) {
+    public void cleanupVideoPlaybackResources(long videoId) {
         VideoPlayerRunnable runnable = mVideoPlayerRunnables.remove(videoId);
         if(runnable != null) {
-            runnable.endPlayback();
+            runnable.cleanupVideoPlaybackResources();
         }
     }
 }

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -530,6 +530,20 @@ MidiManager.OnDeviceOpenedListener{
         }
     }
 
+    public void muteVideoPlayback(long videoId) {
+        VideoPlayerRunnable runnable = mVideoPlayerRunnables.get(videoId);
+        if(runnable != null) {
+            runnable.mute();
+        }
+    }
+
+    public void unmuteVideoPlayback(long videoId) {
+        VideoPlayerRunnable runnable = mVideoPlayerRunnables.get(videoId);
+        if(runnable != null) {
+            runnable.unmute();
+        }
+    }
+
     public void cleanupVideoPlaybackResources(long videoId) {
         VideoPlayerRunnable runnable = mVideoPlayerRunnables.remove(videoId);
         if(runnable != null) {

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
@@ -38,5 +38,6 @@ public class MakepadNative {
     // video playback
     public static native void onVideoPlaybackPrepared(long videoId, int videoWidth, int videoHeight, long duration, VideoPlayer surfaceTexture);
     public static native void onVideoPlaybackCompleted(long videoId);
+    public static native void onVideoPlayerReleased(long videoId);
     public static native void onVideoDecodingError(long videoId, String error);
 }

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayer.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayer.java
@@ -138,6 +138,12 @@ public class VideoPlayer {
     public void endPlayback() {
         mMediaPlayer.stop();
         mMediaPlayer.release();
+        Activity activity = mActivityReference.get();
+        if (activity != null) {
+            activity.runOnUiThread(() -> {
+                MakepadNative.onVideoPlayerReleased(mVideoId);
+            });
+        }
     }
 
     public void setExternalTextureHandle(int textureHandle) {

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayer.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayer.java
@@ -135,6 +135,19 @@ public class VideoPlayer {
         }
     }
 
+    public void mute() {
+        if (mMediaPlayer != null) {
+            mMediaPlayer.setVolume(0, 0);
+        }
+    }
+
+    public void unmute() {
+        if (mMediaPlayer != null) {
+            mMediaPlayer.setVolume(1, 1);
+        }
+    }
+
+
     public void stopAndCleanup() {
         mMediaPlayer.stop();
         mMediaPlayer.release();

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayer.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayer.java
@@ -118,13 +118,7 @@ public class VideoPlayer {
             mSurfaceTexture.updateTexImage();
 
             mAvailableFrames.decrementAndGet();
-            int processedFrames = mFramesProcessed.incrementAndGet();
             updated = true;
-
-            if (mPauseFirstFrame && processedFrames > 0) {
-                mMediaPlayer.pause();
-                mPauseFirstFrame = false;
-            }
         }
         return updated;
     }
@@ -158,32 +152,24 @@ public class VideoPlayer {
         mShouldLoop = shouldLoop;
     }
 
-    public void setPauseFirstFrame(boolean pauseFirstFrame) {
-        mPauseFirstFrame = pauseFirstFrame;
-    }
-
     public void setSource(Object source) {
         mSource = source;
     }
 
     private long mVideoId;
-    private Object mSource;
 
     // player
     private MediaPlayer mMediaPlayer;
     private boolean mIsPrepared = false; 
     private boolean mIsDecoding = false;
+    private Object mSource;
     private int mExternalTextureHandle;
     private SurfaceTexture mSurfaceTexture;
-
+    private AtomicInteger mAvailableFrames = new AtomicInteger(0);
 
     // playback
     private boolean mAutoplay = false;
     private boolean mShouldLoop = false;
-    private boolean mPauseFirstFrame = false;
-
-    private AtomicInteger mAvailableFrames = new AtomicInteger(0);
-    private AtomicInteger mFramesProcessed = new AtomicInteger(0);
     
     // context
     private WeakReference<Activity> mActivityReference;

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayer.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayer.java
@@ -135,7 +135,7 @@ public class VideoPlayer {
         }
     }
 
-    public void endPlayback() {
+    public void stopAndCleanup() {
         mMediaPlayer.stop();
         mMediaPlayer.release();
         Activity activity = mActivityReference.get();

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayerRunnable.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayerRunnable.java
@@ -26,6 +26,14 @@ public class VideoPlayerRunnable implements Runnable {
         mVideoPlayer.resumePlayback();
     }
 
+    public void mute() {
+        mVideoPlayer.mute();
+    }
+
+    public void unmute() {
+        mVideoPlayer.unmute();
+    }
+
     public void cleanupVideoPlaybackResources() {
         mVideoPlayer.stopAndCleanup();
     }

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayerRunnable.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayerRunnable.java
@@ -26,7 +26,7 @@ public class VideoPlayerRunnable implements Runnable {
         mVideoPlayer.resumePlayback();
     }
 
-    public void endPlayback() {
-        mVideoPlayer.endPlayback();
+    public void cleanupVideoPlaybackResources() {
+        mVideoPlayer.stopAndCleanup();
     }
 }

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -129,6 +129,62 @@ impl VideoRef {
             inner.set_source(source);
         }
     }
+
+    pub fn is_unprepared(&self) -> bool {
+        if let Some(inner) = self.borrow() {
+            return inner.playback_state == PlaybackState::Unprepared
+        }
+        false
+    }
+
+    pub fn is_preparing(&self) -> bool {
+        if let Some(inner) = self.borrow() {
+            return inner.playback_state == PlaybackState::Preparing
+        }
+        false
+    }
+
+    pub fn is_prepared(&self) -> bool {
+        if let Some(inner) = self.borrow() {
+            return inner.playback_state == PlaybackState::Prepared
+        }
+        false
+    }
+    
+    pub fn is_playing(&self) -> bool {
+        if let Some(inner) = self.borrow() {
+            return inner.playback_state == PlaybackState::Playing
+        }
+        false
+    }
+
+    pub fn is_paused(&self) -> bool {
+        if let Some(inner) = self.borrow() {
+            return inner.playback_state == PlaybackState::Paused
+        }
+        false
+    }
+
+    pub fn has_completed(&self) -> bool {
+        if let Some(inner) = self.borrow() {
+            return inner.playback_state == PlaybackState::Completed
+        }
+        false
+    }
+
+    pub fn is_cleaning_up(&self) -> bool {
+        if let Some(inner) = self.borrow() {
+            return inner.playback_state == PlaybackState::CleaningUp
+        }
+        false
+    }
+
+    pub fn is_muted(&self) -> bool {
+        if let Some(inner) = self.borrow() {
+            return inner.audio_state == AudioState::Muted
+        }
+        false
+    }
 }
 
 #[derive(Clone, Default, WidgetSet)]

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -100,10 +100,11 @@ impl VideoRef {
         }
     }
 
-    // it will finish playback and cleanup decoding resources
-    pub fn end_playback(&mut self, cx: &mut Cx) {
+    // It will finish playback and cleanup all resources related to playback
+    // including data source, decoding threads, object references, etc.
+    pub fn stop_and_cleanup_resources(&mut self, cx: &mut Cx) {
         if let Some(mut inner) = self.borrow_mut() {
-            inner.end_playback(cx);
+            inner.stop_and_cleanup_resources(cx);
         }
     }
 
@@ -370,9 +371,9 @@ impl Video {
         }
     }
 
-    fn end_playback(&mut self, cx: &mut Cx) {
+    fn stop_and_cleanup_resources(&mut self, cx: &mut Cx) {
         if self.playback_state != PlaybackState::Unprepared {
-            cx.end_video_playback(self.id);
+            cx.cleanup_video_playback_resources(self.id);
         }
         self.playback_state = PlaybackState::CleaningUp;
     }


### PR DESCRIPTION
- Removed preview_first_frame feature, it was a workaround for a specific use case that is now better handled through widget actions
- Added widget actions
- Renamed and fixed video player status
- Fixed some compilation errors on other platforms
- Fixed a jvm reference table overflow issue (improper caching of video player refs)