### PR TITLE
Track `visible_items` state in `PortalList` and expose it publicly

### DIFF
--- a/widgets/src/designer_view.rs
+++ b/widgets/src/designer_view.rs
@@ -124,7 +124,7 @@ enum FingerMove{
 #[derive(Live, Widget)]
 pub struct DesignerView {
     #[walk] walk:Walk,
-    #[rust] area:Area,
+    #[rust] #[area] area:Area,
     #[rust] reapply: bool,
     #[rust(1.5)] zoom: f64,
     #[rust] undo_group: u64,

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -54,6 +54,7 @@ pub struct PortalList {
     #[rust] range_start: usize,
     #[rust(usize::MAX)] range_end: usize,
     #[rust(0usize)] view_window: usize,
+    #[rust(0usize)] visible_items: usize,
     #[live(0.2)] flick_scroll_minimum: f64,
     #[live(80.0)] flick_scroll_maximum: f64,
     #[live(0.005)] flick_scroll_scaling: f64,
@@ -299,6 +300,7 @@ impl PortalList {
         }
 
         cx.end_turtle_with_area(&mut self.area);
+        self.visible_items = visible_items;
     }
 
     /// Returns the index of the next visible item that will be drawn by this PortalList.
@@ -564,6 +566,12 @@ impl PortalList {
     /// is visible in the viewport.
     pub fn is_at_end(&self) -> bool {
         self.at_end
+    }
+
+    /// Returns the number of items that are currently visible in the viewport,
+    /// including partially visible items.
+    pub fn visible_items(&self) -> usize {
+        self.visible_items
     }
 
     /// Returns `true` if this sanity check fails: the first item ID is within the item range.
@@ -862,6 +870,12 @@ impl PortalListRef {
     pub fn is_at_end(&self) -> bool {
         let Some(inner) = self.borrow() else { return false };
         inner.is_at_end()
+    }
+
+    /// See [`PortalList::visible_items()`].
+    pub fn visible_items(&self) -> usize {
+        let Some(inner) = self.borrow() else { return 0 };
+        inner.visible_items()
     }
 
     /// Returns whether the given `actions` contain an action indicating that this PortalList was scrolled.


### PR DESCRIPTION
This allows users of `PortalList` to determine how many items are currently visible within the viewport.
Using `first_id` and `visible_items` together will give you the range of currently-visible item indices.