### PR TITLE
Explicitly return a `Result` when an image cannot be loaded

### DIFF
--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -4,6 +4,7 @@ use crate::{
     makepad_draw::*,
     widget::*
 };
+use std::fmt;
 
 live_design!{
     ImageBase = {{Image}} {}
@@ -36,7 +37,7 @@ impl LiveHook for Image{
         self.lazy_create_image_cache(cx);
         let source = self.source.clone();
         if source.as_str().len()>0 {
-            self.load_image_dep_by_path(cx, source.as_str())
+            let _ = self.load_image_dep_by_path(cx, source.as_str());
         }
     }
 }
@@ -101,21 +102,30 @@ impl Image {
 }
 
 impl ImageRef {
-    pub fn load_image_dep_by_path(&self, cx: &mut Cx, image_path: &str) {
+    /// Loads the image at the given `image_path` into this `ImageRef`.
+    pub fn load_image_dep_by_path(&self, cx: &mut Cx, image_path: &str) -> Result<(), ImageError> {
         if let Some(mut inner) = self.borrow_mut() {
             inner.load_image_dep_by_path(cx, image_path)
+        } else {
+            Ok(()) // preserving existing behavior of silent failures.
         }
     }
     
-    pub fn load_jpg_from_data(&self, cx: &mut Cx, data: &[u8]) {
+    /// Loads a JPEG into this `ImageRef` by decoding the given encoded JPEG `data`.
+    pub fn load_jpg_from_data(&self, cx: &mut Cx, data: &[u8]) -> Result<(), ImageError> {
         if let Some(mut inner) = self.borrow_mut() {
             inner.load_jpg_from_data(cx, data)
+        } else {
+            Ok(()) // preserving existing behavior of silent failures.
         }
     }
     
-    pub fn load_png_from_data(&self, cx: &mut Cx, data: &[u8]) {
+    /// Loads a PNG into this `ImageRef` by decoding the given encoded PNG `data`.
+    pub fn load_png_from_data(&self, cx: &mut Cx, data: &[u8]) -> Result<(), ImageError> {
         if let Some(mut inner) = self.borrow_mut() {
             inner.load_png_from_data(cx, data)
+        } else {
+            Ok(()) // preserving existing behavior of silent failures.
         }
     }
     
@@ -130,4 +140,28 @@ impl ImageRef {
             inner.draw_bg.set_uniform(cx, uniform, value);
         }
     }    
+}
+
+
+/// The possible errors that can occur when loading or creating an image texture.
+#[derive(Debug)]
+pub enum ImageError {
+    /// The image data buffer was empty.
+    EmptyData,
+    /// The image's pixel data was not aligned to 3-byte or 4-byte pixels.
+    InvalidPixelAlignment,
+    /// The image data could not be decoded as a JPEG.
+    JpgDecode(JpgDecodeErrors),
+    /// The image file at the given resource path could not be found.
+    PathNotFound(String),
+    /// The image data could not be decoded as a PNG.
+    PngDecode(PngDecodeErrors),
+    /// The image data was in an unsupported format.
+    /// Currently, only JPEG and PNG are supported.
+    UnsupportedFormat,
+}
+impl fmt::Display for ImageError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
 }

--- a/widgets/src/rotated_image.rs
+++ b/widgets/src/rotated_image.rs
@@ -32,7 +32,7 @@ impl LiveHook for RotatedImage {
         self.lazy_create_image_cache(cx);
         let source = self.source.clone();
         if source.as_str().len()>0{
-            self.load_image_dep_by_path(cx, source.as_str())
+            let _ = self.load_image_dep_by_path(cx, source.as_str());
         }
     }
 }


### PR DESCRIPTION
The `ImageRef::load_*` functions currently just print errors to stdio instead of returning them, making it impossible to programmatically determine whether an image has failed to load.

This PR changes all image-related functions to explicitly return errors that could occur internally, via a new error enum:
```rust
pub enum ImageError {
    /// The image data buffer was empty.
    EmptyData,
    /// The image's pixel data was not aligned to 3-byte or 4-byte pixels.
    InvalidPixelAlignment,
    /// The image data could not be decoded as a JPEG.
    JpgDecode(JpgDecodeErrors),
    /// The image file at the given resource path could not be found.
    PathNotFound(String),
    /// The image data could not be decoded as a PNG.
    PngDecode(PngDecodeErrors),
    /// The image data was in an unsupported format.
    /// Currently, only JPEG and PNG are supported.
    UnsupportedFormat,
}
```

To preserve backwards compatibility, I silently drop that `Result` in a few places where there is currently no way to return it, e.g., in a few `LiveApply` trait impls.