### PR TITLE
Improve public API of PortalList

### DIFF
--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -818,6 +818,18 @@ impl PortalListRef {
             inner.tail_range = tail_range
         }
     }
+
+    pub fn scrolled(&self, actions: &Actions) -> bool {
+        if let PortalListAction::Scroll = actions.find_widget_action(self.widget_uid()).cast() {
+            return true;
+        }
+        false
+    }
+
+    pub fn scroll_position(&self) -> f64 {
+        let Some(inner) = self.borrow_mut() else { return 0.0 };
+        inner.first_scroll
+    }
     
     /// A convenience wrapper around [`PortalList::item()`].
     pub fn item(&self, cx: &mut Cx, entry_id: usize, template: LiveId) -> Option<WidgetRef> {


### PR DESCRIPTION
I have a use case where I need to have better control of the portal list widget.

This PR is adding:
* A public `scrolled` function to check if the action `PortalListAction::Scroll` was emitted by a particular portal list instance.
* A public `scroll_position` function to get the exact position of the scroll. We have `first_item` but this is not enough when you want to know if the widget is scrolled at the top, for instance. 