### PR TITLE
`cargo-makepad`: support installing the full Android NDK (macOS only)

### DIFF
--- a/libs/shell/src/shell.rs
+++ b/libs/shell/src/shell.rs
@@ -1,7 +1,7 @@
 use std::{
     path::{Path, PathBuf},
     fs::File,
-    io::{Write},
+    io::Write,
     fs,
     io::prelude::*,
     io::BufReader,

--- a/tools/cargo_makepad/src/android/compile.rs
+++ b/tools/cargo_makepad/src/android/compile.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use crate::android::{HostOs, AndroidTarget};
 use crate::utils::*;
 use crate::makepad_shell::*;
+use super::sdk::NDK_VERSION_FULL;
 
 struct BuildPaths {
     tmp_dir: PathBuf,
@@ -19,6 +20,7 @@ pub struct BuildResult {
 }
 
 fn manifest_xml(label:&str, class_name:&str, url:&str)->String{
+    println!("manifest_xml(): label: {:?}, class_name: {:?}, url: {:?}", label, class_name, url); // TODO: remove before merge
     format!(r#"<?xml version="1.0" encoding="utf-8"?>
     <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
@@ -33,7 +35,7 @@ fn manifest_xml(label:&str, class_name:&str, url:&str)->String{
             tools:targetApi="33">
             <meta-data android:name="android.max_aspect" android:value="2.1" />
             <activity
-                android:name="{class_name}"
+                android:name=".{class_name}"
                 android:configChanges="orientation|screenSize|keyboardHidden"
                 android:exported="true">
                 <intent-filter>
@@ -74,13 +76,14 @@ fn rust_build(sdk_dir: &Path, host_os: HostOs, args: &[String], android_targets:
     for android_target in android_targets {
         let clang_filename = format!("{}33-clang", android_target.clang());
         
-        let linker = match host_os{
-            HostOs::MacosX64=>format!("NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin/{clang_filename}"),
-            HostOs::MacosAarch64=>format!("NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin/{clang_filename}"),
-            HostOs::WindowsX64=>format!("NDK/toolchains/llvm/prebuilt/windows-x86_64/bin/{clang_filename}.cmd"),
-            HostOs::LinuxX64=>format!("NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/{clang_filename}"),
-            _=>panic!()
+        let bin_path = |bin_filename: &str| match host_os {
+            HostOs::MacosX64     => format!("ndk/{NDK_VERSION_FULL}/toolchains/llvm/prebuilt/darwin-x86_64/bin/{bin_filename}"),
+            HostOs::MacosAarch64 => format!("ndk/{NDK_VERSION_FULL}/toolchains/llvm/prebuilt/darwin-x86_64/bin/{bin_filename}"),
+            HostOs::WindowsX64   => format!("ndk/{NDK_VERSION_FULL}/toolchains/llvm/prebuilt/windows-x86_64/bin/{bin_filename}.cmd"),
+            HostOs::LinuxX64     => format!("ndk/{NDK_VERSION_FULL}/toolchains/llvm/prebuilt/linux-x86_64/bin/{bin_filename}"),
+            _ => panic!()
         };
+        let full_clang_path = sdk_dir.join(bin_path(&clang_filename));
 
         let toolchain = android_target.toolchain();
         let target_opt = format!("--target={toolchain}");
@@ -100,12 +103,20 @@ fn rust_build(sdk_dir: &Path, host_os: HostOs, args: &[String], android_targets:
             args_out.push(arg);
         }
 
-        let target_str = android_target.to_str();
-        let cfg_flag = format!("--cfg android_target=\"{}\"", target_str);
+        let target_arch_str = android_target.to_str();
+        let cfg_flag = format!("--cfg android_target=\"{}\"", target_arch_str);
          
         shell_env(
-            &[ 
-                (&android_target.linker_env_var(), (sdk_dir.join(linker).to_str().unwrap())),
+            &[
+                // Set the linker env var to the path of the target-specific `clang` binary.
+                (&android_target.linker_env_var(), full_clang_path.to_str().unwrap()),
+
+                // We set these three env vars to allow native library C/C++ builds to succeed with no additional app-side config.
+                // The naming conventions of these env variable keys are established by the `cc` Rust crate.
+                (&format!("CC_{toolchain}"),     full_clang_path.to_str().unwrap()),
+                (&format!("AR_{toolchain}"),     sdk_dir.join(bin_path("llvm-ar")).to_str().unwrap()),
+                (&format!("RANLIB_{toolchain}"), sdk_dir.join(bin_path("llvm-ranlib")).to_str().unwrap()),
+
                 ("RUSTFLAGS", &cfg_flag),
                 ("MAKEPAD", "lines"),
             ],
@@ -197,6 +208,8 @@ fn compile_java(sdk_dir: &Path, build_paths: &BuildPaths) -> Result<(), String> 
     let r_class_path = build_paths.tmp_dir.join(makepad_package_path).join("R.java");
     let makepad_java_classes_dir = &cargo_manifest_dir.join("src/android/java/").join(makepad_package_path);
 
+    println!("compile_java: {:?}", &build_paths.java_file);  // TODO: remove before merge
+
     shell_env(
         &[("JAVA_HOME", (java_home.to_str().unwrap()))],
         &cwd,
@@ -229,6 +242,7 @@ fn build_dex(sdk_dir: &Path, build_paths: &BuildPaths) -> Result<(), String> {
     let cwd = std::env::current_dir().unwrap();
 
     let compiled_java_classes_dir = build_paths.out_dir.join(makepad_package_path);
+    println!("build_dex(): compiled_java_classes_dir: {:?}", compiled_java_classes_dir); // TODO: remove before merge
 
     shell_env_cap( 
         &[("JAVA_HOME", (java_home.to_str().unwrap()))],

--- a/tools/cargo_makepad/src/android/compile.rs
+++ b/tools/cargo_makepad/src/android/compile.rs
@@ -20,7 +20,6 @@ pub struct BuildResult {
 }
 
 fn manifest_xml(label:&str, class_name:&str, url:&str)->String{
-    println!("manifest_xml(): label: {:?}, class_name: {:?}, url: {:?}", label, class_name, url); // TODO: remove before merge
     format!(r#"<?xml version="1.0" encoding="utf-8"?>
     <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
@@ -208,8 +207,6 @@ fn compile_java(sdk_dir: &Path, build_paths: &BuildPaths) -> Result<(), String> 
     let r_class_path = build_paths.tmp_dir.join(makepad_package_path).join("R.java");
     let makepad_java_classes_dir = &cargo_manifest_dir.join("src/android/java/").join(makepad_package_path);
 
-    println!("compile_java: {:?}", &build_paths.java_file);  // TODO: remove before merge
-
     shell_env(
         &[("JAVA_HOME", (java_home.to_str().unwrap()))],
         &cwd,
@@ -242,7 +239,6 @@ fn build_dex(sdk_dir: &Path, build_paths: &BuildPaths) -> Result<(), String> {
     let cwd = std::env::current_dir().unwrap();
 
     let compiled_java_classes_dir = build_paths.out_dir.join(makepad_package_path);
-    println!("build_dex(): compiled_java_classes_dir: {:?}", compiled_java_classes_dir); // TODO: remove before merge
 
     shell_env_cap( 
         &[("JAVA_HOME", (java_home.to_str().unwrap()))],

--- a/tools/cargo_makepad/src/android/mod.rs
+++ b/tools/cargo_makepad/src/android/mod.rs
@@ -188,7 +188,8 @@ pub fn handle_android(mut args: &[String]) -> Result<(), String> {
             sdk::rustup_toolchain_install(&targets) ?;
             sdk::download_sdk(&sdk_dir, host_os, &args[1..]) ?;
             sdk::expand_sdk(&sdk_dir, host_os, &args[1..], &targets) ?;
-            sdk::remove_sdk_sources(&sdk_dir, host_os, &args[1..]) ?;
+            // FIXME: re-enable this before merging
+            // sdk::remove_sdk_sources(&sdk_dir, host_os, &args[1..]) ?;
             println!("\nAndroid toolchain has been installed\n");
             Ok(())
         }

--- a/tools/cargo_makepad/src/android/mod.rs
+++ b/tools/cargo_makepad/src/android/mod.rs
@@ -131,6 +131,7 @@ pub fn handle_android(mut args: &[String]) -> Result<(), String> {
     let mut package_name = None;
     let mut app_label = None;
     let mut targets = vec![AndroidTarget::aarch64];
+    let mut keep_sdk_sources = false;
     // pull out options
     for i in 0..args.len() {
         let v = &args[i];
@@ -148,6 +149,9 @@ pub fn handle_android(mut args: &[String]) -> Result<(), String> {
         }
         else if let Some(opt) = v.strip_prefix("--abi=") {
             targets = AndroidTarget::from_str(opt)?;
+        }
+        else if v.trim() == "--keep-sdk-sources" {
+            keep_sdk_sources = true;
         }
         else {
             args = &args[i..];
@@ -188,8 +192,9 @@ pub fn handle_android(mut args: &[String]) -> Result<(), String> {
             sdk::rustup_toolchain_install(&targets) ?;
             sdk::download_sdk(&sdk_dir, host_os, &args[1..]) ?;
             sdk::expand_sdk(&sdk_dir, host_os, &args[1..], &targets) ?;
-            // FIXME: re-enable this before merging
-            // sdk::remove_sdk_sources(&sdk_dir, host_os, &args[1..]) ?;
+            if !keep_sdk_sources {
+                sdk::remove_sdk_sources(&sdk_dir, host_os, &args[1..]) ?;
+            }
             println!("\nAndroid toolchain has been installed\n");
             Ok(())
         }

--- a/tools/cargo_makepad/src/android/sdk.rs
+++ b/tools/cargo_makepad/src/android/sdk.rs
@@ -199,8 +199,7 @@ pub fn expand_sdk(sdk_dir: &Path, host_os: HostOs, args: &[String], targets:&[An
             let copy_fn = if full_ndk { shell::cp_all } else { shell::cp };
             copy_fn(&mount_point.join(source_path), &sdk_dir.join(dest_path), *exec) ?;
         }
-        // TODO: restore before merging
-        // shell(sdk_dir, "umount", &[mount_point.to_str().unwrap()]) ?;
+        shell(sdk_dir, "umount", &[mount_point.to_str().unwrap()]) ?;
         Ok(())
     }
     

--- a/tools/cargo_makepad/src/android/sdk.rs
+++ b/tools/cargo_makepad/src/android/sdk.rs
@@ -342,18 +342,17 @@ pub fn expand_sdk(sdk_dir: &Path, host_os: HostOs, args: &[String], targets:&[An
                 #[cfg(any(target_os = "macos", target_os = "linux"))] {
                     use std::os::unix::fs::PermissionsExt;
                     let bin_dir = sdk_dir.join(NDK_OUT).join("bin");
-                    for bin_file in std::fs::read_dir(bin_dir)
+                    std::fs::read_dir(bin_dir)
                         .expect("failed to read NDK `bin/` dir: {bin_dir:?}")
                         .filter_map(|r| r.ok().and_then(|entry| {
                             let path = entry.path();
                             path.is_file().then_some(path)
                         }))
-                    {
-                        std::fs::set_permissions(&bin_file, PermissionsExt::from_mode(0o744))
-                            .expect("failed to set exec permissions on {bin_file:?}");
-                    }
+                        .for_each(|bin_file|
+                            std::fs::set_permissions(&bin_file, PermissionsExt::from_mode(0o744))
+                                .expect("failed to set exec permissions on {bin_file:?}")
+                        );
                 }
-
             } else {
                 let mut ndk_extract = Vec::new();
                 #[allow(non_snake_case)]

--- a/tools/cargo_makepad/src/android/sdk.rs
+++ b/tools/cargo_makepad/src/android/sdk.rs
@@ -1,7 +1,8 @@
+#![allow(non_snake_case)]
 
 use makepad_miniz::zip_file::*;
 use std::{
-    path::{Path},
+    path::Path,
     fs::{File, OpenOptions},
     io::{Write, Read, Seek},
 };
@@ -24,6 +25,11 @@ const URL_PLATFORM_TOOLS_33_WINDOWS: &str = "https://dl.google.com/android/repos
 const URL_NDK_33_MACOS: &str = "https://dl.google.com/android/repository/android-ndk-r25c-darwin.dmg";
 const URL_NDK_33_LINUX: &str = "https://dl.google.com/android/repository/android-ndk-r25c-linux.zip";
 const URL_NDK_33_WINDOWS: &str = "https://dl.google.com/android/repository/android-ndk-r25c-windows.zip";
+
+pub const _NDK_VERSION_MAJOR: &str = "25";
+pub const _NDK_VERSION_MINOR: &str = "2";
+pub const _NDK_VERSION_BUILD: &str = "9519653";
+pub const NDK_VERSION_FULL:  &str = "25.2.9519653";
 
 const URL_OPENJDK_17_0_2_WINDOWS_X64: &str = "https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_windows-x64_bin.zip";
 const URL_OPENJDK_17_0_2_MACOS_AARCH64: &str = "https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_macos-aarch64_bin.tar.gz";
@@ -217,16 +223,15 @@ pub fn expand_sdk(sdk_dir: &Path, host_os: HostOs, _args: &[String], targets:&[A
                 ("platform-tools/AdbWinUsbApi.dll", false),
             ]) ?;
             const NDK_IN: &str = "android-ndk-r25c/toolchains/llvm/prebuilt/windows-x86_64";
-            const NDK_OUT: &str = "NDK/toolchains/llvm/prebuilt/windows-x86_64";
+            let NDK_OUT = &format!("ndk/{NDK_VERSION_FULL}/toolchains/llvm/prebuilt/windows-x86_64");
             
             let mut ndk_extract = Vec::new();
-            #[allow(non_snake_case)]
             for target in targets{
                 let sys_dir = target.sys_dir();
                 let clang = target.clang();
                 let unwind_dir = target.unwind_dir();
                 let SYS_IN = &format!("android-ndk-r25c/toolchains/llvm/prebuilt/windows-x86_64/sysroot/usr/lib/{sys_dir}/33");
-                let SYS_OUT = &format!("NDK/toolchains/llvm/prebuilt/windows-x86_64/sysroot/usr/lib/{sys_dir}/33");
+                let SYS_OUT = &format!("ndk/{NDK_VERSION_FULL}/toolchains/llvm/prebuilt/windows-x86_64/sysroot/usr/lib/{sys_dir}/33");
                 let UNWIND_IN = &format!("android-ndk-r25c/toolchains/llvm/prebuilt/windows-x86_64/lib64/clang/14.0.7/lib/linux/{unwind_dir}"); 
                 
                 ndk_extract.extend_from_slice(&[
@@ -258,7 +263,7 @@ pub fn expand_sdk(sdk_dir: &Path, host_os: HostOs, _args: &[String], targets:&[A
             unzip(4, src_dir, sdk_dir, URL_NDK_33_WINDOWS, &ndk_extract) ?;
             // patch the .cmd file to stop complaining
             {
-                let cmd_file_path = sdk_dir.join("NDK/toolchains/llvm/prebuilt/windows-x86_64/bin/aarch64-linux-android33-clang.cmd");
+                let cmd_file_path = sdk_dir.join("ndk/{NDK_VERSION_FULL}/toolchains/llvm/prebuilt/windows-x86_64/bin/aarch64-linux-android33-clang.cmd");
 
                 // Open the file for reading
                 let mut ndk_cmd = OpenOptions::new()
@@ -324,7 +329,7 @@ pub fn expand_sdk(sdk_dir: &Path, host_os: HostOs, _args: &[String], targets:&[A
                 ("platform-tools/adb", true),
             ]) ?;
             const NDK_IN: &str = "AndroidNDK9519653.app/Contents/NDK/toolchains/llvm/prebuilt/darwin-x86_64";
-            const NDK_OUT: &str = "NDK/toolchains/llvm/prebuilt/darwin-x86_64";
+            let NDK_OUT = &format!("ndk/{NDK_VERSION_FULL}/toolchains/llvm/prebuilt/darwin-x86_64");
             
             let mut ndk_extract = Vec::new();
             #[allow(non_snake_case)]
@@ -333,7 +338,7 @@ pub fn expand_sdk(sdk_dir: &Path, host_os: HostOs, _args: &[String], targets:&[A
                 let clang = target.clang();
                 let unwind_dir = target.unwind_dir();
                 let SYS_IN = &format!("AndroidNDK9519653.app/Contents/NDK/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/lib/{sys_dir}/33");
-                let SYS_OUT = &format!("NDK/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/lib/{sys_dir}/33");
+                let SYS_OUT = &format!("ndk/{NDK_VERSION_FULL}/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/lib/{sys_dir}/33");
                 let UNWIND_IN = &format!("AndroidNDK9519653.app/Contents/NDK/toolchains/llvm/prebuilt/darwin-x86_64/lib64/clang/14.0.7/lib/linux/{unwind_dir}"); 
                 ndk_extract.extend_from_slice(&[
                     (copy_map(NDK_IN, NDK_OUT, &format!("bin/{clang}33-clang")), true),
@@ -405,7 +410,7 @@ pub fn expand_sdk(sdk_dir: &Path, host_os: HostOs, _args: &[String], targets:&[A
                 ("platform-tools/adb", true),
             ]) ?;
             const NDK_IN: &str = "android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64";
-            const NDK_OUT: &str = "NDK/toolchains/llvm/prebuilt/linux-x86_64";
+            let NDK_OUT = &format!("ndk/{NDK_VERSION_FULL}/toolchains/llvm/prebuilt/linux-x86_64");
             
             let mut ndk_extract = Vec::new();
             #[allow(non_snake_case)]
@@ -414,7 +419,7 @@ pub fn expand_sdk(sdk_dir: &Path, host_os: HostOs, _args: &[String], targets:&[A
                 let clang = target.clang();
                 let unwind_dir = target.unwind_dir();
                 let SYS_IN = &format!("android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/{sys_dir}/33");
-                let SYS_OUT = &format!("NDK/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/{sys_dir}/33");
+                let SYS_OUT = &format!("ndk/{NDK_VERSION_FULL}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/{sys_dir}/33");
                 let UNWIND_IN = &format!("android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/lib64/clang/14.0.7/lib/linux/{unwind_dir}"); 
                 ndk_extract.extend_from_slice(&[
                     (copy_map(NDK_IN, NDK_OUT, &format!("bin/{clang}33-clang")), true),

--- a/tools/cargo_makepad/src/main.rs
+++ b/tools/cargo_makepad/src/main.rs
@@ -58,6 +58,7 @@ fn show_help(err: &str){
     println!("       --app-label=\"applabel\"                  The app label");
     println!("       --sdk-path=./android_33_sdk               The path to read/write the android SDK");
     println!("       --full-ndk                                Install the full NDK prebuilts for the selected Host OS (default is a minimal subset).");
+    println!("       --keep-sdk-sources                        Keep downloaded SDK source files (default is to remove them).");
     println!("       --host-os=<linux-x64|windows-x64|macos-aarch64|macos-x64>");
     println!("                                                 Host OS is autodetected but can be overridden here");
     println!("    [Android install-toolchain separated steps]");

--- a/tools/cargo_makepad/src/main.rs
+++ b/tools/cargo_makepad/src/main.rs
@@ -57,6 +57,7 @@ fn show_help(err: &str){
     println!("       --package-name=\"package\"                The package name");
     println!("       --app-label=\"applabel\"                  The app label");
     println!("       --sdk-path=./android_33_sdk               The path to read/write the android SDK");
+    println!("       --full-ndk                                Install the full NDK prebuilts for the selected Host OS (default is a minimal subset).");
     println!("       --host-os=<linux-x64|windows-x64|macos-aarch64|macos-x64>");
     println!("                                                 Host OS is autodetected but can be overridden here");
     println!("    [Android install-toolchain separated steps]");


### PR DESCRIPTION
Currently this is macOS only because that's the only machine I have to test it on right now.

Also includes the following related changes:

* Use the canonical directory structure for the NDK toolchain path.
  * This enables a user of `cargo-makepad` to point to a separate regular installation
    of the Android SDK, e.g., one installed automatically via Android Studio's SDK manager.
* Export three environment variables to make native code builds "just work"® with the `cc` crate:
  * "CC_{target-triple}"
  * "AR_{target-triple}"
  * "RANLIB_{target-triple}"