### PR TITLE
Fix Segfaults Caused by Objective-C Block Memory Mismanagement

### DIFF
--- a/platform/src/os/apple/metal_xpc.rs
+++ b/platform/src/os/apple/metal_xpc.rs
@@ -1,20 +1,13 @@
 
 use {
-    std::collections::HashMap,
-    std::sync::Mutex,
     crate::{
         //makepad_error_log::*,
-        makepad_objc_sys::objc_block,
-        makepad_objc_sys::objc_block_invoke,
-        os::{
+        apple_util::nsstring_to_string, makepad_objc_sys::{objc_block, objc_block_invoke}, os::{
             apple::apple_sys::*,
-            apple_util::{
-                //nsstring_to_string,
-                str_to_nsstring,
-            },
+            apple_util::str_to_nsstring,
             cx_stdin::PresentableImageId,
-        },
-    }
+        }
+    }, std::{collections::HashMap, sync::Mutex}
 };
 
 static mut METAL_XPC_CLASSES: *const MetalXPCClasses = 0 as *const _;
@@ -71,13 +64,11 @@ pub fn xpc_service_proxy() -> RcObjcId {
         ];
         let () = msg_send![connection, setRemoteObjectInterface: iface];
         let () = msg_send![connection, resume];
-        /*
-        let _error_handler = objc_block!(move | error: ObjcId | {
+        let error_handler = objc_block!(move | error: ObjcId | {
             let desc: ObjcId = msg_send![error, localizedDescription];
-            log!("xpc_service_proxy got error: {}", nsstring_to_string(desc));
+            crate::log!("xpc_service_proxy got error: {}", nsstring_to_string(desc));
         });
-        */
-        let proxy: ObjcId = msg_send![connection, remoteObjectProxyWithErrorHandler: nil];
+        let proxy: ObjcId = msg_send![connection, remoteObjectProxyWithErrorHandler: &error_handler];
         RcObjcId::from_unowned(NonNull::new(proxy).unwrap())
     }
 }

--- a/platform/src/os/apple/url_session.rs
+++ b/platform/src/os/apple/url_session.rs
@@ -140,7 +140,7 @@ impl OsWebSocket{
                 _=>panic!()
             };
                         
-            let () = msg_send![*Arc::as_ptr(&self.data_task), sendMessage: msg completionHandler:handler];
+            let () = msg_send![*Arc::as_ptr(&self.data_task), sendMessage: msg completionHandler: &handler];
             Ok(())
         } 
     }

--- a/platform/src/os/apple/url_session.rs
+++ b/platform/src/os/apple/url_session.rs
@@ -189,7 +189,7 @@ impl OsWebSocket{
                     }
                     set_message_receive_handler(data_task.clone(), rx_sender.clone())
                 });
-                let () = msg_send![*Arc::as_ptr(&data_task2), receiveMessageWithCompletionHandler: handler];
+                let () = msg_send![*Arc::as_ptr(&data_task2), receiveMessageWithCompletionHandler: &handler];
             }
             let () = msg_send![data_task, setDelegate: web_socket_delegate_instance];
             let data_task = Arc::new(data_task);


### PR DESCRIPTION
Found this issue on my macbook pro m2 (2022) running Sonoma 14.3.1.

I came across a segmentation fault by building apps from Makepad Studio, which would crash when attempting to open the websocket connection.

**lldb backtrace:**
```
* thread #2, stop reason = EXC_BAD_ACCESS (code=1, address=0xc010000000000008)
frame #0: 0x00007ff8051f0208 libsystem_blocks.dylib`_Block_copy + 44
libsystem_blocks.dylib:

-> 0x7ff8051f0208 <+44>: movq 0x8(%rax), %r15
0x7ff8051f020c <+48>: movq %r15, %rdi
0x7ff8051f020f <+51>: callq 0x7ff8051f24ba ; symbol stub for: malloc
0x7ff8051f0214 <+56>: testq %rax, %rax

Target 0: (makepad-example-simple) stopped.
```

The issue is that objc blocks passed as handlers (for handling websocket messages) are being internally copied by objective-c, in my machine that results in segmentation faults because the original memory region of the block gets dropped before the copying.

`url_session.rs`
```rs
let handler = objc_block!(move | message: ObjcId, error: ObjcId | {
  ...
  set_message_receive_handler(data_task.clone(), rx_sender.clone())
});
let _: () = msg_send![*Arc::as_ptr(&data_task2), receiveMessageWithCompletionHandler: handler];
```


Back in September we nil'ed out an error handler when setting up the XPC service, because it wasn't working for me:
`metal_xpc.rs`
```rs
let _error_handler = objc_block!(move | error: ObjcId | {
  let desc: ObjcId = msg_send![error, localizedDescription];
  crate::log!("xpc_service_proxy got error: {}", nsstring_to_string(desc));
});
let proxy: ObjcId = msg_send![connection, remoteObjectProxyWithErrorHandler: nil]; // passing error_handler would segfault
```

Now, objc blocks work in some other places, and that's because we're either heapifying the block or passing a reference instead:
`metal_xpc.rs`
```rs
let completion_block = hackily_heapify_block2_obj_u64(&completion_block as *const _ as *const _);
let () = msg_send![proxy, fetchTexture: id.as_u64() _padding: 0 with: completion_block];
```
`audio_unit.rs`
```rs
msg_send![self.au_audio_unit, setInputHandler: &input_handler];
```

Just passing references fixes that issue for me. As to why this hasn't been problematic for most people, I'd guess this is just undefined behavior and my system is re-using or invalidating the stack more aggressively which exposes the problem (or some runtime/architecture differences).

---

### Update

Updating this to mention that we confirmed the issue was triggered by macOS using Rosetta to translate ARM-based builds to Intel. This is why most people couldn't replicate this issue. Either way, the safe and sound approach should be to always heapify these blocks. 