### PR TITLE
fix linux timers compiled with opt-level > 0

### DIFF
--- a/platform/src/os/linux/select_timer.rs
+++ b/platform/src/os/linux/select_timer.rs
@@ -1,15 +1,6 @@
-use {
-    std::{
-        collections::{VecDeque},
-        time::Instant,
-        mem,
-        os::raw::{c_int},
-        ptr,
-    },
-    self::super::{
-        libc_sys,
-    },
-};
+use std::{collections::VecDeque, mem, os::raw::c_int, ptr, time::Instant};
+
+use self::super::libc_sys;
 
 
 #[derive(Clone, Copy)]
@@ -47,26 +38,21 @@ impl SelectTimers {
         // If there are any timers, we set the timeout for select to the `delta_timeout`
         // of the first timer that should be fired. Otherwise, we set the timeout to
         // None, so that select will block indefinitely.
-        let timeout = if let Some(timer) = self.timers.front() { 
-            Some(libc_sys::timeval {
+        let mut timeout = self.timers.front().map(|timer| 
+            libc_sys::timeval {
                 // `tv_sec` is in seconds, so take the integer part of `delta_timeout`
                 tv_sec: timer.delta_timeout.trunc() as libc_sys::time_t,
                 // `tv_usec` is in microseconds, so take the fractional part of
                 // `delta_timeout` 1000000.0.
                 tv_usec: (timer.delta_timeout.fract() * 1000_000.0) as libc_sys::time_t,
-            })
-        }  
-        else { 
-            None
-        };
+            });
         let _nfds = unsafe {libc_sys::select(
             fd+1,
             fds.as_mut_ptr(),
             ptr::null_mut(),
             ptr::null_mut(),
-            if let Some(mut timeout) = timeout {&mut timeout} else {ptr::null_mut()}
+            timeout.as_mut().map(|t| t as *mut _).unwrap_or(ptr::null_mut())
         )};  
-       // println!("RETURNED!");
     }
     
     pub fn time_now(&self) -> f64 {


### PR DESCRIPTION
`as_mut()` is the only important part, the rest is just cleanup. this is another one of my "fixes without deep understanding" => take it with a grain of salt, but it makes sense.