### PR TITLE
Android: add an Intent opening permission to the default Android manifest

### DIFF
--- a/tools/cargo_makepad/src/android/compile.rs
+++ b/tools/cargo_makepad/src/android/compile.rs
@@ -79,6 +79,13 @@ fn manifest_xml(label:&str, class_name:&str, url:&str)->String{
         <uses-permission android:name="android.permission.CAMERA"/>
         <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
         <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+        <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:ignore="QueryAllPackagesPermission" />
+
+        <queries>
+            <intent>
+                <action android:name="android.intent.action.MAIN" />
+            </intent>
+        </queries>
     </manifest>
     "#)
 }


### PR DESCRIPTION


This is required to support `robius-open`, which some makepad apps are now using.