### PR TITLE
Button widget hover state additions

### DIFF
--- a/widgets/src/button.rs
+++ b/widgets/src/button.rs
@@ -229,6 +229,15 @@ impl ButtonRef {
             inner.enabled = enabled;
         }
     }
+
+    /// Resets the hover state of this button. This is useful in certain cases the
+    /// hover state should be reseted in a specific way that is not the default behavior
+    /// which is based on the mouse cursor position and movement.
+    pub fn reset_hover(&self, cx: &mut Cx) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.animator_cut(cx, id!(hover.off));
+        }
+    }
 }
 
 impl ButtonSet {
@@ -240,6 +249,12 @@ impl ButtonSet {
     }
     pub fn released(&self, actions: &Actions) -> bool {
         self.iter().any(|v| v.released(actions))
+    }
+
+    pub fn reset_hover(&self, cx: &mut Cx) {
+        for item in self.iter() {
+            item.reset_hover(cx)
+        }
     }
     
     pub fn which_clicked_modifiers(&self, actions: &Actions) -> Option<(usize,KeyModifiers)> {


### PR DESCRIPTION
This PR adds two ways to fine tune the behavior of hover states in `Button` widget instances.

* Developers could use the live boolean value `reset_hover_on_click` to make buttons to reset the hover state upon being clicked. This is useful when buttons are used to navigate away or other situations where the button is not longer visible or unable to reach subsequent mouse events (in such cases, the existing approach to change the hover state to off won't work).

* It adds a `reset_hover` fn to the public API of `Button` to manually reset the hover state (turning it off). We don't expect this is a widely used function, but it could be needed when developing very specialized widgets using the existing `Button` widget (such us, a button that would remain in hover state after displaying a floating menu, and it should be restarted when the menu is hidden).