### PR TITLE
WidgetRef, WidgetNode add handle_event_with

### DIFF
--- a/widgets/src/widget.rs
+++ b/widgets/src/widget.rs
@@ -37,6 +37,9 @@ pub trait WidgetNode: LiveApply{
 }
 
 pub trait Widget: WidgetNode {
+    fn handle_event_with(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope, _sweep_area: Area) {
+        self.handle_event(cx, event, scope)
+    }
     fn handle_event(&mut self, _cx: &mut Cx, _event: &Event, _scope: &mut Scope) {
     }
 
@@ -376,7 +379,39 @@ impl WidgetRef {
             widget,
         }))))
     }
-    
+    /// ## handle event with a sweep area
+    /// 
+    /// this is used for the sweep event, this fn can help to pass the event into popup,
+    /// the widget should implement the `handle_event_with` fn in `impl Widget for $Widget`
+    /// 
+    /// ### Example
+    /// ```rust
+    /// impl Widget for Button {
+    /// fn handle_event_with(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope, sweep_area: Area) {
+    ///     let uid = self.widget_uid();
+    ///
+    ///     if self.animator_handle_event(cx, event).must_redraw() {
+    ///         self.draw_button.redraw(cx);
+    ///     }
+    ///     match event.hits_with_options(cx, self.draw_button.area(), HitOptions::new().with_sweep_area(sweep_area) ) {
+    ///         Hit::FingerDown(f_down) => {
+    ///             if self.grab_key_focus {
+    ///                  cx.set_key_focus(self.sweep_area);
+    ///             }
+    ///             cx.widget_action(uid, &scope.path, GButtonEvent::Pressed(f_down.modifiers));
+    ///             self.animator_play(cx, id!(hover.pressed));
+    ///         }
+    ///         _ =>()
+    ///     }
+    /// }
+    /// ```
+    /// ### Details
+    /// See [Flexible Popup](https://palpus-rs.github.io/Gen-UI.github.io/makepad/code/widgets/flexible_popup.html)
+    pub fn handle_event_with(&self, cx: &mut Cx, event: &Event, scope: &mut Scope, sweep_area: Area) {
+        if let Some(inner) = self.0.borrow_mut().as_mut() {
+            inner.widget.handle_event_with(cx, event, scope, sweep_area)
+        }
+    }
     pub fn handle_event(&self, cx: &mut Cx, event: &Event, scope:&mut Scope){
         if let Some(inner) = self.0.borrow_mut().as_mut() {
             // if we're in a draw event, do taht here


### PR DESCRIPTION
this is used for the sweep event, this fn can help to pass the event into popup, the widget should implement the `handle_event_with` fn in `impl Widget for $Widget`

we can use this fn to build a popup which can write any widget

![微信图片_20240729225621](https://github.com/user-attachments/assets/ee1d728e-20e3-4566-986c-67e5bf99189a)

## details
See [Flexible Popup](https://palpus-rs.github.io/Gen-UI.github.io/makepad/code/widgets/flexible_popup.html)
code: https://github.com/palpus-rs/GenUI/blob/main/gen/components/src/components/popup.rs