### PR TITLE
Key repeat on x11

### DIFF
--- a/platform/src/os/linux/x11/x11_sys.rs
+++ b/platform/src/os/linux/x11/x11_sys.rs
@@ -82,6 +82,10 @@ pub const EnterWindowMask: u32 = 16;
 pub const LeaveWindowMask: u32 = 32;
 pub const XBufferOverflow: i32 = -1;
 
+pub const QueuedAlready: i32 = 0;
+pub const QueuedAfterReading: i32 = 1;
+pub const QueuedAfterFlush: i32 = 2;
+
 // Added, from https://community.khronos.org/t/list-for-xevent-structures-type-component/70768
 pub const VisibilityNotify: u32 = 15;
 // Added, from https://tronche.com/gui/x/xlib/events/window-state-change/visibility.html
@@ -271,6 +275,10 @@ extern "C" {
     pub fn XPending(arg1: *mut Display) -> c_int;
     
     pub fn XNextEvent(arg1: *mut Display, arg2: *mut XEvent) -> c_int;
+
+    pub fn XPeekEvent(arg1: *mut Display, arg2: *mut XEvent) -> c_int;
+
+    pub fn XEventsQueued(arg1: *mut Display, arg2: c_int) -> c_int;
     
     pub fn XGetWindowProperty(
         arg1: *mut Display,

--- a/platform/src/os/linux/x11/xlib_app.rs
+++ b/platform/src/os/linux/x11/xlib_app.rs
@@ -56,6 +56,7 @@ pub struct XlibApp {
     pub internal_cursor: MouseCursor,
     pub atoms: XlibAtoms,
     pub dnd: Dnd,
+    pub next_keypress_is_repeat: bool,
 }
 
 impl XlibApp {
@@ -86,6 +87,7 @@ impl XlibApp {
                 current_cursor: MouseCursor::Default,
                 internal_cursor: MouseCursor::Default,
                 dnd: Dnd::new(display),
+                next_keypress_is_repeat: false,
             }
         }
     }
@@ -471,10 +473,11 @@ impl XlibApp {
                             let block_text = modifiers.control || modifiers.logo || modifiers.alt;
                             self.do_callback(XlibEvent::KeyDown(KeyEvent {
                                 key_code: key_code,
-                                is_repeat: false,
+                                is_repeat: self.next_keypress_is_repeat,
                                 modifiers: modifiers,
                                 time: self.time_now()
                             }));
+                            self.next_keypress_is_repeat = false;
                             block_text
                         }else {false};
                         
@@ -510,7 +513,6 @@ impl XlibApp {
                 x11_sys::KeyRelease => {
                     // if the next event is a keypress, this comes from a repeat
                     // Therefore, forget both this event and the next
-                    let mut is_repeat = false;
                     if x11_sys::XEventsQueued(self.display, x11_sys::QueuedAfterReading) > 0 {
                         let mut nev = mem::MaybeUninit::uninit();
                         x11_sys::XPeekEvent(self.display, nev.as_mut_ptr());
@@ -518,12 +520,10 @@ impl XlibApp {
                         if nev.type_ as u32 == x11_sys::KeyPress
                             && nev.xkey.time == event.xkey.time
                             && nev.xkey.keycode == event.xkey.keycode {
-                            let mut nnev = mem::MaybeUninit::uninit();
-                            x11_sys::XNextEvent(self.display, nnev.as_mut_ptr());
-                            is_repeat = true;
+                            self.next_keypress_is_repeat = true;
                         }
                     }
-                    if !is_repeat {
+                    if !self.next_keypress_is_repeat {
                         self.do_callback(XlibEvent::KeyUp(KeyEvent {
                             key_code: self.xkeyevent_to_keycode(&mut event.xkey),
                             is_repeat: false,


### PR DESCRIPTION
I noticed in ironfish that holding down a key caused a lot of repeated notes, which was annoying.

I modified the instructions [here](https://stackoverflow.com/questions/2100654/ignore-auto-repeat-in-x11-applications) to detect autorepeat. When an autorepeat is detected, I mutate a flag on XlibApp, and then the next keypress reads that flag to correctly set is_repeat.

I haven't done intensive testing, but it seems to have fixed the annoying behavior in ironfish, and key repeat still works in the text_flow example.