### PR TITLE
Fix panic in text drawing, improve whitespace handling in HTML

### DIFF
--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -198,12 +198,12 @@ impl<'a> WordIterator<'a> {
     
     fn next_char(&mut self){
         if let Some((i, c)) = self.char_iter.next() {
-            self.last_char = c;
             self.last_index = i;
+            self.last_char = c;
         }
         else{
+            self.last_index += self.last_char.len_utf8();
             self.last_char = '\0';
-            self.last_index += 1;
         };
     }
     

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -115,7 +115,8 @@ impl Html {
                 trim_whitespace_in_text = TrimWhitespaceInText::Trim;
             }
             some_id!(code) => {
-                tf.push_size_abs_scale(0.85);
+                tf.push_size_rel_scale(0.85);
+                tf.top_drop.push(1.412); // to get back to top_drop of 1.2
                 tf.combine_spaces.push(false);
                 tf.fixed.push();
                 tf.inline_code.push();
@@ -277,6 +278,7 @@ impl Html {
             }
             some_id!(code) => {
                 tf.inline_code.pop();
+                tf.top_drop.pop();
                 tf.font_sizes.pop();
                 tf.combine_spaces.pop();
                 tf.fixed.pop(); 

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -115,8 +115,9 @@ impl Html {
                 trim_whitespace_in_text = TrimWhitespaceInText::Trim;
             }
             some_id!(code) => {
-                tf.push_size_rel_scale(0.85);
-                tf.top_drop.push(1.412); // to get back to top_drop of 1.2
+                const FIXED_FONT_SIZE_SCALE: f64 = 0.85;
+                tf.push_size_rel_scale(FIXED_FONT_SIZE_SCALE);
+                tf.top_drop.push(1.2/FIXED_FONT_SIZE_SCALE); // to achieve a top_drop of 1.2
                 tf.combine_spaces.push(false);
                 tf.fixed.push();
                 tf.inline_code.push();

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -155,7 +155,7 @@ impl Html {
             some_id!(sub) => {
                 // Adjust the top drop to move the text slightly downwards.
                 let curr_top_drop = tf.top_drop.last()
-                    .unwrap_or(&1.1);
+                    .unwrap_or(&1.2);
                 // A 55% increase in top_drop seems to look good for subscripts,
                 // which should be slightly below the halfway point in the line
                 let new_top_drop = curr_top_drop * 1.55;

--- a/widgets/src/image_cache.rs
+++ b/widgets/src/image_cache.rs
@@ -94,7 +94,6 @@ impl ImageBuffer {
                 }
             }
             Err(err) => {
-                error!("Error decoding PNG: {:?}", err);
                 Err(ImageError::PngDecode(err))
             }
         }
@@ -111,7 +110,6 @@ impl ImageBuffer {
                 ImageBuffer::new(&data, info.width as usize, info.height as usize)
             },
             Err(err) => {
-                error!("Error decoding JPG: {:?}", err);
                 Err(ImageError::JpgDecode(err))
             }
         }
@@ -173,7 +171,6 @@ pub trait ImageCacheImpl {
                 Ok(())
             }
             Err(err)=>{
-                error!("load_png_from_data: Cannot load png image from data: {}", err);
                 Err(err)
             }
         }
@@ -186,7 +183,6 @@ pub trait ImageCacheImpl {
                 Ok(())
             }
             Err(err)=>{
-                error!("load_jpg_from_data: Cannot load png image from data: {}", err);
                 Err(err)
             }
         }


### PR DESCRIPTION
* Fix bug in draw text when iterating through each word.

* Allow each tag to specify whether whitespace should be kept or trimmed (i.e., removing trailing and leading whitespsace) in the text body within that tag.

* Remove some error log outputs in image handling, as it is not always an error for those to occur.