### PR TITLE
Don't require a mutable borrow for `find_widgets()`

### DIFF
--- a/code_editor/src/code_editor.rs
+++ b/code_editor/src/code_editor.rs
@@ -323,7 +323,7 @@ impl CodeEditor {
         self.walk
     }
     
-    pub fn find_widgets(&mut self, _path: &[LiveId], _cached: WidgetCache, _results: &mut WidgetSet){
+    pub fn find_widgets(&self, _path: &[LiveId], _cached: WidgetCache, _results: &mut WidgetSet){
     }
         
     pub fn draw_walk_editor(&mut self, cx: &mut Cx2d, session: &mut Session, walk:Walk) {

--- a/widgets/derive_widget/src/derive_widget.rs
+++ b/widgets/derive_widget/src/derive_widget.rs
@@ -60,7 +60,7 @@ pub fn derive_widget_node_impl(input: TokenStream) ->  TokenStream {
         if let Some(wrap_field) = &wrap_field{
             tb.add("    fn walk(&mut self, cx:&mut Cx) -> Walk { self.").ident(&wrap_field).add(".walk(cx)}");            
             tb.add("    fn redraw(&mut self, cx:&mut Cx) { self.").ident(&wrap_field).add(".redraw(cx)}");
-            tb.add("    fn find_widgets(&mut self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet){self.").ident(&wrap_field).add(".find_widgets(path, cached, results)}");
+            tb.add("    fn find_widgets(&self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet){self.").ident(&wrap_field).add(".find_widgets(path, cached, results)}");
         }
         else{
             if let Some(walk_field) = &walk_field{
@@ -86,17 +86,17 @@ pub fn derive_widget_node_impl(input: TokenStream) ->  TokenStream {
                 return error("Need either a field marked redraw or deref or wrap to find redraw method")
             }
             if find_fields.len()>0{
-                tb.add("    fn find_widgets(&mut self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet){");
+                tb.add("    fn find_widgets(&self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet){");
                 for find_field in find_fields{
                     tb.add("    self.").ident(&find_field).add(".find_widgets(path, cached, results);");
                 }
                 tb.add("    }");
             }
             else if let Some(deref_field) = &deref_field{
-                tb.add("    fn find_widgets(&mut self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet){self.").ident(&deref_field).add(".find_widgets(path, cached, results)}");
+                tb.add("    fn find_widgets(&self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet){self.").ident(&deref_field).add(".find_widgets(path, cached, results)}");
             }
             else{
-                tb.add("    fn find_widgets(&mut self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet){}");
+                tb.add("    fn find_widgets(&self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet){}");
             }
             
         }
@@ -299,11 +299,11 @@ pub fn derive_widget_ref_impl(input: TokenStream) -> TokenStream {
             tb.add("}");
             
             tb.add("pub trait").ident(&widget_ext).add("{");
-            tb.add("    fn ").ident(&get_fn).add("(&mut self, path: &[LiveId]) -> ").ident(&ref_name).add(";");
+            tb.add("    fn ").ident(&get_fn).add("(&self, path: &[LiveId]) -> ").ident(&ref_name).add(";");
             tb.add("}");
             
             tb.add("impl<T> ").ident(&widget_ext).add(" for T where T: Widget{");
-            tb.add("    fn ").ident(&get_fn).add("(&mut self, path: &[LiveId]) -> ").ident(&ref_name).add("{");
+            tb.add("    fn ").ident(&get_fn).add("(&self, path: &[LiveId]) -> ").ident(&ref_name).add("{");
             tb.add("        ").ident(&ref_name).add("(self.widget(path))");
             tb.add("    }");
             tb.add("}");

--- a/widgets/src/bare_step.rs
+++ b/widgets/src/bare_step.rs
@@ -15,7 +15,7 @@ impl WidgetNode for BareStep{
         
     fn redraw(&mut self, _cx: &mut Cx){}
         
-    fn find_widgets(&mut self, _path: &[LiveId], _cached: WidgetCache, _results: &mut WidgetSet) {
+    fn find_widgets(&self, _path: &[LiveId], _cached: WidgetCache, _results: &mut WidgetSet) {
     }
 }   
 

--- a/widgets/src/dock.rs
+++ b/widgets/src/dock.rs
@@ -74,8 +74,8 @@ impl WidgetNode for Dock{
         self.area.redraw(cx)
     }
     
-    fn find_widgets(&mut self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet) {
-        if let Some((_, widget)) = self.items.get_mut(&path[0]) {
+    fn find_widgets(&self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet) {
+        if let Some((_, widget)) = self.items.get(&path[0]) {
             if path.len()>1 {
                 widget.find_widgets(&path[1..], cached, results);
             }
@@ -84,7 +84,7 @@ impl WidgetNode for Dock{
             }
         }
         else {
-            for (_, widget) in self.items.values_mut() {
+            for (_, widget) in self.items.values() {
                 widget.find_widgets(path, cached, results);
             }
         }

--- a/widgets/src/multi_window.rs
+++ b/widgets/src/multi_window.rs
@@ -53,8 +53,8 @@ impl WidgetNode for MultiWindow{
     }
     fn walk(&mut self, _cx:&mut Cx) -> Walk {Walk::default()}
         
-    fn find_widgets(&mut self, path: &[LiveId], cached: WidgetCache, results:&mut WidgetSet){
-        for window in self.windows.values_mut() {
+    fn find_widgets(&self, path: &[LiveId], cached: WidgetCache, results:&mut WidgetSet){
+        for window in self.windows.values() {
             window.find_widgets(path, cached, results);
         }
     }

--- a/widgets/src/page_flip.rs
+++ b/widgets/src/page_flip.rs
@@ -98,8 +98,8 @@ impl WidgetNode for PageFlip{
         self.area.redraw(cx)
     }
         
-    fn find_widgets(&mut self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet) {
-        if let Some(page) = self.pages.get_mut(&path[0]) {
+    fn find_widgets(&self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet) {
+        if let Some(page) = self.pages.get(&path[0]) {
             if path.len() == 1{
                 results.push(page.clone());
             }
@@ -107,7 +107,7 @@ impl WidgetNode for PageFlip{
                 page.find_widgets(&path[1..], cached, results);
             }
         }
-        for page in self.pages.values_mut(){
+        for page in self.pages.values() {
             page.find_widgets(path, cached, results);
         }
     }

--- a/widgets/src/root.rs
+++ b/widgets/src/root.rs
@@ -53,8 +53,8 @@ impl WidgetNode for Root{
     }
     fn walk(&mut self, _cx:&mut Cx) -> Walk {Walk::default()}
         
-    fn find_widgets(&mut self, path: &[LiveId], cached: WidgetCache, results:&mut WidgetSet){
-        for window in self.windows.values_mut() {
+    fn find_widgets(&self, path: &[LiveId], cached: WidgetCache, results:&mut WidgetSet){
+        for window in self.windows.values() {
             window.find_widgets(path, cached, results);
         }
     }

--- a/widgets/src/slides_view.rs
+++ b/widgets/src/slides_view.rs
@@ -32,8 +32,8 @@ impl WidgetNode for SlidesView{
         self.area.redraw(cx)
     }
     
-    fn find_widgets(&mut self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet) {
-        for child in self.children.values_mut() {
+    fn find_widgets(&self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet) {
+        for child in self.children.values() {
             child.find_widgets(path, cached, results);
         }
     }

--- a/widgets/src/stack_navigation.rs
+++ b/widgets/src/stack_navigation.rs
@@ -251,7 +251,7 @@ impl WidgetNode for StackNavigation {
         }
     }
 
-    fn find_widgets(&mut self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet) {
+    fn find_widgets(&self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet) {
         self.view.find_widgets(path, cached, results);
     }
 }

--- a/widgets/src/widget.rs
+++ b/widgets/src/widget.rs
@@ -23,7 +23,7 @@ pub trait WidgetDesign {
 }
 
 pub trait WidgetNode: LiveApply{
-    fn find_widgets(&mut self, _path: &[LiveId], _cached: WidgetCache, _results: &mut WidgetSet);
+    fn find_widgets(&self, _path: &[LiveId], _cached: WidgetCache, _results: &mut WidgetSet);
     fn walk(&mut self, _cx:&mut Cx) -> Walk;
     fn redraw(&mut self, _cx: &mut Cx);
 }
@@ -32,13 +32,13 @@ pub trait Widget: WidgetNode {
     fn handle_event(&mut self, _cx: &mut Cx, _event: &Event, _scope: &mut Scope) {
     }
 
-    fn widget(&mut self, path: &[LiveId]) -> WidgetRef {
+    fn widget(&self, path: &[LiveId]) -> WidgetRef {
         let mut results = WidgetSet::default();
         self.find_widgets(path, WidgetCache::Yes, &mut results);
         return results.into_first()
     }
     
-    fn widgets(&mut self, paths: &[&[LiveId]]) -> WidgetSet {
+    fn widgets(&self, paths: &[&[LiveId]]) -> WidgetSet {
         let mut results = WidgetSet::default();
         for path in paths {
             self.find_widgets(path, WidgetCache::Yes, &mut results);
@@ -259,7 +259,7 @@ impl WidgetSet {
     pub fn widgets(&self, paths: &[&[LiveId]]) -> WidgetSet {
         let mut results = WidgetSet::default();
         for widget in self.iter() {
-            if let Some(inner) = widget.0.borrow_mut().as_mut() {
+            if let Some(inner) = widget.0.borrow().as_ref() {
                 for path in paths {
                     inner.widget.find_widgets(path, WidgetCache::Yes, &mut results);
                 }
@@ -401,12 +401,12 @@ impl WidgetRef {
     }
     
     pub fn find_widgets(
-        &mut self,
+        &self,
         path: &[LiveId],
         cached: WidgetCache,
         results: &mut WidgetSet
     ) {
-        if let Some(inner) = self.0.borrow_mut().as_mut() {
+        if let Some(inner) = self.0.borrow().as_ref() {
             inner.widget.find_widgets(path, cached, results)
         }
     }


### PR DESCRIPTION
This function previously required a mutable borrow of `self` (borrowing the widget instance itself) in order to traverse a path and return a reference to a particular widget.
This was only done to update the cache of found widgets, in order to accelerate future searches for the same path ID.

This is not necessary, and in fact it results in Makepad app devs having to adopt unnecessary clones and other inefficient code patterns in more complex app code.

This changeset enables code like this to compile:
```rust
fn handle_event(...) {
    // this is an immutable borrow of `self`. The `info` state is massive.
    let Some(info) = self.info.as_ref() else { return };

    if let Event::Actions(actions) = event {
        // this use to fail due to *mutably* borrowing `self`.
        if self.button(id!(copy_link_to_user_button)).clicked(actions) {
             .... 
        }

        if let Some(room_member) = info.room_member.as_ref() {
            if self.button(id!(ignore_user_button)).clicked(actions) {
                ....
            }
        }

        // here, there are a bunch more path searches similar to `self.button(...)`
    }
}
```