### PR TITLE
Avoid path dependencies for published crates because they can cause duplicate crate instances

### DIFF
--- a/libs/android_state/Cargo.toml
+++ b/libs/android_state/Cargo.toml
@@ -12,6 +12,5 @@ homepage = "https://github.com/makepad/makepad/"
 repository = "https://github.com/makepad/makepad/"
 metadata.makepad-auto-version = "ue5pTU0e_KaMiNqLQpo2CaD-WeQ="
 
-#[target.'cfg(target_os = "android")'.dependencies]
 [dependencies]
-makepad-jni-sys = { path = "../jni-sys", version = "0.4.0" }
+makepad-jni-sys = "0.4.0"

--- a/libs/android_state/README.md
+++ b/libs/android_state/README.md
@@ -28,3 +28,5 @@ All other functions are intended for Makepad-internal use only,
 and will not be useful for external users.
 
 [`robius-android-env`]: https://github.com/project-robius/robius-android-env
+[`get_java_vm()`]: https://docs.rs/makepad-android-state/latest/makepad_android_state/fn.get_java_vm.html
+[`get_activity()`]: https://docs.rs/makepad-android-state/latest/makepad_android_state/fn.get_activity.html

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -45,8 +45,10 @@ makepad-objc-sys = { path = "../libs/objc-sys", version = "0.4.0" }
 [target.aarch64-unknown-linux-gnu.dependencies]
 
 [target.'cfg(target_os = "android")'.dependencies]
-makepad-jni-sys = { path = "../libs/jni-sys", version = "0.4.0" }
-makepad-android-state = { path = "../libs/android_state", version = "0.1.0" }
+## Note: we must not use local 'path' dependencies on `makepad-jni-sys` or `makepad-android-state`
+## in order to guarantee that only one instance of each crate exists in the app binary.
+makepad-jni-sys = "0.4.0"
+makepad-android-state = "0.1.0"
 
 [target.'cfg(windows)'.dependencies.makepad-futures-legacy]
 path = "../libs/futures_legacy"


### PR DESCRIPTION
Duplicate crate instances are problematic for certain crates, currently only:
`makepad-android-state` and `makepad-jni-sys`.

Also, fix links in the README of `makepad-android-state`.