### PR TITLE
Fix crash when CMD+V with no-text content in the clipboard (MacOS)

### DIFF
--- a/platform/src/os/apple/macos/macos_app.rs
+++ b/platform/src/os/apple/macos/macos_app.rs
@@ -390,14 +390,16 @@ impl MacosApp {
                             // was a paste
                             let pasteboard: ObjcId = get_macos_app_global().pasteboard;
                             let nsstring: ObjcId = msg_send![pasteboard, stringForType: NSStringPboardType];
-                            let string = nsstring_to_string(nsstring);
-                            MacosApp::do_callback(
-                                MacosEvent::TextInput(TextInputEvent {
-                                    input: string,
-                                    was_paste: true,
-                                    replace_last: false
-                                })
-                            );
+                            if nsstring != std::ptr::null_mut() {
+                                let string = nsstring_to_string(nsstring);
+                                MacosApp::do_callback(
+                                    MacosEvent::TextInput(TextInputEvent {
+                                        input: string,
+                                        was_paste: true,
+                                        replace_last: false
+                                    })
+                                );
+                            }
                         },
                         KeyCode::KeyC => if modifiers.logo || modifiers.control {
                             let pasteboard: ObjcId = get_macos_app_global().pasteboard;


### PR DESCRIPTION
A hard crash happens when pressing CMD+V in any Makepad app, while having no-text content in the clipboard (e.g. an image).

```
stack backtrace:
   0: rust_begin_unwind
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/panicking.rs:652:5
   1: core::panicking::panic_nounwind_fmt::runtime
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/panicking.rs:110:18
   2: core::panicking::panic_nounwind_fmt
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/panicking.rs:120:5
   3: core::panicking::panic_nounwind
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/panicking.rs:219:5
   4: core::slice::raw::from_raw_parts::precondition_check
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/ub_checks.rs:68:21
   5: core::slice::raw::from_raw_parts
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/ub_checks.rs:75:17
   6: makepad_platform::os::apple::apple_util::nsstring_to_string
             at /Users/jorgebejar/Projects/makepad/platform/src/os/apple/apple_util.rs:27:21
   7: makepad_platform::os::apple::macos::macos_app::MacosApp::process_ns_event
             at /Users/jorgebejar/Projects/makepad/platform/src/os/apple/macos/macos_app.rs:393:42
   8: makepad_platform::os::apple::macos::macos_app::MacosApp::event_loop
             at /Users/jorgebejar/Projects/makepad/platform/src/os/apple/macos/macos_app.rs:554:29
   9: makepad_platform::os::apple::macos::macos::<impl makepad_platform::cx::Cx>::event_loop
             at /Users/jorgebejar/Projects/makepad/platform/src/os/apple/macos/macos.rs:179:9
```