### PR TITLE
Retrieve and use the proper mouse button number for other mouse button clicks (macOS only)

### DIFF
--- a/platform/src/os/apple/apple_util.rs
+++ b/platform/src/os/apple/apple_util.rs
@@ -406,6 +406,19 @@ pub fn bottom_left_to_top_left(rect: NSRect) -> f64 {
     height as f64 - (rect.origin.y + rect.size.height)
 }
 
+/// Retrieves the mouse button number for the given `event.
+///
+/// Button numbers are as follows:
+/// * 0: Main (left) mouse button
+/// * 1: Secondary (right) mouse button
+/// * 2: Middle mouse button (clicking the scroll wheel)
+/// * 3: Fourth mouse button, commonly the "back" button
+/// * 4: Fifth mouse button, commonly the "forward" button
+pub fn get_event_mouse_button(event: ObjcId) -> usize {
+    let button_number: usize = unsafe {msg_send![event, buttonNumber]};
+    button_number
+}
+
 pub fn load_mouse_cursor(cursor: MouseCursor) -> ObjcId {
     match cursor {
         MouseCursor::Arrow | MouseCursor::Default | MouseCursor::Hidden => load_native_cursor("arrowCursor"),

--- a/platform/src/os/apple/macos/macos_delegates.rs
+++ b/platform/src/os/apple/macos/macos_delegates.rs
@@ -1,3 +1,5 @@
+use crate::apple_util::get_event_mouse_button;
+
 use {
     std::{
         rc::Rc,
@@ -387,13 +389,15 @@ pub fn define_cocoa_view_class() -> *const Class {
     extern fn other_mouse_down(this: &Object, _sel: Sel, event: ObjcId) {
         let cw = get_cocoa_window(this);
         let modifiers = get_event_key_modifier(event);
-        cw.send_mouse_down(2, modifiers);
+        let button = get_event_mouse_button(event);
+        cw.send_mouse_down(button, modifiers);
     }
     
     extern fn other_mouse_up(this: &Object, _sel: Sel, event: ObjcId) {
         let cw = get_cocoa_window(this);
         let modifiers = get_event_key_modifier(event);
-        cw.send_mouse_up(2, modifiers);
+        let button = get_event_mouse_button(event);
+        cw.send_mouse_up(button, modifiers);
     }
     
     fn mouse_pos_from_event(view: &Object, event: ObjcId) -> DVec2 {


### PR DESCRIPTION
* Currently, the button numbers in use are based off of the `buttonNumber` property from macOS `NSEvent` API: <https://developer.apple.com/documentation/appkit/nsevent/1527828-buttonnumber>
  * 0: Main (left) mouse button
  * 1: Secondary (right) mouse button
  * 2: Middle mouse button (clicking the scroll wheel)
  * 3: Fourth mouse button, commonly the "back" button
  * 4: Fifth mouse button, commonly the "forward" button

-------------

As I said on Discord, I'm not sure if any Makepad widget impls or apps actually depend on the previous simplified behavior of always using `2` for any other mouse button press.

If so, I can augment this PR with a MouseButton enum in `platform/events` that can be used across Makepad such that we discourage usage of raw integers.