### PR TITLE
Labels hover actions rework

### DIFF
--- a/widgets/src/label.rs
+++ b/widgets/src/label.rs
@@ -49,7 +49,7 @@ impl Widget for Label {
 
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         let uid = self.widget_uid();
-        match event.hits(cx, self.area) {
+        match event.hits_with_capture_overload(cx, self.area, true) {
             Hit::FingerHoverIn(fh) => {
                 cx.widget_action(uid, &scope.path, LabelAction::HoverIn(fh.rect));
             }

--- a/widgets/src/label.rs
+++ b/widgets/src/label.rs
@@ -27,6 +27,12 @@ pub struct Label {
     #[rust] area: Area,
     //margin: Margin,
     #[live] text: RcStringMut,
+
+    // Indicates if this label responds to hover events
+    // It is not turned on by default because it will consume finger events
+    // and prevent other widgets from receiving them, if it is not considered with care
+    // The primary use case for this kind of emitted actions is for tooltips displaying
+    #[live(false)] hover_actions_enabled: bool
 } 
 
 impl Widget for Label {
@@ -48,15 +54,17 @@ impl Widget for Label {
     }
 
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        let uid = self.widget_uid();
-        match event.hits_with_capture_overload(cx, self.area, true) {
-            Hit::FingerHoverIn(fh) => {
-                cx.widget_action(uid, &scope.path, LabelAction::HoverIn(fh.rect));
+        if self.hover_actions_enabled {
+            let uid = self.widget_uid();
+            match event.hits_with_capture_overload(cx, self.area, true) {
+                Hit::FingerHoverIn(fh) => {
+                    cx.widget_action(uid, &scope.path, LabelAction::HoverIn(fh.rect));
+                }
+                Hit::FingerHoverOut(_) => {
+                    cx.widget_action(uid, &scope.path, LabelAction::HoverOut);
+                },
+                _ => ()
             }
-            Hit::FingerHoverOut(_) => {
-                cx.widget_action(uid, &scope.path, LabelAction::HoverOut);
-            },
-            _ => ()
         }
     }
 }

--- a/widgets/src/slider.rs
+++ b/widgets/src/slider.rs
@@ -62,6 +62,11 @@ pub struct Slider {
     #[live] default: f64,
     
     #[live] bind: String,
+
+    // Indicates if the label of the slider responds to hover events
+    // The primary use case for this kind of emitted actions is for tooltips displaying
+    // and it is turned on by default, since this component already consumes finger events
+    #[live(true)] hover_actions_enabled: bool,
     
     #[rust] pub relative_value: f64,
     #[rust] pub dragging: Option<f64>,
@@ -177,14 +182,16 @@ impl Widget for Slider {
             }
         };
 
-        match event.hits_with_capture_overload(cx, self.label_area, true) {
-            Hit::FingerHoverIn(fh) => {
-                cx.widget_action(uid, &scope.path, SliderAction::LabelHoverIn(fh.rect));
+        if self.hover_actions_enabled {
+            match event.hits_with_capture_overload(cx, self.label_area, true) {
+                Hit::FingerHoverIn(fh) => {
+                    cx.widget_action(uid, &scope.path, SliderAction::LabelHoverIn(fh.rect));
+                }
+                Hit::FingerHoverOut(_) => {
+                    cx.widget_action(uid, &scope.path, SliderAction::LabelHoverOut);
+                },
+                _ => ()
             }
-            Hit::FingerHoverOut(_) => {
-                cx.widget_action(uid, &scope.path, SliderAction::LabelHoverOut);
-            },
-            _ => ()
         }
 
         match event.hits(cx, self.draw_slider.area()) {

--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -147,6 +147,8 @@ pub struct View {
     block_signal_event: bool,
     #[live]
     cursor: Option<MouseCursor>,
+    #[live(false)]
+    capture_overload: bool,
     #[live]
     scroll_bars: Option<LivePtr>,
     #[live(false)]
@@ -620,7 +622,7 @@ impl Widget for View {
         }
 
         if self.visible && self.cursor.is_some() || self.animator.live_ptr.is_some() {
-            match event.hits(cx, self.area()) {
+            match event.hits_with_capture_overload(cx, self.area(), self.capture_overload) {
                 Hit::FingerDown(e) => {
                     if self.grab_key_focus {
                         cx.set_key_focus(self.area());


### PR DESCRIPTION
The recent addition into Label widget of hover events actions was problematic because the widget is not consuming finger events, impeding other widgets (such as regular views cointaining the labels) to receive similar events.

This PR adds fine-grained options to Label, Slider and View to control when the hover actions want to be emitted, leaving the options turned off for regular labels, which is a better default for now.