### PR TITLE
Additions in some widgets for Moxin specific needs

### DIFF
--- a/widgets/src/drop_down.rs
+++ b/widgets/src/drop_down.rs
@@ -89,6 +89,7 @@ impl DropDown {
     
     pub fn set_open(&mut self, cx: &mut Cx) {
         self.is_open = true;
+        self.draw_bg.apply_over(cx, live!{open: 1.0});
         self.draw_bg.redraw(cx);
         let global = cx.global::<PopupMenuGlobal>().clone();
         let mut map = global.map.borrow_mut();
@@ -100,6 +101,7 @@ impl DropDown {
     
     pub fn set_closed(&mut self, cx: &mut Cx) {
         self.is_open = false;
+        self.draw_bg.apply_over(cx, live!{open: 0.0});
         self.draw_bg.redraw(cx);
         cx.sweep_unlock(self.draw_bg.area());
     }

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -650,6 +650,13 @@ impl TextInputRef {
         }
         None
     }
+
+    pub fn returned(&self, actions: &Actions) -> Option<String> {
+        if let TextInputAction::Return(val) = actions.find_widget_action_cast(self.widget_uid()) {
+            return Some(val);
+        }
+        None
+    }
     
     pub fn return_key(&self, actions: &Actions) -> Option<String> {
         if let TextInputAction::Return(val) = actions.find_widget_action_cast(self.widget_uid()) {

--- a/widgets/src/theme_desktop_dark.rs
+++ b/widgets/src/theme_desktop_dark.rs
@@ -1609,6 +1609,7 @@ live_design! {
             instance hover: 0.0
             instance pressed: 0.0
             instance focus: 0.0,
+            instance open: 0.0,
             uniform border_radius: 0.5
 
             fn get_bg(self, inout sdf: Sdf2d) {

--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -275,6 +275,8 @@ pub enum ViewAction {
     FingerDown(FingerDownEvent),
     FingerUp(FingerUpEvent),
     FingerMove(FingerMoveEvent),
+    FingerHoverIn(FingerHoverEvent),
+    FingerHoverOut(FingerHoverEvent),
     KeyDown(KeyEvent),
     KeyUp(KeyEvent),
 }
@@ -301,6 +303,24 @@ impl ViewRef {
     pub fn finger_move(&self, actions: &Actions) -> Option<FingerMoveEvent> {
         if let Some(item) = actions.find_widget_action(self.widget_uid()) {
             if let ViewAction::FingerMove(fd) = item.cast() {
+                return Some(fd);
+            }
+        }
+        None
+    }
+
+    pub fn finger_hover_in(&self, actions: &Actions) -> Option<FingerHoverEvent> {
+        if let Some(item) = actions.find_widget_action(self.widget_uid()) {
+            if let ViewAction::FingerHoverIn(fd) = item.cast() {
+                return Some(fd);
+            }
+        }
+        None
+    }
+
+    pub fn finger_hover_out(&self, actions: &Actions) -> Option<FingerHoverEvent> {
+        if let Some(item) = actions.find_widget_action(self.widget_uid()) {
+            if let ViewAction::FingerHoverOut(fd) = item.cast() {
                 return Some(fd);
             }
         }
@@ -634,7 +654,8 @@ impl Widget for View {
                         self.animator_play(cx, id!(down.off));
                     }
                 }
-                Hit::FingerHoverIn(_) => {
+                Hit::FingerHoverIn(e) => {
+                    cx.widget_action(uid, &scope.path, ViewAction::FingerHoverIn(e));
                     if let Some(cursor) = &self.cursor {
                         cx.set_cursor(*cursor);
                     }
@@ -642,7 +663,8 @@ impl Widget for View {
                         self.animator_play(cx, id!(hover.on));
                     }
                 }
-                Hit::FingerHoverOut(_) => {
+                Hit::FingerHoverOut(e) => {
+                    cx.widget_action(uid, &scope.path, ViewAction::FingerHoverOut(e));
                     if self.animator.live_ptr.is_some() {
                         self.animator_play(cx, id!(hover.off));
                     }


### PR DESCRIPTION
This PR adds:

* A flag to indicate if `DropDown` is open in shader code
* A public function to check if a `TextInput::Return` event was emitted
* New actions emitted from the `View` widget related with focus events