### PR TITLE
Initialize Image Cache on Video Widget

### DIFF
--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -285,6 +285,7 @@ impl LiveHook for Video {
     }
 
     fn after_apply(&mut self, cx: &mut Cx, _apply: &mut Apply, _index: usize, _nodes: &[LiveNode]) {
+        self.lazy_create_image_cache(cx);
         self.thumbnail_texture = Some(Texture::new(cx));
 
         let target_w = self.walk.width.fixed_or_zero();


### PR DESCRIPTION
Adds missing call to initialize the image cache on Video Widget (for thumbnails). Didn't catch this before because I was always using thumbnails in apps where other widgets had initialized the cache.