### PR TITLE
disable rustfmt

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true


### PR DESCRIPTION
i'd rather push some nice config and enable it, but stabilizing Rik's [must-have feature](https://github.com/rust-lang/rustfmt/pull/5968) will take some time => better to disable it so we don't have to fight rustfmt all the time.