### PR TITLE
consistent meaning of value at slider widget + set_value

### DIFF
--- a/widgets/src/slider.rs
+++ b/widgets/src/slider.rs
@@ -133,8 +133,11 @@ impl Slider {
     }
 
     pub fn set_value(&mut self, v: f64) {
+        let prev_value = self.value();
         self.set_internal(v);
-        self.update_text_input();
+        if v != prev_value {
+            self.update_text_input();
+        }
     }
 }
 


### PR DESCRIPTION
# Problem
- Given a variable `slider` of type `SliderRef`, if you do `slider.value()` you get the current value (acording to what you defined as possible values in the slider configuration).
- But, if you do `slider.borrow().value` you get something different. You get the relative position of the slider (from 0 to 1).

This is confusing, and also makes hard to set a value programmatically for the slider as you would need to do `slider.borrow_mut().value = /* insert calculations based on the min/max configuration to translate to the relative value */`. And there are no getters for `min` and `max` anyways. 

> Please note that is not only the `value()` method, but also the `slided()` event returns the absolute value, not the relative one.

# Changes

- Adds a `value()` function in the `Slider` impl.
- Make the existing `value()` function at `SliderRef` just call that.
- Adds `set_value` functions to both struct impls.
  - This is to support what I was originally trying [here](https://github.com/moxin-org/moxin/blob/7dd935d2a927b2aa8833755ed2ad3d4dac016591/src/chat/chat_params.rs#L175).
- Changes the name of the `value` field of the `Slider` struct, so it's not just "value" anymore.
  - This is technically a **breaking change** as this field is public. Although I don't see is being used in code of the makepad repo.