### PR TITLE
Video Player API Improvements

### DIFF
--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -76,6 +76,7 @@ pub enum CxOsOp {
     HttpRequest{request_id: LiveId, request:HttpRequest},
 
     PrepareVideoPlayback(LiveId, VideoSource, u32, bool, bool),
+    BeginVideoPlayback(LiveId),
     PauseVideoPlayback(LiveId),
     ResumeVideoPlayback(LiveId),
     MuteVideoPlayback(LiveId),
@@ -438,6 +439,10 @@ impl Cx {
 */
     pub fn prepare_video_playback(&mut self, video_id: LiveId, source: VideoSource, external_texture_id: u32, autoplay: bool, should_loop: bool) {
         self.platform_ops.push(CxOsOp::PrepareVideoPlayback(video_id, source, external_texture_id, autoplay, should_loop));
+    }
+
+    pub fn begin_video_playback(&mut self, video_id: LiveId) {
+        self.platform_ops.push(CxOsOp::BeginVideoPlayback(video_id));
     }
 
     pub fn pause_video_playback(&mut self, video_id: LiveId) {

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -312,6 +312,7 @@ impl Cx {
                     crate::log!("Show clipboard actions not supported yet");
                 }
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
+                CxOsOp::BeginVideoPlayback(_) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
                 CxOsOp::MuteVideoPlayback(_) => todo!(),

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -528,6 +528,7 @@ impl Cx {
                     todo!()
                 }*/
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
+                CxOsOp::BeginVideoPlayback(_) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
                 CxOsOp::MuteVideoPlayback(_) => todo!(),

--- a/platform/src/os/apple/tvos/tvos.rs
+++ b/platform/src/os/apple/tvos/tvos.rs
@@ -262,6 +262,7 @@ impl Cx {
                     crate::log!("Show clipboard actions not supported yet");
                 }
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
+                CxOsOp::BeginVideoPlayback(_) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
                 CxOsOp::MuteVideoPlayback(_) => todo!(),

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -703,6 +703,12 @@ impl Cx {
                         android_jni::to_java_prepare_video_playback(env, video_id, source, external_texture_id, autoplay, should_loop);
                     }
                 },
+                CxOsOp::BeginVideoPlayback(video_id) => {
+                    unsafe {
+                        let env = attach_jni_env();
+                        android_jni::to_java_begin_video_playback(env, video_id);
+                    }
+                }
                 CxOsOp::PauseVideoPlayback(video_id) => {
                     unsafe {
                         let env = attach_jni_env();

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -313,7 +313,13 @@ impl Cx {
                         self.call_event_handler(&e);
                     },
                     FromJavaMessage::VideoPlayerReleased {video_id} => {
-                        self.os.video_surfaces.remove(&LiveId(video_id));
+                        if let Some(decoder_ref) = self.os.video_surfaces.remove(&LiveId(video_id)) {
+                            unsafe {
+                                let env = attach_jni_env();
+                                android_jni::to_java_cleanup_video_decoder_ref(env, decoder_ref);
+                            }
+                        }
+                        
                         let e = Event::VideoPlaybackResourcesReleased(
                             VideoPlaybackResourcesReleasedEvent {
                                 video_id: LiveId(video_id)

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -733,6 +733,16 @@ pub unsafe fn to_java_update_tex_image(env: *mut jni_sys::JNIEnv, video_decoder_
     updated != 0
 }
 
+pub unsafe fn to_java_begin_video_playback(env: *mut jni_sys::JNIEnv, video_id: LiveId) {
+    ndk_utils::call_void_method!(
+        env,
+        ACTIVITY,
+        "beginVideoPlayback",
+        "(J)V",
+        video_id
+    );
+}
+
 pub unsafe fn to_java_pause_video_playback(env: *mut jni_sys::JNIEnv, video_id: LiveId) {
     ndk_utils::call_void_method!(
         env,

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -714,6 +714,8 @@ pub unsafe fn to_java_prepare_video_playback(env: *mut jni_sys::JNIEnv, video_id
         autoplay as jni_sys::jboolean as std::ffi::c_uint,
         should_loop as jni_sys::jboolean as std::ffi::c_uint
     );
+
+    (**env).DeleteLocalRef.unwrap()(env, video_source);
 }
 
 pub unsafe fn to_java_update_tex_image(env: *mut jni_sys::JNIEnv, video_decoder_ref: jni_sys::jobject) -> bool {
@@ -791,4 +793,8 @@ pub unsafe fn to_java_cleanup_video_playback_resources(env: *mut jni_sys::JNIEnv
         "(J)V",
         video_id
     );
+}
+
+pub unsafe fn to_java_cleanup_video_decoder_ref(env: *mut jni_sys::JNIEnv, video_decoder_ref: jni_sys::jobject) {
+    (**env).DeleteGlobalRef.unwrap()(env, video_decoder_ref);
 }

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -327,6 +327,7 @@ impl Cx {
                     todo!()
                 },
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
+                CxOsOp::BeginVideoPlayback(_) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
                 CxOsOp::MuteVideoPlayback(_) => todo!(),

--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -495,6 +495,7 @@ impl Cx {
                     });
                 },*/
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
+                CxOsOp::BeginVideoPlayback(_) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
                 CxOsOp::MuteVideoPlayback(_) => todo!(),

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -370,6 +370,7 @@ impl Cx {
                     todo!("HttpRequest not implemented yet on windows, we'll get there");
                 },
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
+                CxOsOp::BeginVideoPlayback(_) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),
                 CxOsOp::ResumeVideoPlayback(_) => todo!(),
                 CxOsOp::MuteVideoPlayback(_) => todo!(),

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -555,6 +555,7 @@ MidiManager.OnDeviceOpenedListener{
         VideoPlayerRunnable runnable = mVideoPlayerRunnables.remove(videoId);
         if(runnable != null) {
             runnable.cleanupVideoPlaybackResources();
+            runnable = null;
         }
     }
 }

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -516,6 +516,13 @@ MidiManager.OnDeviceOpenedListener{
         mVideoPlaybackHandler.post(runnable);
     }
 
+    public void beginVideoPlayback(long videoId) {
+        VideoPlayerRunnable runnable = mVideoPlayerRunnables.get(videoId);
+        if(runnable != null) {
+            runnable.beginPlayback();
+        }
+    }
+
     public void pauseVideoPlayback(long videoId) {
         VideoPlayerRunnable runnable = mVideoPlayerRunnables.get(videoId);
         if(runnable != null) {

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayerRunnable.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayerRunnable.java
@@ -18,6 +18,10 @@ public class VideoPlayerRunnable implements Runnable {
         }
     }
 
+    public void beginPlayback() {
+        mVideoPlayer.beginPlayback();
+    }
+
     public void pausePlayback() {
         mVideoPlayer.pausePlayback();
     }

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayerRunnable.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayerRunnable.java
@@ -3,7 +3,7 @@ package dev.makepad.android;
 import java.nio.ByteBuffer;
 
 public class VideoPlayerRunnable implements Runnable {
-    private final VideoPlayer mVideoPlayer;
+    private VideoPlayer mVideoPlayer;
     private boolean mIsPrepared = false;
 
     public VideoPlayerRunnable(VideoPlayer VideoPlayer) {
@@ -40,5 +40,6 @@ public class VideoPlayerRunnable implements Runnable {
 
     public void cleanupVideoPlaybackResources() {
         mVideoPlayer.stopAndCleanup();
+        mVideoPlayer = null;
     }
 }

--- a/widgets/src/base.rs
+++ b/widgets/src/base.rs
@@ -201,6 +201,8 @@ live_design!{
     }
 
     Video = <VideoBase> {
+        width: 100, height: 100
+
         draw_bg: {
             shape: Solid,
             fill: Image

--- a/widgets/src/base.rs
+++ b/widgets/src/base.rs
@@ -206,8 +206,10 @@ live_design!{
         draw_bg: {
             shape: Solid,
             fill: Image
-            texture image: textureOES
-            
+            texture video_texture: textureOES
+            texture thumbnail_texture: texture2d
+            uniform show_thumbnail: 0.0
+
             instance opacity: 1.0
             instance image_scale: vec2(1.0, 1.0)
             instance image_pan: vec2(0.5, 0.5)
@@ -242,15 +244,15 @@ live_design!{
                 let adjusted_pan_y = pan_range_y * pan.y;
                 let adjusted_pan = vec2(adjusted_pan_x, adjusted_pan_y);
 
-                return sample2dOES(self.image, (self.pos * scale) + adjusted_pan);
-            }
-
-            fn get_color(self) -> vec4 {
-                return self.get_color_scale_pan()
+                if self.show_thumbnail > 0.0 {
+                    return sample2d(self.thumbnail_texture, (self.pos * scale) + adjusted_pan).xyzw;
+                } else {
+                    return sample2dOES(self.video_texture, (self.pos * scale) + adjusted_pan);
+                }      
             }
 
             fn pixel(self) -> vec4 {
-                let color = self.get_color();
+                let color = self.get_color_scale_pan();
                 return Pal::premul(vec4(color.xyz, color.w * self.opacity));
             }
         }

--- a/widgets/src/base.rs
+++ b/widgets/src/base.rs
@@ -218,12 +218,21 @@ live_design!{
             uniform target_size: vec2(-1.0, -1.0)
 
             fn get_color_scale_pan(self) -> vec4 {
+                // Early return for default scaling and panning,
+                // used when walk size is not specified or non-fixed.
+                if self.target_size.x <= 0.0 && self.target_size.y <= 0.0 {
+                    if self.show_thumbnail > 0.0 {
+                        return sample2d(self.thumbnail_texture, self.pos).xyzw;
+                    } else {
+                        return sample2dOES(self.video_texture, self.pos);
+                    }  
+                }
+
                 let scale = self.image_scale;
                 let pan = self.image_pan;
                 let source_aspect_ratio = self.source_size.x / self.source_size.y;
                 let target_aspect_ratio = self.target_size.x / self.target_size.y;
 
-                // TODO: only if target_size is setup
                 // Adjust scale based on aspect ratio difference
                 if (source_aspect_ratio != target_aspect_ratio) {
                     if (source_aspect_ratio > target_aspect_ratio) {
@@ -243,11 +252,12 @@ live_design!{
                 let adjusted_pan_x = pan_range_x * pan.x;
                 let adjusted_pan_y = pan_range_y * pan.y;
                 let adjusted_pan = vec2(adjusted_pan_x, adjusted_pan_y);
+                let adjusted_pos = (self.pos * scale) + adjusted_pan;
 
                 if self.show_thumbnail > 0.0 {
-                    return sample2d(self.thumbnail_texture, (self.pos * scale) + adjusted_pan).xyzw;
+                    return sample2d(self.thumbnail_texture, adjusted_pos).xyzw;
                 } else {
-                    return sample2dOES(self.video_texture, (self.pos * scale) + adjusted_pan);
+                    return sample2dOES(self.video_texture, adjusted_pos);
                 }      
             }
 

--- a/widgets/src/base.rs
+++ b/widgets/src/base.rs
@@ -254,7 +254,7 @@ live_design!{
                 let adjusted_pan = vec2(adjusted_pan_x, adjusted_pan_y);
                 let adjusted_pos = (self.pos * scale) + adjusted_pan;
 
-                if self.show_thumbnail > 0.0 {
+                if self.show_thumbnail > 0.5 {
                     return sample2d(self.thumbnail_texture, adjusted_pos).xyzw;
                 } else {
                     return sample2dOES(self.video_texture, adjusted_pos);

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -414,6 +414,8 @@ impl Video {
             self.should_prepare_playback = true;
             self.autoplay = true;
             self.maybe_prepare_playback(cx);
+        } else if self.playback_state == PlaybackState::Prepared {
+            cx.begin_video_playback(self.id);
         }
     }
 

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -418,14 +418,11 @@ impl Video {
                     self.pause_playback(cx);
                 }
             }
-            Hit::FingerUp(fe) => {
-                if self.hold_to_pause && fe.was_tap() {
-                    if self.playback_state == PlaybackState::Playing {
-                        self.pause_playback(cx);
-                    } else if self.playback_state == PlaybackState::Paused {
-                        self.resume_playback(cx);
-                    }
+            Hit::FingerUp(_fe) => {
+                if self.hold_to_pause {
+                    self.resume_playback(cx);
                 }
+            }
             }
             _ => (),
         }

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -115,7 +115,7 @@ impl VideoRef {
 
     // It will finish playback and cleanup all resources related to playback
     // including data source, decoding threads, object references, etc.
-    pub fn stop_and_cleanup_resources(&mut self, cx: &mut Cx) {
+    pub fn stop_and_cleanup_resources(&self, cx: &mut Cx) {
         if let Some(mut inner) = self.borrow_mut() {
             inner.stop_and_cleanup_resources(cx);
         }
@@ -324,10 +324,23 @@ impl Video {
         self.video_height = event.video_height as usize;
         self.total_duration = event.duration;
 
+        // TODO: add DPI awareness and fallback sizes
         self.draw_bg
-            .set_uniform(cx, id!(video_height), &[self.video_height as f32]);
+            .set_uniform(cx, id!(source_size), &[self.video_width as f32, self.video_height as f32]);
+        
+        let target_w = if self.walk.width.is_fixed() {
+            self.walk.width.fixed_or_zero()
+        } else {
+            -1
+        };
+        let target_h = if self.walk.height.is_fixed() {
+            self.walk.height.fixed_or_zero()
+        } else {
+            -1
+        };
+
         self.draw_bg
-            .set_uniform(cx, id!(video_width), &[self.video_width as f32]);
+            .set_uniform(cx, id!(target_size), &[target_w as f32, target_h as f32]);
 
         if self.mute && self.audio_state != AudioState::Muted {
             cx.mute_video_playback(self.id);

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -64,6 +64,10 @@ pub struct Video {
     #[rust]
     audio_state: AudioState,
 
+    // Actions
+    #[rust(false)]
+    should_dispatch_texture_updates: bool,
+
     // Original video metadata
     #[rust]
     video_width: usize,
@@ -124,6 +128,12 @@ impl VideoRef {
     pub fn set_source(&mut self, source: VideoDataSource) {
         if let Some(mut inner) = self.borrow_mut() {
             inner.set_source(source);
+        }
+    }
+
+    pub fn should_dispatch_texture_updates(&self, should_dispatch: bool) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.should_dispatch_texture_updates = should_dispatch;
         }
     }
 
@@ -253,7 +263,9 @@ impl Widget for Video {
                     self.playback_state = PlaybackState::Playing;
                     cx.widget_action(uid, &scope.path, VideoAction::PlaybackBegan);
                 }
-                cx.widget_action(uid, &scope.path, VideoAction::TextureUpdated);
+                if self.should_dispatch_texture_updates {
+                    cx.widget_action(uid, &scope.path, VideoAction::TextureUpdated);
+                }
             }
             Event::VideoPlaybackCompleted(event) =>  if event.video_id == self.id {
                 if !self.is_looping {

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -324,35 +324,17 @@ impl Video {
         self.video_height = event.video_height as usize;
         self.total_duration = event.duration;
 
-        // TODO: add DPI awareness and fallback sizes
         self.draw_bg
             .set_uniform(cx, id!(source_size), &[self.video_width as f32, self.video_height as f32]);
         
-        let target_w = if self.walk.width.is_fixed() {
-            self.walk.width.fixed_or_zero()
-        } else {
-            -1
-        };
-        let target_h = if self.walk.height.is_fixed() {
-            self.walk.height.fixed_or_zero()
-        } else {
-            -1
-        };
-
+        let target_w = self.walk.width.fixed_or_zero();
+        let target_h = self.walk.height.fixed_or_zero();
         self.draw_bg
             .set_uniform(cx, id!(target_size), &[target_w as f32, target_h as f32]);
 
         if self.mute && self.audio_state != AudioState::Muted {
             cx.mute_video_playback(self.id);
         }
-
-        // Debug
-        // log!(
-        //     "Video id {} - decoding initialized: \n {}x{}px |",
-        //     self.id.0,
-        //     self.video_width,
-        //     self.video_height,
-        // );
     }
 
     fn handle_gestures(&mut self, cx: &mut Cx, event: &Event) {

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -271,6 +271,7 @@ impl LiveHook for Video {
     }
 
     fn after_apply(&mut self, cx: &mut Cx, _apply: &mut Apply, _index: usize, _nodes: &[LiveNode]) {
+        self.thumbnail_texture = Some(Texture::new(cx));
         if self.show_thumbnail_before_playback {
             self.load_thumbnail_image(cx);
             self.draw_bg


### PR DESCRIPTION
### Updates to Video Widget

- Adds the ability to use custom aspect ratios and panning

- Removes the default dispatching of `TextureUpdated` actions by default. This amount of action dispatching was very noisy when debugging actions/events and it's unnecessary processing if the user doesn't use them. If we have a lot videos playing at 60fps and we're constantly casting and checking for actions matching a specific video, we quickly run into tiny delays.
Now a `should_dispatch_texture_updates(bool)` is provided to enable the dispatching.

- Adds documentation for the Video API.

- Adds the ability to use video thumbnails, a separate texture is can be updated through API or setup to a `LiveDependency` on the DSL.

- Fixes a memory leak at the JNI level when passing the video byte array data.