### PR TITLE
Add ability to enter newlines in TextInput

### DIFF
--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -663,13 +663,6 @@ impl TextInputRef {
         None
     }
     
-    pub fn return_key(&self, actions: &Actions) -> Option<String> {
-        if let TextInputAction::Return(val) = actions.find_widget_action_cast(self.widget_uid()) {
-            return Some(val);
-        }
-        None
-    }
-    
     pub fn set_cursor(&self, head:usize, tail: usize){
         if let Some(mut inner) = self.borrow_mut(){
             inner.set_cursor(head, tail);

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -138,6 +138,11 @@ impl Widget for TextInput {
                 KeyCode::Tab => {
                     // dispatch_action(cx, self, TextInputAction::Tab(key.mod_shift));
                 }
+                KeyCode::ReturnKey if ke.modifiers.shift => {
+                    if self.change(cx, "\n"){
+                        self.push_change_action(uid, scope, cx)
+                    }
+                },
                 KeyCode::ReturnKey => {
                     cx.hide_text_ime();
                     cx.widget_action(uid, &scope.path, TextInputAction::Return(self.text.clone()));


### PR DESCRIPTION
When pressing SHIFT+ENTER a new line is inserted to the test.
Also, this PR removes a duplicated function from this widget.