### PR TITLE
Add Icon widget

### DIFF
--- a/widgets/src/base.rs
+++ b/widgets/src/base.rs
@@ -14,6 +14,7 @@ live_design!{
     import crate::fold_button::FoldButtonBase;
     import crate::fold_header::FoldHeaderBase;
     import crate::image::ImageBase;
+    import crate::icon::IconBase;
     import crate::rotated_image::RotatedImageBase;
     import crate::video::VideoBase;
     import crate::popup_menu::PopupMenuBase;
@@ -74,6 +75,24 @@ live_design!{
                         closed: 0.0
                     }
                 }
+            }
+        }
+    }
+
+    Icon = <IconBase> {
+        width: Fit,
+        height: Fit,
+
+        icon_walk: {
+            margin: {left: 5.0},
+            width: Fit,
+            height: Fit,
+        }
+
+        draw_bg: {
+            instance color: #0000,
+            fn pixel(self) -> vec4 {
+                return self.color;
             }
         }
     }
@@ -682,6 +701,7 @@ live_design!{
     FoldButtonBase = <FoldButtonBase> {}
     FoldHeaderBase = <FoldHeaderBase> {}
     ImageBase = <ImageBase> {}
+    IconBase = <IconBase> {}
     RotatedImageBase = <RotatedImageBase> {}
     VideoBase = <VideoBase> {}
     LabelBase = <LabelBase> {}

--- a/widgets/src/icon.rs
+++ b/widgets/src/icon.rs
@@ -1,0 +1,36 @@
+use crate::{
+    makepad_derive_widget::*,
+    makepad_draw::*,
+    widget::*
+};
+
+live_design! {
+    IconBase = {{Icon}} {}
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct Icon {
+    #[redraw]
+    #[live]
+    draw_bg: DrawQuad,
+    #[live]
+    draw_icon: DrawIcon,
+    #[live]
+    icon_walk: Walk,
+    #[walk]
+    walk: Walk,
+    #[layout]
+    layout: Layout,
+}
+
+impl Widget for Icon {
+    fn handle_event(&mut self, _cx: &mut Cx, _event: &Event, _scope: &mut Scope) {
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, _scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.draw_bg.begin(cx, walk, self.layout);
+        self.draw_icon.draw_walk(cx, self.icon_walk);
+        self.draw_bg.end(cx);
+        DrawStep::done()
+    }
+}

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -9,6 +9,7 @@ pub use makepad_markdown;
 pub mod button;
 pub mod label;
 pub mod image;
+pub mod icon;
 pub mod link_label;
 pub mod drop_down;
 pub mod popup_menu;
@@ -72,6 +73,7 @@ pub use crate::{
     button::*,
     view::*,
     image::*,
+    icon::*,
     label::*,
     slider::*,
     check_box::*,
@@ -132,6 +134,7 @@ pub fn live_design(cx: &mut Cx) {
     crate::label::live_design(cx);
     crate::nav_control::live_design(cx);
     crate::image::live_design(cx);
+    crate::icon::live_design(cx);
     crate::rotated_image::live_design(cx);
     crate::video::live_design(cx);
     crate::view::live_design(cx);


### PR DESCRIPTION
Example:

```
<Icon> {
    icon_walk: {width: 100, height: 100},
    draw_icon: {
        svg_file: dep("crate://makepad-widgets/resources/icons/back.svg"),
        color: #000;
        brightness: 0.8;
    }
}
```