### PR TITLE
Demo of infinite loop in ShapeCache: run `html_experiment` to crash Makepad

### DIFF
--- a/draw/src/font_atlas.rs
+++ b/draw/src/font_atlas.rs
@@ -89,10 +89,12 @@ impl ShapeCache {
         font_atlas: &CxFontAtlas,
         glyph_infos: &mut Vec<GlyphInfo>,
     ) -> Result<(), ()> {
+        warning!("Shape internal: text: {text:?} \n  font_ids: {font_ids:?} \n  glyph_infos: {glyph_infos:?}");
         let Some((&font_id, font_ids)) = font_ids.split_first() else {
             return Err(());
         };
         let Some(font) = &font_atlas.fonts[font_id] else {
+            warning!("No font with ID {}", font_id);
             return self.shape_internal(text, font_ids, font_atlas, glyph_infos);
         };
 
@@ -107,11 +109,13 @@ impl ShapeCache {
         let mut info_slot = info_iter.next();
         while let Some(info) = info_slot {
             if info.glyph_id == 0 {
-                glyph_infos.push(GlyphInfo {
+                let gli = GlyphInfo {
                     font_id,
                     glyph_id: info.glyph_id,
                     byte_index: info.cluster as usize,
-                });
+                };
+                warning!("Glyph Id is 0, {gli:#?}");
+                glyph_infos.push(gli);
             } else {
                 let start = info.cluster as usize;
                 let end = loop {

--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -386,6 +386,7 @@ impl DrawText {
     fn draw_inner(&mut self, cx: &mut Cx2d, position: DVec2, chunk: &str, font_atlas: &mut CxFontAtlas) {
         let shape_cache_rc = cx.shape_cache_rc.clone();
         let mut shape_cache = shape_cache_rc.0.borrow_mut();
+        warning!("DrawText::draw_inner(): chunk={chunk:?}");
         let glyph_infos = shape_cache.shape(
             Direction::LeftToRight,
             chunk,

--- a/experiments/html_experiment/src/app.rs
+++ b/experiments/html_experiment/src/app.rs
@@ -137,6 +137,8 @@ live_design!{
                     }
 
                     body: "
+                        If registration is disabled... no user name is available 🙂
+                        <br>
                         <a href=\"https://github.com/element-hq/element-web/releases/tag/v1.11.48\">https://github.com/element-hq/element-web/releases/tag/v1.11.48</a> I can find it? <b>text</b><br>
                         
                     "


### PR DESCRIPTION
DO NOT MERGE. This is just an example.

The failure occurs when trying to draw emoji. See discord for more.