### PR TITLE
Display `LiveFileError`'s location info as a clickable link

### DIFF
--- a/platform/live_compiler/src/live_error.rs
+++ b/platform/live_compiler/src/live_error.rs
@@ -58,7 +58,7 @@ impl fmt::Display for LiveFileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{}: {}:{} - {}\n   origin: {}",
+            "{}:{}:{} - {}\n   origin: {}",
             self.file,
             self.span.start.line+1,
             self.span.start.column+1,


### PR DESCRIPTION
Many IDEs/terminals parse file links as `<file>:<line>:<column>`, so adhering to that format enables a developer to jump directly to the origin of the error.

(All this does is remove a single space, lol)

See example screenshot below:

![image](https://github.com/makepad/makepad/assets/1139460/857d7159-1929-4876-9cca-e32cf5ebec94)
