### PR TITLE
html_experiment: hyphenated attributes not working (`data-mx-color`)

### DIFF
--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -17,7 +17,7 @@ live_design!{
 
     HtmlLinkBase = {{HtmlLink}} {
         link = {
-            draw_text = {
+            draw_text: {
                 // other blue hyperlink colors: #1a0dab, // #0969da  // #0c50d1
                 color: #1a0dab
             }

--- a/widgets/src/image_cache.rs
+++ b/widgets/src/image_cache.rs
@@ -198,7 +198,6 @@ pub trait ImageCacheImpl {
         image_path: &str,
         id: usize,
     ) -> Result<(), ImageError> {
-        log!("LOADING FROM DISK  {}", image_path);
         if let Some(texture) = cx.get_global::<ImageCache>().map.get(image_path){
             self.set_texture(Some(texture.clone()), id);
             Ok(())


### PR DESCRIPTION
In `html_experiment`, the first two lines of `body` work, as they test the default `color` attributes.

However, the third line starting with `"testing span with colors"` does not work, as those attributes have hyphens.... at least I _think_ that may be the cause.

Similarly, the fourth line `"testing spoiler"` doesn't yet work, but that's okay because i haven't implemented the click handler for it. However, its `data-mx-spoiler` attribute also doesn't get parsed properly.