### PR TITLE
feat(platform): initial HTTP implementation for linux

### DIFF
--- a/libs/http/Cargo.toml
+++ b/libs/http/Cargo.toml
@@ -9,6 +9,8 @@ metadata.makepad-auto-version = "kWH3whvtKxZm5SPPZmvzKa4dNe0="
 
 [dependencies]
 makepad-url = { path = "../url" }
+
+[target.'cfg(target_os = "linux")'.dependencies]
 makepad-net = { path = "../net" }
 
 [dev-dependencies]

--- a/libs/http/Cargo.toml
+++ b/libs/http/Cargo.toml
@@ -6,3 +6,10 @@ edition = "2021"
 description = "Makepad http utils"
 license = "MIT OR Apache-2.0"
 metadata.makepad-auto-version = "kWH3whvtKxZm5SPPZmvzKa4dNe0="
+
+[dependencies]
+makepad-url = { path = "../url" }
+makepad-net = { path = "../net" }
+
+[dev-dependencies]
+async-std = { version = "1.12.0", features = [ "attributes" ] }

--- a/libs/http/src/client.rs
+++ b/libs/http/src/client.rs
@@ -1,0 +1,186 @@
+use std::io::{BufRead, BufReader, Read};
+use std::collections::BTreeMap;
+use std::sync::{Arc};
+use std::thread::{spawn, JoinHandle};
+
+use makepad_url::Url;
+use makepad_net::tcp::Socket;
+use crate::server::HttpServerResponse;
+
+
+#[derive(Debug)]
+enum HttpResponseError {
+    InvalidStatusLine,
+    InvalidStatusCode
+}
+
+fn parse_header_line(header_line: String) -> (String, Vec<String>) {
+    let (key, value) = header_line.split_once(":").unwrap();
+    (key.trim().to_string(), vec![value.trim().to_string()])
+}
+
+fn prepare_headers(method: String, url: Url, headers: BTreeMap<String, Vec<String>>) -> Vec<String> {
+    let mut payload: Vec<String> = Vec::new();
+    let request_line = format!("{} {} HTTP/1.1", method, url.pathname);
+    payload.push(request_line);
+    payload.push(format!("Host: {}", url.hostname));
+    for (key, values) in headers {
+        payload.push(format!("{}: {}", key, values.join("")))
+    }
+    payload.push(String::new());
+    payload.push(String::new());
+    payload
+}
+
+fn parse_response_status(status_line: String) -> Result<(u16, String), HttpResponseError> {
+    let mut split: Vec<&str> = status_line.splitn(3," ").collect();
+    if split.len() == 2 {
+        split.push("");
+    }
+    if split.len() != 3 {
+        return Err(HttpResponseError::InvalidStatusLine);
+    }
+    let status_str: &str = split[1];
+    match status_str.parse() {
+        Ok(code) => Ok((code, split[2].to_string())),
+        _ => Err(HttpResponseError::InvalidStatusCode)
+    }
+}
+
+pub struct HttpClient {
+    url: Url,
+    headers: Option<BTreeMap<String, Vec<String>>>,
+    socket: Option<Arc<Socket>>
+}
+
+impl HttpClient {
+    pub fn new(url: Url) -> Self {
+        Self {
+            url,
+            headers: None,
+            socket: None
+        }
+    }
+
+    pub fn set_socket(mut self, socket: Arc<Socket>) -> Self {
+        self.socket = Some(socket);
+        self
+    }
+
+    pub fn set_headers(mut self, headers: BTreeMap<String, Vec<String>>) -> Self {
+        self.headers = Some(headers);
+        self
+    }
+
+    pub fn get<T: Send + 'static>(self, on_complete: impl 'static + Send + FnOnce(u16, HttpServerResponse) -> T)  -> JoinHandle<T> {
+        self.send("GET".into(), None, on_complete)
+    }
+
+    pub fn post<T: Send + 'static>(self, body: Option<&[u8]>, on_complete: impl 'static + Send + FnOnce(u16, HttpServerResponse) -> T)  -> JoinHandle<T> {
+        self.send("POST".into(), body, on_complete)
+    }
+
+    pub fn put<T: Send + 'static>(self, body: Option<&[u8]>, on_complete: impl 'static + Send + FnOnce(u16, HttpServerResponse) -> T)  -> JoinHandle<T> {
+        self.send("PUT".into(), body, on_complete)
+    }
+
+    pub fn patch<T: Send + 'static>(self, body: Option<&[u8]>, on_complete: impl 'static + Send + FnOnce(u16, HttpServerResponse) -> T)  -> JoinHandle<T> {
+        self.send("PATCH".into(), body, on_complete)
+    }
+
+    pub fn delete<T: Send + 'static>(self, body: Option<&[u8]>, on_complete: impl 'static + Send + FnOnce(u16, HttpServerResponse) -> T)  -> JoinHandle<T> {
+        self.send("DELETE".into(), body, on_complete)
+    }
+
+    fn create_socket(&mut self) -> Socket {
+        let port = self.url.port.unwrap();
+        let host = self.url.host.as_str();
+        Socket::bind(host, port, self.url.secure).unwrap()
+    }
+
+    fn send<T: Send + 'static>(mut self, method: &str, body: Option<&[u8]>, on_complete: impl 'static + Send + FnOnce(u16, HttpServerResponse) -> T) -> JoinHandle<T> {
+        let url = self.url.to_owned();
+        let raw_headers= self.headers.to_owned();
+        let headers = prepare_headers(method.into(), url, raw_headers.clone().unwrap_or_default());
+        let socket = match self.socket.clone() {
+            Some(s) => s.clone(),
+            None => Arc::new(self.create_socket())
+        };
+        let binding = socket.clone();
+        let mut output_stream = binding.output_stream.lock().unwrap();
+        output_stream.write_all(headers.join("\r\n").as_bytes()).unwrap();
+        if let Some(body) = body {
+            output_stream.write_all(body).unwrap();
+        }
+        spawn(move || {
+            let (status_code, response) = self.read_response(socket);
+            return on_complete(status_code, response);
+        })
+    }
+
+    fn read_response(&mut self, socket: Arc<Socket>) -> (u16, HttpServerResponse) {
+        let mut input_stream = socket.input_stream.lock().unwrap();
+        let mut reader = BufReader::new(&mut *input_stream);
+        let mut done = false;
+        let mut status_line = String::new();
+        let mut headers: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        let mut len = reader.read_line(&mut status_line).unwrap();
+        let (status_code, _) = parse_response_status(status_line).unwrap();
+        while len > 0 && !done {
+            let mut line = String::new();
+            len = reader.read_line(&mut line).unwrap();
+            if line.trim() == "" {
+                done = true;
+            } else {
+                let (key, values) = parse_header_line(line);
+                headers.insert(key.to_lowercase(), values);
+            }
+        }
+        let body = match headers.get("content-length") {
+            Some(length_str) => {
+                let size: usize = length_str[0].parse().unwrap();
+                let mut body: Vec<u8> = vec![0; size];
+                reader.read_exact(&mut body).unwrap();
+                body
+            },
+            _ => Vec::new()
+        };
+        let response = HttpServerResponse {
+            header: headers.iter().map(
+                |(key, values)| format!("{}: {}", key, values.join(""))
+            ).collect::<Vec<_>>().join("\r\n"),
+            body
+        };
+        (status_code, response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use makepad_url::Url;
+    use crate::client::{HttpClient, prepare_headers};
+
+    #[test]
+    fn generate_request_with_headers() {
+        let url = Url::parse("http://localhost:8080/").unwrap();
+        let mut headers = BTreeMap::new();
+        headers.insert("Authorization".to_string(), vec!["Bearer token".to_string()]);
+        headers.insert("Content-Type".to_string(), vec!["application/json".to_string()]);
+        let payload = prepare_headers("GET".to_string(), url, headers);
+        assert_eq!(payload.len(), 5);
+        assert_eq!(payload[0], "GET / HTTP/1.1");
+        assert_eq!(payload[1], "Host: localhost:8080");
+        assert_eq!(payload[2], "Authorization: Bearer token");
+        assert_eq!(payload[3], "Content-Type: application/json");
+        assert_eq!(payload[4], "");
+    }
+
+    #[async_std::test]
+    async fn it_works() {
+        let http = HttpClient::new("http://localhost:8080/".into());
+        http.get(move |status_code, _| {
+            assert_eq!(status_code, 200);
+        }).join().unwrap();
+    }
+}

--- a/libs/http/src/lib.rs
+++ b/libs/http/src/lib.rs
@@ -2,3 +2,4 @@
  pub mod utils;
  pub mod server;
  pub mod websocket;
+ pub mod client;

--- a/libs/http/src/lib.rs
+++ b/libs/http/src/lib.rs
@@ -2,4 +2,5 @@
  pub mod utils;
  pub mod server;
  pub mod websocket;
+ #[cfg(target_os = "linux")]
  pub mod client;

--- a/libs/http/src/utils.rs
+++ b/libs/http/src/utils.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::net::{TcpStream, Shutdown, SocketAddr};
 use std::io::BufReader;
 use std::io::prelude::*;
@@ -56,6 +57,20 @@ pub fn parse_url_path(url: &str) -> Option<(String, Option<String>)> {
     }
     
     Some((url, search))
+}
+
+pub fn parse_headers(headers_string: String) -> BTreeMap<String, Vec<String>> {
+    let mut headers = BTreeMap::new();
+    for line in headers_string.lines() {
+        let mut split = line.split(":");
+        let key = split.next().unwrap();
+        let values = split.next().unwrap().to_string();
+        for val in values.split(",") {
+            let entry = headers.entry(key.to_string()).or_insert(Vec::new());
+            entry.push(val.to_string());
+        }
+    }
+    headers
 }
 
 #[derive(Debug)]

--- a/libs/net/Cargo.toml
+++ b/libs/net/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "makepad-net"
+version = "0.1.0"
+authors = ["Makepad <info@makepad.nl>"]
+edition = "2021"
+description = "Makepad http utils"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+openssl = "0.10.64"
+makepad-url = { path = "../url" }

--- a/libs/net/src/lib.rs
+++ b/libs/net/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod tcp;

--- a/libs/net/src/tcp/mod.rs
+++ b/libs/net/src/tcp/mod.rs
@@ -1,0 +1,2 @@
+mod socket;
+pub use socket::Socket;

--- a/libs/net/src/tcp/socket.rs
+++ b/libs/net/src/tcp/socket.rs
@@ -1,0 +1,105 @@
+use std::{
+    cell::UnsafeCell,
+    error::Error,
+    io::{Read, Write},
+    net::TcpStream,
+    sync::{Arc, Mutex}
+};
+use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
+
+struct UnsafeMutator<T> {
+    value: UnsafeCell<T>,
+}
+
+impl<T> UnsafeMutator<T> {
+    fn new(value: T) -> UnsafeMutator<T> {
+        return UnsafeMutator {
+            value: UnsafeCell::new(value),
+        };
+    }
+
+    fn mut_value(&self) -> &mut T {
+        return unsafe { &mut *self.value.get() };
+    }
+}
+
+unsafe impl<T> Sync for UnsafeMutator<T> {}
+
+struct ReadWrapper<R>
+    where
+        R: Read,
+{
+    inner: Arc<UnsafeMutator<R>>,
+}
+
+impl<R: Read> Read for ReadWrapper<R> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, std::io::Error> {
+        return self.inner.mut_value().read(buf);
+    }
+}
+
+struct WriteWrapper<W>
+    where
+        W: Write,
+{
+    inner: Arc<UnsafeMutator<W>>,
+}
+
+impl<W: Write> Write for WriteWrapper<W> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, std::io::Error> {
+        return self.inner.mut_value().write(buf);
+    }
+
+    fn flush(&mut self) -> Result<(), std::io::Error> {
+        return self.inner.mut_value().flush();
+    }
+}
+
+pub struct Socket {
+    pub output_stream: Arc<Mutex<dyn Write + Send>>,
+    pub input_stream: Arc<Mutex<dyn Read + Send>>,
+}
+
+impl Socket {
+    pub fn bind(host: &str, port: u16, secure: bool) -> Result<Socket, Box<dyn Error>> {
+        let tcp_stream = match TcpStream::connect((host, port)) {
+            Ok(x) => x,
+            Err(e) => return Err(Box::new(e)),
+        };
+        if secure {
+            //        let tls_connector = TlsConnector::builder().build().unwrap();
+            let mut tls_connector_builder = SslConnector::builder(SslMethod::tls()).unwrap();
+            tls_connector_builder.set_verify(SslVerifyMode::NONE); // Disable certificate verification
+            let tls_connector = tls_connector_builder.build();
+
+            let tls_stream = match tls_connector.connect(host, tcp_stream) {
+                Ok(x) => x,
+                Err(e) => return Err(Box::new(e)),
+            };
+            let mutator = Arc::new(UnsafeMutator::new(tls_stream));
+            let input_stream = Arc::new(Mutex::new(ReadWrapper {
+                inner: mutator.clone(),
+            }));
+            let output_stream = Arc::new(Mutex::new(WriteWrapper { inner: mutator }));
+
+            let socket = Socket {
+                output_stream,
+                input_stream,
+            };
+            return Ok(socket);
+        } else {
+            let mutator = Arc::new(UnsafeMutator::new(tcp_stream));
+            let input_stream = Arc::new(Mutex::new(ReadWrapper {
+                inner: mutator.clone(),
+            }));
+            let output_stream = Arc::new(Mutex::new(WriteWrapper {
+                inner: mutator
+            }));
+            let socket = Socket {
+                output_stream,
+                input_stream,
+            };
+            return Ok(socket);
+        }
+    }
+}

--- a/libs/url/Cargo.toml
+++ b/libs/url/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "makepad-url"
+version = "0.1.0"
+authors = ["Makepad <info@makepad.nl>"]
+edition = "2021"
+description = "Makepad url utils"
+license = "MIT OR Apache-2.0"

--- a/libs/url/src/lib.rs
+++ b/libs/url/src/lib.rs
@@ -1,4 +1,4 @@
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Url {
     /**
      * The scheme part of the URL
@@ -91,6 +91,19 @@ impl Url {
     }
 }
 
+impl From<&str> for Url {
+    fn from(str: &str) -> Self {
+        Url::parse(str).unwrap()
+    }
+}
+
+impl From<String> for Url {
+    fn from(str: String) -> Self {
+        Url::parse(str.as_str()).unwrap()
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
     use crate::Url;
@@ -123,5 +136,11 @@ mod tests {
         assert_eq!(url.hostname, "example.org".to_string());
         assert_eq!(url.pathname, "/a/long/path".to_string());
         assert_eq!(url.secure, true);
+    }
+
+    #[test]
+    fn if_converts_from_str() {
+        let url: Url = "https://example.org/".into();
+        assert_eq!(url.hostname, "example.org".to_string());
     }
 }

--- a/libs/url/src/lib.rs
+++ b/libs/url/src/lib.rs
@@ -1,0 +1,127 @@
+#[derive(Debug)]
+pub struct Url {
+    /**
+     * The scheme part of the URL
+     */
+    pub scheme: Option<String>,
+    /**
+     A string containing the domain (that is the hostname) followed by (if a port was specified) a
+     * ':' and the port of the URL.
+     */
+    pub host: String,
+    /**
+     * A string containing the domain of the URL.
+     */
+    pub hostname: String,
+    /**
+     * The port number of the URL if available.
+     */
+    pub port: Option<u16>,
+    /**
+     * A string containing an initial '/' followed by the path of the URL. Including query string
+     * and fragment for now
+     */
+    pub pathname: String,
+    /**
+     * A boolean to set the connection as secured.
+     */
+    pub secure: bool
+}
+
+#[derive(Debug)]
+pub enum UrlParseError {
+    InvalidScheme,
+    InvalidHost
+}
+
+impl Url {
+    pub fn parse_string(url: String) -> Result<Url, UrlParseError> {
+        Url::parse(url.as_str())
+    }
+
+    pub fn parse(url: &str) -> Result<Url, UrlParseError> {
+        let (scheme, rest) = Url::scheme(url).unwrap();
+        let (hostname, rest) = Url::hostname(rest).unwrap();
+        let (host, port) = Url::port(scheme, &hostname);
+        let pathname = ("/".to_owned() + rest).to_string();
+        let secure= match scheme { Some("https") | Some("wss") => true, _ => false };
+        Ok(Url {
+            scheme: scheme.map(|s| s.to_string()),
+            host,
+            hostname,
+            port,
+            pathname,
+            secure
+        })
+    }
+
+    pub fn scheme(input: &str) -> Result<(Option<&str>, &str), UrlParseError> {
+        match input.split_once("://") {
+            Some((scheme, rest)) => Ok((Some(scheme), rest)),
+            _ => Err(UrlParseError::InvalidScheme)
+        }
+    }
+
+    pub fn hostname(input: &str) -> Result<(String, &str), UrlParseError> {
+        match input.split_once("/") {
+            Some((hostname, rest)) => Ok((hostname.to_string(), rest)),
+            _ => Err(UrlParseError::InvalidHost)
+        }
+    }
+
+    pub fn port<'a>(scheme: Option<&str>, hostname: &String) -> (String, Option<u16>) {
+        match hostname.split_once(":") {
+            Some((host, port)) => {
+                match port.parse() {
+                    Ok(port) => (host.to_string(), Some(port)),
+                    _ => (host.to_string(), None)
+                }
+            }
+            _ => (hostname.to_owned(), Url::default_port(scheme))
+        }
+    }
+
+    pub fn default_port(scheme: Option<&str>) -> Option<u16> {
+        match scheme.unwrap() {
+            "http" | "ws" => Some(80),
+            "https" | "wss" => Some(443),
+            "ftp" => Some(21),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Url;
+
+    #[test]
+    fn it_works() {
+        let url = Url::parse("https://example.org/").unwrap();
+        assert_eq!(url.scheme, Some("https".to_string()));
+        assert_eq!(url.hostname, "example.org".to_string());
+        assert_eq!(url.port, Some(443));
+        assert_eq!(url.pathname, "/".to_string());
+        assert_eq!(url.secure, true);
+    }
+
+    #[test]
+    fn it_works_with_port() {
+        let url = Url::parse("http://example.org:8080/").unwrap();
+        assert_eq!(url.scheme, Some("http".to_string()));
+        assert_eq!(url.host, "example.org".to_string());
+        assert_eq!(url.hostname, "example.org:8080".to_string());
+        assert_eq!(url.port, Some(8080));
+        assert_eq!(url.pathname, "/".to_string());
+        assert_eq!(url.secure, false);
+    }
+
+    #[test]
+    fn it_works_with_pathname() {
+        let url = Url::parse("https://example.org/a/long/path").unwrap();
+        assert_eq!(url.scheme, Some("https".to_string()));
+        assert_eq!(url.hostname, "example.org".to_string());
+        assert_eq!(url.pathname, "/a/long/path".to_string());
+        assert_eq!(url.secure, true);
+    }
+}

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -16,6 +16,9 @@ makepad-http = { path = "../libs/http", version="0.4.0" }
 makepad-url = { path = "../libs/url" }
 smallvec = {version ="1.11.2"}
 
+[target.'cfg(target_os = "linux")'.dependencies]
+makepad-net = { path = "../libs/net" }
+
 [target.wasm32-unknown-unknown.dependencies]
 makepad-wasm-bridge = { path = "../libs/wasm_bridge", version = "0.4.0" }
 

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -13,6 +13,7 @@ metadata.makepad-auto-version = "ue5pTU0e_KaMiNqLQpo2CaD-WeQ="
 makepad-futures = { path = "../libs/futures", version = "0.4.0" }
 makepad-shader-compiler = { path = "./shader_compiler", version = "0.5.0" }
 makepad-http = { path = "../libs/http", version="0.4.0" }
+makepad-url = { path = "../libs/url" }
 smallvec = {version ="1.11.2"}
 
 [target.wasm32-unknown-unknown.dependencies]

--- a/platform/src/event/network.rs
+++ b/platform/src/event/network.rs
@@ -3,6 +3,7 @@ use crate::makepad_live_id::*;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::collections::BTreeMap;
 use std::str;
+use makepad_http::utils::parse_headers;
 
 #[derive(Clone, Debug)]
 pub struct NetworkResponseItem{
@@ -125,7 +126,7 @@ impl HttpResponse {
         HttpResponse {
             metadata_id,
             status_code,
-            headers: HttpResponse::parse_headers(string_headers),
+            headers: parse_headers(string_headers),
             body
         }
     }
@@ -160,20 +161,6 @@ impl HttpResponse {
                 col:0
             })
         }
-    }
-
-    fn parse_headers(headers_string: String) -> BTreeMap<String, Vec<String>> {
-        let mut headers = BTreeMap::new();
-        for line in headers_string.lines() {
-            let mut split = line.split(":");
-            let key = split.next().unwrap();
-            let values = split.next().unwrap().to_string();
-            for val in values.split(",") {
-                let entry = headers.entry(key.to_string()).or_insert(Vec::new());
-                entry.push(val.to_string());
-            }
-        }
-        headers
     }
 }
 

--- a/platform/src/event/network.rs
+++ b/platform/src/event/network.rs
@@ -191,6 +191,7 @@ pub enum HttpMethod{
 }
 
 impl HttpMethod {
+    // to_string returns a &str ?
     pub fn to_string(&self) -> &str {
         match self {
             Self::GET => "GET",

--- a/platform/src/os/linux/mod.rs
+++ b/platform/src/os/linux/mod.rs
@@ -10,6 +10,9 @@ pub mod gl_sys;
 pub mod libc_sys;
 pub mod opengl;
 
+#[cfg(target_os="linux")]
+pub mod url_session;
+
 #[cfg(not(target_os="android"))]
 pub mod dma_buf;
 #[cfg(not(target_os="android"))]

--- a/platform/src/os/linux/url_session.rs
+++ b/platform/src/os/linux/url_session.rs
@@ -1,42 +1,38 @@
-use {
-    crate::{
-        event::{
-            HttpRequest,
-            HttpResponse,
-            NetworkResponse,
-            NetworkResponseItem,
-        },
-        makepad_live_id::LiveId,
-    },
-    std::{
-        sync::{
-            mpsc::Sender
-        }
-    },
-    makepad_http::client::send
+use std::{
+    sync::{
+        mpsc::Sender
+    }
 };
-use makepad_http::client::HttpRequestOptions;
+
+use makepad_http::client::HttpClient;
 use makepad_url::Url;
+
+use crate::{
+    event::{
+        HttpRequest,
+        HttpResponse,
+        NetworkResponse,
+        NetworkResponseItem,
+    },
+    makepad_live_id::LiveId,
+};
 
 
 pub fn make_http_request(request_id: LiveId, request: HttpRequest, networking_sender: Sender<NetworkResponseItem>) {
-    let method = request.method.to_string().to_string();
     let url = Url::parse_string(request.url).unwrap();
-    let options = HttpRequestOptions {
-        headers: request.headers,
-        body: request.body
-    };
+    let headers = request.headers;
     let request_id = request_id.clone();
-
-    send(method, url, options, move |response_code, response| {
-        let response = HttpResponse::new(
-            request.metadata_id,
-            response_code,
-            "".to_string(),
-            Some(response.body),
-        );
-        handle_http_response(request_id, response, networking_sender);
-    });
+    HttpClient::new(url)
+        .set_headers(headers)
+        .get(move |response_code, response| {
+            let response = HttpResponse::new(
+                request.metadata_id,
+                response_code,
+                "".to_string(),
+                Some(response.body),
+            );
+            handle_http_response(request_id, response, networking_sender);
+        });
 }
 
 pub fn handle_http_response(request_id: LiveId, response: HttpResponse, networking_sender: Sender<NetworkResponseItem>) {

--- a/platform/src/os/linux/url_session.rs
+++ b/platform/src/os/linux/url_session.rs
@@ -1,0 +1,48 @@
+use {
+    crate::{
+        event::{
+            HttpRequest,
+            HttpResponse,
+            NetworkResponse,
+            NetworkResponseItem,
+        },
+        makepad_live_id::LiveId,
+    },
+    std::{
+        sync::{
+            mpsc::Sender
+        }
+    },
+    makepad_http::client::send
+};
+use makepad_http::client::HttpRequestOptions;
+use makepad_url::Url;
+
+
+pub fn make_http_request(request_id: LiveId, request: HttpRequest, networking_sender: Sender<NetworkResponseItem>) {
+    let method = request.method.to_string().to_string();
+    let url = Url::parse_string(request.url).unwrap();
+    let options = HttpRequestOptions {
+        headers: request.headers,
+        body: request.body
+    };
+    let request_id = request_id.clone();
+
+    send(method, url, options, move |response_code, response| {
+        let response = HttpResponse::new(
+            request.metadata_id,
+            response_code,
+            "".to_string(),
+            Some(response.body),
+        );
+        handle_http_response(request_id, response, networking_sender);
+    });
+}
+
+pub fn handle_http_response(request_id: LiveId, response: HttpResponse, networking_sender: Sender<NetworkResponseItem>) {
+    let message = NetworkResponseItem {
+        request_id,
+        response: NetworkResponse::HttpResponse(response),
+    };
+    networking_sender.send(message).unwrap();
+}


### PR DESCRIPTION
It is a quick attempt to bring a basic HTTP support for Linux platform.

I didn't want to change anything about the actual structure, but I guess we should unify all the request & response structs and move them to makepad-http. For now I've done useless transformations.

- it uses raw tcp + openssl
- created 2 new crates
  * makepad-net: has the tcp Socket
  * makepad-url: URL parsing


