### PR TITLE
Add function to check if SlidePanel is animating

### DIFF
--- a/widgets/src/slide_panel.rs
+++ b/widgets/src/slide_panel.rs
@@ -117,6 +117,13 @@ impl SlidePanelRef {
             }
         }
     }
+    pub fn is_animating(&self, cx: &mut Cx) -> bool {
+        if let Some(inner) = self.borrow() {
+            inner.animator.is_track_animating(cx, id!(closed))
+        } else {
+            false
+        }
+    }
 }
 
 impl SlidePanelSet {


### PR DESCRIPTION
This is a functionality that would help developers to orchestrate what to do when the panel is opening/closing.

An alternative will be to relevant emit actions, but this is left for another PR.