### PR TITLE
[Ergonomics] Add `has_texture` function to `Image`.

### DIFF
--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -56,6 +56,11 @@ impl Image {
             .and_then(|t| t.get_format(cx).vec_width_height())
     }
 
+    /// True if a texture has been set on this `Image`.
+    pub fn has_texture(&self) -> bool {
+        self.texture.is_some()
+    }
+
     pub fn draw_walk(&mut self, cx: &mut Cx2d, mut walk: Walk) -> DrawStep {
         // alright we get a walk. depending on our aspect ratio
         // we change either nothing, or width or height
@@ -166,6 +171,15 @@ impl ImageRef {
             inner.size_in_pixels(cx)
         } else {
             None
+        }
+    }
+
+    /// See [`Image::has_texture()`].
+    pub fn has_texture(&self) -> bool {
+        if let Some(inner) = self.borrow() {
+            inner.has_texture()
+        } else {
+            false
         }
     }
 }


### PR DESCRIPTION
Allow knowing if an image has an image set or not.

As a workaround to do the same, you can currently use `size_in_pixels` and see if it returns `None` knowing that that happens when there is no texture set, but that's an indirect way to ask and requires the context parameter that is not necessary for knowing if there is a texture or not.

The `has_texture` function added allow us to directly ask that, without exposing internals.

- [Example without `has_texture`](https://github.com/noxware/makepad/blob/6660a029f8915db9056f4afe340687b5b99475ca/examples/image_viewer/src/ui.rs#L50)

- [Example with `has_texture`](https://github.com/noxware/makepad/blob/8200bb07751a43bc709457cf6108032c9434b0c4/examples/image_viewer/src/ui.rs#L49)