### PR TITLE
Android: Fallback render loop for platforms without Choreographer API

### DIFF
--- a/platform/build.rs
+++ b/platform/build.rs
@@ -12,7 +12,7 @@ fn main() {
     file.write_all(&format!("{}", cwd.display()).as_bytes()).unwrap();
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target = env::var("TARGET").unwrap();
-    println!("cargo:rustc-check-cfg=cfg(apple_sim,lines,linux_direct,use_unstable_unix_socket_ancillary_data_2021)");
+    println!("cargo:rustc-check-cfg=cfg(apple_sim,lines,linux_direct,no_android_choreographer,use_unstable_unix_socket_ancillary_data_2021)");
     println!("cargo:rerun-if-env-changed=MAKEPAD");
     println!("cargo:rerun-if-env-changed=MAKEPAD_PACKAGE_DIR");
     if let Ok(configs) = env::var("MAKEPAD"){
@@ -20,6 +20,7 @@ fn main() {
             match config{
                 "lines"=>println!("cargo:rustc-cfg=lines"), 
                 "linux_direct"=>println!("cargo:rustc-cfg=linux_direct"), 
+                "no_android_choreographer"=>println!("cargo:rustc-cfg=no_android_choreographer"), 
                 _=>{}
             }
         }

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -172,7 +172,6 @@ pub unsafe fn init_choreographer() {
     // If the Choreographer is not available (e.g. OHOS), use a manual render loop
     #[cfg(no_android_choreographer)]
     {
-        crate::log!("🛑 Choreographer NOT AVAILABLE");
         std::thread::spawn(|| {
             loop {
                 send_from_java_message(FromJavaMessage::RenderLoop);
@@ -182,7 +181,6 @@ pub unsafe fn init_choreographer() {
         return;
     }
     
-    crate::log!("🚧🚧🚧🚧 Choreogrpaher AVAILABLE");
     CHOREOGRAPHER = ndk_sys::AChoreographer_getInstance();
     post_vsync_callback();
 }

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -186,34 +186,12 @@ pub unsafe fn init_choreographer() {
     }
 }
 
-// Function to check if the Choreographer API is available
 fn is_choreographer_available() -> bool {
-    unsafe {
-        // Open the libandroid.so library
-        let filename = c"libandroid.so";
-        let lib = libc_sys::dlopen(filename.as_ptr(), libc_sys::RTLD_LAZY);
-        if lib.is_null() {
-            return false;
-        }
+    #[cfg(no_android_choreographer)]
+    return false;
 
-        // Attempt to load the necessary symbols
-        let get_instance_symbol = c"AChoreographer_getInstance";
-        let get_instance: *mut std::ffi::c_void = libc_sys::dlsym(lib, get_instance_symbol.as_ptr());
-        let post_callback_symbol = c"AChoreographer_postFrameCallback";
-        let post_callback: *mut std::ffi::c_void = libc_sys::dlsym(lib, post_callback_symbol.as_ptr());
-
-        // Close the library
-        libc_sys::dlclose(lib);
-
-        // Check if both symbols were found
-        if !get_instance.is_null() && !post_callback.is_null() {
-            return true;
-        }
-
-        false
-    }
+    true
 }
-
 
 unsafe extern "C" fn vsync_callback(
     _data: *mut ndk_sys::AChoreographerFrameCallbackData,

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -159,28 +159,46 @@ unsafe fn create_native_window(surface: jni_sys::jobject) -> *mut ndk_sys::ANati
 
 static mut CHOREOGRAPHER: *mut ndk_sys::AChoreographer = std::ptr::null_mut();
 
+/// Initializes the render loop which used the Android Choreographer when available to ensure proper vsync.
+/// If `no_android_choreographer` is present (e.g. OHOS with non-compatiblity), we fallback to a simple loop with frame pacing.
+/// This will be replaced by proper a vsync mechanism once we firgure it out for that OHOS.
+#[allow(unused)]
 #[no_mangle]
 pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_initChoreographer(
     _: *mut jni_sys::JNIEnv,
     _: jni_sys::jclass,
+    device_refresh_rate: jni_sys::jfloat,
 ) {
-    init_choreographer();
-}
-
-#[allow(unused)]
-pub unsafe fn init_choreographer() {
     // If the Choreographer is not available (e.g. OHOS), use a manual render loop
     #[cfg(no_android_choreographer)]
     {
-        std::thread::spawn(|| {
+        std::thread::spawn(move || {
+            let mut last_frame_time = std::time::Instant::now();
+            let target_frame_time = std::time::Duration::from_secs_f32(1.0 / device_refresh_rate);
             loop {
-                send_from_java_message(FromJavaMessage::RenderLoop);
-                std::thread::sleep(std::time::Duration::from_millis(8));
+                let now = std::time::Instant::now();
+                let elapsed = now - last_frame_time;
+                
+                if elapsed >= target_frame_time {
+                    let frame_start = std::time::Instant::now();
+                    send_from_java_message(FromJavaMessage::RenderLoop);
+                    let frame_duration = frame_start.elapsed();
+                    
+                    // Adaptive sleep: sleep less if the last frame took longer to process
+                    if frame_duration < target_frame_time {
+                        std::thread::sleep(target_frame_time - frame_duration);
+                    }
+                    
+                    last_frame_time = now;
+                } else {
+                    std::thread::sleep(target_frame_time - elapsed);
+                }
             }
         });
         return;
     }
     
+    // Otherwise use the actual Choreographer
     CHOREOGRAPHER = ndk_sys::AChoreographer_getInstance();
     post_vsync_callback();
 }

--- a/tools/cargo_makepad/src/android/compile.rs
+++ b/tools/cargo_makepad/src/android/compile.rs
@@ -137,7 +137,7 @@ fn rust_build(sdk_dir: &Path, host_os: HostOs, args: &[String], android_targets:
         let target_arch_str = android_target.to_str();
         let cfg_flag = format!("--cfg android_target=\"{}\"", target_arch_str);
          
-        let mut makepad_env = std::env::var("MAKEPAD").unwrap_or("lines".to_string());
+        let makepad_env = std::env::var("MAKEPAD").unwrap_or("lines".to_string());
         shell_env(
             &[
                 // Set the linker env var to the path of the target-specific `clang` binary.

--- a/tools/cargo_makepad/src/android/compile.rs
+++ b/tools/cargo_makepad/src/android/compile.rs
@@ -137,6 +137,7 @@ fn rust_build(sdk_dir: &Path, host_os: HostOs, args: &[String], android_targets:
         let target_arch_str = android_target.to_str();
         let cfg_flag = format!("--cfg android_target=\"{}\"", target_arch_str);
          
+        let mut makepad_env = std::env::var("MAKEPAD").unwrap_or("lines".to_string());
         shell_env(
             &[
                 // Set the linker env var to the path of the target-specific `clang` binary.
@@ -162,7 +163,7 @@ fn rust_build(sdk_dir: &Path, host_os: HostOs, args: &[String], android_targets:
                 (&format!("RANLIB_{toolchain}"), full_llvm_ranlib_path.to_str().unwrap()),
 
                 ("RUSTFLAGS", &cfg_flag),
-                ("MAKEPAD", "lines"),
+                ("MAKEPAD", &makepad_env),
             ],
             &cwd,
             "rustup",

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -296,7 +296,8 @@ MidiManager.OnDeviceOpenedListener{
         // Set volume keys to control music stream, we might want make this flexible for app devs
         setVolumeControlStream(AudioManager.STREAM_MUSIC);
 
-        MakepadNative.initChoreographer();        
+        float refreshRate = getDeviceRefreshRate();
+        MakepadNative.initChoreographer(refreshRate);
         //% MAIN_ACTIVITY_ON_CREATE
     }
 
@@ -647,5 +648,27 @@ MidiManager.OnDeviceOpenedListener{
         } catch (IOException e) {
             return "Unknown";
         }
+    }
+
+    @SuppressWarnings("deprecation")
+    public float getDeviceRefreshRate() {
+        float refreshRate = 60.0f;  // Default to a common refresh rate
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            // Use getDisplay() API on Android 11 and above
+            Display display = getDisplay();
+            if (display != null) {
+                refreshRate = display.getRefreshRate();
+            }
+        } else {
+            // Use the old method for Android 10 and below
+            WindowManager windowManager = (WindowManager) getSystemService(Context.WINDOW_SERVICE);
+            if (windowManager != null) {
+                Display display = windowManager.getDefaultDisplay();
+                refreshRate = display.getRefreshRate();
+            }
+        }
+
+        return refreshRate;
     }
 }

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
@@ -17,7 +17,7 @@ public class MakepadNative {
     public static native void onAndroidParams(String cache_path, float dentify, boolean isEmulator, String androidVersion, String buildNumber,
         String kernelVersion);
 
-    public native static void initChoreographer();
+    public native static void initChoreographer(float deviceRefreshRate);
 
     public native static void onBackPressed();
 


### PR DESCRIPTION
Adds support for devices and operating systems that don't provide the Android Choreographer API, such as OpenHarmony OS. Key changes include:

- Conditional compilation to use a manual render loop when Choreographer is unavailable
- Implementation of simple adaptive frame pacing algorithm to maintain consistent frame rates
- Addition of a device refresh rate detection
- Fallback to 60 FPS when unable to detect the device's refresh rate

To run Makepad without the Choreographer and falling back to the manual render loop:
1. Make sure to update cargo-makepad `cargo install --path ./tools/cargo_makepad`
2. Run your usual command appending `MAKEPAD=no_android_choreographer`: e.g.:
```
MAKEPAD=no_android_choreographer cargo makepad android run -p makepad-example-simple --release
```