### PR TITLE
Support setting font/underline/strikethrough color of HtmlLink via underlying TextFlow

### DIFF
--- a/experiments/html_experiment/src/app.rs
+++ b/experiments/html_experiment/src/app.rs
@@ -123,9 +123,9 @@ live_design!{
                     draw_block:{ 
                         line_color: (MESSAGE_TEXT_COLOR)
                         sep_color: (MESSAGE_TEXT_COLOR)
+                        code_color: (#3)
                         quote_bg_color: (#4)
                         quote_fg_color: (#7)
-                        block_color: (#3)
                     }
                     list_item_layout: { line_spacing: 5.0, padding: {top: 1.0, bottom: 1.0}, }
 

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -429,7 +429,7 @@ struct HtmlLink {
     #[rust] drawn_areas: SmallVec<[Area; 2]>,
     #[live(true)] grab_key_focus: bool,
 
-    #[live] hover: f32,
+    #[live] hovered: f32,
     #[live] pressed: f32,
 
     /// The default font color for the link when not hovered on or pressed.
@@ -471,7 +471,16 @@ impl LiveHook for HtmlLink {
 impl Widget for HtmlLink {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         if self.animator_handle_event(cx, event).must_redraw() {
-            self.redraw(cx);
+            // Currently, this conditional will never be true because the `scope`
+            // isn't yet populated with the Html's TextFlow.
+            if let Some(tf) = scope.data.get_mut::<TextFlow>() {
+                tf.redraw(cx);
+            } else {
+                self.drawn_areas.iter().for_each(|area| area.redraw(cx));
+            }
+
+            // This won't work, as this widget owns no views, so redrawing it does nothing.
+            // self.redraw(cx);
         }
 
         for area in self.drawn_areas.clone().into_iter() {
@@ -522,10 +531,8 @@ impl Widget for HtmlLink {
         // Here: the text flow has already began drawing, so we just need to draw the text.
         tf.underline.push();
         tf.areas_tracker.push_tracker();
-        // TODO: how to handle colors for links? there are many DrawText instances
-        //       that could be selected by TextFlow, but we don't know which one to set the color for...
         let mut pushed_color = false;
-        if self.hover > 0.0 {
+        if self.hovered > 0.0 {
             if let Some(color) = self.hover_color {
                 tf.font_colors.push(color);
                 pushed_color = true;

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -429,6 +429,15 @@ struct HtmlLink {
     #[rust] drawn_areas: SmallVec<[Area; 2]>,
     #[live(true)] grab_key_focus: bool,
 
+    /// The default font color for the link when not hovered on or pressed.
+    #[live] color: Vec4,
+    /// The font color used when the link is hovered on.
+    #[live] hover_color: Vec4,
+    /// The font color used when the link is pressed.
+    #[live] pressed_color: Vec4,
+    // TODO: should the following be #[calc]??
+    #[rust] calc_font_color: Vec4,
+
     #[live] pub text: ArcStringMut,
     #[live] pub url: String,
 }
@@ -464,6 +473,7 @@ impl Widget for HtmlLink {
             self.redraw(cx);
         }
 
+        let mut needs_redraw = false;
         for area in self.drawn_areas.clone().into_iter() {
             match event.hits(cx, area) {
                 Hit::FingerDown(_fe) => {
@@ -471,13 +481,19 @@ impl Widget for HtmlLink {
                         cx.set_key_focus(self.area());
                     }
                     self.animator_play(cx, id!(hover.pressed));
+                    self.calc_font_color = self.pressed_color;
+                    needs_redraw = true;
                 }
                 Hit::FingerHoverIn(_) => {
                     cx.set_cursor(MouseCursor::Hand);
                     self.animator_play(cx, id!(hover.on));
+                    self.calc_font_color = self.hover_color;
+                    needs_redraw = true;
                 }
                 Hit::FingerHoverOut(_) => {
                     self.animator_play(cx, id!(hover.off));
+                    self.calc_font_color = self.color;
+                    needs_redraw = true;
                 }
                 Hit::FingerUp(fe) => {
                     if fe.is_over {
@@ -492,15 +508,22 @@ impl Widget for HtmlLink {
 
                         if fe.device.has_hovers() {
                             self.animator_play(cx, id!(hover.on));
+                            self.calc_font_color = self.hover_color;
                         } else {
                             self.animator_play(cx, id!(hover.off));
+                            self.calc_font_color = self.color
                         }
                     } else {
                         self.animator_play(cx, id!(hover.off));
+                        self.calc_font_color = self.color;
                     }
+                    needs_redraw = true;
                 }
                 _ => (),
             }
+        }
+        if needs_redraw {
+            self.redraw(cx);
         }
     }
     
@@ -514,8 +537,11 @@ impl Widget for HtmlLink {
         tf.areas_tracker.push_tracker();
         // TODO: how to handle colors for links? there are many DrawText instances
         //       that could be selected by TextFlow, but we don't know which one to set the color for...
+        tf.font_colors.push(self.calc_font_color);
         tf.draw_text(cx, self.text.as_ref());
+        tf.font_colors.pop();
         tf.underline.pop();
+
         let (start, end) = tf.areas_tracker.pop_tracker();
 
         self.drawn_areas = SmallVec::from(

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -10,6 +10,7 @@ live_design!{
         // ok so we can use one drawtext
         // change to italic, change bold (SDF), strikethrough
         font_size: 8,
+        // font_color: (THEME_COLOR_TEXT_DEFAULT),
         flow: RightWrap,
     }
 }
@@ -68,11 +69,15 @@ pub struct TextFlow {
     
     #[live] draw_block: DrawFlowBlock,
     
+    /// The default font size used for all text if not otherwise specified.
     #[live] font_size: f64,
+    /// The default font color used for all text if not otherwise specified.
+    #[live] font_color: Vec4,
     #[walk] walk: Walk,
     
     #[rust] area_stack: SmallVec<[Area;4]>,
     #[rust] pub font_sizes: SmallVec<[f64;8]>,
+    #[rust] pub font_colors: SmallVec<[Vec4;8]>,
    // #[rust] pub font: SmallVec<[Font;2]>,
     #[rust] pub top_drop: SmallVec<[f64;4]>,
     #[rust] pub combine_spaces: SmallVec<[bool;4]>,
@@ -222,6 +227,7 @@ impl TextFlow{
         self.inline_code.clear();
         //self.font.clear();
         self.font_sizes.clear();
+        self.font_colors.clear();
         self.area_stack.clear();
         self.top_drop.clear();
         self.combine_spaces.clear();
@@ -240,7 +246,7 @@ impl TextFlow{
             self.font_size * scale
         );
     }
-    
+
     pub fn end(&mut self, cx: &mut Cx2d){
         // lets end the turtle with how far we walked
         cx.end_turtle_with_area(&mut self.area);
@@ -263,6 +269,8 @@ impl TextFlow{
         // alright we are going to push a block with a layout and a walk
         let fs = self.font_sizes.last().unwrap_or(&self.font_size);
         self.draw_normal.text_style.font_size = *fs;
+        let fc = self.font_colors.last().unwrap_or(&self.font_color);
+        self.draw_normal.color = *fc;
         let pad = self.draw_normal.get_font_size() * pad;
         cx.begin_turtle(self.list_item_walk, Layout{
             padding:Padding{
@@ -349,8 +357,10 @@ impl TextFlow{
             };
 
             let font_size = self.font_sizes.last().unwrap_or(&self.font_size);
+            let font_color = self.font_colors.last().unwrap_or(&self.font_color);
             dt.text_style.top_drop = *self.top_drop.last().unwrap_or(&1.2);
             dt.text_style.font_size = *font_size;
+            dt.color = *font_color;
             dt.ignore_newlines = *self.ignore_newlines.last().unwrap_or(&true);
             dt.combine_spaces = *self.combine_spaces.last().unwrap_or(&true);
             //if let Some(font) = self.font

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -391,6 +391,7 @@ impl TextFlow{
             }
             else if self.strikethrough.value() > 0{
                 let db = &mut self.draw_block;
+                db.line_color = *font_color;
                 db.block_type = FlowBlockType::Strikethrough;
                 dt.draw_walk_resumable_with(cx, text, |cx, rect|{
                     db.draw_abs(cx, rect);
@@ -399,6 +400,7 @@ impl TextFlow{
             }
             else if self.underline.value() > 0{
                 let db = &mut self.draw_block;
+                db.line_color = *font_color;
                 db.block_type = FlowBlockType::Underline;
                 dt.draw_walk_resumable_with(cx, text, |cx, rect|{
                     db.draw_abs(cx, rect);

--- a/widgets/src/theme_desktop_dark.rs
+++ b/widgets/src/theme_desktop_dark.rs
@@ -419,18 +419,17 @@ live_design! {
         hover_color: #x00EE00,
         pressed_color: #xEE0000,
         
-        instance hover: 0.0
-        instance pressed: 0.0
+        // instance hovered: 0.0
+        // instance pressed: 0.0
 
         animator: {
             hover = {
                 default: off,
                 off = {
                     redraw: true,
-                    from: {all: Forward {duration: 0.1}}
+                    from: {all: Forward {duration: 0.01}}
                     apply: {
-                        // TODO: how to influence the TextFlow's active draw_text's color?
-                        hover:   0.0,
+                        hovered: 0.0,
                         pressed: 0.0,
                     }
                 }
@@ -442,18 +441,16 @@ live_design! {
                         pressed: Forward {duration: 0.01}
                     }
                     apply: {
-                        // TODO: how to influence the TextFlow's active draw_text's color?
-                        hover:   [{time: 0.0, value: 1.0}],
+                        hovered: [{time: 0.0, value: 1.0}],
                         pressed: [{time: 0.0, value: 1.0}],
                     }
                 }
 
                 pressed = {
                     redraw: true,
-                    from: {all: Forward {duration: 0.2}}
+                    from: {all: Forward {duration: 0.01}}
                     apply: {
-                        // TODO: how to influence the TextFlow's active draw_text's color?
-                        hover:   [{time: 0.0, value: 1.0}],
+                        hovered: [{time: 0.0, value: 1.0}],
                         pressed: [{time: 0.0, value: 1.0}],
                     }
                 }

--- a/widgets/src/theme_desktop_dark.rs
+++ b/widgets/src/theme_desktop_dark.rs
@@ -417,7 +417,7 @@ live_design! {
 
         color: #x0000EE,
         hover_color: #x00EE00,
-        pressed_color: #1a0dab
+        pressed_color: #xEE0000,
         
         instance hover: 0.0
         instance pressed: 0.0
@@ -426,6 +426,7 @@ live_design! {
             hover = {
                 default: off,
                 off = {
+                    redraw: true,
                     from: {all: Forward {duration: 0.1}}
                     apply: {
                         // TODO: how to influence the TextFlow's active draw_text's color?
@@ -435,6 +436,7 @@ live_design! {
                 }
 
                 on = {
+                    redraw: true,
                     from: {
                         all: Forward {duration: 0.1}
                         pressed: Forward {duration: 0.01}
@@ -447,6 +449,7 @@ live_design! {
                 }
 
                 pressed = {
+                    redraw: true,
                     from: {all: Forward {duration: 0.2}}
                     apply: {
                         // TODO: how to influence the TextFlow's active draw_text's color?

--- a/widgets/src/theme_desktop_dark.rs
+++ b/widgets/src/theme_desktop_dark.rs
@@ -415,6 +415,13 @@ live_design! {
         width: Fit, height: Fit,
         align: {x: 0., y: 0.}
 
+        color: #x0000EE,
+        hover_color: #0969da,
+        pressed_color: #1a0dab
+        
+        instance hover: 0.0
+        instance pressed: 0.0
+
         animator: {
             hover = {
                 default: off,
@@ -422,6 +429,8 @@ live_design! {
                     from: {all: Forward {duration: 0.1}}
                     apply: {
                         // TODO: how to influence the TextFlow's active draw_text's color?
+                        // hover:   0.0,
+                        // pressed: 0.0,
                     }
                 }
 
@@ -432,6 +441,8 @@ live_design! {
                     }
                     apply: {
                         // TODO: how to influence the TextFlow's active draw_text's color?
+                        // hover:   [{time: 0.0, value: 1.0}],
+                        // pressed: [{time: 0.0, value: 1.0}],
                     }
                 }
 
@@ -439,6 +450,8 @@ live_design! {
                     from: {all: Forward {duration: 0.2}}
                     apply: {
                         // TODO: how to influence the TextFlow's active draw_text's color?
+                        // hover:   [{time: 0.0, value: 1.0}],
+                        // pressed: [{time: 0.0, value: 1.0}],
                     }
                 }
             }
@@ -454,6 +467,7 @@ live_design! {
 
         line_spacing: (THEME_FONT_LINE_SPACING),
         font_size: (THEME_FONT_SIZE_P),
+        font_color: (THEME_COLOR_TEXT_DEFAULT),
 
         draw_normal: {
             text_style: <THEME_FONT_REGULAR> {

--- a/widgets/src/theme_desktop_dark.rs
+++ b/widgets/src/theme_desktop_dark.rs
@@ -416,7 +416,7 @@ live_design! {
         align: {x: 0., y: 0.}
 
         color: #x0000EE,
-        hover_color: #0969da,
+        hover_color: #x00EE00,
         pressed_color: #1a0dab
         
         instance hover: 0.0
@@ -429,8 +429,8 @@ live_design! {
                     from: {all: Forward {duration: 0.1}}
                     apply: {
                         // TODO: how to influence the TextFlow's active draw_text's color?
-                        // hover:   0.0,
-                        // pressed: 0.0,
+                        hover:   0.0,
+                        pressed: 0.0,
                     }
                 }
 
@@ -441,8 +441,8 @@ live_design! {
                     }
                     apply: {
                         // TODO: how to influence the TextFlow's active draw_text's color?
-                        // hover:   [{time: 0.0, value: 1.0}],
-                        // pressed: [{time: 0.0, value: 1.0}],
+                        hover:   [{time: 0.0, value: 1.0}],
+                        pressed: [{time: 0.0, value: 1.0}],
                     }
                 }
 
@@ -450,8 +450,8 @@ live_design! {
                     from: {all: Forward {duration: 0.2}}
                     apply: {
                         // TODO: how to influence the TextFlow's active draw_text's color?
-                        // hover:   [{time: 0.0, value: 1.0}],
-                        // pressed: [{time: 0.0, value: 1.0}],
+                        hover:   [{time: 0.0, value: 1.0}],
+                        pressed: [{time: 0.0, value: 1.0}],
                     }
                 }
             }


### PR DESCRIPTION
not fully working, since i'm not doing it properly with the animator. But I cannot figure out how to make that syntax work since HtmlLink doesn't actually have a persistent TextFlow instance, so we cannot set the TextFlow's various `DrawText`s' states in the animator.