### PR TITLE
Android: Only use GL_OES_EGL_image_external if supported

### DIFF
--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -467,6 +467,8 @@ impl Cx {
             if unsafe {(libegl.eglMakeCurrent.unwrap())(egl_display, surface, surface, egl_context)} == 0 {
                 panic!();
             }
+            cx.maybe_warn_hardware_support();
+
             cx.os.display = Some(CxAndroidDisplay {
                 libegl,
                 egl_display,

--- a/platform/src/os/linux/gl_sys.rs
+++ b/platform/src/os/linux/gl_sys.rs
@@ -71,6 +71,7 @@ pub const NO_ERROR: types::GLenum = 0x0;
 pub const UNPACK_ALIGNMENT: types::GLenum = 0x0CF5;
 pub const UNPACK_ROW_LENGTH: types::GLenum = 0x0CF2;
 pub const TEXTURE_EXTERNAL_OES: types::GLenum = 0x8D65;
+pub const EXTENSIONS: types::GLenum = 0x1F03;
 
 #[inline] pub unsafe fn GenVertexArrays(n: types::GLsizei, arrays: *mut types::GLuint) -> () {mem::transmute::<_, extern "system" fn(types::GLsizei, *mut types::GLuint) -> ()>(storage::GenVertexArrays.f)(n, arrays)}
 #[inline] pub unsafe fn BindVertexArray(array: types::GLuint) -> () {mem::transmute::<_, extern "system" fn(types::GLuint) -> ()>(storage::BindVertexArray.f)(array)}
@@ -129,6 +130,7 @@ pub const TEXTURE_EXTERNAL_OES: types::GLenum = 0x8D65;
 #[inline] pub unsafe fn DeleteVertexArrays(n: types::GLsizei, arrays: *const types::GLuint) -> () { mem::transmute::<_, extern "system" fn(types::GLsizei, *const types::GLuint) -> ()>(storage::DeleteVertexArrays.f)(n, arrays) }
 #[inline] pub unsafe fn GenerateMipmap(target: types::GLenum) -> () { mem::transmute::<_, extern "system" fn(types::GLenum) -> ()>( storage::GenerateMipmap.f)(target)}
 #[inline] pub unsafe fn PixelStorei(pname: types::GLenum, param: types::GLint) -> () { mem::transmute::<_, extern "system" fn(types::GLenum, types::GLint) -> ()>(storage::PixelStorei.f)(pname, param)}
+#[inline] pub unsafe fn GetString(name: types::GLenum) -> *const types::GLubyte { mem::transmute::<_, extern "system" fn(types::GLenum) -> *const types::GLubyte>(storage::GetString.f)(name)}
 
 mod storage {
     use super::FnPtr;
@@ -190,6 +192,7 @@ mod storage {
     pub static mut DeleteVertexArrays: FnPtr = FnPtr::default();
     pub static mut GenerateMipmap: FnPtr = FnPtr::default();
     pub static mut PixelStorei: FnPtr = FnPtr::default();
+    pub static mut GetString: FnPtr = FnPtr::default();
 }
 
 pub unsafe fn load_with<F>(mut loadfn: F) where F: FnMut(&'static str) -> *const raw::c_void {
@@ -251,6 +254,7 @@ pub unsafe fn load_with<F>(mut loadfn: F) where F: FnMut(&'static str) -> *const
     storage::DeleteVertexArrays = FnPtr::new(metaloadfn(&mut loadfn, "glDeleteVertexArrays", &["glDeleteVertexArraysAPPLE", "glDeleteVertexArraysOES"]));
     storage::GenerateMipmap = FnPtr::new(metaloadfn(&mut loadfn, "glGenerateMipmap", &[]));
     storage::PixelStorei = FnPtr::new(metaloadfn(&mut loadfn, "glPixelStorei", &[]));
+    storage::GetString = FnPtr::new(metaloadfn(&mut loadfn, "glGetString", &[]));
 }
 
 #[inline(never)]

--- a/platform/src/os/linux/gl_sys.rs
+++ b/platform/src/os/linux/gl_sys.rs
@@ -72,6 +72,8 @@ pub const UNPACK_ALIGNMENT: types::GLenum = 0x0CF5;
 pub const UNPACK_ROW_LENGTH: types::GLenum = 0x0CF2;
 pub const TEXTURE_EXTERNAL_OES: types::GLenum = 0x8D65;
 pub const EXTENSIONS: types::GLenum = 0x1F03;
+pub const VENDOR: types::GLenum = 0x1F00;
+pub const RENDERER: types::GLenum = 0x1F01;
 
 #[inline] pub unsafe fn GenVertexArrays(n: types::GLsizei, arrays: *mut types::GLuint) -> () {mem::transmute::<_, extern "system" fn(types::GLsizei, *mut types::GLuint) -> ()>(storage::GenVertexArrays.f)(n, arrays)}
 #[inline] pub unsafe fn BindVertexArray(array: types::GLuint) -> () {mem::transmute::<_, extern "system" fn(types::GLuint) -> ()>(storage::BindVertexArray.f)(array)}

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -489,6 +489,16 @@ impl Cx {
         }
         self.draw_shaders.compile_set.clear();
     }
+
+    pub fn maybe_warn_hardware_support(&self) {
+        // Temporary warning for Adreno failing at compiling shaders that use samplerExternalOES.
+        let gpu_renderer = get_gl_string(gl_sys::RENDERER);
+        if gpu_renderer.contains("Adreno") {
+            crate::log!("WARNING: This device is using {gpu_renderer} renderer.
+            OpenGL extrnal textures (GL_OES_EGL_image_external extension) are currently not working on makepad for most Adreno GPUs.
+            This is likely due to a driver bug. External texture support is being disbaled, which means you won't be able to use the Video widget on this device.");
+        }
+    }
 }
 
 
@@ -737,14 +747,18 @@ impl GlShader{
 
 impl CxOsDrawShader {
     pub fn new(vertex: &str, pixel: &str) -> Self {
-        // Check if GL_OES_EGL_image_external is available in the current device, otherwise do not attempt to use in the shaders
-        let available_extensions = get_gl_extensions();
+        // Check if GL_OES_EGL_image_external extension is available in the current device, otherwise do not attempt to use in the shaders.
+        let available_extensions = get_gl_string(gl_sys::EXTENSIONS);
         let is_external_texture_supported = available_extensions.split_whitespace().any(|ext| ext == "GL_OES_EGL_image_external");
 
-        // FIXME: We should inform the user of extension unavailability and use it as pre-condition for video widget
         let mut maybe_ext_tex_extension_import = String::new();
         let mut maybe_ext_tex_extension_sampler = String::new();
-        if is_external_texture_supported {
+
+        // Some Android devices running Adreno GPUs suddenly stopped compiling shaders when passing the samplerExternalOES sampler to texture2D functions. 
+        // This seems like a driver bug (no confirmation from Qualcomm yet).
+        // Therefore we're disabling the external texture support for Adreno until this is fixed.
+        let is_vendor_adreno = get_gl_string(gl_sys::RENDERER).contains("Adreno"); 
+        if is_external_texture_supported && !is_vendor_adreno {
             maybe_ext_tex_extension_import = "#extension GL_OES_EGL_image_external : require\n".to_string();
             maybe_ext_tex_extension_sampler = "vec4 sample2dOES(samplerExternalOES sampler, vec2 pos){{ return texture2D(sampler, vec2(pos.x, pos.y));}}".to_string();
         }
@@ -790,11 +804,11 @@ impl CxOsDrawShader {
     }
 }
 
-// Returns list of currently available GL extensions
-fn get_gl_extensions() -> String {
+
+fn get_gl_string(key: gl_sys::types::GLenum) -> String {
     unsafe {
-        let ext_ptr = gl_sys::GetString(gl_sys::EXTENSIONS) as *const u8;
-        CStr::from_ptr(ext_ptr).to_string_lossy().into_owned()
+        let string_ptr = gl_sys::GetString(key) as *const u8;
+        CStr::from_ptr(string_ptr).to_string_lossy().into_owned()
     }
 }
 

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -495,8 +495,8 @@ impl Cx {
         let gpu_renderer = get_gl_string(gl_sys::RENDERER);
         if gpu_renderer.contains("Adreno") {
             crate::log!("WARNING: This device is using {gpu_renderer} renderer.
-            OpenGL extrnal textures (GL_OES_EGL_image_external extension) are currently not working on makepad for most Adreno GPUs.
-            This is likely due to a driver bug. External texture support is being disbaled, which means you won't be able to use the Video widget on this device.");
+            OpenGL external textures (GL_OES_EGL_image_external extension) are currently not working on makepad for most Adreno GPUs.
+            This is likely due to a driver bug. External texture support is being disabled, which means you won't be able to use the Video widget on this device.");
         }
     }
 }


### PR DESCRIPTION
Fixes #359
Updates shaders definition to only require OpenGL extension `GL_OES_EGL_image_external` if it is actually available.

It also disables the extension for Adreno GPU renderers since some of them currently can't compile shaders which use the `samplerExternalEOS`. This is likely a driver bug but it hasn't been confirmed yet by Qualcomm. 

When a Makepad app runs in a device with a Adreno renderer:
- If Video widget is used it won't crash but it won't be able to show image. 
- A warning will be logged like so:

  > WARNING: This device is using Adreno (TM) 730 renderer.
  > OpenGL external textures (GL_OES_EGL_image_external extension) are currently not working on makepad for most Adreno GPUs.
  > This is likely due to a driver bug. External texture support is being disabled, which means you won't be able to use the Video widget on this device.

This still does not solve emulating Android on macOS. When emulating with macOS as host, the virtual device will inform that the extension is available but it will fail at compiling. This is because the OpenGL provided in the emulation is the deprecated/buggy implementation present in macOS, which is usually spotty at supporting these extensions.