### PR TITLE
draw: reset the atlas when full.

### DIFF
--- a/draw/src/font_atlas.rs
+++ b/draw/src/font_atlas.rs
@@ -173,6 +173,8 @@ impl CxFontsAtlas {
                 cxfont.atlas_pages.clear();
             }
         }
+        self.alloc.todo.clear();
+        self.alloc.full = false;
         self.alloc.xpos = 0.;
         self.alloc.ypos = 0.;
         self.alloc.hmax = 0.;
@@ -212,6 +214,10 @@ impl<'a> Cx2d<'a> {
         let fonts_atlas_rc = self.fonts_atlas_rc.clone();
         let mut fonts_atlas = fonts_atlas_rc.0.borrow_mut();
         let fonts_atlas = &mut*fonts_atlas;
+
+        if fonts_atlas.alloc.full {
+            fonts_atlas.reset_fonts_atlas();
+        }
 
         // Will be automatically filled after the first use.
         let mut reuse_sdfer_bufs = None;


### PR DESCRIPTION
This doesn't get rid of the messages so you still end up with spam like this:
```console
$ cargo run -p makepad-example-slides --release
   Compiling makepad-draw v0.6.0 (/home/eddy/Projects/makepad/draw)
   Compiling makepad-widgets v0.6.0 (/home/eddy/Projects/makepad/widgets)
   Compiling makepad-example-slides v0.6.0 (/home/eddy/Projects/makepad/examples/slides)
    Finished release [optimized] target(s) in 10.56s
     Running `target/release/makepad-example-slides`
FONT ATLAS FULL, TODO FIX THIS 4265 > 4096,
FONT ATLAS FULL, TODO FIX THIS 4133 > 4096,
FONT ATLAS FULL, TODO FIX THIS 4205 > 4096,
FONT ATLAS FULL, TODO FIX THIS 4277 > 4096,
FONT ATLAS FULL, TODO FIX THIS 4277 > 4096,
FONT ATLAS FULL, TODO FIX THIS 4277 > 4096,
FONT ATLAS FULL, TODO FIX THIS 4277 > 4096,
```
(tested by holding the → key, with the current 4x SDF scaling, which is overkill and due to be replaced)