### PR TITLE
Use TextFlow in HtmlLink to preserve external Html formatting

### DIFF
--- a/experiments/html_experiment/src/app.rs
+++ b/experiments/html_experiment/src/app.rs
@@ -137,6 +137,14 @@ live_design!{
                     }
 
                     body: "
+                    Testing plaintext link: <a href=\"https://www.google.com\">Google</a>
+                    
+                    <h2>Header 2 link to <a href=\"https://www.google.com\">Google</a> </h2>
+
+                    <b>Bold and <i>italic link to <a href=\"https://www.google.com\">Google</a></i></b>
+
+                    <h4>Header 4 <b> bold link to <a href=\"https://www.google.com\">Google</a></b></h4>
+
                     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed venenatis, lorem sodales lacinia ornare, nisi lorem congue urna, eget dictum urna lacus ut quam. Duis elementum vehicula tellus vel mollis. Vivamus ut orci sed lorem aliquet posuere. Ut sem augue, gravida vitae luctus placerat, vulputate at ligula. Ut sit amet commodo massa. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Pellentesque sodales, eros id dictum bibendum, nisi neque iaculis augue, ac suscipit dolor nisi et velit. Integer dignissim interdum metus. Etiam ultricies nibh eu bibendum ultricies. Maecenas dictum maximus mollis.
 
                     Morbi sit amet placerat metus. Vivamus eleifend elementum lectus, in dignissim elit pulvinar sed. Nam eleifend a dui condimentum vestibulum. Nam nec orci pretium, sodales orci quis, aliquam dolor. Maecenas id neque tempor, sollicitudin nisi at, bibendum turpis. Donec consectetur tellus a ornare dictum. Mauris mollis laoreet consequat. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nunc in fermentum velit.

--- a/widgets/src/button.rs
+++ b/widgets/src/button.rs
@@ -1,4 +1,4 @@
-use crate::{makepad_derive_widget::*, makepad_draw::*, widget::*};
+use crate::{makepad_derive_widget::*, makepad_draw::*, widget::*, TextFlow};
 live_design! {
     ButtonBase = {{Button}} {}
 }
@@ -116,15 +116,22 @@ impl Widget for Button {
         }
     }
 
-    fn draw_walk(&mut self, cx: &mut Cx2d, _scope: &mut Scope, walk: Walk) -> DrawStep {
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         if !self.visible {
             return DrawStep::done();
         }
 
         self.draw_bg.begin(cx, walk, self.layout);
         self.draw_icon.draw_walk(cx, self.icon_walk);
-        self.draw_text
-            .draw_walk(cx, self.label_walk, Align::default(), self.text.as_ref());
+
+        if let Some(text_flow) = scope.data.get_mut::<TextFlow>() {
+            // Here: the text flow has already began drawing, so we just need to draw the text.
+            text_flow.draw_text(cx, self.text.as_ref());
+        } else {
+            self.draw_text
+                .draw_walk(cx, self.label_walk, Align::default(), self.text.as_ref());
+        }
+
         self.draw_bg.end(cx);
         DrawStep::done()
     }


### PR DESCRIPTION
WIP, not yet completed. Still needs to handle multiple disjoint areas in the Button widget to support wrapping.