### PR TITLE
CxOp: Copy to clipboard

### DIFF
--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -69,6 +69,7 @@ pub enum CxOsOp {
     StartDragging(Vec<DragItem>),
     UpdateMacosMenu(MacosMenu),
     ShowClipboardActions(String),
+    CopyToClipboard(String),
 
     HttpRequest {
         request_id: LiveId,
@@ -178,6 +179,11 @@ impl Cx {
     pub fn show_clipboard_actions(&mut self, selected: String) {
         self.platform_ops
             .push(CxOsOp::ShowClipboardActions(selected));
+    }
+
+    pub fn copy_to_clipboard(&mut self, content: String) {
+        self.platform_ops
+            .push(CxOsOp::CopyToClipboard(content));
     }
 
     pub fn start_dragging(&mut self, items: Vec<DragItem>) {

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -181,6 +181,9 @@ impl Cx {
             .push(CxOsOp::ShowClipboardActions(selected));
     }
 
+    /// Copies the given string to the clipboard.
+    /// 
+    /// Due to lack of platform clipboard support, it does not work on Web or tvOS.
     pub fn copy_to_clipboard(&mut self, content: &str) {
         self.platform_ops.push(CxOsOp::CopyToClipboard(content.to_owned()));
     }

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -181,9 +181,8 @@ impl Cx {
             .push(CxOsOp::ShowClipboardActions(selected));
     }
 
-    pub fn copy_to_clipboard(&mut self, content: String) {
-        self.platform_ops
-            .push(CxOsOp::CopyToClipboard(content));
+    pub fn copy_to_clipboard(&mut self, content: &str) {
+        self.platform_ops.push(CxOsOp::CopyToClipboard(content.to_owned()));
     }
 
     pub fn start_dragging(&mut self, items: Vec<DragItem>) {

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -313,6 +313,9 @@ impl Cx {
                 CxOsOp::ShowClipboardActions(_request) => {
                     crate::log!("Show clipboard actions not supported yet");
                 }
+                CxOsOp::CopyToClipboard(content) => {
+                    get_ios_app_global().copy_to_clipboard(&content);
+                }
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::BeginVideoPlayback(_) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -517,7 +517,10 @@ impl Cx {
                 },
                 CxOsOp::ShowClipboardActions(_request) => {
                     crate::log!("Show clipboard actions not supported yet");
-                }
+                },
+                CxOsOp::CopyToClipboard(content) => {
+                    get_macos_app_global().copy_to_clipboard(&content);
+                },
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::BeginVideoPlayback(_) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),

--- a/platform/src/os/apple/macos/macos_app.rs
+++ b/platform/src/os/apple/macos/macos_app.rs
@@ -745,6 +745,15 @@ impl MacosApp {
         };
     }*/
 
+    pub fn copy_to_clipboard(&mut self, content: &str) {
+        unsafe {
+            let pasteboard: ObjcId = self.pasteboard;
+            let nsstring = str_to_nsstring(content);
+            let array: ObjcId = msg_send![class!(NSArray), arrayWithObject: NSStringPboardType];
+            let () = msg_send![pasteboard, declareTypes: array owner: nil];
+            let () = msg_send![pasteboard, setString: nsstring forType: NSStringPboardType];
+        }
+    }
 
     pub fn open_save_file_dialog(&mut self, _settings: FileDialog)
     {

--- a/platform/src/os/apple/tvos/tvos.rs
+++ b/platform/src/os/apple/tvos/tvos.rs
@@ -258,6 +258,9 @@ impl Cx {
                 CxOsOp::ShowClipboardActions(_request) => {
                     crate::log!("Show clipboard actions not supported yet");
                 }
+                CxOsOp::CopyToClipboard(_request) => {
+                    crate::error!("Clipboard actions not yet implemented for tvOS");
+                }
                 CxOsOp::PrepareVideoPlayback(_, _, _, _, _) => todo!(),
                 CxOsOp::BeginVideoPlayback(_) => todo!(),
                 CxOsOp::PauseVideoPlayback(_) => todo!(),

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -732,6 +732,9 @@ impl Cx {
                 CxOsOp::ShowClipboardActions(_selected) => {
                     //to_java.show_clipboard_actions(selected.as_str());
                 },
+                CxOsOp::CopyToClipboard(content) => {
+                    unsafe {android_jni::to_java_copy_to_clipboard(content);}
+                },
                 CxOsOp::HttpRequest {request_id, request} => {
                     unsafe {android_jni::to_java_http_request(request_id, request);}
                 },

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -619,10 +619,16 @@ pub(crate) unsafe fn to_java_load_asset(filepath: &str)->Option<Vec<u8>> {
     return None;
 }
 
-
 pub unsafe fn to_java_show_keyboard(visible: bool) {
     let env = attach_jni_env();
     ndk_utils::call_void_method!(env, ACTIVITY, "showKeyboard", "(Z)V", visible as i32);
+}
+
+pub unsafe fn to_java_copy_to_clipboard(content: String) {
+    let env = attach_jni_env();
+    let content = CString::new(content.clone()).unwrap();
+    let content = ((**env).NewStringUTF.unwrap())(env, content.as_ptr());
+    ndk_utils::call_void_method!(env, ACTIVITY, "copyToClipboard", "(Ljava/lang/String;)V", content);
 }
 
 pub unsafe fn to_java_http_request(request_id: LiveId, request: HttpRequest) {

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -10,6 +10,7 @@ use {
         egl_sys,
         x11::xlib_event::*,
         x11::xlib_app::*,
+        x11::x11_sys,
         linux_media::CxLinuxMedia
     },
     crate::{
@@ -289,6 +290,13 @@ impl Cx {
                     }
                 },
                 CxOsOp::ShowClipboardActions(_) =>{
+                },
+                CxOsOp::CopyToClipboard(content) => {
+                    if let Some(window) = opengl_windows.get(0) {
+                        unsafe {
+                            xlib_app.copy_to_clipboard(&content, window.xlib_window.window.unwrap(), x11_sys::CurrentTime as u64)
+                        }
+                    }
                 }
                 CxOsOp::FullscreenWindow(_window_id) => {
                     todo!()

--- a/platform/src/os/linux/x11/xlib_app.rs
+++ b/platform/src/os/linux/x11/xlib_app.rs
@@ -449,7 +449,7 @@ impl XlibApp {
                                         }));
                                         let response = response.borrow();
                                         if let Some(response) = response.as_ref() {
-                                            self.copy_to_clipboard(response, &window, &event);
+                                            self.copy_to_clipboard(response, window.window.unwrap(), event.xkey.time);
                                         }
                                     }
                                     KeyCode::KeyX => {
@@ -459,7 +459,7 @@ impl XlibApp {
                                         }));
                                         let response = response.borrow();
                                         if let Some(response) = response.as_ref() {
-                                            self.copy_to_clipboard(response, &window, &event);
+                                            self.copy_to_clipboard(response, window.window.unwrap(), event.xkey.time);
                                         }
                                     }
                                     _ => ()
@@ -839,15 +839,15 @@ impl XlibApp {
         }
     }
 
-    unsafe fn copy_to_clipboard(&mut self, text: &String, window: &XlibWindow, event: &XEvent) {
+    pub unsafe fn copy_to_clipboard(&mut self, text: &String, window_id: c_ulong, time: u64) {
         // store the text on the clipboard
         self.clipboard = text.clone();
         // lets set the owner
         x11_sys::XSetSelectionOwner(
             self.display,
             self.atoms.clipboard,
-            window.window.unwrap(),
-            event.xkey.time
+            window_id,
+            time
         );
         x11_sys::XFlush(self.display);
     }

--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -437,6 +437,9 @@ impl Cx {
                 },
                 CxOsOp::ShowClipboardActions(_) =>{
                 }
+                CxOsOp::CopyToClipboard(_) =>{
+                    crate::error!("Clipboard actions not supported in web")
+                }
                 CxOsOp::SetCursor(cursor) => {
                     self.os.from_wasm(FromWasmSetMouseCursor::new(cursor));
                 },

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -735,7 +735,7 @@ impl Win32Window {
         //run_catch_panic(-1, || callback_inner(window, msg, wparam, lparam))
     }
 
-    unsafe fn copy_to_clipboard(text: &String) {
+    pub unsafe fn copy_to_clipboard(text: &String) {
         // plug it into the windows clipboard
         // make utf16 dta
         if let Ok(()) = OpenClipboard(None) {

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -15,6 +15,7 @@ use {
                 win32_event::*,
                 d3d11::{D3d11Window, D3d11Cx},
                 win32_app::*,
+                win32_window::Win32Window,
             },
             cx_native::EventFlow,
         },
@@ -347,7 +348,12 @@ impl Cx {
                     }
                 }
                 CxOsOp::ShowClipboardActions(_) => {
-                }
+                },
+                CxOsOp::CopyToClipboard(content) => {
+                    unsafe {
+                        Win32Window::copy_to_clipboard(&content);
+                    }
+                },
                 CxOsOp::XrStartPresenting => {
                     //todo!()
                 },

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -9,6 +9,10 @@ import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.content.Context;
 
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.pm.ApplicationInfo;
+
 import java.util.HashMap;
 import java.util.ArrayList;
 import java.io.OutputStream;
@@ -378,6 +382,20 @@ MidiManager.OnDeviceOpenedListener{
                 }
             }
         });
+    }
+
+    public void copyToClipboard(String content) {
+        ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+        // User-facing description of the clipboard content
+        String clipLabel = getApplicationName() + " clip";
+        ClipData clip = ClipData.newPlainText(clipLabel, content);
+        clipboard.setPrimaryClip(clip);
+    }
+
+    private String getApplicationName() {
+        ApplicationInfo applicationInfo = getApplicationContext().getApplicationInfo();
+        CharSequence appName = applicationInfo.loadLabel(getPackageManager());
+        return appName.toString();
     }
 
     public void requestHttp(long id, long metadataId, String url, String method, String headers, byte[] body) {


### PR DESCRIPTION
Adds a `cx` function for copying text into the OS clipboard:

```
cx.copy_to_clipboard(&my_string);
```

Supports:

- macOS
- Linux
- Windows
- iOS
- Android

Because there's no clipboard support on Web or tvOS, those platforms just emit an error message on copy.