### PR TITLE
Loader Widgets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ workspace.members = [
     "examples/slides",
     "examples/graph",
     "examples/image_viewer",
+    "examples/content_loading",
     "studio",
     "tools/cargo_makepad",
      "tools/auto_version",

--- a/examples/content_loading/Cargo.toml
+++ b/examples/content_loading/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "makepad-example-content-loading"
+version = "0.6.0"
+authors = ["Makepad <info@makepad.nl>"]
+edition = "2021"
+description = "Usage examples for the ContentLoader and ImageLoader widgets."
+license = "MIT OR Apache-2.0"
+metadata.makepad-auto-version = "db3R5Gxh5Njhx8E-8kuZ2plQ1AI="
+
+[dependencies]
+makepad-widgets = { path = "../../widgets", version = "0.6.0" }

--- a/examples/content_loading/src/app.rs
+++ b/examples/content_loading/src/app.rs
@@ -1,0 +1,135 @@
+use makepad_widgets::*;
+
+live_design! {
+    import makepad_widgets::base::*;
+    import makepad_widgets::theme_desktop_dark::*;
+
+    LoaderLabel = <Label> {
+        width: Fill, height: Fill
+        draw_text:{text_style: {font_size: 13.}}
+    }
+
+    App = {{App}} {
+        ui: <Root>{
+            main_window = <Window>{
+                window: {inner_size: vec2(1280, 890)},
+                show_bg: true
+                width: Fill,
+                height: Fill
+
+                draw_bg: {
+                    fn pixel(self) -> vec4 {
+                        return mix(#7, #3, self.pos.y);
+                    }
+                }
+
+                body = <ScrollXYView>{
+                    flow: Down,
+                    spacing: 20,
+                    align: {
+                        x: 0.5,
+                        y: 0.5
+                    },
+                    padding: 100
+                    input1 = <TextInput> {
+                        width: 900, height: Fit
+                        text: "https://images.unsplash.com/photo-1667053312990-c17655704190?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+                        empty_message: "someurl.com/image.jpg"
+                    }
+                    button1 = <Button> {
+                        text: "Update image"
+                        draw_text:{color:#f00}
+                    }
+
+                    image_loader = <ImageLoader> {
+                        width: 896, height: 560
+
+                        content: {
+                            image = <Image> {
+                                width: Fill, height: Fill
+                                fit: Vertical
+                            }
+                        }
+                    }
+
+                    content_loader = <ContentLoader> {
+                        width: 896, height: 560
+
+                        placeholder: <View> {
+                            label = <LoaderLabel> {
+                                text: "Loading..."
+                            }
+                        }
+
+                        content: <View> {
+                            label = <LoaderLabel> {
+                                text: "Your image is ready!"
+                            }
+                        }
+
+                        error: <View> {
+                            label = <LoaderLabel> { 
+                                text: "Ooops, sorry about that. Please try some other image."
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+app_main!(App);
+
+#[derive(Live, LiveHook)]
+pub struct App {
+    #[live]
+    ui: WidgetRef,
+}
+
+impl LiveRegister for App {
+    fn live_register(cx: &mut Cx) {
+        crate::makepad_widgets::live_design(cx);
+    }
+}
+
+impl MatchEvent for App {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions) {
+        for action in actions {
+            match action.as_widget_action().cast() {
+                ImageLoaderAction::ImageLoaded => {
+                    self.ui
+                        .content_loader(id!(content_loader))
+                        .set_content_loading_status(ContentLoadingStatus::Loaded);
+                    self.ui.redraw(cx);
+                }
+                ImageLoaderAction::ImageLoadingFailed => {
+                    self.ui
+                        .content_loader(id!(content_loader))
+                        .set_content_loading_status(ContentLoadingStatus::Failed);
+                    self.ui.redraw(cx);
+                }
+                _ => (),
+            }
+        }
+
+        if self.ui.button(id!(button1)).clicked(&actions) {
+            let uri = self.ui.text_input(id!(input1)).text();
+            self.ui
+                .image_loader(id!(image_loader))
+                .load_from_url(cx, &uri);
+
+            self.ui
+                .content_loader(id!(content_loader))
+                .set_content_loading_status(ContentLoadingStatus::Loading);
+            self.ui.redraw(cx);
+        }
+    }
+}
+
+impl AppMain for App {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event) {
+        self.match_event(cx, event);
+        self.ui.handle_event(cx, event, &mut Scope::empty());
+    }
+}

--- a/examples/content_loading/src/lib.rs
+++ b/examples/content_loading/src/lib.rs
@@ -1,0 +1,2 @@
+pub use makepad_widgets;
+pub mod app;

--- a/examples/content_loading/src/main.rs
+++ b/examples/content_loading/src/main.rs
@@ -1,0 +1,6 @@
+// this stub is necessary because some platforms require building
+// as dll (mobile / wasm) and some require to be built as executable
+// unfortunately cargo doesn't facilitate this without a main.rs stub
+fn main(){
+    makepad_example_content_loading::app::app_main()
+}

--- a/widgets/src/base.rs
+++ b/widgets/src/base.rs
@@ -16,6 +16,8 @@ live_design!{
     import crate::image::ImageBase;
     import crate::multi_image::MultiImageBase;
     import crate::image_blend::ImageBlendBase;
+    import crate::content_loader::*;
+    import crate::image_loader::*;
     import crate::icon::IconBase;
     import crate::rotated_image::RotatedImageBase;
     import crate::video::VideoBase;
@@ -947,6 +949,9 @@ live_design!{
     ImageBase = <ImageBase> {}
     IconBase = <IconBase> {}
     RotatedImageBase = <RotatedImageBase> {}
+    ContentLoaderBase = <ContentLoaderBase> {}
+    LoaderPlaceholderBase = <LoaderPlaceholderBase> {}
+    ImageLoaderBase = <ImageLoaderBase> {}
     VideoBase = <VideoBase> {}
     LabelBase = <LabelBase> {}
     LinkLabelBase = <LinkLabelBase> {}

--- a/widgets/src/content_loader.rs
+++ b/widgets/src/content_loader.rs
@@ -1,0 +1,162 @@
+use crate::{makepad_derive_widget::*, makepad_draw::*, widget::*, View};
+
+live_design! {
+    LoaderPlaceholderBase = {{LoaderPlaceholder}} {}
+    ContentLoaderBase = {{ContentLoader}} {}
+}
+
+#[derive(Clone, Debug, DefaultNone)]
+pub enum ContentLoaderAction {
+    None,
+    ContentLoaded,
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct ContentLoader {
+    #[redraw]
+    #[live]
+    draw_bg: DrawQuad,
+
+    #[walk]
+    walk: Walk,
+    #[layout]
+    layout: Layout,
+
+    /// A placeholder view to show while the content is loading.
+    #[live]
+    placeholder: LoaderPlaceholder,
+
+    /// The actual content to be displayed once loaded.
+    #[live]
+    pub content: View,
+
+    /// An error view to show if the content fails to load.
+    #[live]
+    pub error: View,
+
+    /// Wether to display the image as soon as it's loaded.
+    #[rust(true)]
+    show_content_on_load: bool,
+
+    #[rust]
+    content_loading_status: ContentLoadingStatus,
+}
+
+#[derive(Default, Debug)]
+pub enum ContentLoadingStatus {
+    #[default]
+    NotStarted,
+    Loading,
+    Loaded,
+    Failed,
+}
+
+impl Widget for ContentLoader {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.placeholder.handle_event(cx, event, scope);
+        self.content.handle_event(cx, event, scope);
+        self.error.handle_event(cx, event, scope);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.draw_bg.begin(cx, walk, self.layout);
+
+        match self.content_loading_status {
+            ContentLoadingStatus::Loaded => {
+                if self.show_content_on_load {
+                    let _ = self.content.draw_walk(cx, scope, walk);
+                }
+            }
+            ContentLoadingStatus::NotStarted | ContentLoadingStatus::Loading => {
+                let _ = self.placeholder.draw_walk(cx, scope, walk);
+            }
+            ContentLoadingStatus::Failed => {
+                let _ = self.error.draw_walk(cx, scope, walk);
+            }
+        }
+
+        self.draw_bg.end(cx);
+        DrawStep::done()
+    }
+}
+
+impl ContentLoader {
+    pub fn set_content_loading_status(&mut self, status: ContentLoadingStatus) {
+        self.content_loading_status = status;
+    }
+
+    pub fn set_loaded_and_show_content(&mut self, cx: &mut Cx) {
+        self.content_loading_status = ContentLoadingStatus::Loaded;
+        self.show_content_on_load = true;
+        self.redraw(cx);
+        cx.widget_action(
+            self.widget_uid(),
+            &HeapLiveIdPath::default(),
+            ContentLoaderAction::ContentLoaded,
+        );
+    }
+
+    pub fn set_show_content_on_load(&mut self, show: bool) {
+        self.show_content_on_load = show;
+    }
+}
+
+impl ContentLoaderRef {
+    pub fn set_content_loading_status(&mut self, status: ContentLoadingStatus) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_content_loading_status(status)
+        }
+    }
+
+    pub fn set_loaded_and_show_content(&mut self, cx: &mut Cx) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_loaded_and_show_content(cx);
+        }
+    }
+
+    pub fn set_show_content_on_load(&mut self, show: bool) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_show_content_on_load(show);
+        }
+    }
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct LoaderPlaceholder {
+    #[deref]
+    view: View,
+
+    #[animator]
+    animator: Animator,
+}
+
+impl Widget for LoaderPlaceholder {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        if self.animator_handle_event(cx, event).must_redraw() {
+            self.view.redraw(cx);
+        }
+        if self.animator.need_init() {
+            self.animator_play(cx, id!(spinner.spin));
+        }
+
+        self.view.handle_event(cx, event, scope);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk)
+    }
+}
+
+impl LoaderPlaceholderRef {
+    pub fn set_animator_play(&mut self, cx: &mut Cx, id: &[LiveId; 2]) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.animator_play(cx, id);
+        }
+    }
+
+    pub fn set_visible(&mut self, visible: bool) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.view.visible = visible;
+        }
+    }
+}

--- a/widgets/src/content_loader.rs
+++ b/widgets/src/content_loader.rs
@@ -28,11 +28,11 @@ pub struct ContentLoader {
 
     /// The actual content to be displayed once loaded.
     #[live]
-    pub content: View,
+    content: View,
 
     /// An error view to show if the content fails to load.
     #[live]
-    pub error: View,
+    error: View,
 
     /// Wether to display the image as soon as it's loaded.
     #[rust(true)]
@@ -98,6 +98,18 @@ impl ContentLoader {
 
     pub fn set_show_content_on_load(&mut self, show: bool) {
         self.show_content_on_load = show;
+    }
+
+    pub fn content_view(&mut self) -> &mut View {
+        &mut self.content
+    }
+    
+    pub fn error_view(&mut self) -> &mut View {
+        &mut self.error
+    }
+
+    pub fn placeholder_view(&mut self) -> &mut LoaderPlaceholder {
+        &mut self.placeholder
     }
 }
 

--- a/widgets/src/image_loader.rs
+++ b/widgets/src/image_loader.rs
@@ -69,8 +69,8 @@ impl WidgetMatchEvent for ImageLoader {
                                 // cx.get_global::<NetworkImageCache>()
                                 //     .insert(response.metadata_id, body);
 
-                                // TODO: instead of content being pub, use a callback with imageref access like in text_or_image
-                                let image_ref = self.content_loader.content.image(id!(image));
+                                let image_ref =
+                                    self.content_loader.content_view().image(id!(image));
 
                                 let image_format = get_image_format(&body);
                                 match image_format {
@@ -126,7 +126,7 @@ impl ImageLoader {
         self.content_loader
             .set_content_loading_status(ContentLoadingStatus::Failed);
         self.content_loader
-            .error
+            .error_view()
             .label(id!(error_message))
             .set_text(&error);
         cx.widget_action(
@@ -141,7 +141,7 @@ impl ImageLoader {
         self.image_loading_status = ImageLoadingStatus::Loading;
         self.content_loader
             .set_content_loading_status(ContentLoadingStatus::Loading);
-        self.content.redraw(cx);
+        self.content_view().redraw(cx);
 
         let mut request = HttpRequest::new(uri.to_string(), HttpMethod::GET);
         request.metadata_id = LiveId::from_str(&uri);

--- a/widgets/src/image_loader.rs
+++ b/widgets/src/image_loader.rs
@@ -1,0 +1,207 @@
+use std::fmt::{self, Display, Formatter};
+
+use crate::{
+    makepad_derive_widget::*, makepad_draw::*, widget::*, ContentLoader, ContentLoadingStatus,
+    ImageWidgetExt, LabelWidgetExt, WidgetMatchEvent,
+};
+
+live_design! {
+    ImageLoaderBase = {{ImageLoader}} {}
+}
+
+#[derive(Clone, Debug, DefaultNone)]
+pub enum ImageLoaderAction {
+    None,
+    ImageLoaded,
+    ImageLoadingFailed,
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct ImageLoader {
+    #[deref]
+    content_loader: ContentLoader,
+
+    #[rust]
+    uri: Option<String>,
+    #[rust]
+    image_loading_status: ImageLoadingStatus,
+}
+
+#[derive(Default)]
+pub enum ImageLoadingStatus {
+    #[default]
+    NotStarted,
+    Loading,
+    Loaded,
+    Failed,
+}
+
+impl Widget for ImageLoader {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.content_loader.handle_event(cx, event, scope);
+        self.widget_match_event(cx, event, scope);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.content_loader.draw_walk(cx, scope, walk)
+    }
+}
+
+impl WidgetMatchEvent for ImageLoader {
+    fn handle_network_responses(
+        &mut self,
+        cx: &mut Cx,
+        responses: &NetworkResponsesEvent,
+        scope: &mut Scope,
+    ) {
+        if self.uri.is_none() {
+            return;
+        }
+        for event in responses {
+            if event.request_id == live_id!(image_loader_request) {
+                match &event.response {
+                    NetworkResponse::HttpResponse(response) => {
+                        let uri = self.uri.as_ref().unwrap();
+                        let is_expected_response = response.metadata_id == LiveId::from_str(&uri);
+                        if response.status_code == 200 && is_expected_response {
+                            if let Some(body) = response.get_body() {
+                                // TODO: Caching
+                                // cx.get_global::<NetworkImageCache>()
+                                //     .insert(response.metadata_id, body);
+
+                                // TODO: instead of content being pub, use a callback with imageref access like in text_or_image
+                                let image_ref = self.content_loader.content.image(id!(image));
+
+                                let image_format = get_image_format(&body);
+                                match image_format {
+                                    Some(ImageFormat::PNG) => {
+                                        let _ = image_ref.load_png_from_data(cx, &body);
+                                        self.content_loader.set_loaded_and_show_content(cx);
+                                        self.image_loading_status = ImageLoadingStatus::Loaded;
+                                    }
+                                    Some(ImageFormat::JPEG) => {
+                                        let _ = image_ref.load_jpg_from_data(cx, &body);
+                                        self.content_loader.set_loaded_and_show_content(cx);
+                                        self.image_loading_status = ImageLoadingStatus::Loaded;
+                                    }
+                                    None => {
+                                        let error = "Failed to determine image format";
+                                        error!("{error}");
+                                        self.fail_image_loading(cx, &error);
+                                    }
+                                    _ => {
+                                        let error = format!(
+                                            "Unsupported image format: {}",
+                                            image_format.unwrap()
+                                        );
+                                        error!("{error}");
+                                        self.fail_image_loading(cx, &error);
+                                    }
+                                }
+
+                                cx.widget_action(
+                                    self.widget_uid(),
+                                    &scope.path,
+                                    ImageLoaderAction::ImageLoaded,
+                                );
+                                self.redraw(cx);
+                            }
+                        } else {
+                            self.fail_image_loading(cx, "Failed to fetch image");
+                        }
+                    }
+                    NetworkResponse::HttpRequestError(error) => {
+                        error!("Error fetching gallery image: {:?}", error);
+                    }
+                    _ => (),
+                }
+            }
+        }
+    }
+}
+
+impl ImageLoader {
+    fn fail_image_loading(&mut self, cx: &mut Cx, error: &str) {
+        self.image_loading_status = ImageLoadingStatus::Failed;
+        self.content_loader
+            .set_content_loading_status(ContentLoadingStatus::Failed);
+        self.content_loader
+            .error
+            .label(id!(error_message))
+            .set_text(&error);
+        cx.widget_action(
+            self.widget_uid(),
+            &HeapLiveIdPath::default(),
+            ImageLoaderAction::ImageLoadingFailed,
+        );
+        self.redraw(cx);
+    }
+
+    pub fn load_from_url(&mut self, cx: &mut Cx, uri: &str) {
+        self.image_loading_status = ImageLoadingStatus::Loading;
+        self.content_loader
+            .set_content_loading_status(ContentLoadingStatus::Loading);
+        self.content.redraw(cx);
+
+        let mut request = HttpRequest::new(uri.to_string(), HttpMethod::GET);
+        request.metadata_id = LiveId::from_str(&uri);
+        cx.http_request(live_id!(image_loader_request), request);
+        self.uri = Some(uri.to_string());
+    }
+}
+
+impl ImageLoaderRef {
+    pub fn load_from_url(&mut self, cx: &mut Cx, uri: &str) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.load_from_url(cx, uri);
+        }
+    }
+}
+
+// TODO: Find a better place for these
+#[derive(Debug, PartialEq)]
+pub enum ImageFormat {
+    PNG,
+    JPEG,
+    GIF,
+    BMP,
+    ICO,
+    WebP,
+    TIFF,
+}
+
+impl Display for ImageFormat {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ImageFormat::PNG => write!(f, "PNG"),
+            ImageFormat::JPEG => write!(f, "JPEG"),
+            ImageFormat::GIF => write!(f, "GIF"),
+            ImageFormat::BMP => write!(f, "BMP"),
+            ImageFormat::ICO => write!(f, "ICO"),
+            ImageFormat::WebP => write!(f, "WebP"),
+            ImageFormat::TIFF => write!(f, "TIFF"),
+        }
+    }
+}
+
+fn get_image_format(data: &[u8]) -> Option<ImageFormat> {
+    if data.len() < 8 {
+        // Not enough data to determine format
+        return None;
+    }
+
+    match &data[0..8] {
+        [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A] => Some(ImageFormat::PNG),
+        [0xFF, 0xD8, 0xFF, ..] => Some(ImageFormat::JPEG),
+        [0x47, 0x49, 0x46, 0x38, 0x37, 0x61, ..] | [0x47, 0x49, 0x46, 0x38, 0x39, 0x61, ..] => {
+            Some(ImageFormat::GIF)
+        }
+        [0x42, 0x4D, ..] => Some(ImageFormat::BMP),
+        [0x00, 0x00, 0x01, 0x00, ..] => Some(ImageFormat::ICO),
+        [0x52, 0x49, 0x46, 0x46, _, _, _, _, 0x57, 0x45, 0x42, 0x50] if data.len() >= 12 => {
+            Some(ImageFormat::WebP)
+        }
+        [0x49, 0x49, 0x2A, 0x00] | [0x4D, 0x4D, 0x00, 0x2A] => Some(ImageFormat::TIFF),
+        _ => None,
+    }
+}

--- a/widgets/src/image_loader.rs
+++ b/widgets/src/image_loader.rs
@@ -65,10 +65,7 @@ impl WidgetMatchEvent for ImageLoader {
                         let is_expected_response = response.metadata_id == LiveId::from_str(&uri);
                         if response.status_code == 200 && is_expected_response {
                             if let Some(body) = response.get_body() {
-                                // TODO: Caching
-                                // cx.get_global::<NetworkImageCache>()
-                                //     .insert(response.metadata_id, body);
-
+                                // TODO: Add caching and decode in background threads
                                 let image_ref =
                                     self.content_loader.content_view().image(id!(image));
 

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -10,6 +10,8 @@ pub mod button;
 pub mod label;
 pub mod image;
 pub mod image_blend;
+pub mod content_loader;
+pub mod image_loader;
 pub mod icon;
 pub mod link_label;
 pub mod drop_down;
@@ -85,6 +87,8 @@ pub use crate::{
     button::*,
     view::*,
     image::*,
+    content_loader::*,
+    image_loader::*,
     image_blend::*,
     icon::*,
     label::*,
@@ -155,6 +159,8 @@ pub fn live_design(cx: &mut Cx) {
     crate::image_blend::live_design(cx);
     crate::icon::live_design(cx);
     crate::rotated_image::live_design(cx);
+    crate::content_loader::live_design(cx);
+    crate::image_loader::live_design(cx);
     crate::video::live_design(cx);
     crate::view::live_design(cx);
     crate::fold_button::live_design(cx);

--- a/widgets/src/theme_desktop_dark.rs
+++ b/widgets/src/theme_desktop_dark.rs
@@ -192,6 +192,8 @@ live_design! {
         line_spacing: 1.16
     }
 
+    PI = 3.14159
+
     Label = <LabelBase> {
         width: Fit, height: Fit,
         draw_text: {
@@ -3850,24 +3852,151 @@ live_design! {
                     width: Fit,
                     spacing: 10,
                 }
+
+                animator: {
+                    panel = {
+                        default: open,
+                        open = {
+                            redraw: true,
+                            from: {all: Forward {duration: 0.3}}
+                            ease: ExpDecay {d1: 0.80, d2: 0.97}
+                            apply: {animator_panel_progress: 1.0, open_content = { draw_bg: {opacity: 1.0} }}
+                        }
+                        close = {
+                            redraw: true,
+                            from: {all: Forward {duration: 0.3}}
+                            ease: ExpDecay {d1: 0.80, d2: 0.97}
+                            apply: {animator_panel_progress: 0.0, open_content = { draw_bg: {opacity: 0.0} }}
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    LoaderPlaceholder = <LoaderPlaceholderBase> {
+        width: Fill, height: Fill
+        show_bg: true
+        draw_bg: {
+            instance spinner_thiccness: 0.01
+            instance spinner_radius: 0.1
+            instance spinner_speed: 3.8
+            instance custom_time: 0.0
+
+            // Spinner shader adapted from https://www.shadertoy.com/view/Xd3cR8
+            fn pixel(self) -> vec4 {
+                // Center the UV coordinates
+                let uv = (self.pos - 0.5);
+                let aspect = self.rect_size.x / self.rect_size.y;
+                uv.x *= aspect;
+
+                let geo = ring(uv, vec2(0.0), (self.spinner_radius) - (self.spinner_thiccness), (self.spinner_radius));
+
+                // let rot = self.spinner_speed * self.custom_time;//self.custom_time * (self.spinner_speed);
+                let rot = fract(self.custom_time) * PI * self.spinner_speed;
+
+                let rot_mat = mat2(cos(rot), sin(rot), -sin(rot), cos(rot));
+                let uv_rot = uv * rot_mat;
+
+                let a = 1.0 - (atan(uv_rot.x, uv_rot.y) / (2.0 * PI) + 0.5);
+                
+                let circle_val = 1.0 - smoothstep((self.spinner_thiccness) / 2.0, (self.spinner_thiccness) / 2.0 + 0.005,
+                    length(uv_rot - vec2(0.0, -(self.spinner_radius) + (self.spinner_thiccness) / 2.0)));
+                a = max(a, circle_val);
+
+                let color = vec4(a * geo);
+
+                return mix(#0f0e0c, #333535, color.x)
+            }
+
+            fn ring(uv: vec2, pos: vec2, inner_rad: float, outer_rad: float) -> float {
+                let dist = length(uv - pos);
+                return (1.0 - smoothstep(outer_rad, outer_rad + 0.005, dist)) *
+                       smoothstep(inner_rad - 0.005, inner_rad, dist)
             }
         }
 
         animator: {
-            panel = {
-                default: open,
-                open = {
-                    redraw: true,
-                    from: {all: Forward {duration: 0.3}}
-                    ease: ExpDecay {d1: 0.80, d2: 0.97}
-                    apply: {animator_panel_progress: 1.0, open_content = { draw_bg: {opacity: 1.0} }}
+            spinner = {
+                default: off
+                off = {
+                    from: {all: Forward {duration: 2.0}}
+                    apply: {
+                        draw_bg: {custom_time: 0.5}
+                    }
                 }
-                close = {
+                spin = {
                     redraw: true,
-                    from: {all: Forward {duration: 0.3}}
-                    ease: ExpDecay {d1: 0.80, d2: 0.97}
-                    apply: {animator_panel_progress: 0.0, open_content = { draw_bg: {opacity: 0.0} }}
+                    from: {all: Loop {duration: 1.0, end: 1.0}}
+                    apply: {
+                        draw_bg: {custom_time: 1.0}
+                    }
                 }
+            }
+        }
+    }
+
+    LoaderErrorView = <View> {
+        width: Fill, height: Fill
+        align: {x: 0.5, y: 0.5}
+        flow: Down
+        show_bg: true
+        draw_bg: {
+            color: #0f0e0c
+        }
+        icon = <View> {
+            width: Fill, height: 100
+            show_bg: true
+            draw_bg: {
+                fn pixel(self) -> vec4 {
+                    let sdf = Sdf2d::viewport(self.pos * self.rect_size);
+                    sdf.aa *= 3.0;
+                    let sz = 20.0;
+                    let c = self.rect_size * vec2(0.5, 0.5);
+                    sdf.move_to(c.x - sz, c.y - sz);
+                    sdf.line_to(c.x + sz, c.y + sz);
+                    sdf.move_to(c.x - sz, c.y + sz);
+                    sdf.line_to(c.x + sz, c.y - sz);
+                    sdf.stroke((THEME_COLOR_TEXT_DEFAULT), 1.5 + 1.5 * self.dpi_dilate);
+                    return sdf.result;
+                }
+            }
+        }
+        error_message = <H4> {
+            width: Fit, height: Fit
+            text: "Error laoding content",
+            draw_text: {color: (THEME_COLOR_TEXT_DEFAULT)}
+        }
+    }
+
+    ContentLoader = <ContentLoaderBase> {
+        align: {x: 0.5, y: 0.5}
+        draw_bg: {
+            fn pixel(self) -> vec4 {
+                let sdf = Sdf2d::viewport(self.pos * self.rect_size);
+                return sdf.result
+            }
+        }
+        placeholder: <LoaderPlaceholder> {}
+        content: <View> {}
+        error: <LoaderErrorView> {}
+    }
+
+    ImageLoader = <ImageLoaderBase> {
+        align: {x: 0.5, y: 0.5}
+        draw_bg: {
+            fn pixel(self) -> vec4 {
+                let sdf = Sdf2d::viewport(self.pos * self.rect_size);
+                return sdf.result
+            }
+        }
+        placeholder: <LoaderPlaceholder> {}
+        content: <View> {
+            image = <Image> {}
+        }
+        error: <LoaderErrorView> {
+            error_message = {
+                text: "Error laoding image",
             }
         }
     }


### PR DESCRIPTION
Introduces two new widgets:

1. `ContentLoader`: a "parent" widget used to easily switch between loading animations, error messages, and content.
    - `content` a view containing the actual content to be displayed once loaded
    - `placeholder` a widget (wraps view) that contains a loading spinner animation. This can be replaced by any other view as shown in the example application.
    - `error` a view that wrap arounds the errors to show when content fails to load. Again this can be overwritten completely.

2. `ImageLoader`: based on `ContentLoader`, provides a `load_from_url()` method that automatically handles network fetching. It also overrides the base ImageLoader with some image-specific errors.

You can see the newly add example `examples/content_loading/src/app.rs` for usage.