### PR TITLE
Slider widget emits focus in/out actions for the labels

### DIFF
--- a/widgets/src/theme_desktop_dark.rs
+++ b/widgets/src/theme_desktop_dark.rs
@@ -3457,7 +3457,7 @@ live_design! {
             }
         }
 
-        label_walk: { width: Fill, height: Fill }
+        label_walk: { width: Fill, height: Fit }
 
         text_input: <TextInput> {
             width: Fit, padding: 0.,


### PR DESCRIPTION
It is meant to be useful for applications implementing tooltips or similar visual indications when the slider label is hovered.