### PR TITLE
fix: ensure x11 IM/Display close only once

### DIFF
--- a/platform/src/os/linux/x11/xlib_app.rs
+++ b/platform/src/os/linux/x11/xlib_app.rs
@@ -600,9 +600,14 @@ impl XlibApp {
     
     pub fn terminate_event_loop(&mut self) {
         self.event_loop_running = false;
-        unsafe {x11_sys::XCloseIM(self.xim)};
-        unsafe {x11_sys::XCloseDisplay(self.display)};
-        self.display = ptr::null_mut();
+        if !self.xim.is_null() {
+            unsafe {x11_sys::XCloseIM(self.xim)};
+            self.xim = ptr::null_mut();
+        }
+        if !self.display.is_null() {
+            unsafe {x11_sys::XCloseDisplay(self.display)};
+            self.display = ptr::null_mut();
+        }
     }
     
     pub fn start_timer(&mut self, id: u64, timeout: f64, repeats: bool) {


### PR DESCRIPTION
Currently, the `terminate_event_loop` is called twice in my system, which is a Xubuntu 22.04 distribution, and segment fault with core dumped after close the window.

There's someone found the same issue #352 #241