### PR TITLE
Support querying the NSBundle resource path for any Apple bundle

### DIFF
--- a/platform/build.rs
+++ b/platform/build.rs
@@ -12,7 +12,7 @@ fn main() {
     file.write_all(&format!("{}", cwd.display()).as_bytes()).unwrap();
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target = env::var("TARGET").unwrap();
-    println!("cargo:rustc-check-cfg=cfg(apple_sim,lines,linux_direct,no_android_choreographer,use_unstable_unix_socket_ancillary_data_2021)");
+    println!("cargo:rustc-check-cfg=cfg(apple_bundle,apple_sim,lines,linux_direct,no_android_choreographer,use_unstable_unix_socket_ancillary_data_2021)");
     println!("cargo:rerun-if-env-changed=MAKEPAD");
     println!("cargo:rerun-if-env-changed=MAKEPAD_PACKAGE_DIR");
     if let Ok(configs) = env::var("MAKEPAD"){
@@ -21,6 +21,7 @@ fn main() {
                 "lines"=>println!("cargo:rustc-cfg=lines"), 
                 "linux_direct"=>println!("cargo:rustc-cfg=linux_direct"), 
                 "no_android_choreographer"=>println!("cargo:rustc-cfg=no_android_choreographer"), 
+                "apple_bundle"=>println!("cargo:rustc-cfg=apple_bundle"), 
                 _=>{}
             }
         }
@@ -49,12 +50,14 @@ fn main() {
         "ios"=>{
             if target == "aarch64-apple-ios-sim"{
                 println!("cargo:rustc-cfg=apple_sim"); 
+                println!("cargo:rustc-cfg=apple_bundle"); 
             }
             println!("cargo:rustc-link-lib=framework=MetalKit");
         }
         "tvos"=>{
             if target == "aarch64-apple-tvos-sim"{
                 println!("cargo:rustc-cfg=apple_sim"); 
+                println!("cargo:rustc-cfg=apple_bundle"); 
             }
             println!("cargo:rustc-link-lib=framework=MetalKit");
         }

--- a/platform/src/os/apple/apple_resources.rs
+++ b/platform/src/os/apple/apple_resources.rs
@@ -1,0 +1,42 @@
+use {
+    std::{
+        rc::Rc,
+        io::prelude::*,
+        fs::File,
+    },
+    crate::{
+        os::{
+            apple::apple_sys::*,
+            apple::apple_util::nsstring_to_string,
+        },
+        cx::Cx,
+    }
+};
+
+impl Cx {
+    /// Loads resources as dependencies from the NSBundle's resource path.
+    ///
+    /// This is used for any Apple app bundle on iOS, macOS, or tvOS.
+    pub(crate) fn apple_bundle_load_dependencies(&mut self) {
+        let bundle_path = unsafe{
+            let main:ObjcId = msg_send![class!(NSBundle), mainBundle];
+            let path:ObjcId = msg_send![main, resourcePath];
+            nsstring_to_string(path)
+        };
+
+        for (path,dep) in &mut self.dependencies{
+            if let Ok(mut file_handle) = File::open(format!("{}/{}",bundle_path,path)) {
+                let mut buffer = Vec::<u8>::new();
+                if file_handle.read_to_end(&mut buffer).is_ok() {
+                    dep.data = Some(Ok(Rc::new(buffer)));
+                }
+                else{
+                    dep.data = Some(Err("read_to_end failed".to_string()));
+                }
+            }
+            else{
+                dep.data = Some(Err("File open failed".to_string()));
+            }
+        }
+    }
+}

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -583,6 +583,10 @@ impl CxOsApi for Cx {
             self.start_disk_live_file_watcher(100);
         }
         self.live_scan_dependencies();
+
+        #[cfg(apple_bundle)]
+        self.apple_bundle_load_dependencies();
+        #[cfg(not(apple_bundle))]
         self.native_load_dependencies();
     }
     

--- a/platform/src/os/apple/mod.rs
+++ b/platform/src/os/apple/mod.rs
@@ -15,6 +15,9 @@ pub mod tvos;
 #[cfg(target_os = "macos")]
 pub mod metal_xpc;
 
+#[cfg(apple_bundle)]
+mod apple_resources;
+
 pub mod url_session;
 pub mod apple_classes;
 pub mod audio_unit;
@@ -31,4 +34,3 @@ pub(crate) use self::tvos::*;
 
 pub(crate) use self::core_midi::{OsMidiInput, OsMidiOutput};
 pub(crate) use self::url_session::{OsWebSocket};
-

--- a/platform/src/os/apple/tvos/tvos.rs
+++ b/platform/src/os/apple/tvos/tvos.rs
@@ -103,31 +103,6 @@ impl Cx {
         }
     }
     
-    #[allow(dead_code)]
-    pub (crate) fn tvos_load_dependencies(&mut self){
-        
-        let bundle_path = unsafe{
-            let main:ObjcId = msg_send![class!(NSBundle), mainBundle];
-            let path:ObjcId = msg_send![main, resourcePath];
-            nsstring_to_string(path)
-        };
-        
-        for (path,dep) in &mut self.dependencies{
-            if let Ok(mut file_handle) = File::open(format!("{}/{}",bundle_path,path)) {
-                let mut buffer = Vec::<u8>::new();
-                if file_handle.read_to_end(&mut buffer).is_ok() {
-                    dep.data = Some(Ok(Rc::new(buffer)));
-                }
-                else{
-                    dep.data = Some(Err("read_to_end failed".to_string()));
-                }
-            }
-            else{
-                dep.data = Some(Err("File open failed".to_string()));
-            }
-        }
-    }
-    
     fn tvos_event_callback(
         &mut self,
         event:TvosEvent,
@@ -302,12 +277,11 @@ impl CxOsApi for Cx {
         self.start_disk_live_file_watcher(50);
         
         self.live_scan_dependencies();
-        //#[cfg(target_feature="sim")]
-        #[cfg(apple_sim)]
+
+        #[cfg(apple_bundle)]
+        self.apple_bundle_load_dependencies();
+        #[cfg(not(apple_bundle))]
         self.native_load_dependencies();
-        
-        #[cfg(not(apple_sim))]
-        self.tvos_load_dependencies();
     }
     
     fn spawn_thread<F>(&mut self, f: F) where F: FnOnce() + Send + 'static {

--- a/platform/src/os/cx_shared.rs
+++ b/platform/src/os/cx_shared.rs
@@ -170,6 +170,7 @@ impl Cx {
             self.inner_key_focus_change();
             if counter > 100 {
                 crate::error!("Action feedback loop detected");
+                crate::error!("New actions {:#?}", self.new_actions);
                 break
             }
         }


### PR DESCRIPTION
This adds a new cfg feature called "apple_bundle", which you can enable by setting the `MAKEPAD` env var:
```sh
MAKEPAD=apple_bundle cargo build -p your-app
```

This is also used when packaging up Makepad apps into macOS `.app` bundles and `.dmg` disk images, as an app binary in a bundle cannot possibly know where its `Resources/` folder is located without using the official Apple NSBundle APIs.

`makepad-platform` also now uses the same functions for this across macOS, tvOS, and iOS, instead of having separate functions for each.