### PR TITLE
Add new smooth_scroll_to() method to portal list

### DIFF
--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -672,7 +672,6 @@ impl Widget for PortalList {
         match &mut self.scroll_state {
             ScrollState::ScrollingTo {target_id, delta, next_frame} => {
                 if let Some(_) = next_frame.is_event(event) {
-
 		    let target_reached_or_passed = (*target_id as isize - self.first_id as isize).signum() == delta.signum() as isize;
 
                     if !target_reached_or_passed {

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -1,3 +1,4 @@
+
 use crate::{
     widget::*,
     makepad_derive_widget::*,
@@ -634,6 +635,7 @@ impl PortalList {
 
 
 impl Widget for PortalList {
+
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         let uid = self.widget_uid();
         

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -675,24 +675,22 @@ impl Widget for PortalList {
                     let target_id = *target_id;
 
                     let distance_to_target = target_id as isize - self.first_id as isize;
-
                     let target_passed = distance_to_target.signum() == delta.signum() as isize;
-                    let target_reached = distance_to_target.signum() == 0;
+                    // check to see if we passed the target and fix it. this may happen if the delta is too high,
+                    // so we can just correct the first id, since the animation isn't being smooth anyways.
+                    if target_passed {
+                        self.first_id = target_id;
+                    }
 
-                    if !target_reached || !target_passed {
+                    let distance_to_target = target_id as isize - self.first_id as isize;
+                    let target_reached = distance_to_target == 0;
+
+                    if !target_reached {
                         *next_frame = cx.new_next_frame();
                         let delta = *delta;
 
-                        
                         self.delta_top_scroll(cx, delta, true);
                         cx.widget_action(uid, &scope.path, PortalListAction::Scroll);
-
-                        // check to see if we passed the target and fix it. this may happen if the delta is too high,
-                        // so we can just correct the first id, since the animation isn't being smooth anyways.
-                        if target_passed {
-                            self.first_id = target_id;
-                            self.scroll_state = ScrollState::Stopped;
-                        }
 
                         self.area.redraw(cx);
                     } else {


### PR DESCRIPTION
Implements a public method for the portal list that allows to scroll smoothly to a given target.
Also adds a new action and helper methods to be able to keep track of the smooth scrolling from the outside.