### PR TITLE
widgets: don't also scale `View` additionally based on `dpi_factor`.

### DIFF
--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -681,14 +681,29 @@ impl Widget for View {
                                 .draw_vars
                                 .set_texture(0, &texture_cache.color_texture);
                             let mut rect = cx.walk_turtle_with_area(&mut self.area, walk);
-                            rect.size *= 2.0 / self.dpi_factor.unwrap_or(1.0);
+                            // NOTE(eddyb) see comment lower below for why this is
+                            // disabled (it used to match `set_pass_scaled_area`).
+                            if false {
+                                rect.size *= 2.0 / self.dpi_factor.unwrap_or(1.0);
+                            }
                             self.draw_bg.draw_abs(cx, rect);
                             self.area = self.draw_bg.area();
-                            cx.set_pass_scaled_area(
-                                &texture_cache.pass,
-                                self.area,
-                                2.0 / self.dpi_factor.unwrap_or(1.0),
-                            );
+                            if false {
+                                // FIXME(eddyb) this was the previous logic,
+                                // but the only tested apps that use `CachedView`
+                                // are sized correctly (regardless of `dpi_factor`)
+                                // *without* extra scaling here.
+                                cx.set_pass_scaled_area(
+                                    &texture_cache.pass,
+                                    self.area,
+                                    2.0 / self.dpi_factor.unwrap_or(1.0),
+                                );
+                            } else {
+                                cx.set_pass_area(
+                                    &texture_cache.pass,
+                                    self.area,
+                                );
+                            }
                         }
                         return DrawStep::done();
                     }
@@ -823,11 +838,22 @@ impl Widget for View {
                         self.draw_bg.draw_abs(cx, rect);
                         let area = self.draw_bg.area();
                         let texture_cache = self.texture_cache.as_mut().unwrap();
-                        cx.set_pass_scaled_area(
-                            &texture_cache.pass,
-                            area,
-                            2.0 / self.dpi_factor.unwrap_or(1.0),
-                        );
+                        if false {
+                            // FIXME(eddyb) this was the previous logic,
+                            // but the only tested apps that use `CachedView`
+                            // are sized correctly (regardless of `dpi_factor`)
+                            // *without* extra scaling here.
+                            cx.set_pass_scaled_area(
+                                &texture_cache.pass,
+                                area,
+                                2.0 / self.dpi_factor.unwrap_or(1.0),
+                            );
+                        } else {
+                            cx.set_pass_area(
+                                &texture_cache.pass,
+                                area,
+                            );
+                        }
                     }
                 }
                 self.draw_state.end();


### PR DESCRIPTION
This change allows `CachedView` users to avoid [hardcoding `dpi_factor: 2.0`](https://github.com/project-robius/makepad_wonderous/blob/3caa7d579a42b0bf470c59ed167be0a4e60d4782/src/shared/widgets.rs#L8-L9) in order to get the correct size: with this PR, all `dpi_factor`¹ values produce the same effective size in the app, only the density of the backing texture changes (so e.g. you can produce a pixellation effect by using a small `dpi_factor` value, while the relative size of UI elements remains unchanged).

¹(including not setting it, which should give native pixels and better quality than a hardcoded factor)

---

The failure mode was stranger than simply the wrong sizes of UI elements, certain events must've been setting/resetting this extra `2.0 / ...` factor, because it could flicker from frame to frame, and mouse events (possibly scrolling the view constantly?) would make one state more likely than the other.

Sadly I don't have a better way of demonstrating it than triggering the exact failure mode we saw:
```sh
git clone https://github.com/project-robius/makepad_wonderous
cd makepad_wonderous
git switch --detach 3caa7d579a42b0bf470c59ed167be0a4e60d4782
sed -i 's|dpi_factor: 2.0,|//\0|' src/shared/widgets.rs
cargo run
```

---

I am frankly not sure at all what happened with this code, and AFAICT this is the sole user of `set_pass_scaled_area` and the variant `CxPassRect::ScaledArea` - I'm worried there may be some situation in which a different formula makes sense (nested `CachedView`s, perhaps?), so I've wrapped the old code in `if else` instead of just removing it.