### PR TITLE
Document how Button actions work. Add HtmlLink action.

### DIFF
--- a/experiments/html_experiment/src/app.rs
+++ b/experiments/html_experiment/src/app.rs
@@ -76,7 +76,7 @@ live_design!{
             
             draw_bg: {
                 fn pixel(self) -> vec4 {
-                    return #fff
+                    return #999
                     // test
                     // return mix(#7, #3, self.pos.y);
                 }
@@ -136,12 +136,6 @@ live_design!{
                     img = <HtmlImage> {
                     }
 
-                    a = {
-                        draw_text: {
-                            text_style: { height_factor: (HTML_TEXT_HEIGHT_FACTOR), line_spacing: (HTML_LINE_SPACING), top_drop: 1.2}
-                        }
-                    }
-
                     body: "
                         <a href=\"https://github.com/element-hq/element-web/releases/tag/v1.11.48\">https://github.com/element-hq/element-web/releases/tag/v1.11.48</a> I can find it? <b>text</b><br>
                         
@@ -174,6 +168,12 @@ impl MatchEvent for App {
             self.counter += 1;
             let label = self.ui.label(id!(label1));
             label.set_text_and_redraw(cx,&format!("Counter: {}", self.counter));
+        }
+
+        for action in actions {
+            if let HtmlLinkAction::Clicked { url, .. } = action.as_widget_action().cast() {
+                log!("got HtmlLinkAction::Clicked: url: {:?}", url);
+            }
         }
     }
 }

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -455,7 +455,6 @@ impl Widget for HtmlLink {
         match event {
             Event::Actions(actions) => {
                 if let Some(key_modifiers) = self.link.clicked_modifiers(actions) {
-                    log!("HtmlLink::handle_actions(): clicked! URL: {:?}", self.url);
                     cx.widget_action(
                         self.widget_uid(),
                         &scope.path,
@@ -464,14 +463,6 @@ impl Widget for HtmlLink {
                             key_modifiers,
                         },
                     );
-                }
-        
-                if self.link.released(actions) {
-                    log!("HtmlLink::handle_actions(): released! URL: {:?}", self.url);
-                }
-        
-                if self.link.pressed(actions) {
-                    log!("HtmlLink::handle_actions(): pressed! URL: {:?}", self.url);
                 }
             }
             _ => ()

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -408,11 +408,18 @@ fn handle_custom_widget(
 }
 
 
+#[derive(Debug, Clone, DefaultNone)]
+pub enum HtmlLinkAction {
+    Clicked {
+        url: String,
+        key_modifiers: KeyModifiers,
+    },
+    None,
+}
 
 #[derive(Live, Widget)]
 struct HtmlLink {
     #[deref] link: LinkLabel,
-    #[live] href: String,
 }
 
 impl LiveHook for HtmlLink {
@@ -421,15 +428,15 @@ impl LiveHook for HtmlLink {
     fn after_apply(&mut self, _cx: &mut Cx, apply: &mut Apply, _index: usize, _nodes: &[LiveNode]) {
         //log!("HtmlLink::after_apply(): apply.from: {:?}, apply.scope exists: {:?}", apply.from, apply.scope.is_some());
         match apply.from {
-            ApplyFrom::NewFromDoc {..}=> {
+            ApplyFrom::NewFromDoc {..} => {
                 let scope = apply.scope.as_ref().unwrap();
                 let doc =  scope.props.get::<HtmlDoc>().unwrap();
                 let mut walker = doc.new_walker_with_index(scope.index + 1);
                 
-                if let Some((lc, attr)) = walker.while_attr_lc(){
+                if let Some((lc, attr)) = walker.while_attr_lc() {
                     match lc {
-                        live_id!(href)=>{
-                            self.href = attr.into()
+                        live_id!(href)=> {
+                            self.link.url = attr.into()
                         }
                         _=>()
                     }
@@ -440,27 +447,35 @@ impl LiveHook for HtmlLink {
     }
 }
 
-impl MatchEvent for HtmlLink {
-    fn handle_actions(&mut self, _cx: &mut Cx, actions: &Actions) {
-        if self.link.clicked(actions) {
-            log!("HtmlLink::handle_actions(): clicked! href: {:?}", self.href);
-        }
-
-        if self.link.released(actions) {
-            log!("HtmlLink::handle_actions(): released! href: {:?}", self.href);
-        }
-    }
-}
-
 impl Widget for HtmlLink {
-    fn handle_event(
-        &mut self,
-        cx: &mut Cx,
-        event: &Event,
-        scope: &mut Scope,
-    ) {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         self.link.handle_event(cx, event, scope);
-        self.match_event(cx, event)
+
+        // Handle the action of the HtmlLink being clicked
+        match event {
+            Event::Actions(actions) => {
+                if let Some(key_modifiers) = self.link.clicked_modifiers(actions) {
+                    log!("HtmlLink::handle_actions(): clicked! URL: {:?}", self.url);
+                    cx.widget_action(
+                        self.widget_uid(),
+                        &scope.path,
+                        HtmlLinkAction::Clicked {
+                            url: self.url.clone(),
+                            key_modifiers,
+                        },
+                    );
+                }
+        
+                if self.link.released(actions) {
+                    log!("HtmlLink::handle_actions(): released! URL: {:?}", self.url);
+                }
+        
+                if self.link.pressed(actions) {
+                    log!("HtmlLink::handle_actions(): pressed! URL: {:?}", self.url);
+                }
+            }
+            _ => ()
+        }
     }
     
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {

--- a/widgets/src/link_label.rs
+++ b/widgets/src/link_label.rs
@@ -9,11 +9,14 @@ live_design!{
     LinkLabelBase = {{LinkLabel}} {}
 }
 
+/// A clickable label widget that opens a URL when clicked.
+///
+/// This is a wrapper around (and derefs to) a [`Button`] widget.
 #[derive(Live, LiveHook, Widget)]
 pub struct LinkLabel {
     #[deref] button: Button,
-    #[live] url: String,
-    #[live] open_in_place: bool
+    #[live] pub url: String,
+    #[live] pub open_in_place: bool,
 }
 
 impl Widget for LinkLabel {
@@ -45,42 +48,34 @@ impl Widget for LinkLabel {
     }
 }
 
-impl LinkLabel {
-    pub fn clicked(&self, actions:&Actions) -> bool {
-        self.button.clicked(actions)
-    }
-
-    pub fn pressed(&self, actions:&Actions) -> bool {
-        self.button.pressed(actions)
-    }
-
-    pub fn released(&self, actions:&Actions) -> bool {
-        self.button.released(actions)
-    }
-}
-
 impl LinkLabelRef {
-    pub fn clicked(&self, actions:&Actions) -> bool {
-        if let Some(inner) = self.borrow(){ 
-            inner.clicked(actions)
-        } else {
-            false
-        }
-    }
-    
-    pub fn pressed(&self, actions:&Actions) -> bool {
-        if let Some(inner) = self.borrow(){ 
-            inner.pressed(actions)
-        } else {
-            false
-        }
+    /// See [`Button::clicked()`].
+    pub fn clicked(&self, actions: &Actions) -> bool {
+        self.borrow().map_or(false, |b| b.clicked(actions))
     }
 
-    pub fn released(&self, actions:&Actions) -> bool {
-        if let Some(inner) = self.borrow(){ 
-            inner.released(actions)
-        } else {
-            false
-        }
+    /// See [`Button::pressed()`].
+    pub fn pressed(&self, actions: &Actions) -> bool {
+        self.borrow().map_or(false, |b| b.pressed(actions))
+    }
+
+    /// See [`Button::released()`].
+    pub fn released(&self, actions: &Actions) -> bool {
+        self.borrow().map_or(false, |b| b.released(actions))
+    }
+
+    /// See [`Button::clicked_modifiers()`].
+    pub fn clicked_modifiers(&self, actions: &Actions) -> Option<KeyModifiers> {
+        self.borrow().and_then(|b| b.clicked_modifiers(actions))
+    }
+
+    /// See [`Button::pressed_modifiers()`].
+    pub fn pressed_modifiers(&self, actions: &Actions) -> Option<KeyModifiers> {
+        self.borrow().and_then(|b| b.pressed_modifiers(actions))
+    }
+
+    /// See [`Button::released_modifiers()`].
+    pub fn released_modifiers(&self, actions: &Actions) -> Option<KeyModifiers> {
+        self.borrow().and_then(|b| b.released_modifiers(actions))
     }
 }


### PR DESCRIPTION
* Clean up the `Button` API to make it consistent with that of `LinkLabel`.
* Simplify the implementation of `Button`, `ButtonRef`, `LinkLabel`, and `LinkLabelRef` to reduce code duplication.

* Use `LinkLabel`'s `url` field in `HtmlLink` instead of unnecessarily duplicating it.

* Add dedicated `HtmlLinkAction` that includes both the URL and the active keyboard modifiers, which makes it a lot easier for users to access and handle the URL for a link embedded in an Html string, or in any general case where you cannot name the HtmlLink via the live DSL.

* Improve the `html_experiment` demo app to be more visible (given the recent theme changes)
  and to provide an example of how use our new `HtmlLinkAction` action enum.