### PR TITLE
Video Widget: don't attempt to import image_external on emulators

### DIFF
--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -123,7 +123,7 @@ pub struct Cx {
 }
 
 #[derive(Clone)]
-pub struct CxRef(pub Rc<RefCell<Cx>>); //TODO: I probably shouldn't remove the (crate)
+pub struct CxRef(pub Rc<RefCell<Cx>>);
 
 pub struct CxDependency {
     pub data: Option<Result<Rc<Vec<u8>>, String >>
@@ -131,7 +131,8 @@ pub struct CxDependency {
 #[derive(Clone, Debug)]
 pub struct AndroidParams {
     pub cache_path: String,
-    pub density: f64
+    pub density: f64,
+    pub is_emulator: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -170,10 +170,12 @@ pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onAndroidParams(
     _: jni_sys::jclass,
     cache_path: jni_sys::jstring,
     density: jni_sys::jfloat,
+    is_emulator: jni_sys::jboolean,
 ) {
     send_from_java_message(FromJavaMessage::Init(AndroidParams {
         cache_path: jstring_to_string(env, cache_path),
         density: density as f64,
+        is_emulator: is_emulator != 0,
     }));
 }
 

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -269,8 +269,9 @@ MidiManager.OnDeviceOpenedListener{
 
         String cache_path = this.getCacheDir().getAbsolutePath();
         float density = getResources().getDisplayMetrics().density;
+        boolean isEmulator = this.isEmulator();
 
-        MakepadNative.onAndroidParams(cache_path, density);
+        MakepadNative.onAndroidParams(cache_path, density, isEmulator);
 
         // Set volume keys to control music stream, we might want make this flexible for app devs
         setVolumeControlStream(AudioManager.STREAM_MUSIC);
@@ -557,5 +558,18 @@ MidiManager.OnDeviceOpenedListener{
             runnable.cleanupVideoPlaybackResources();
             runnable = null;
         }
+    }
+
+    public boolean isEmulator() {
+        // hints that the app is running on emulator
+        return Build.MODEL.startsWith("sdk")
+            || "google_sdk".equals(Build.MODEL)
+            || Build.MODEL.contains("Emulator")
+            || Build.MODEL.contains("Android SDK")
+            || Build.MODEL.toLowerCase().contains("droid4x")
+            || Build.FINGERPRINT.startsWith("generic")
+            || Build.PRODUCT == "sdk"
+            || Build.PRODUCT == "google_sdk"
+            || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"));
     }
 }

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
@@ -12,7 +12,7 @@ public class MakepadNative {
     public native static void activityOnPause();
     public native static void activityOnStop();
     public native static void activityOnDestroy();
-    public static native void onAndroidParams(String cache_path, float dentify);
+    public static native void onAndroidParams(String cache_path, float dentify, boolean isEmulator);
 
     // belongs to QuadSurface class
     public native static void surfaceOnSurfaceCreated(Surface surface);

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -260,13 +260,27 @@ impl LiveHook for Video {
         self.id = LiveId::unique();
 
         #[cfg(target_os = "android")]
-        if self.video_texture.is_none() {
-            let new_texture = Texture::new_with_format(cx, TextureFormat::VideoRGB);
-            self.video_texture = Some(new_texture);
+        {
+            if self.video_texture.is_none() {
+                let new_texture = Texture::new_with_format(cx, TextureFormat::VideoRGB);
+                self.video_texture = Some(new_texture);
+            }
+            let texture = self.video_texture.as_mut().unwrap();
+            self.draw_bg.draw_vars.set_texture(0, &texture);
         }
 
-        let texture = self.video_texture.as_mut().unwrap();
-        self.draw_bg.draw_vars.set_texture(0, &texture);
+        #[cfg(not(target_os = "android"))]
+        error!("Video Widget is currently only supported on Android.");
+
+        match cx.os_type() {
+            OsType::Android(params) => {
+                if params.is_emulator {
+                    panic!("Video Widget is currently only supported on real devices. (unreliable support for external textures on some emulators hosts)");
+                }
+            },
+            _ => {}
+        }
+        
         self.should_prepare_playback = self.autoplay;
     }
 


### PR DESCRIPTION
Previously we were querying OpenGL Extensions support at runtime, and checking if `GL_OES_EGL_image_external` was listed.
This wasn't enough for Android emulators, specially when hosting from macOS, where support for extensions is spotty.

With these changes we now check if we're running on an emulator, and if so we disable the external textures completely. We do this so that apps don't crash on emulators if video isn't used at all.

It also improves the error logs (shorter and clearer) when using video on an emulator or on other platforms.