### PR TITLE
Fix texture pool not updating inner item on re-use

### DIFF
--- a/platform/src/id_pool.rs
+++ b/platform/src/id_pool.rs
@@ -85,8 +85,9 @@ impl<T> IdPool<T> where T: Default {
             });
     
         if let Some((index, id)) = maybe_free_id {
-            self.pool[id].generation += 1;
             self.free.0.borrow_mut().remove(index);
+            self.pool[id].generation += 1;
+            self.pool[id].item = item;
     
             let pool_id = PoolId {
                 id,

--- a/platform/src/os/apple/metal.rs
+++ b/platform/src/os/apple/metal.rs
@@ -822,16 +822,7 @@ impl CxTexture {
         &mut self,
         metal_cx: &MetalCx,
     ) {
-        // ok lets see if we need to alloc
-        let should_gen_new = self.generation_changed || self.alloc_vec();
-        if self.generation_changed {
-            if self.os.texture.is_some() {
-                self.os.texture = None;
-            }
-            self.generation_changed = false;
-        }
-
-        if should_gen_new {
+        if self.alloc_vec() {
             let alloc = self.alloc.as_ref().unwrap();
             
             let descriptor = RcObjcId::from_owned(NonNull::new(unsafe {

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -860,16 +860,8 @@ pub struct CxOsTexture {
 impl CxTexture {
     
     pub fn update_vec_texture(&mut self) {
-        let should_gen_new = self.generation_changed || self.alloc_vec();
-        if self.generation_changed {
-            if self.os.gl_texture.is_some() {
-                self.free_resources();
-            }
-            self.generation_changed = false;
-        }
-
-        if should_gen_new {
-            //let alloc = self.alloc.as_ref().unwrap();
+        if self.alloc_vec() {
+            self.free_resources();
             if self.os.gl_texture.is_none() { 
                 unsafe {
                     let mut gl_texture = std::mem::MaybeUninit::uninit();
@@ -997,13 +989,8 @@ impl CxTexture {
     pub fn setup_video_texture(&mut self) -> bool {
         while unsafe { gl_sys::GetError() } != 0 {}
 
-        let should_gen_new = self.generation_changed || self.alloc_video();
-        if self.generation_changed {
+        if self.alloc_video() {
             self.free_resources();
-            self.generation_changed = false;
-        }
-
-        if should_gen_new {
             if self.os.gl_texture.is_none() { 
                 unsafe {
                     let mut gl_texture = std::mem::MaybeUninit::uninit();

--- a/platform/src/texture.rs
+++ b/platform/src/texture.rs
@@ -35,7 +35,6 @@ impl CxTexturePool {
             is_video == item.item.format.is_video()
         }, cx_texture);
 
-        self.0.pool[new_id.id].generation_changed = new_id.generation != 0;
         Texture(Rc::new(new_id))
     }
 }
@@ -511,5 +510,4 @@ pub struct CxTexture {
     pub (crate) format: TextureFormat,
     pub (crate) alloc: Option<TextureAlloc>,
     pub os: CxOsTexture,
-    pub generation_changed: bool
 }


### PR DESCRIPTION
Fixes a bug where setting images within a list of multiple images with `load_png_from_bytes()`, causes the most recently-loaded image to be re-used all other images in the list. 

![Screenshot 2024-01-03 at 16 03 31](https://github.com/makepad/makepad/assets/22042418/2461e132-7aee-439d-aced-e9f539559235)

The problem is that textures won't update their contents/format when being re-used with `new_with_format` because the texture pool (`IdPool`) is not updating the inner item when providing textures from the free pool.

Updating the inner item (`self.pool[id].item = item`) fixes the issue. 

![image](https://github.com/makepad/makepad/assets/22042418/60533e10-3818-4a58-ac4a-897b87fb039a)

Also, this removes the need for the `generation_changed` flag. Since we're now properly updating the contents of the texture, `alloc` will be set as `None` and therefore always require the graphics backend to regenerate textures.

Originally reported here: https://github.com/project-robius/robrix/commit/5a79e97cfc78a12d221918fb77a8e50a768fa6ae


