### PR TITLE
Markdown widget fixes and changes

### DIFF
--- a/draw/src/turtle.rs
+++ b/draw/src/turtle.rs
@@ -599,6 +599,18 @@ impl<'a> Cx2d<'a> {
             turtle.pos.y = next_y;
         }
     }
+
+    pub fn turtle_new_line_with_spacing(&mut self, spacing: f64){
+        let turtle = self.turtles.last_mut().unwrap();
+        turtle.pos.x = turtle.origin.x + turtle.layout.padding.left;
+        let next_y = turtle.height_used + turtle.origin.y + spacing;
+        if turtle.pos.y == next_y{
+            turtle.pos.y += spacing;
+        }
+        else{
+            turtle.pos.y = next_y;
+        }
+    }
     
     fn move_align_list(&mut self, dx: f64, dy: f64, align_start: usize, align_end: usize, shift_clip: bool, turtle_shift:DVec2) {
         //let current_dpi_factor = self.current_dpi_factor();

--- a/libs/markdown/src/lib.rs
+++ b/libs/markdown/src/lib.rs
@@ -183,7 +183,6 @@ pub fn parse_markdown(body:&str)->MarkdownDoc{
                         }
                         Kind::Quote(blocks)=>{
                             let last_is_space = cursor.last_char == ' ';
-                            cursor.next();
                             let mut spaces = 0;
                             while cursor.chars[0] == ' '{
                                 cursor.next();
@@ -204,6 +203,12 @@ pub fn parse_markdown(body:&str)->MarkdownDoc{
                             }
                             else if !last_is_space{
                                 push_char(&mut nodes, &mut decoded, ' ');
+                            }
+                            else {
+                                for _ in 0..*blocks{
+                                    nodes.push(MarkdownNode::EndQuote);
+                                }
+                                state = State::Root{spaces};
                             }
                         }
                         Kind::Normal=>{
@@ -337,7 +342,25 @@ pub fn parse_markdown(body:&str)->MarkdownDoc{
                 } 
                                 
                 ['`','`','`'] =>{ // big code block
-                    nodes.push(MarkdownNode::EndHead);
+                    match kind{
+                        Kind::Head => {
+                            nodes.push(MarkdownNode::EndHead);
+                            state = State::Root{spaces:0};
+                        }
+                        Kind::Quote(blocks) => {
+                            for _ in 0..*blocks{
+                                nodes.push(MarkdownNode::EndQuote);
+                            }
+                        }
+                        Kind::Normal => {
+                            nodes.push(MarkdownNode::EndNormal)
+                        }
+                        Kind::List(depth) => {
+                            for _ in 0..*depth{
+                                nodes.push(MarkdownNode::EndListItem);
+                            }
+                        }
+                    }
                     state = State::Root{spaces:0};
                 }
                 ['`',_,_] =>{ // inline code block

--- a/widgets/src/markdown.rs
+++ b/widgets/src/markdown.rs
@@ -120,11 +120,13 @@ impl Widget for Markdown {
                 },
                 MarkdownNode::BeginCode=>{
                     cx.turtle_new_line();
+                    tf.combine_spaces.push(false);
                     tf.fixed.push();
-                    tf.begin_code(cx);     
+                    tf.begin_code(cx);
                 },
                 MarkdownNode::EndCode=>{
                     tf.fixed.pop();
+                    tf.combine_spaces.pop();
                     tf.end_code(cx);
                 },
                 MarkdownNode::BeginBold=>{
@@ -154,7 +156,20 @@ impl Widget for Markdown {
     } 
     
     fn set_text(&mut self, v:&str){
-        self.body = Rc::new(v.to_string())
+        self.body = Rc::new(v.to_string());
+
+        let new_doc = parse_markdown(&*self.body);
+        if new_doc != self.doc{
+            self.doc = new_doc;
+            self.text_flow.clear_items();
+        }
     }
-} 
+}
+
+impl MarkdownRef {
+    pub fn set_text(&mut self, v:&str) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.set_text(v)
+    }
+}
  

--- a/widgets/src/markdown.rs
+++ b/widgets/src/markdown.rs
@@ -20,6 +20,7 @@ live_design!{
 pub struct Markdown{
     #[deref] text_flow: TextFlow,
     #[live] body: Rc<String>,
+    #[live] paragraph_spacing: f64,
     #[rust] doc: MarkdownDoc
 }
 
@@ -50,7 +51,7 @@ impl Widget for Markdown {
                     tf.bold.push();
                 },
                 MarkdownNode::Separator=>{
-                    cx.turtle_new_line();
+                    cx.turtle_new_line_with_spacing(self.paragraph_spacing);
                     tf.sep(cx);
                 }
                 MarkdownNode::EndHead=>{
@@ -59,10 +60,10 @@ impl Widget for Markdown {
                     cx.turtle_new_line();
                 },
                 MarkdownNode::NewLine=>{
-                    cx.turtle_new_line();
+                    cx.turtle_new_line_with_spacing(self.paragraph_spacing);
                 },
                 MarkdownNode::BeginNormal=>{
-                    cx.turtle_new_line();
+                    cx.turtle_new_line_with_spacing(self.paragraph_spacing);
                 },
                 MarkdownNode::EndNormal=>{
                     
@@ -98,7 +99,7 @@ impl Widget for Markdown {
                     tf.draw_text(cx, " ]");
                 },
                 MarkdownNode::BeginQuote=>{
-                    cx.turtle_new_line();
+                    cx.turtle_new_line_with_spacing(self.paragraph_spacing);
                     tf.begin_quote(cx);
                 },
                 MarkdownNode::EndQuote=>{
@@ -119,12 +120,18 @@ impl Widget for Markdown {
                     tf.inline_code.pop();                 
                 },
                 MarkdownNode::BeginCode=>{
-                    cx.turtle_new_line();
+                    cx.turtle_new_line_with_spacing(self.paragraph_spacing);
                     tf.combine_spaces.push(false);
                     tf.fixed.push();
+
+                    // This adjustment is necesary to do not add too much spacing
+                    // between lines inside the code block.
+                    tf.top_drop.push(0.2);
+
                     tf.begin_code(cx);
                 },
                 MarkdownNode::EndCode=>{
+                    tf.top_drop.pop();
                     tf.fixed.pop();
                     tf.combine_spaces.pop();
                     tf.end_code(cx);

--- a/widgets/src/markdown.rs
+++ b/widgets/src/markdown.rs
@@ -47,6 +47,7 @@ impl Widget for Markdown {
         for node in &self.doc.nodes{
             match node{
                 MarkdownNode::BeginHead{level}=>{
+                    cx.turtle_new_line_with_spacing(self.paragraph_spacing);
                     tf.push_size_abs_scale(4.5 / *level as f64);
                     tf.bold.push();
                 },

--- a/widgets/src/markdown.rs
+++ b/widgets/src/markdown.rs
@@ -27,11 +27,7 @@ pub struct Markdown{
 // alright lets parse the HTML
 impl LiveHook for Markdown{
     fn after_apply_from(&mut self, _cx: &mut Cx, _apply:&mut Apply) {
-        let new_doc = parse_markdown(&*self.body);
-        if new_doc != self.doc{
-            self.doc = new_doc;
-            self.text_flow.clear_items();
-        }
+        self.parse_text();
     }
 }
  
@@ -165,7 +161,12 @@ impl Widget for Markdown {
     
     fn set_text(&mut self, v:&str){
         self.body = Rc::new(v.to_string());
+        self.parse_text();
+    }
+}
 
+impl Markdown {
+    fn parse_text(&mut self) {
         let new_doc = parse_markdown(&*self.body);
         if new_doc != self.doc{
             self.doc = new_doc;

--- a/widgets/src/theme_desktop_dark.rs
+++ b/widgets/src/theme_desktop_dark.rs
@@ -656,6 +656,7 @@ live_design! {
 
         line_spacing: (THEME_FONT_LINE_SPACING),
         font_size: (THEME_FONT_SIZE_P),
+        paragraph_spacing: 16,
 
         draw_normal: {
             text_style: <THEME_FONT_REGULAR> {

--- a/widgets/src/theme_desktop_dark.rs
+++ b/widgets/src/theme_desktop_dark.rs
@@ -719,6 +719,12 @@ live_design! {
         }
 
         draw_block: {
+            line_color: (THEME_COLOR_TEXT_DEFAULT)
+            sep_color: (THEME_COLOR_DIVIDER)
+            quote_bg_color: (THEME_COLOR_BG_HIGHLIGHT)
+            quote_fg_color: (THEME_COLOR_TEXT_DEFAULT)
+            code_color: (THEME_COLOR_BG_HIGHLIGHT)
+
             fn pixel(self) -> vec4 {
                 let sdf = Sdf2d::viewport(self.pos * self.rect_size);
                 match self.block_type {
@@ -730,7 +736,7 @@ live_design! {
                             self.rect_size.y,
                             2.
                         );
-                        sdf.fill(THEME_COLOR_BG_HIGHLIGHT)
+                        sdf.fill(self.quote_bg_color)
                         sdf.box(
                             THEME_SPACE_1,
                             THEME_SPACE_1,
@@ -738,7 +744,7 @@ live_design! {
                             self.rect_size.y - THEME_SPACE_2,
                             1.5
                         );
-                        sdf.fill(THEME_COLOR_TEXT_DEFAULT);
+                        sdf.fill(self.quote_fg_color)
                         return sdf.result;
                     }
                     FlowBlockType::Sep => {
@@ -749,7 +755,7 @@ live_design! {
                             self.rect_size.y-2.,
                             2.
                         );
-                        sdf.fill(THEME_COLOR_DIVIDER);
+                        sdf.fill(self.sep_color);
                         return sdf.result;
                     }
                     FlowBlockType::Code => {
@@ -760,7 +766,7 @@ live_design! {
                             self.rect_size.y,
                             2.
                         );
-                        sdf.fill(THEME_COLOR_BG_HIGHLIGHT);
+                        sdf.fill(self.code_color);
                         return sdf.result;
                     }
                     FlowBlockType::InlineCode => {
@@ -771,7 +777,7 @@ live_design! {
                             self.rect_size.y - 2.,
                             2.
                         );
-                        sdf.fill(THEME_COLOR_BG_HIGHLIGHT_INLINE);
+                        sdf.fill(self.code_color);
                         return sdf.result;
                     }
                     FlowBlockType::Underline => {
@@ -782,7 +788,7 @@ live_design! {
                             2.0,
                             0.5
                         );
-                        sdf.fill(THEME_COLOR_TEXT_DEFAULT);
+                        sdf.fill(self.line_color);
                         return sdf.result;
                     }
                     FlowBlockType::Strikethrough => {
@@ -793,7 +799,7 @@ live_design! {
                             2.0,
                             0.5
                         );
-                        sdf.fill(THEME_COLOR_TEXT_DEFAULT);
+                        sdf.fill(self.line_color);
                         return sdf.result;
                     }
                 }


### PR DESCRIPTION
Changes

* Adds vertical space "before" key elements such as headers, text blocks (paragraphs), etc. So it looks with some spacing between those entities.

* Adds color instances values to code and quote blocks, as we have in HTML widget, so we can easily override theme colors.

* Implements `set_text`

* Supports some invalid markdown by auto-closing some blocks in case an expected one is starting. This is a necessity in Moxin since we deal with models-generated markdown content which is not always correct or complete.

* Fixes minor issues related with newlines and spacing.