### PR TITLE
Android Shader Cache Invalidation

### DIFF
--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -130,6 +130,9 @@ pub struct AndroidParams {
     pub cache_path: String,
     pub density: f64,
     pub is_emulator: bool,
+    pub android_version: String,
+    pub build_number: String,
+    pub kernel_version: String
 }
 
 #[derive(Clone, Debug)]

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -165,11 +165,17 @@ pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onAndroidParams(
     cache_path: jni_sys::jstring,
     density: jni_sys::jfloat,
     is_emulator: jni_sys::jboolean,
+    android_version: jni_sys::jstring,
+    build_number: jni_sys::jstring,
+    kernel_version: jni_sys::jstring,
 ) {
     send_from_java_message(FromJavaMessage::Init(AndroidParams {
         cache_path: jstring_to_string(env, cache_path),
         density: density as f64,
         is_emulator: is_emulator != 0,
+        android_version: jstring_to_string(env, android_version),
+        build_number: jstring_to_string(env, build_number),
+        kernel_version: jstring_to_string(env, kernel_version),
     }));
 }
 

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -1,6 +1,6 @@
 use {
     std::{
-        fs::File,
+        fs::{File, remove_file},
         io::prelude::*,
         mem,
         ptr,
@@ -66,7 +66,7 @@ impl Cx {
                         &shp.vertex,
                         &shp.pixel,
                         &sh.mapping,
-                        self.os_type.get_cache_dir().as_ref()
+                        &self.os_type,
                     ));
                 }
                 let shgl = shp.gl_shader.as_ref().unwrap();
@@ -524,19 +524,45 @@ pub struct GlShader {
 }
 
 impl GlShader{
-    pub fn new(vertex: &str, pixel: &str, mapping: &CxDrawShaderMapping, cache_dir: Option<&String>)->Self{
-        unsafe fn read_cache(vertex:&str, pixel:&str, cache_dir:Option<&String>)->Option<gl_sys::GLuint>{ 
-            if let Some(cache_dir) = cache_dir {
+    pub fn new(vertex: &str, pixel: &str, mapping: &CxDrawShaderMapping, os_type: &OsType)->Self{
+        unsafe fn read_cache(vertex: &str, pixel: &str, os_type: &OsType) -> Option<gl_sys::GLuint> {
+            if let Some(cache_dir) = os_type.get_cache_dir() {
                 let shader_hash = live_id!(shader).str_append(&vertex).str_append(&pixel);
-                if let Ok(mut cache_file) = File::open(format!("{}/shader_{:08x}.bin", cache_dir, shader_hash.0)) {
+                let mut base_filename = format!("{}/shader_{:08x}", cache_dir, shader_hash.0);
+
+                match os_type {
+                    OsType::Android(params) => {
+                        base_filename = format!("{}_av{}_bn{}_kv{}", base_filename, params.android_version, params.build_number, params.kernel_version);
+                    },
+                    _ => (),
+                };
+
+                let filename = format!("{}.bin", base_filename);
+
+                if let Ok(mut cache_file) = File::open(&filename) {
                     let mut binary = Vec::new();
                     let mut format_bytes = [0u8; 4];
                     if cache_file.read(&mut format_bytes).is_ok() {
                         let binary_format = u32::from_be_bytes(format_bytes);
                         if cache_file.read_to_end(&mut binary).is_ok() {
-                            let program = gl_sys::CreateProgram();
-                            gl_sys::ProgramBinary(program, binary_format, binary.as_ptr() as *const _, binary.len() as i32);
-                            return Some(program)
+                            let mut version_consistency_conflict = false;
+                            // On Android, invalidate the cached file if there have been significant system updates
+                            match os_type {
+                                OsType::Android(params) => {
+                                    let current_filename = format!("{}/shader_{:08x}_av{}_bn{}_kv{}.bin", cache_dir, shader_hash.0, params.android_version, params.build_number, params.kernel_version);
+                                    version_consistency_conflict = filename != current_filename;
+                                },
+                                _ => (),
+                            };
+            
+                            if !version_consistency_conflict {
+                                let program = gl_sys::CreateProgram();
+                                gl_sys::ProgramBinary(program, binary_format, binary.as_ptr() as *const _, binary.len() as i32);
+                                return Some(program);
+                            } else {
+                                // Version mismatch, delete the old cache file
+                                let _ = remove_file(&filename);
+                            }
                         }
                     }
                 }
@@ -545,7 +571,7 @@ impl GlShader{
         }
         
         unsafe {
-            let program = if let Some(program) = read_cache(&vertex,&pixel,cache_dir){
+            let program = if let Some(program) = read_cache(&vertex,&pixel,os_type){
                 program
             }
             else{ 
@@ -576,7 +602,7 @@ impl GlShader{
                 program
             };
             
-            if let Some(cache_dir) = cache_dir {
+            if let Some(cache_dir) = os_type.get_cache_dir() {
                 let mut binary = Vec::new();
                 let mut binary_len = 0;
                 gl_sys::GetProgramiv(program, gl_sys::PROGRAM_BINARY_LENGTH, &mut binary_len);
@@ -588,8 +614,20 @@ impl GlShader{
                     if return_size != 0 {
                         //log!("GOT FORMAT {}", format);
                         let shader_hash = live_id!(shader).str_append(&vertex).str_append(&pixel);
+                        let mut filename = format!("{}/shader_{:08x}", cache_dir, shader_hash.0);
+
+                        match os_type {
+                            Android(params) => {
+                                filename = format!("{}_av{}_bn{}_kv{}", filename, params.android_version, params.build_number, params.kernel_version);
+                            },
+                            _ => (),
+                        };
+
+                        // add .bin
+                        filename = format!("{}.bin", filename);
+
                         binary.resize(return_size as usize, 0u8);
-                        if let Ok(mut cache) = File::create(format!("{}/shader_{:08x}.bin", cache_dir, shader_hash.0)) {
+                        if let Ok(mut cache) = File::create(filename) {
                             let _ = cache.write_all(&binary_format.to_be_bytes());
                             let _ = cache.write_all(&binary);
                         }

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -623,7 +623,6 @@ impl GlShader{
                             _ => (),
                         };
 
-                        // add .bin
                         filename = format!("{}.bin", filename);
 
                         binary.resize(return_size as usize, 0u8);

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -75,7 +75,10 @@ import android.media.MediaFormat;
 
 import java.nio.ByteBuffer;
 import android.media.MediaDataSource;
+
 import java.io.IOException;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 
 import dev.makepad.android.MakepadNative;
 
@@ -278,8 +281,11 @@ MidiManager.OnDeviceOpenedListener{
         String cache_path = this.getCacheDir().getAbsolutePath();
         float density = getResources().getDisplayMetrics().density;
         boolean isEmulator = this.isEmulator();
+        String androidVersion = Build.VERSION.RELEASE;
+        String buildNumber = Build.DISPLAY;
+        String kernelVersion = this.getKernelVersion();
 
-        MakepadNative.onAndroidParams(cache_path, density, isEmulator);
+        MakepadNative.onAndroidParams(cache_path, density, isEmulator, androidVersion, buildNumber, kernelVersion);
 
         // Set volume keys to control music stream, we might want make this flexible for app devs
         setVolumeControlStream(AudioManager.STREAM_MUSIC);
@@ -602,5 +608,20 @@ MidiManager.OnDeviceOpenedListener{
             || Build.PRODUCT == "sdk"
             || Build.PRODUCT == "google_sdk"
             || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"));
+    }
+
+    private String getKernelVersion() {
+        try {
+            Process process = Runtime.getRuntime().exec("uname -r");
+            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            StringBuilder stringBuilder = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                stringBuilder.append(line);
+            }
+            return stringBuilder.toString();
+        } catch (IOException e) {
+            return "Unknown";
+        }
     }
 }

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
@@ -14,7 +14,8 @@ public class MakepadNative {
     public native static void activityOnStop();
     public native static void activityOnDestroy();
     public native static void activityOnWindowFocusChanged(boolean has_focus);
-    public static native void onAndroidParams(String cache_path, float dentify, boolean isEmulator);
+    public static native void onAndroidParams(String cache_path, float dentify, boolean isEmulator, String androidVersion, String buildNumber,
+        String kernelVersion);
 
     public native static void onBackPressed();
 


### PR DESCRIPTION
#### Problem
Currently there's no invalidation mechanisms implemented for any platform.
On android we've seen this become problematic on different system updates/upgrades that make installed apps stop working due to issues with the cached compiled shaders (silent errors, invalid files, or unable to access them, etc.).

#### Fix
This PR Adds invalidation of the compiled shaders cache on Android. 
When storing shaders in the filesystem it uses the android version, build number and kernel version in the filename.
If at app startup any of these versions does not match the current runtime versions, it deletes the cached files and re-generates the shaders.

While this makes the caching a bit more robust (and tested that it solves the issues on my devices), I haven't fully tested different types of system updates/upgrades to make sure it covers all cases. 
In the future we might want a more complete solution, for instance this doesn't cover GPU driver updates since version of the GPU driver is not easily accessible through standard Android APIs or system properties (however we're not sure if that would be problematic).