### PR TITLE
x11: handle VisibilityNotify event and redraw

### DIFF
--- a/platform/src/os/linux/x11/x11_sys.rs
+++ b/platform/src/os/linux/x11/x11_sys.rs
@@ -82,6 +82,13 @@ pub const EnterWindowMask: u32 = 16;
 pub const LeaveWindowMask: u32 = 32;
 pub const XBufferOverflow: i32 = -1;
 
+// Added, from https://community.khronos.org/t/list-for-xevent-structures-type-component/70768
+pub const VisibilityNotify: u32 = 15;
+// Added, from https://tronche.com/gui/x/xlib/events/window-state-change/visibility.html
+pub const VisibilityUnobscured: i32 = 0;
+pub const VisibilityPartiallyObscured: i32 = 1;
+pub const VisibilityFullyObscured: i32 = 2;
+
 pub const XIMPreeditNothing: u32 = 8;
 pub const XIMStatusNothing: u32 = 1024;
 

--- a/platform/src/os/linux/x11/xlib_app.rs
+++ b/platform/src/os/linux/x11/xlib_app.rs
@@ -538,6 +538,16 @@ impl XlibApp {
                     (glx.glXSwapBuffers)(display, window);
                     */
                 },
+                x11_sys::VisibilityNotify => {
+                    let event = event.xvisibility;
+                    if event.state != x11_sys::VisibilityFullyObscured {
+                        if let Some(window_ptr) = self.window_map.get(&event.window) {
+                            let window = &mut (**window_ptr);
+                            window.send_focus_event();
+                        }
+                    }
+                }
+
                 _ => {}
             }
         }


### PR DESCRIPTION
DWM window manager uses "Geom" changes on view/update, which does not cause a full redraw of the application before this diff. That results in a blank/old-garbage-content texture, instead of the Makepad UI. This fix simply asks the UI to do a full redraw.