### PR TITLE
Add basic support for images in RadioButton

### DIFF
--- a/widgets/src/radio_button.rs
+++ b/widgets/src/radio_button.rs
@@ -1,7 +1,9 @@
 use crate::{
         makepad_derive_widget::*,
         makepad_draw::*,
-        widget::*, View,
+        widget::*,
+        View,
+        Image,
     };
 
 live_design!{
@@ -31,6 +33,13 @@ pub enum RadioType {
     Tab = shader_enum(2),
 }
 
+#[derive(Live, LiveHook)]
+pub enum MediaType {
+    Image,
+    #[pick] Icon,
+    None,
+}
+
 #[derive(Live, LiveHook, Widget)]
 pub struct RadioButtonGroup {
     #[deref] frame: View
@@ -41,12 +50,16 @@ pub struct RadioButton {
     #[redraw] #[live] draw_radio: DrawRadioButton,
     #[live] draw_icon: DrawIcon,
     #[live] draw_text: DrawText,
+
+    #[live] value: LiveValue,
+
+    #[live] media: MediaType,
     
     #[live] icon_walk: Walk,
     #[walk] walk: Walk,
-    
-    #[live] value: LiveValue,
-    
+
+    #[live] image: Image,
+
     #[layout] layout: Layout,
     #[animator] animator: Animator,
     
@@ -71,7 +84,16 @@ impl RadioButtonGroup {
 impl RadioButton {
     pub fn draw_walk(&mut self, cx: &mut Cx2d, walk: Walk) {
         self.draw_radio.begin(cx, walk, self.layout);
-        self.draw_icon.draw_walk(cx, self.icon_walk);
+        match self.media {
+            MediaType::Image => {
+                let image_walk = self.image.walk(cx);
+                let _ = self.image.draw_walk(cx, image_walk);
+            }
+            MediaType::Icon => {
+                self.draw_icon.draw_walk(cx, self.icon_walk);
+            }
+            MediaType::None => {}
+        }
         self.draw_text.draw_walk(cx, self.label_walk, self.label_align, &self.label);
         self.draw_radio.end(cx);
     }


### PR DESCRIPTION
Examples:

1) Render a radio button control with label and image

```
<RadioButton> {
    label: "Option 1"
    media: Image,

    image: <Image> {
        source: dep("crate://self/resources/tinrs_mobile.png"),
        width: 30,
        height: 30,
        margin: { top: 0.0, right: 0.0, bottom: 0.0, left: 0.0  }
        padding: 0
    }
}
```

2) Render a radio button option with a label and an icon

```
<RadioButton> {
    label: "Option 1"
    media: Icon, # this is the default option, could be omitted
    
    draw_icon: {
        svg_file: (ICO_LIVEPLAY),
        fn get_color(self) -> vec4 {
            return #888;
        }
    }
}
```