### PR TITLE
Remove useless fn `PortalList::next_visible_item_with_scroll`

### DIFF
--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -303,14 +303,6 @@ impl PortalList {
 
     /// Returns the index of the next visible item that will be drawn by this PortalList.
     pub fn next_visible_item(&mut self, cx: &mut Cx2d) -> Option<usize> {
-        self.next_visible_item_with_scroll(cx).map(|(index, _)| index)
-    }
-
-    /// Similar to [`PortalList::next_visible_item()`], but also returns the item's "scroll offset".
-    ///
-    /// The item's "scroll offset" (or scroll position) is the distance from
-    /// the beginning of the PortalList's viewport to the beginning of that item.
-    pub fn next_visible_item_with_scroll(&mut self, cx: &mut Cx2d) -> Option<(usize, f64)> {
         let vi = self.vec_index;
         let layout = if vi == Vec2Index::Y { Layout::flow_down() } else { Layout::flow_right() };
         if let Some(draw_state) = self.draw_state.get() {
@@ -351,7 +343,7 @@ impl PortalList {
                             }, layout);
                         }
                     }
-                    return Some((self.first_id, self.first_scroll));
+                    return Some(self.first_id);
                 }
                 ListDrawState::Down {index, pos, viewport} | ListDrawState::DownAgain {index, pos, viewport} => {
                     let is_down_again = draw_state.is_down_again();
@@ -392,7 +384,7 @@ impl PortalList {
                                     }, layout);
                                 }
                             }
-                            return Some((self.first_id - 1, pos));
+                            return Some(self.first_id - 1);
                         }
                         else {
                             self.draw_state.set(ListDrawState::End {viewport});
@@ -431,7 +423,7 @@ impl PortalList {
                             }, layout);
                         }
                     }
-                    return Some((index + 1, pos));
+                    return Some(index + 1);
                 }
                 ListDrawState::Up {index, pos, hit_bottom, viewport} => {
                     let did_draw = cx.turtle_has_align_items();
@@ -463,7 +455,7 @@ impl PortalList {
                                     width: Size::Fill,
                                     height: Size::Fit
                                 }, Layout::flow_down());
-                                return Some((last_index + 1, pos));
+                                return Some(last_index + 1);
                             }
                         }
                         self.draw_state.set(ListDrawState::End {viewport});
@@ -489,7 +481,7 @@ impl PortalList {
                         height: Size::Fit
                     }, Layout::flow_down());
                     
-                    return Some((index - 1, pos));
+                    return Some(index - 1);
                 }
                 _ => ()
             }


### PR DESCRIPTION
The returned scroll offset values from this function are only intermediary values that will all change after the PortalList ends its drawing procedured, so relying on them is always wrong and likely misleading.