### PR TITLE
Add ExpandablePanel widget

### DIFF
--- a/widgets/src/base.rs
+++ b/widgets/src/base.rs
@@ -41,6 +41,7 @@ live_design!{
     import crate::page_flip::PageFlipBase;
     import crate::stack_navigation::StackNavigationViewBase;
     import crate::stack_navigation::StackNavigationBase;
+    import crate::expandable_panel::ExpandablePanelBase;
     import crate::keyboard_view::KeyboardViewBase;
     import crate::window_menu::WindowMenuBase;
     
@@ -575,7 +576,7 @@ live_design!{
             }
         }
     }
-    
+
     CachedRoundedView = <ViewBase> {
                 
         optimize: Texture,
@@ -622,7 +623,43 @@ live_design!{
             }
         }
     }
-    
+
+    ExpandablePanel = <ExpandablePanelBase> {
+        flow: Overlay,
+        width: Fill,
+        height: Fill,
+
+        initial_offset: 400.0;
+
+        body = <View> {}
+
+        panel = <View> {
+            flow: Down,
+            width: Fill,
+            height: Fit,
+
+            show_bg: true,
+            draw_bg: {
+                color: #FFF
+            }
+
+            align: { x: 0.5, y: 0 }
+            padding: 20,
+            spacing: 10,
+
+            scroll_handler = <RoundedView> {
+                width: 40,
+                height: 6,
+
+                show_bg: true,
+                draw_bg: {
+                    color: #333
+                    radius: 2.
+                }
+            }
+        }
+    }
+
     MultiWindow = <MultiWindowBase>{}
     PageFlip = <PageFlipBase>{}
     KeyboardView = <KeyboardViewBase>{}
@@ -667,4 +704,5 @@ live_design!{
     WindowMenuBase = <WindowMenuBase>{}
     StackNavigationViewBase = <StackNavigationViewBase>{}
     StackNavigationBase = <StackNavigationBase>{}
+    ExpandablePanelBase = <ExpandablePanelBase>{}
 }

--- a/widgets/src/expandable_panel.rs
+++ b/widgets/src/expandable_panel.rs
@@ -1,0 +1,77 @@
+use {
+    crate::{
+        touch_gesture::*,
+        makepad_derive_widget::*,
+        makepad_draw::*,
+        widget::*,
+        view::*,
+    }
+};
+
+live_design! {
+    ExpandablePanelBase = {{ExpandablePanel}} {}
+}
+
+#[derive(Clone, DefaultNone, Debug)]
+pub enum ExpandablePanelAction {
+    ScrolledAt(f64),
+    None,
+}
+
+#[derive(Live, Widget)]
+pub struct ExpandablePanel {
+    #[deref] view: View,
+    #[rust] touch_gesture: Option<TouchGesture>,
+    #[live] initial_offset: f64,
+}
+
+impl LiveHook for ExpandablePanel {
+    fn after_apply_from(&mut self, cx: &mut Cx, apply: &mut Apply) {
+        if apply.from.is_from_doc() {
+            self.apply_over(cx, live! {
+                panel = { margin: { top: (self.initial_offset) }}
+            });
+        }
+    }
+}
+
+impl Widget for ExpandablePanel {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+
+        if let Some(touch_gesture) = self.touch_gesture.as_mut() {
+            if touch_gesture.handle_event(cx, event, self.view.area()).has_changed() {
+                let scrolled_at = touch_gesture.scrolled_at;
+                let panel_margin = self.initial_offset - scrolled_at;
+                self.apply_over(cx, live! {
+                    panel = { margin: { top: (panel_margin) }}
+                });
+                self.redraw(cx);
+
+                cx.widget_action(
+                    self.widget_uid(),
+                    &scope.path,
+                    ExpandablePanelAction::ScrolledAt(scrolled_at),
+                );
+            }
+        }
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        let result = self.view.draw_walk(cx, scope, walk);
+
+        if self.touch_gesture.is_none() {
+            let mut touch_gesture = TouchGesture::new();
+            touch_gesture.set_mode(ScrollMode::Swipe);
+
+            // Limit the amount of dragging allowed for the panel
+            let panel_height = self.view(id!(panel)).area().rect(cx).size.y;
+            touch_gesture.set_range(0.0, panel_height - self.initial_offset);
+
+            touch_gesture.reset_scrolled_at();
+            self.touch_gesture = Some(touch_gesture);
+        }
+
+        result
+    }
+}

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -29,6 +29,7 @@ pub mod tab_bar;
 pub mod tab_close_button;
 pub mod portal_list;
 pub mod stack_navigation;
+pub mod expandable_panel;
 pub mod desktop_button;
 pub mod window;
 pub mod scroll_shadow;
@@ -53,6 +54,8 @@ pub mod nav_control;
 pub mod view;
 pub mod widget;
 pub mod widget_match_event;
+
+pub mod touch_gesture;
 
 #[macro_use]
 pub mod data_binding;
@@ -81,6 +84,7 @@ pub use crate::{
     fold_button::*,
     dock::*,
     stack_navigation::*,
+    expandable_panel::*,
     window::*,
     tab::TabClosable,
     scroll_bars::{ScrollBars},
@@ -157,4 +161,5 @@ pub fn live_design(cx: &mut Cx) {
     crate::keyboard_view::live_design(cx);
     crate::vectorline::live_design(cx);
     crate::stack_navigation::live_design(cx);
+    crate::expandable_panel::live_design(cx);
 }

--- a/widgets/src/touch_gesture.rs
+++ b/widgets/src/touch_gesture.rs
@@ -1,0 +1,273 @@
+use crate::{
+    Area,
+    Cx,
+    Event,
+    Hit,
+    MouseCursor,
+    NextFrame,
+};
+
+#[derive(Clone, Copy, Debug)]
+struct ScrollSample{
+    abs: f64,
+    time: f64,
+}
+
+#[derive(Default, Clone, Debug)]
+pub enum ScrollMode {
+    #[default]
+    DragAndDrop,
+    Swipe,
+}
+
+#[derive(Default, Clone, Debug)]
+enum ScrollState {
+    #[default]
+    Stopped,
+    Drag{samples:Vec<ScrollSample>},
+    Flick {delta: f64, next_frame: NextFrame},
+    Pulldown {next_frame: NextFrame},
+}
+
+#[derive(Default, PartialEq)]
+pub enum TouchMotionChange {
+    #[default]
+    None,
+    ScrollStateChanged,
+    ScrolledAtChanged,
+}
+
+#[derive(Default, Clone)]
+pub struct TouchGesture {
+    flick_scroll_minimum: f64,
+    flick_scroll_maximum: f64,
+    flick_scroll_scaling: f64,
+    flick_scroll_decay: f64,
+
+    scroll_mode: ScrollMode,
+    scroll_state: ScrollState,
+
+    min_scrolled_at: f64,
+    max_scrolled_at: f64,
+    pulldown_maximum: f64,
+
+    pub scrolled_at: f64,
+}
+
+impl TouchGesture {
+    pub fn new() -> Self {
+        Self {
+            flick_scroll_minimum: 0.2,
+            flick_scroll_maximum: 80.0,
+            flick_scroll_scaling: 0.005,
+            flick_scroll_decay: 0.98,
+
+            scroll_state: ScrollState::Stopped,
+            scroll_mode: ScrollMode::DragAndDrop,
+
+            scrolled_at: 0.0,
+            min_scrolled_at: f64::MIN,
+            max_scrolled_at: f64::MAX,
+            pulldown_maximum: 60.0,
+        }
+    }
+
+    pub fn reset_scrolled_at(&mut self) {
+        self.scrolled_at = 0.0;
+    }
+
+    pub fn set_mode(&mut self, scroll_mode: ScrollMode) {
+        self.scroll_mode = scroll_mode;
+    }
+
+    pub fn set_range(&mut self, min_offset: f64, max_offset: f64) {
+        self.min_scrolled_at = min_offset;
+        self.max_scrolled_at = max_offset;
+        self.scrolled_at = self.scrolled_at.clamp(
+            self.min_scrolled_at - self.pulldown_maximum,
+            self.max_scrolled_at + self.pulldown_maximum
+        );
+    }
+
+    pub fn stop(&mut self) {
+        self.scrolled_at = 0.0;
+        self.scroll_state = ScrollState::Stopped;
+    }
+
+    pub fn is_stopped(&self) -> bool {
+        match self.scroll_state {
+            ScrollState::Stopped => true,
+            _ => false
+        }
+    }
+
+    pub fn is_dragging(&self) -> bool {
+        match self.scroll_state {
+            ScrollState::Drag {..} => true,
+            _ => false
+        }
+    }
+
+    pub fn handle_event(&mut self, cx: &mut Cx, event: &Event, area: Area) -> TouchMotionChange {
+        let needs_pulldown_when_flicking = self.needs_pulldown_when_flicking();
+        let needs_pulldown = self.needs_pulldown();
+
+        match &mut self.scroll_state {
+            ScrollState::Flick {delta, next_frame} => {
+                if let Some(_) = next_frame.is_event(event) {
+                    *delta = *delta * self.flick_scroll_decay;
+                    if needs_pulldown_when_flicking {
+                        self.scroll_state = ScrollState::Pulldown {next_frame: cx.new_next_frame()};
+                        return TouchMotionChange::ScrollStateChanged
+                    } else if delta.abs() > self.flick_scroll_minimum {
+                        *next_frame = cx.new_next_frame();
+                        let delta = *delta;
+
+                        let new_offset = self.scrolled_at - delta;
+                        self.scrolled_at = new_offset.clamp(
+                            self.min_scrolled_at - self.pulldown_maximum,
+                            self.max_scrolled_at + self.pulldown_maximum
+                        );
+
+                        return TouchMotionChange::ScrolledAtChanged
+                    } else {
+                        if needs_pulldown {
+                            self.scroll_state = ScrollState::Pulldown {next_frame: cx.new_next_frame()};
+                        } else {
+                            self.scroll_state = ScrollState::Stopped;
+                        }
+
+                        return TouchMotionChange::ScrollStateChanged
+                    }
+                }
+            }
+            ScrollState::Pulldown {next_frame} => {
+                if let Some(_) = next_frame.is_event(event) {
+                    if self.scrolled_at < self.min_scrolled_at {
+                        self.scrolled_at += (self.min_scrolled_at - self.scrolled_at) * 0.1;
+                        if self.min_scrolled_at - self.scrolled_at < 1.0 {
+                            self.scrolled_at = self.min_scrolled_at + 0.5;
+                        }
+                        else {
+                            *next_frame = cx.new_next_frame();
+                        }
+
+                        return TouchMotionChange::ScrolledAtChanged
+                    }
+                    else if self.scrolled_at > self.max_scrolled_at {
+                        self.scrolled_at -= (self.scrolled_at - self.max_scrolled_at) * 0.1;
+                        if self.scrolled_at - self.max_scrolled_at < 1.0 {
+                            self.scrolled_at = self.max_scrolled_at - 0.5;
+
+                            return TouchMotionChange::ScrolledAtChanged
+                        }
+                        else {
+                            *next_frame = cx.new_next_frame();
+                        }
+
+                        return TouchMotionChange::ScrolledAtChanged
+                    }
+                    else {
+                        self.scroll_state = ScrollState::Stopped;
+                        return TouchMotionChange::ScrollStateChanged
+                    }
+                }
+            }
+            _=>()
+        }
+
+        match event.hits_with_capture_overload(cx, area, true) {
+            Hit::FingerDown(e) => {
+                self.scroll_state = ScrollState::Drag {
+                    samples: vec![ScrollSample{abs: e.abs.y, time: e.time}]
+                };
+
+                return TouchMotionChange::ScrollStateChanged
+            }
+            Hit::FingerMove(e) => {
+                cx.set_cursor(MouseCursor::Default);
+                match &mut self.scroll_state {
+                    ScrollState::Drag {samples}=>{
+                        let new_abs = e.abs.y;
+                        let old_sample = *samples.last().unwrap();
+                        samples.push(ScrollSample{abs: new_abs, time: e.time});
+                        if samples.len() > 4 {
+                            samples.remove(0);
+                        }
+                        let new_offset = self.scrolled_at + old_sample.abs - new_abs;
+                        self.scrolled_at = new_offset.clamp(
+                            self.min_scrolled_at - self.pulldown_maximum,
+                            self.max_scrolled_at + self.pulldown_maximum
+                        );
+
+                        return TouchMotionChange::ScrolledAtChanged
+                    }
+                    _=>()
+                }
+            }
+            Hit::FingerUp(_e) => {
+                match &mut self.scroll_state {
+                    ScrollState::Drag {samples} => {
+                        match self.scroll_mode {
+                            ScrollMode::Swipe => {
+                                let mut last = None;
+                                let mut scaled_delta = 0.0;
+                                let mut total_delta = 0.0;
+                                for sample in samples.iter().rev() {
+                                    if last.is_none() {
+                                        last = Some(sample);
+                                    }
+                                    else {
+                                        total_delta += last.unwrap().abs - sample.abs;
+                                        scaled_delta += (last.unwrap().abs - sample.abs)/ (last.unwrap().time - sample.time)
+                                    }
+                                }
+                                scaled_delta *= self.flick_scroll_scaling;
+
+                                if self.needs_pulldown() {
+                                    self.scroll_state = ScrollState::Pulldown {next_frame: cx.new_next_frame()};
+                                }
+                                else if total_delta.abs() > 10.0 && scaled_delta.abs() > self.flick_scroll_minimum {
+                                    self.scroll_state = ScrollState::Flick {
+                                        delta: scaled_delta.min(self.flick_scroll_maximum).max(-self.flick_scroll_maximum),
+                                        next_frame: cx.new_next_frame()
+                                    };
+                                } else {
+                                    self.scroll_state = ScrollState::Stopped;
+                                }
+
+                                return TouchMotionChange::ScrollStateChanged
+                            }
+                            ScrollMode::DragAndDrop => {
+                                self.scroll_state = ScrollState::Stopped;
+                                return TouchMotionChange::ScrollStateChanged
+                            }
+                        }
+                    }
+                    _=>()
+                }
+            }
+            _ => ()
+        }
+
+        TouchMotionChange::None
+    }
+
+    fn needs_pulldown(&self) -> bool {
+        self.scrolled_at < self.min_scrolled_at || self.scrolled_at > self.max_scrolled_at
+    }
+
+    fn needs_pulldown_when_flicking(&self) -> bool {
+        self.scrolled_at - 0.5 < self.min_scrolled_at - self.pulldown_maximum ||
+            self.scrolled_at + 0.5 > self.max_scrolled_at + self.pulldown_maximum
+    }
+}
+
+impl TouchMotionChange {
+    pub fn has_changed(&self) -> bool {
+        match self {
+            TouchMotionChange::None => false,
+            _ => true
+        }
+    }
+}


### PR DESCRIPTION
It adds a `ExpandablePanel` widget.

https://github.com/makepad/makepad/assets/487140/db5698a4-3ce2-42dc-ba7b-7047b612cff7

In addition, it is the first step to extract the swipe gesture logic from the existing `PortalList`. Further work is needed to make this widget to reuse the logic extracted.

