### PR TITLE
Print warning about missing templates for list-like widgets (FlatList, PortalList, Dock)

### DIFF
--- a/widgets/src/dock.rs
+++ b/widgets/src/dock.rs
@@ -524,12 +524,12 @@ impl Dock {
             let entry = self.items.get_or_insert(cx, entry_id, | cx | {
                 (template, WidgetRef::new_from_ptr(cx, Some(*ptr)))
             });
-            return Some(entry.1.clone())
+            Some(entry.1.clone())
         }
         else {
-            log!("PortalList template not found {}", template);
+            warning!("Template not found: {template}. Did you add it to the <Dock> instance in `live_design!{{}}`?");
+            None
         }
-        None
     }
     
     pub fn items(&mut self) -> &ComponentMap<LiveId, (LiveId, WidgetRef)> {

--- a/widgets/src/flat_list.rs
+++ b/widgets/src/flat_list.rs
@@ -119,9 +119,12 @@ impl FlatList {
             let (_, entry) = self.items.get_or_insert(cx, id, | cx | {
                 (template, WidgetRef::new_from_ptr(cx, Some(*ptr)))
             });
-            return Some(entry.clone())
+            Some(entry.clone())
         }
-        None
+        else {
+            warning!("Template not found: {template}. Did you add it to the <FlatList> instance in `live_design!{{}}`?");
+            None
+        }
     }
 
     /*

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -440,9 +440,12 @@ impl PortalList {
             let entry = self.items.get_or_insert(cx, (entry_id, template), | cx | {
                 WidgetRef::new_from_ptr(cx, Some(*ptr))
             });
-            return Some(entry.clone())
+            Some(entry.clone())
         }
-        None
+        else {
+            warning!("Template not found: {template}. Did you add it to the <PortalList> instance in `live_design!{{}}`?");
+            None
+        }
     }
     
     pub fn set_item_range(&mut self, cx: &mut Cx, range_start: usize, range_end: usize) {


### PR DESCRIPTION
I constantly seem to forget to add newly-created widget templates to lists, and I assume a lot of other devs also make this mistake. This results in me always taking a few minutes to remember where I went wrong and what I need to do to fix it.

This small PR improves that dev experience by printing out a warning about the missing template with a suggestion of how to fix it. Hopefully will result in less wasted time tracking down silly absent-minded mistakes like this.

Ideally we would be able to detect this at compile time, but that'd be quite a major redesign of the live_design system. Probably best left to an LSP + IDE plugin later.