### PR TITLE
Stack Navigation enhacements

### DIFF
--- a/platform/src/animator.rs
+++ b/platform/src/animator.rs
@@ -189,6 +189,10 @@ impl Ease {
     pub fn map(&self, t: f64) -> f64 {
         match self {
             Self::ExpDecay {d1, d2, max} => { // there must be a closed form for this
+                if t > 0.999 {
+                    return 1.0;
+                }
+
                 // first we count the number of steps we'd need to decay
                 let mut di = *d1;
                 let mut dt = 1.0;

--- a/widgets/src/stack_navigation.rs
+++ b/widgets/src/stack_navigation.rs
@@ -20,6 +20,12 @@ pub enum StackNavigationAction {
     NavigateTo(LiveId)
 }
 
+#[derive(Clone, Default, Eq, Hash, PartialEq, Debug)]
+pub enum StackNavigationViewState {
+    Active,
+    #[default] Inactive,
+}
+
 /// Actions that are delivered to an incoming or outgoing "active" widget/view
 /// within a stack navigation container.
 #[derive(Clone, DefaultNone, Eq, Hash, PartialEq, Debug)]
@@ -53,43 +59,20 @@ pub struct StackNavigationView {
 
     #[animator]
     animator: Animator,
+
+    #[rust]
+    state: StackNavigationViewState,
 }
 
 impl Widget for StackNavigationView {
-    fn handle_event(&mut self, cx:&mut Cx, event:&Event, scope:&mut Scope) {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         if self.animator_handle_event(cx, event).must_redraw() {
             self.view.redraw(cx);
         }
 
+        self.handle_stack_view_closure_request(cx, event, scope);
+        self.finish_closure_animation_if_done(cx);
         self.view.handle_event(cx, event, scope);
-        self.widget_match_event(cx, event, scope);
-
-        // Clicking the "back" button on the mouse
-        // TODO: in the future, a swipe right gesture on touchscreen, or two-finger swipe on trackpad
-        let back_mouse_button_released = match event {
-            Event::MouseUp(mouse) => mouse.button == 3, // the "back" button on the mouse
-            _ => false,
-        };
-        if back_mouse_button_released {
-            self.hide_stack_view(cx);
-        }
-
-        if self.animator.animator_in_state(cx, id!(slide.hide))
-        {
-            if self.offset > self.offset_to_hide {
-                self.apply_over(cx, live! {visible: false});
-
-                // The active stack view is about to be no longer active, so let's
-                // send a `HideEnd` action to it so it can be aware of the transition conclusion.
-                cx.widget_action(
-                    self.widget_uid(),
-                    &HeapLiveIdPath::default(),
-                    StackNavigationTransitionAction::HideEnd,
-                );
-
-                self.animator_cut(cx, id!(slide.hide));
-            }
-        }
     }
 
     fn draw_walk(&mut self, cx:&mut Cx2d, scope:&mut Scope, walk:Walk) -> DrawStep{
@@ -122,6 +105,42 @@ impl StackNavigationView {
             StackNavigationTransitionAction::HideBegin,
         );
     }
+
+    fn handle_stack_view_closure_request(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        // This will invoke WidgetMatchEvent::handle_actions() on the widget.
+        // If the back button was clicked, it will be handled there.
+        self.widget_match_event(cx, event, scope);
+
+        // Clicking the "back" button on the mouse must also hide the active stack view.
+        let back_mouse_button_released = match event {
+            Event::MouseUp(mouse) => mouse.button == 3, // the "back" button on the mouse
+            _ => false,
+        };
+        if back_mouse_button_released {
+            self.hide_stack_view(cx);
+        }
+
+        // TODO: in the future, a swipe right gesture on touchscreen, or two-finger swipe on trackpad
+    }
+
+    fn finish_closure_animation_if_done(&mut self, cx: &mut Cx) {
+        if self.state == StackNavigationViewState::Active
+            && self.animator.animator_in_state(cx, id!(slide.hide))
+        {
+            if self.offset > self.offset_to_hide {
+                self.apply_over(cx, live! { visible: false });
+
+                cx.widget_action(
+                    self.widget_uid(),
+                    &HeapLiveIdPath::default(),
+                    StackNavigationTransitionAction::HideEnd,
+                );
+
+                self.animator_cut(cx, id!(slide.hide));
+                self.state = StackNavigationViewState::Inactive;
+            }
+        }
+    }
 }
 
 impl StackNavigationViewRef {
@@ -129,6 +148,7 @@ impl StackNavigationViewRef {
         if let Some(mut inner) = self.borrow_mut() {
             inner.apply_over(cx, live! {offset: (root_width), visible: true});
             inner.offset_to_hide = root_width;
+            inner.state = StackNavigationViewState::Active;
             inner.animator_play(cx, id!(slide.show));
         }
     }
@@ -192,10 +212,14 @@ impl LiveHook for StackNavigation {
 
 impl Widget for StackNavigation {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        self.widget_match_event(cx, event, scope);
         for widget_ref in self.get_active_views(cx).iter() {
             widget_ref.handle_event(cx, event, scope);
         }
+
+        // Leaving this to the final step, so that the active stack view can handle the event first.
+        // It is releveant when the active stack view is animating out and want to handle
+        // the StackNavigationTransitionAction::HideEnd action.
+        self.widget_match_event(cx, event, scope);
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep  {
@@ -216,7 +240,7 @@ impl WidgetNode for StackNavigation {
             widget_ref.redraw(cx);
         }
     }
-    
+
     fn find_widgets(&mut self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet) {
         self.view.find_widgets(path, cached, results);
     }
@@ -225,12 +249,19 @@ impl WidgetNode for StackNavigation {
 impl WidgetMatchEvent for StackNavigation {
     fn handle_actions(&mut self, _cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
         for action in actions {
+            // If the window is resized, we need to record the new screen width to
+            // fit the transition animation for the new dimensions.
             if let WindowAction::WindowGeomChange(ce) = action.as_widget_action().cast() {
                 self.screen_width = ce.new_geom.inner_size.x * ce.new_geom.dpi_factor;
                 if let ActiveStackView::Active(stack_view_id) = self.active_stack_view {
                     let mut stack_view_ref = self.stack_navigation_view(&[stack_view_id]);
                     stack_view_ref.set_offset_to_hide(self.screen_width);
                 }
+            }
+
+            // If the active stack view is already hidden, we need to reset the active stack view.
+            if let StackNavigationTransitionAction::HideEnd = action.as_widget_action().cast() {
+                self.active_stack_view = ActiveStackView::None;
             }
         }
     }
@@ -268,12 +299,10 @@ impl StackNavigation {
                     if stack_view_ref.is_animating(cx) {
                         views.push(self.view.widget(id!(root_view)));
                     }
-                    views.push(stack_view_ref.0.clone());
-                    views
-                } else {
-                    self.active_stack_view = ActiveStackView::None;
-                    vec![self.view.widget(id!(root_view))]
                 }
+
+                views.push(stack_view_ref.0.clone());
+                views
             }
         }
     }


### PR DESCRIPTION
This PR includes:

* Makes sure that children view can listen and respond to `StackNavigationTransitionAction::HideEnd`
* `StackNavigationTransitionAction::Show replaced by `ShowBegin` and `ShowEnd`
* Fixes an issue related with the `ExpDecay` animation ease calculation that was preventing the opening animation to fully reach to the final position (0 in the horizontal axis).