### PR TITLE
Button cursor and hover issues

### DIFF
--- a/widgets/src/button.rs
+++ b/widgets/src/button.rs
@@ -97,6 +97,11 @@ impl Widget for Button {
                 }
                 _ => (),
             }
+        } else {
+            // Make sure to not show hover state if button is disabled or hidden
+            if self.animator_in_state(cx, id!(hover.on)) {
+                self.animator_play(cx, id!(hover.off));
+            }
         }
     }
 

--- a/widgets/src/button.rs
+++ b/widgets/src/button.rs
@@ -235,6 +235,12 @@ impl ButtonRef {
             inner.enabled = enabled;
         }
     }
+
+    pub fn reset_hover(&self, cx: &mut Cx) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.animator_cut(cx, id!(hover.off));
+        }
+    }
 }
 
 impl ButtonSet {
@@ -246,6 +252,12 @@ impl ButtonSet {
     }
     pub fn released(&self, actions: &Actions) -> bool {
         self.iter().any(|v| v.released(actions))
+    }
+
+    pub fn reset_hover(&self, cx: &mut Cx) {
+        for item in self.iter() {
+            item.reset_hover(cx)
+        }
     }
     
     pub fn which_clicked_modifiers(&self, actions: &Actions) -> Option<(usize,KeyModifiers)> {

--- a/widgets/src/button.rs
+++ b/widgets/src/button.rs
@@ -79,6 +79,7 @@ impl Widget for Button {
                     self.animator_play(cx, id!(hover.on));
                 }
                 Hit::FingerHoverOut(_) => {
+                    cx.set_cursor(MouseCursor::Default);
                     self.animator_play(cx, id!(hover.off));
                 }
                 Hit::FingerUp(fe) => {


### PR DESCRIPTION
This PR solves 2 specific issues related with the finger events with Buttons instances

- Under certain circumstances, the cursor remains with the hand icon after hovering out from buttons. We have determined it happens with buttons that are part of PortalList items. Testing the News Feed example app is easy to spot the issue.
- Under certain circumstances, the hover state of buttons is not restarted, so it will remain as hovered when the cursor is in another place.
  - It is easy to see this issue when buttons disappear (or the whole surronding UI is replaced) upon clicking a button (e.g. dismissing a modal with a close button).
  - In this case, the issue is likely related with the button not longer receiving events when hidden or inactive. The current behavior is to fire an animation to transition to the "hover off" state, but it can happen without listening events.
  
The changes in this PR to solve (or alleviate) this issues:

- The default cursor is explicitly set on `Hit::FingerHoverOut` in buttons. This seems to work better in the mentioned example app and also in Moxin. Also tested in Ironfish, where there is no gain or harm, as far I can tell.
- Put disabled or not visible buttons in "hover out" state immediately (without animated transition).
- Added `reset_hover` function to Button widget API, so developers have a way to restore the hover state in more complicated cases where the previous solution is not enough (e.g. modal dismissals). 