### PR TITLE
Fix issue in markdown parsing of multiline block code

### DIFF
--- a/libs/markdown/src/lib.rs
+++ b/libs/markdown/src/lib.rs
@@ -32,7 +32,7 @@ pub enum MarkdownNode{
     BeginCode,
     EndCode,
     BeginInlineCode,
-    NewLine,
+    NewLine{paragraph:bool},
     EndInlineCode,
     BeginBold,
     BeginItalic,
@@ -148,7 +148,7 @@ pub fn parse_markdown(body:&str)->MarkdownDoc{
             nodes.push(MarkdownNode::BeginCode);
         }
         else{
-            nodes.push(MarkdownNode::NewLine);
+            nodes.push(MarkdownNode::NewLine{paragraph: false});
         }
         nodes.push(MarkdownNode::Text{start, end:decoded.len()});
         nodes.push(MarkdownNode::EndCode);
@@ -158,7 +158,7 @@ pub fn parse_markdown(body:&str)->MarkdownDoc{
         match &mut state{
             State::Inline{kind, bold, italic, underline}=> match cursor.chars{
                 [' ',' ','\n']=>{
-                    nodes.push(MarkdownNode::NewLine);
+                    nodes.push(MarkdownNode::NewLine{paragraph: true});
                     cursor.skip(2);
                 }
                 ['\n',_,_] | ['\0',_,_]=>{
@@ -560,7 +560,7 @@ pub fn parse_markdown(body:&str)->MarkdownDoc{
                     let start = decoded.len();
                     while cursor.chars != ['`','`','`'] && !cursor.at_end(){
                         if cursor.chars[0] == '\n' && start != decoded.len(){
-                            nodes.push(MarkdownNode::NewLine);
+                            nodes.push(MarkdownNode::NewLine{paragraph: false});
                         }
                         else{
                             push_char(&mut nodes, &mut decoded, cursor.chars[0]);
@@ -571,7 +571,7 @@ pub fn parse_markdown(body:&str)->MarkdownDoc{
                         cursor.skip(3);
                     }
                     // remove last newline
-                    if let Some(MarkdownNode::NewLine) = nodes.last(){
+                    if let Some(MarkdownNode::NewLine{..}) = nodes.last(){
                         nodes.pop();
                     }
                     nodes.push(MarkdownNode::EndCode);
@@ -610,9 +610,9 @@ pub fn parse_markdown(body:&str)->MarkdownDoc{
                             _=>panic!()
                         }});
                         
-                        state = State::Inline{kind:Kind::List(depth), bold:0, italic:0, underline:0}
+                        state = State::Inline{kind:Kind::List(depth), bold:0, italic:0, underline:0};
+                        cursor.skip(2);
                     }
-                    cursor.skip(2);
                     //push_optional_char(&mut nodes, &mut decoded, ' ');
                 }
                 ['\n',_,_]=>{ // skip it

--- a/widgets/src/markdown.rs
+++ b/widgets/src/markdown.rs
@@ -55,8 +55,11 @@ impl Widget for Markdown {
                     tf.font_sizes.pop();
                     cx.turtle_new_line();
                 },
-                MarkdownNode::NewLine=>{
+                MarkdownNode::NewLine{paragraph: true}=>{
                     cx.turtle_new_line_with_spacing(self.paragraph_spacing);
+                },
+                MarkdownNode::NewLine{paragraph: false}=>{
+                    cx.turtle_new_line();
                 },
                 MarkdownNode::BeginNormal=>{
                     cx.turtle_new_line_with_spacing(self.paragraph_spacing);


### PR DESCRIPTION
Fixes an issue with multiline block code (when block code is determined by 4 whitespaces). See the screenshots.

Also, it returns a boolean in `NewLine` to distinguish between newlines outside a block from internal ones.

Before
<img width="944" alt="image" src="https://github.com/user-attachments/assets/809936b0-4c97-4280-a7e3-098e2d038cfc">

After
![Screenshot 2024-09-13 at 5 32 53 PM](https://github.com/user-attachments/assets/4950f09a-618b-42f7-9bf1-34bb85c05997)
