### PR TITLE
Make texture pool format-aware on re-usage

### DIFF
--- a/audio_graph/audio_widgets/src/display_audio.rs
+++ b/audio_graph/audio_widgets/src/display_audio.rs
@@ -94,7 +94,7 @@ const WAVE_SIZE_Y: usize = 16;
 impl LiveHook for DisplayAudio {
 
     fn after_new_from_doc(&mut self, cx: &mut Cx) {
-        self.wave_texture.set_format(cx, TextureFormat::VecBGRAu8_32 {
+        self.wave_texture = Texture::new_with_format(cx, TextureFormat::VecBGRAu8_32 {
             data: {
                 let mut data = Vec::new();
                 data.resize(WAVE_SIZE_X * WAVE_SIZE_Y, 0);

--- a/draw/src/font_atlas.rs
+++ b/draw/src/font_atlas.rs
@@ -235,8 +235,7 @@ pub struct CxDrawFontsAtlas {
 impl CxDrawFontsAtlas {
     pub fn new(cx: &mut Cx) -> Self {
         
-        let atlas_texture = Texture::new(cx);
-        atlas_texture.set_format(cx, TextureFormat::RenderBGRAu8{
+        let atlas_texture = Texture::new_with_format(cx, TextureFormat::RenderBGRAu8{
             size: TextureSize::Auto
         });
         //cx.fonts_atlas.texture_id = Some(atlas_texture.texture_id());

--- a/draw/src/icon_atlas.rs
+++ b/draw/src/icon_atlas.rs
@@ -341,8 +341,7 @@ pub struct CxDrawIconAtlas {
 impl CxDrawIconAtlas {
     pub fn new(cx: &mut Cx) -> Self {
         
-        let atlas_texture = Texture::new(cx);
-        atlas_texture.set_format(cx, TextureFormat::RenderBGRAu8{
+        let atlas_texture = Texture::new_with_format(cx, TextureFormat::RenderBGRAu8{
             size: TextureSize::Auto
         });
         //cx.fonts_atlas.texture_id = Some(atlas_texture.texture_id());

--- a/examples/fractal_zoom/src/mandelbrot.rs
+++ b/examples/fractal_zoom/src/mandelbrot.rs
@@ -147,8 +147,7 @@ impl TileCache {
         for i in 0..TILE_CACHE_SIZE {
             empty.push(Tile::new(i));
             
-            let texture = Texture::new(cx);
-            texture.set_format(cx, TextureFormat::VecBGRAu8_32 {
+            let texture = Texture::new_with_format(cx, TextureFormat::VecBGRAu8_32 {
                 data: vec![],
                 width: TILE_SIZE_X,
                 height: TILE_SIZE_Y,

--- a/examples/sdxl/src/app.rs
+++ b/examples/sdxl/src/app.rs
@@ -525,11 +525,14 @@ impl MatchEvent for App {
             }
         }
         while let Ok((id, mut vfb)) = self.video_recv.try_recv() {
-            self.video_input[id].set_format(cx, TextureFormat::VecBGRAu8_32{
-                data: vec![],
-                width: vfb.format.width/2,
-                height: vfb.format.height
-            });
+            let (img_width, img_height) = self.video_input[0].get_format(cx).vec_width_height().unwrap();
+            if img_width != vfb.format.width / 2 || img_height != vfb.format.height {
+                self.video_input[id] = Texture::new_with_format(cx, TextureFormat::VecBGRAu8_32{
+                    data: vec![],
+                    width: vfb.format.width/2,
+                    height: vfb.format.height
+                });
+            }
             if let Some(buf) = vfb.as_vec_u32() {
                 self.video_input[id].swap_vec_u32(cx, buf);
             }

--- a/examples/web_cam/src/app.rs
+++ b/examples/web_cam/src/app.rs
@@ -68,11 +68,15 @@ impl LiveRegister for App {
 impl MatchEvent for App{
     fn handle_signal(&mut self, cx:&mut Cx){
         while let Ok((id, mut vfb)) = self.video_recv.try_recv() {
-            self.video_input[id].set_format(cx, TextureFormat::VecBGRAu8_32{
-                data: vec![],
-                width: vfb.format.width / 2,
-                height: vfb.format.height
-            });
+            let (current_w, current_h) = self.video_input[id].get_format(cx).vec_width_height().unwrap();
+            if current_w != vfb.format.width / 2 || current_h != vfb.format.height {
+                self.video_input[id] = Texture::new_with_format(cx, TextureFormat::VecBGRAu8_32{
+                    data: vec![],
+                    width: vfb.format.width / 2,
+                    height: vfb.format.height
+                });
+            } 
+
             if let Some(buf) = vfb.as_vec_u32() {
                 self.video_input[id].swap_vec_u32(cx, buf);
             }

--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -199,13 +199,11 @@ impl Cx {
         //crate::makepad_error_log::set_panic_hook();
         // the null texture
         let mut textures = CxTexturePool::default();
-        let null_texture = textures.alloc();
-        let texture = &mut textures[null_texture.texture_id()];
-        texture.format = TextureFormat::VecBGRAu8_32 {
+        let null_texture = textures.alloc(TextureFormat::VecBGRAu8_32 {
             width: 4,
             height: 4,
             data: vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-        };
+        });
         
         let (executor, spawner) = executor::new_executor_and_spawner();
         let (send, recv) = std::sync::mpsc::channel();

--- a/platform/src/os/apple/macos/macos_stdin.rs
+++ b/platform/src/os/apple/macos/macos_stdin.rs
@@ -192,13 +192,12 @@ impl Cx {
                         // this is still pretty bad at 100ms if the service is still starting up
                         // we should 
                         if let Ok(fb) = rx_fb.recv_timeout(std::time::Duration::from_millis(100)) {
-                            let texture = Texture::new(self);
                             let format = TextureFormat::SharedBGRAu8 {
                                 id: presentable_image.id,
                                 width: swapchain.alloc_width as usize,
                                 height: swapchain.alloc_height as usize,
                             };
-                            texture.set_format(self, format);
+                            let texture = Texture::new_with_format(self, format);
                             if self.textures[texture.texture_id()].update_from_shared_handle(
                                 metal_cx,
                                 fb.as_id(),

--- a/platform/src/os/apple/metal.rs
+++ b/platform/src/os/apple/metal.rs
@@ -823,7 +823,15 @@ impl CxTexture {
         metal_cx: &MetalCx,
     ) {
         // ok lets see if we need to alloc
-        if self.alloc_vec(){
+        let should_gen_new = self.generation_changed || self.alloc_vec();
+        if self.generation_changed {
+            if self.os.texture.is_some() {
+                self.os.texture = None;
+            }
+            self.generation_changed = false;
+        }
+
+        if should_gen_new {
             let alloc = self.alloc.as_ref().unwrap();
             
             let descriptor = RcObjcId::from_owned(NonNull::new(unsafe {

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -860,7 +860,15 @@ pub struct CxOsTexture {
 impl CxTexture {
     
     pub fn update_vec_texture(&mut self) {
-        if self.alloc_vec(){
+        let should_gen_new = self.generation_changed || self.alloc_vec();
+        if self.generation_changed {
+            if self.os.gl_texture.is_some() {
+                self.free_resources();
+            }
+            self.generation_changed = false;
+        }
+
+        if should_gen_new {
             //let alloc = self.alloc.as_ref().unwrap();
             if self.os.gl_texture.is_none() { 
                 unsafe {
@@ -989,7 +997,13 @@ impl CxTexture {
     pub fn setup_video_texture(&mut self) -> bool {
         while unsafe { gl_sys::GetError() } != 0 {}
 
-        if self.alloc_video(){
+        let should_gen_new = self.generation_changed || self.alloc_video();
+        if self.generation_changed {
+            self.free_resources();
+            self.generation_changed = false;
+        }
+
+        if should_gen_new {
             if self.os.gl_texture.is_none() { 
                 unsafe {
                     let mut gl_texture = std::mem::MaybeUninit::uninit();

--- a/platform/src/os/linux/x11/linux_x11_stdin.rs
+++ b/platform/src/os/linux/x11/linux_x11_stdin.rs
@@ -171,7 +171,7 @@ impl Cx {
                                     width: new_swapchain.alloc_width as usize,
                                     height: new_swapchain.alloc_height as usize,
                                 };
-                                new_texture.set_format(self, desc);
+                                new_texture = Texture::new_with_format(self, desc);
                                 self.textures[new_texture.texture_id()]
                                 .update_from_shared_dma_buf_image(
                                     self.os.opengl_cx.as_ref().unwrap(),

--- a/platform/src/os/windows/windows_stdin.rs
+++ b/platform/src/os/windows/windows_stdin.rs
@@ -171,13 +171,12 @@ impl Cx {
                     let new_swapchain = new_swapchain.images_map(|pi| {
                         let handle = HANDLE(pi.image as isize);
                         
-                        let texture = Texture::new(self);
                         let format = TextureFormat::SharedBGRAu8 {
                             id: pi.id,
                             width: new_swapchain.alloc_width as usize,
                             height: new_swapchain.alloc_height as usize,
                         };
-                        texture.set_format(self, format);
+                        let texture = Texture::new_with_format(self, format);
                         self.textures[texture.texture_id()].update_from_shared_handle(d3d11_cx, handle);
                         texture
                     });

--- a/platform/src/texture.rs
+++ b/platform/src/texture.rs
@@ -35,6 +35,7 @@ impl CxTexturePool {
             is_video == item.item.format.is_video()
         }, cx_texture);
 
+        self.0.pool[new_id.id].generation_changed = new_id.generation != 0;
         Texture(Rc::new(new_id))
     }
 }
@@ -509,5 +510,6 @@ impl Texture {
 pub struct CxTexture {
     pub (crate) format: TextureFormat,
     pub (crate) alloc: Option<TextureAlloc>,
-    pub os: CxOsTexture
+    pub os: CxOsTexture,
+    pub generation_changed: bool
 }

--- a/platform/src/texture.rs
+++ b/platform/src/texture.rs
@@ -449,26 +449,12 @@ impl Default for TextureFormat {
 
 impl Texture {
     pub fn new(cx: &mut Cx) -> Self {
-        cx.textures.alloc(TextureFormat::VecBGRAu8_32 {
-            width: 4,
-            height: 4,
-            data: vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-        })
+        cx.null_texture()
     }
 
     pub fn new_with_format(cx: &mut Cx, format: TextureFormat) -> Self {
         let texture = cx.textures.alloc(format);
         texture
-    }
-    
-    pub fn set_format(&self, cx: &mut Cx, target_format: TextureFormat) {
-        let current_format = self.get_format(cx);
-        if current_format.is_compatible_with(&target_format) {
-            let cxtexture = &mut cx.textures[self.texture_id()];
-            cxtexture.format = target_format;
-        } else {
-            panic!("Attempted to set incompatible texture format: {:?} != {:?}", current_format, target_format);
-        }
     }
     
     pub fn get_format<'a>(&self, cx: &'a mut Cx) -> &'a mut TextureFormat {

--- a/widgets/src/image_cache.rs
+++ b/widgets/src/image_cache.rs
@@ -56,22 +56,13 @@ impl ImageBuffer {
     }
     
     pub fn into_new_texture(self, cx:&mut Cx)->Texture{
-        let texture = Texture::new(cx);
-        self.into_texture(cx, &texture);
+        let texture = Texture::new_with_format(cx, TextureFormat::VecBGRAu8_32 {
+            width: self.width,
+            height: self.height,
+            data: self.data
+        });
         texture
     }
-    
-    pub fn into_texture(self, cx:&mut Cx, texture:&Texture){
-        texture.set_format(
-            cx,
-            TextureFormat::VecBGRAu8_32 {
-                width: self.width,
-                height: self.height,
-                data: self.data
-            },
-        );
-    }
-    
     
     pub fn from_png(
         data: &[u8]
@@ -132,16 +123,10 @@ pub trait ImageCacheImpl {
         }
     }
 
-
     fn load_png_from_data(&mut self, cx:&mut Cx, data:&[u8]){
         match ImageBuffer::from_png(&*data){
             Ok(data)=>{
-                if let Some(texture) = self.get_texture(){
-                    data.into_texture(cx, texture);
-                }
-                else{
-                    self.set_texture(Some(data.into_new_texture(cx)));
-                }
+                self.set_texture(Some(data.into_new_texture(cx)));
             }
             Err(err)=>{
                 error!("load_png_from_data: Cannot load png image from data {}", err);
@@ -152,12 +137,7 @@ pub trait ImageCacheImpl {
     fn load_jpg_from_data(&mut self, cx:&mut Cx, data:&[u8]){
         match ImageBuffer::from_jpg(&*data){
             Ok(data)=>{
-                if let Some(texture) = self.get_texture(){
-                    data.into_texture(cx, texture);
-                }
-                else{
-                    self.set_texture(Some(data.into_new_texture(cx)));
-                }
+                self.set_texture(Some(data.into_new_texture(cx)));
             }
             Err(err)=>{
                 error!("load_jpg_from_data: Cannot load png image from data {}", err);

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -422,7 +422,7 @@ impl Video {
     }
 
     fn stop_and_cleanup_resources(&mut self, cx: &mut Cx) {
-        if self.playback_state != PlaybackState::Unprepared {
+        if self.playback_state != PlaybackState::Unprepared && self.playback_state != PlaybackState::CleaningUp {
             cx.cleanup_video_playback_resources(self.id);
         }
         self.playback_state = PlaybackState::CleaningUp;

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -213,8 +213,7 @@ impl LiveHook for Video {
 
         #[cfg(target_os = "android")]
         if self.texture.is_none() {
-            let new_texture = Texture::new(cx);
-            new_texture.set_format(cx, TextureFormat::VideoRGB);
+            let new_texture = Texture::new_with_format(cx, TextureFormat::VideoRGB);
             self.texture = Some(new_texture);
         }
 

--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -646,7 +646,7 @@ impl Widget for View {
                         });
                         let texture_cache = self.texture_cache.as_mut().unwrap();
                         //cache.pass.set_depth_texture(cx, &cache.depth_texture, PassClearDepth::ClearWith(1.0));
-                        texture_cache.color_texture.set_format(cx, TextureFormat::RenderBGRAu8{
+                        texture_cache.color_texture = Texture::new_with_format(cx, TextureFormat::RenderBGRAu8{
                             size:TextureSize::Auto
                         });
                         texture_cache.pass.add_color_texture(cx, &texture_cache.color_texture, PassClearColor::ClearWith(vec4(0.0, 0.0, 0.0, 0.0)));

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -59,7 +59,7 @@ impl LiveHook for Window {
     fn after_new_from_doc(&mut self, cx: &mut Cx) {
         self.window.set_pass(cx, &self.pass);
         //self.pass.set_window_clear_color(cx, vec4(0.0,0.0,0.0,0.0));
-        self.depth_texture.set_format(cx, TextureFormat::DepthD32{
+        self.depth_texture = Texture::new_with_format(cx, TextureFormat::DepthD32{
             size:TextureSize::Auto
         });
         self.pass.set_depth_texture(cx, &self.depth_texture, PassClearDepth::ClearWith(1.0));


### PR DESCRIPTION
Fixes font textures breaking on taobao app when using video. 
Currently all Makepad textures are re-used indiscriminately, which breaks in OpenGL when trying to perform `TEXTURE_2D` operations on a previous texture bound with `TEXTURE_EXTERNAL_OES` format.
This PR makes the texture pool check for format compatibility when re-using textures from the free pool.

Changes:
- Extends `IdPool` with an `alloc_with_reuse_filter` method that takes in a filtering callback.
-`Texture::new` now always creates a default black texture, and `texture.set_format(cx, format)` no longer exists. If format (even size alone) needs to be changed, a new texture must be created with `Texture::new_with_format(cx, format)`
- Deletes OS texture handles and re-creates new ones when texture is re-used (generation changed). Added this on OpenGL and Metal, DirectX is already re-creating and I'll update WebGL once we can fully test it.