### PR TITLE
Remove not longer supported values from RotatedImage

### DIFF
--- a/widgets/src/base.rs
+++ b/widgets/src/base.rs
@@ -103,10 +103,6 @@ live_design!{
         
         width: Fit
         height: Fit
-        // This is important to avoid clipping the image, specially when it is rotated.
-        // In any case, it can be override by the app developer.
-        clip_x: false,
-        clip_y: false
         
         draw_bg: {
             texture image: texture2d


### PR DESCRIPTION
Those values were removed time ago, so it is making a lot of noise in the console for our `makepad_image_manipulation` app