### PR TITLE
Fix numbered lists rendering in Markdown

### DIFF
--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -274,8 +274,18 @@ impl TextFlow{
         // lets draw the 'marker' at -x 
         // lets get the turtle position and abs draw 
         
-        let pos = cx.turtle().pos() - dvec2(pad,0.0);
-        
+        let marker_len = dot.chars().count();
+        let pos = match marker_len {
+            1 => {
+                cx.turtle().pos() - dvec2(pad, 0.0)
+            },
+            _ => {
+                // This calculation takes into account when numbers have more than one digit
+                // making sure they are properly aligned.
+                let pad = pad + self.draw_normal.get_font_size() * (marker_len - 2) as f64;
+                cx.turtle().pos() - dvec2(pad, 0.0)
+            }
+        };
         self.draw_normal.draw_abs(cx, pos, dot);
         
         self.area_stack.push(self.draw_block.draw_vars.area);


### PR DESCRIPTION
This PR fixes an alignment problem rendering numbered lists in the Markdown widget. The problem happens with numbers greater than 9 (more than one digit) 

<img width="476" alt="Screenshot 2024-09-13 at 10 32 33 AM" src="https://github.com/user-attachments/assets/05792af5-827e-4f65-bd53-c7dfe3115deb">

Here is the result for a similar content

<img width="600" alt="image" src="https://github.com/user-attachments/assets/6dc11f69-2850-4642-b04d-fb3950ca1c61">

