### PR TITLE
makepad-platform: force rebuild if `MAKEPAD_PACKAGE_DIR` changes

### DIFF
--- a/platform/build.rs
+++ b/platform/build.rs
@@ -14,6 +14,7 @@ fn main() {
     let target = env::var("TARGET").unwrap();
     println!("cargo:rustc-check-cfg=cfg(apple_sim,lines,linux_direct,use_unstable_unix_socket_ancillary_data_2021)");
     println!("cargo:rerun-if-env-changed=MAKEPAD");
+    println!("cargo:rerun-if-env-changed=MAKEPAD_PACKAGE_DIR");
     if let Ok(configs) = env::var("MAKEPAD"){
         for config in configs.split('+'){
             match config{


### PR DESCRIPTION
This is generally a good idea. But more specifically, this is required when packaging up a makepad app for different platforms/environments, in which the package dir changes across compilation instances on the same platform, but nothing else in cargo's build fingerprint would have changed.