### PR TITLE
OpenGL texture management: Fix memory leak and improve performance

### DIFF
--- a/platform/src/os/linux/gl_sys.rs
+++ b/platform/src/os/linux/gl_sys.rs
@@ -51,6 +51,8 @@ pub const LINEAR_MIPMAP_LINEAR: types::GLenum = 0x2703;
 pub const TEXTURE_BASE_LEVEL: types::GLenum = 0x813C;
 pub const TEXTURE_MAX_LEVEL: types::GLenum = 0x813D;
 pub const TEXTURE_MAG_FILTER: types::GLenum = 0x2800;
+pub const TEXTURE_WIDTH: types::GLenum = 0x1000;
+pub const TEXTURE_HEIGHT: types::GLenum = 0x1001;
 pub const RGBA: types::GLenum = 0x1908;
 pub const BGRA: types::GLenum = 0x80E1;
 pub const RED: types::GLenum = 0x1903;
@@ -118,6 +120,8 @@ pub const RENDERER: types::GLenum = 0x1F01;
 #[inline] pub unsafe fn GenTextures(n: types::GLsizei, textures: *mut types::GLuint) -> () { mem::transmute::<_, extern "system" fn(types::GLsizei, *mut types::GLuint) -> ()>(storage::GenTextures.f)(n, textures) }
 #[inline] pub unsafe fn TexParameteri(target: types::GLenum, pname: types::GLenum, param: types::GLint) -> () { mem::transmute::<_, extern "system" fn(types::GLenum, types::GLenum, types::GLint) -> ()>(storage::TexParameteri.f)(target, pname, param) }
 #[inline] pub unsafe fn TexImage2D(target: types::GLenum, level: types::GLint, internalformat: types::GLint, width: types::GLsizei, height: types::GLsizei, border: types::GLint, format: types::GLenum, type_: types::GLenum, pixels: *const raw::c_void) -> () { mem::transmute::<_, extern "system" fn(types::GLenum, types::GLint, types::GLint, types::GLsizei, types::GLsizei, types::GLint, types::GLenum, types::GLenum, *const raw::c_void) -> ()>(storage::TexImage2D.f)(target, level, internalformat, width, height, border, format, type_, pixels) }
+#[inline] pub unsafe fn TexSubImage2D(target: types::GLenum, level: types::GLint, xoffset: types::GLint, yoffset: types::GLint, width: types::GLsizei, height: types::GLsizei, format: types::GLenum, type_: types::GLenum, pixels: *const raw::c_void) -> () { mem::transmute::<_, extern "system" fn(types::GLenum, types::GLint, types::GLint, types::GLint, types::GLsizei, types::GLsizei, types::GLenum, types::GLenum, *const raw::c_void) -> ()>(storage::TexSubImage2D.f)(target, level, xoffset, yoffset, width, height, format, type_, pixels) }
+#[inline] pub unsafe fn GetTexLevelParameteriv(target: types::GLenum, level: types::GLint, pname: types::GLenum, params: *mut types::GLint) { mem::transmute::<_, extern "system" fn(types::GLenum, types::GLint, types::GLenum, *mut types::GLint)>(storage::GetTexLevelParameteriv.f)(target, level, pname, params) }
 #[inline] pub unsafe fn DeleteTextures(n: types::GLsizei, textures: *const types::GLuint) -> () { mem::transmute::<_, extern "system" fn(types::GLsizei, *const types::GLuint) -> ()>(storage::DeleteTextures.f)(n, textures) }
 #[inline] pub unsafe fn GenBuffers(n: types::GLsizei, buffers: *mut types::GLuint) -> () { mem::transmute::<_, extern "system" fn(types::GLsizei, *mut types::GLuint) -> ()>(storage::GenBuffers.f)(n, buffers) }
 #[inline] pub unsafe fn BufferData(target: types::GLenum, size: types::GLsizeiptr, data: *const raw::c_void, usage: types::GLenum) -> () { mem::transmute::<_, extern "system" fn(types::GLenum, types::GLsizeiptr, *const raw::c_void, types::GLenum) -> ()>(storage::BufferData.f)(target, size, data, usage) }
@@ -180,6 +184,8 @@ mod storage {
     pub static mut GenTextures: FnPtr = FnPtr::default();
     pub static mut TexParameteri: FnPtr = FnPtr::default();
     pub static mut TexImage2D: FnPtr = FnPtr::default();
+    pub static mut TexSubImage2D: FnPtr = FnPtr::default();
+    pub static mut GetTexLevelParameteriv: FnPtr = FnPtr::default();
     pub static mut DeleteTextures: FnPtr = FnPtr::default();
     pub static mut GenBuffers: FnPtr = FnPtr::default();
     pub static mut BufferData: FnPtr = FnPtr::default();
@@ -241,6 +247,8 @@ pub unsafe fn load_with<F>(mut loadfn: F) where F: FnMut(&'static str) -> *const
     storage::GenTextures = FnPtr::new(metaloadfn(&mut loadfn, "glGenTextures", &[]));
     storage::TexParameteri = FnPtr::new(metaloadfn(&mut loadfn, "glTexParameteri", &[]));
     storage::TexImage2D = FnPtr::new(metaloadfn(&mut loadfn, "glTexImage2D", &[]));
+    storage::TexSubImage2D = FnPtr::new(metaloadfn(&mut loadfn, "glTexSubImage2D", &[]));
+    storage::GetTexLevelParameteriv = FnPtr::new(metaloadfn(&mut loadfn, "glGetTexLevelParameteriv", &[]));
     storage::DeleteTextures = FnPtr::new(metaloadfn(&mut loadfn, "glDeleteTextures", &[]));
     storage::GenBuffers = FnPtr::new(metaloadfn(&mut loadfn, "glGenBuffers", &["glGenBuffersARB"]));
     storage::BufferData = FnPtr::new(metaloadfn(&mut loadfn, "glBufferData", &["glBufferDataARB"]));

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -902,17 +902,28 @@ pub struct CxOsTexture {
 
 impl CxTexture {
 
+    /// Updates or creates a texture based on the current texture format.
+    ///
+    /// This method optimizes texture management by:
+    /// 1. Reusing existing OpenGL textures when possible.
+    /// 2. Using `glTexSubImage2D` for updates when dimensions haven't changed.
+    /// 3. Falling back to `glTexImage2D` for new textures or when dimensions change.
+    ///
+    /// Internal workings:
+    /// - If a previous platform resource exists, it's reused to avoid unnecessary allocations.
+    /// - If no texture exists, a new OpenGL texture is generated.
+    /// - The method checks current texture dimensions to decide between `glTexSubImage2D` (update) 
+    ///   and `glTexImage2D` (new allocation).
+    ///
+    /// Note: This method assumes that the texture format doesn't change between updates. 
+    /// This is safe because when allocating textures at the Cx level, there are compatibility checks.
     pub fn update_vec_texture(&mut self) {
         if self.alloc_vec() {
-
-            // This frees the previous texture if one is present, eventually we could just update this texture instead
-            // of freeing and reallocating constantly, unsure of performance implications of either.
-            if self.previous_platform_resource.is_some() {
-                self.os = self.previous_platform_resource.take().unwrap();
-            }
-
-            self.free_previous_resources();
-            if self.os.gl_texture.is_none() { 
+            if let Some(previous) = self.previous_platform_resource.take() {
+                self.os = previous;
+            } 
+            
+            if self.os.gl_texture.is_none() {
                 unsafe {
                     let mut gl_texture = std::mem::MaybeUninit::uninit();
                     gl_sys::GenTextures(1, gl_texture.as_mut_ptr());
@@ -920,119 +931,84 @@ impl CxTexture {
                 }
             }
         }
-        if self.check_updated(){
-            unsafe{
-                gl_sys::BindTexture(gl_sys::TEXTURE_2D, self.os.gl_texture.unwrap());
-                gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_WRAP_S, gl_sys::CLAMP_TO_EDGE as i32);
-                gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_WRAP_T, gl_sys::CLAMP_TO_EDGE as i32);
-            }                       
-            match &self.format{
-                TextureFormat::VecBGRAu8_32{width, height, data}=>unsafe{
-                    gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MIN_FILTER, gl_sys::LINEAR as i32);
-                    gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MAG_FILTER, gl_sys::LINEAR as i32);
-                    gl_sys::TexImage2D(
-                        gl_sys::TEXTURE_2D,
-                        0,
-                        gl_sys::BGRA as i32,
-                        *width as i32,
-                        *height as i32,
-                        0,
-                        gl_sys::BGRA,
-                        gl_sys::UNSIGNED_BYTE,
-                        data.as_ptr() as *const _
-                    );
-                }
-                TextureFormat::VecMipBGRAu8_32{width, height, data, max_level}=>unsafe{
-                    gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MIN_FILTER, gl_sys::LINEAR_MIPMAP_LINEAR as i32);
-                    gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MAG_FILTER, gl_sys::LINEAR as i32);
-                    gl_sys::TexImage2D(
-                        gl_sys::TEXTURE_2D,
-                        0,
-                        gl_sys::BGRA as i32,
-                        *width as i32,
-                        *height as i32,
-                        0,
-                        gl_sys::BGRA,
-                        gl_sys::UNSIGNED_BYTE,
-                        data.as_ptr() as *const _
-                    );
+    
+        if !self.check_updated() {
+            return;
+        }
+    
+        unsafe {
+            gl_sys::BindTexture(gl_sys::TEXTURE_2D, self.os.gl_texture.unwrap());
+            gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_WRAP_S, gl_sys::CLAMP_TO_EDGE as i32);
+            gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_WRAP_T, gl_sys::CLAMP_TO_EDGE as i32);
+    
+            // Set texture parameters based on the format
+            let (width, height, internal_format, format, data_type, data, use_mipmaps) = match &self.format {
+                TextureFormat::VecBGRAu8_32{width, height, data} => 
+                    (*width, *height, gl_sys::BGRA, gl_sys::BGRA, gl_sys::UNSIGNED_BYTE, data.as_ptr() as *const std::ffi::c_void, false),
+                TextureFormat::VecMipBGRAu8_32{width, height, data, max_level: _} => 
+                    (*width, *height, gl_sys::BGRA, gl_sys::BGRA, gl_sys::UNSIGNED_BYTE, data.as_ptr() as *const std::ffi::c_void, true),
+                TextureFormat::VecRGBAf32{width, height, data} => 
+                    (*width, *height, gl_sys::RGBA, gl_sys::RGBA, gl_sys::FLOAT, data.as_ptr() as *const std::ffi::c_void, false),
+                TextureFormat::VecRu8{width, height, data, unpack_row_length} => {
+                    gl_sys::PixelStorei(gl_sys::UNPACK_ALIGNMENT, 1);
+                    if let Some(row_length) = unpack_row_length {
+                        gl_sys::PixelStorei(gl_sys::UNPACK_ROW_LENGTH, *row_length as i32);
+                    }
+                    (*width, *height, gl_sys::R8, gl_sys::RED, gl_sys::UNSIGNED_BYTE, data.as_ptr() as *const std::ffi::c_void, false)
+                },
+                TextureFormat::VecRGu8{width, height, data, unpack_row_length} => {
+                    gl_sys::PixelStorei(gl_sys::UNPACK_ALIGNMENT, 1);
+                    if let Some(row_length) = unpack_row_length {
+                        gl_sys::PixelStorei(gl_sys::UNPACK_ROW_LENGTH, *row_length as i32);
+                    }
+                    (*width, *height, gl_sys::RG, gl_sys::RG, gl_sys::UNSIGNED_BYTE, data.as_ptr() as *const std::ffi::c_void, false)
+                },
+                TextureFormat::VecRf32{width, height, data} => 
+                    (*width, *height, gl_sys::RED, gl_sys::RED, gl_sys::FLOAT, data.as_ptr() as *const std::ffi::c_void, false),
+                _ => panic!("Unsupported texture format"),
+            };
+    
+            let mut current_width = 0;
+            let mut current_height = 0;
+            gl_sys::GetTexLevelParameteriv(gl_sys::TEXTURE_2D, 0, gl_sys::TEXTURE_WIDTH, &mut current_width);
+            gl_sys::GetTexLevelParameteriv(gl_sys::TEXTURE_2D, 0, gl_sys::TEXTURE_HEIGHT, &mut current_height);
+    
+            // Update the texture if the dimensions match the previously allocated image
+            if current_width == width as i32 && current_height == height as i32 {
+                gl_sys::TexSubImage2D(
+                    gl_sys::TEXTURE_2D,
+                    0,
+                    0, 0,
+                    width as i32, height as i32,
+                    format,
+                    data_type,
+                    data
+                );
+            } else {
+                gl_sys::TexImage2D(
+                    gl_sys::TEXTURE_2D,
+                    0,
+                    internal_format as i32,
+                    width as i32, height as i32,
+                    0,
+                    format,
+                    data_type,
+                    data
+                );
+            }
+    
+            gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MIN_FILTER, if use_mipmaps { gl_sys::LINEAR_MIPMAP_LINEAR } else { gl_sys::LINEAR } as i32);
+            gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MAG_FILTER, gl_sys::LINEAR as i32);
+    
+            if use_mipmaps {
+                if let TextureFormat::VecMipBGRAu8_32{max_level, ..} = &self.format {
                     gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_BASE_LEVEL, 0);
                     gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MAX_LEVEL, max_level.unwrap_or(1000) as i32);
-                    gl_sys::GenerateMipmap(gl_sys::TEXTURE_2D);  
-                },
-                TextureFormat::VecRGBAf32{width, height, data}=>unsafe{
-                    gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MIN_FILTER, gl_sys::LINEAR as i32);
-                    gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MAG_FILTER, gl_sys::LINEAR as i32);
-                    gl_sys::TexImage2D(
-                        gl_sys::TEXTURE_2D,
-                        0,
-                        gl_sys::RGBA as i32,
-                        *width as i32,
-                        *height as i32,
-                        0,
-                        gl_sys::RGBA,
-                        gl_sys::FLOAT,
-                        data.as_ptr() as *const _
-                    );
-                },
-                TextureFormat::VecRu8{width, height, data, unpack_row_length}=>unsafe{
-                    gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MIN_FILTER, gl_sys::LINEAR as i32);
-                    gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MAG_FILTER, gl_sys::LINEAR as i32);
-                    gl_sys::PixelStorei(gl_sys::UNPACK_ALIGNMENT, 1);
-                    if let Some(row_length) = unpack_row_length {
-                        gl_sys::PixelStorei(gl_sys::UNPACK_ROW_LENGTH, *row_length as i32);
-                    }
-                    gl_sys::TexImage2D(
-                        gl_sys::TEXTURE_2D,
-                        0,
-                        gl_sys::R8 as i32,
-                        *width as i32,
-                        *height as i32,
-                        0,
-                        gl_sys::RED,
-                        gl_sys::UNSIGNED_BYTE,
-                        data.as_ptr() as *const _
-                    );
-                },
-                TextureFormat::VecRGu8{width, height, data, unpack_row_length}=>unsafe{
-                    gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MIN_FILTER, gl_sys::LINEAR as i32);
-                    gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MAG_FILTER, gl_sys::LINEAR as i32);
-                    gl_sys::PixelStorei(gl_sys::UNPACK_ALIGNMENT, 1);
-                    if let Some(row_length) = unpack_row_length {
-                        gl_sys::PixelStorei(gl_sys::UNPACK_ROW_LENGTH, *row_length as i32);
-                    }
-                    gl_sys::TexImage2D(
-                        gl_sys::TEXTURE_2D,
-                        0,
-                        gl_sys::RG as i32,
-                        *width as i32,
-                        *height as i32,
-                        0,
-                        gl_sys::RG,
-                        gl_sys::UNSIGNED_BYTE,
-                        data.as_ptr() as *const _
-                    );
-                },
-                TextureFormat::VecRf32{width, height, data}=>unsafe{
-                    gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MIN_FILTER, gl_sys::LINEAR as i32);
-                    gl_sys::TexParameteri(gl_sys::TEXTURE_2D, gl_sys::TEXTURE_MAG_FILTER, gl_sys::LINEAR as i32);
-                    gl_sys::TexImage2D(
-                        gl_sys::TEXTURE_2D,
-                        0,
-                        gl_sys::RED as i32,
-                        *width as i32,
-                        *height as i32,
-                        0,
-                        gl_sys::RED,
-                        gl_sys::FLOAT,
-                        data.as_ptr() as *const _
-                    );
-                },
-                _=>{panic!()}
+                    gl_sys::GenerateMipmap(gl_sys::TEXTURE_2D);
+                }
             }
-            unsafe{
-                gl_sys::BindTexture(gl_sys::TEXTURE_2D, 0);
-            }
+    
+            gl_sys::BindTexture(gl_sys::TEXTURE_2D, 0);
         }
     }
 
@@ -1170,6 +1146,7 @@ impl CxTexture {
         if let Some(mut old_os) = self.previous_platform_resource.take(){
             if let Some(gl_texture) = old_os.gl_texture.take(){
                 unsafe{gl_sys::DeleteTextures(1, &gl_texture)};
+                crate::log!("Deleted texture: {}", gl_texture);
             }
             if let Some(gl_renderbuffer) = old_os.gl_renderbuffer.take(){
                 unsafe{gl_sys::DeleteRenderbuffers(1, &gl_renderbuffer)};


### PR DESCRIPTION
This PR addresses a significant memory leak in OpenGL texture handling and introduces performance optimizations for texture management. (Android and Linux)

Key Changes:
1. Memory Leak Fix:
   - Implemented proper cleanup of unused OpenGL textures.
   - Updated `free_previous_resources` mechanism to remove orphaned textures.

2. Texture Reuse Optimization:
   - Reworked IdPool and Texture modules to keep track of the previous platform-specific resources when re-using textures. This provides us a "transitional state" of the platform resources that we can use for either re-usage or deletion at the platform level.
   - Implemented texture reuse when format compatibility is maintained.

3. Performance Improvements:
   - Introduced use of `glTexSubImage2D` for efficient updates when texture dimensions haven't changed.
   - Consolidated texture parameter handling.

Initial fix: ([abaeb44](https://github.com/makepad/makepad/pull/494/commits/abaeb44f140e9f4ebe188790bc113ef62e5ea0e1)): 
Resolved major memory leak by properly freeing unused textures.

Further optimization ([9e004ed](https://github.com/makepad/makepad/pull/494/commits/9e004eded75f8742fcf02a8ef47ff9e67d8f9326)): 
I realized we could achieve additional memory savings by actually reusing compatible textures instead of freeing and re-creating every time. We could also employ `glTexSubImage2D` for efficent updates when the texture dimensions haven't changed since the last update.

---

### Leak

**makepad-example-simple**
Here's the memory consumption of adding a single image to `makepad-example-simple`, and making it swap the contents with each button press, through `load_image_dep_by_path`. See the code: [gist](https://gist.github.com/joulei/4f4d44413bb8a846760565c984fa0548) (also disabling the Cx caching)

![Screenshot 2024-07-16 at 10 16 00 AM](https://github.com/user-attachments/assets/97ffe946-121b-4972-9fd6-900637eeee9e)

**Wonderous**
Here are similar captures for the latest version of Wonderous (https://github.com/project-robius/makepad_wonderous/pull/36), which displays hundreds of unique images coming from network:

![Screenshot 2024-07-11 at 10 26 10 AM](https://github.com/user-attachments/assets/457bb19b-4dda-42f9-93de-414fb9b77623)

![Screenshot 2024-07-11 at 3 03 50 PM](https://github.com/user-attachments/assets/7330c448-2ade-44bd-b10d-093cb35c3ba1)

### Initial Fix

**makepad-example-simple**
![image](https://github.com/user-attachments/assets/b3a77cce-b757-48f8-a5eb-decb20ee4a8c)

**Wonderous**
![image](https://github.com/user-attachments/assets/77a15cf0-75e5-407b-8951-bf0f2980ea08)

### Texture update optimizations (reusing gl textures and applying SubImage2D)

**makepad-example-simple**
![image](https://github.com/user-attachments/assets/fa2f07cf-03a0-4d22-b6cb-c9a38fac6310)

**Wonderous**
![image](https://github.com/user-attachments/assets/e908337c-1d3f-44de-9c0e-8e99238fe5dc)

For Wonderous, even if only ~ 20% of the images share dimensions, using `SubImage` makes a significant difference in GPU usage.
These small adjustments significantly reduce GPU memory usage and improve overall performance, especially for applications with frequent texture updates.

---

Testing:
- Verified fixes and improvements using Android Studio profiling tools.
- Tested across various apps on Android and Linux.