### PR TITLE
Extend Choreographer support to Android SDK < 33

### DIFF
--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -1,7 +1,9 @@
 use makepad_jni_sys as jni_sys;
+use crate::module_loader::ModuleLoader;
+
 use {
     std::sync::Mutex,
-    std::{cell::{Cell}, ffi::CString, sync::mpsc::{self, Sender}},
+    std::{cell::Cell, ffi::CString, sync::mpsc::{self, Sender}},
     self::super::{
         ndk_sys,
         ndk_utils,
@@ -160,6 +162,9 @@ unsafe fn create_native_window(surface: jni_sys::jobject) -> *mut ndk_sys::ANati
 #[cfg(not(no_android_choreographer))]
 static mut CHOREOGRAPHER: *mut ndk_sys::AChoreographer = std::ptr::null_mut();
 
+#[cfg(not(no_android_choreographer))]
+static mut CHOREOGRAPHER_POST_CALLBACK_FN: Option<unsafe extern "C" fn(*mut ndk_sys::AChoreographer, Option<unsafe extern "C" fn(*mut ndk_sys::AChoreographerFrameCallbackData, *mut std::ffi::c_void)>, *mut std::ffi::c_void) -> i32> = None;
+
 /// Initializes the render loop which used the Android Choreographer when available to ensure proper vsync.
 /// If `no_android_choreographer` is present (e.g. OHOS with non-compatiblity), we fallback to a simple loop with frame pacing.
 /// This will be replaced by proper a vsync mechanism once we firgure it out for that OHOS.
@@ -169,39 +174,28 @@ pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_initChoreographe
     _: *mut jni_sys::JNIEnv,
     _: jni_sys::jclass,
     device_refresh_rate: jni_sys::jfloat,
+    sdk_version: jni_sys::jint,
 ) {
     // If the Choreographer is not available (e.g. OHOS), use a manual render loop
     #[cfg(no_android_choreographer)]
     {
-        std::thread::spawn(move || {
-            let mut last_frame_time = std::time::Instant::now();
-            let target_frame_time = std::time::Duration::from_secs_f32(1.0 / device_refresh_rate);
-            loop {
-                let now = std::time::Instant::now();
-                let elapsed = now - last_frame_time;
-                
-                if elapsed >= target_frame_time {
-                    let frame_start = std::time::Instant::now();
-                    send_from_java_message(FromJavaMessage::RenderLoop);
-                    let frame_duration = frame_start.elapsed();
-                    
-                    // Adaptive sleep: sleep less if the last frame took longer to process
-                    if frame_duration < target_frame_time {
-                        std::thread::sleep(target_frame_time - frame_duration);
-                    }
-                    
-                    last_frame_time = now;
-                } else {
-                    std::thread::sleep(target_frame_time - elapsed);
-                }
-            }
-        });
+        init_simple_render_loop(device_refresh_rate);
         return;
     }
+    #[allow(unused)]
     #[cfg(not(no_android_choreographer))]
     {
         // Otherwise use the actual Choreographer
         CHOREOGRAPHER = ndk_sys::AChoreographer_getInstance();
+        if sdk_version >= 33 {
+            let lib = ModuleLoader::load("libandroid.so").expect("Failed to load libandroid.so");
+            let func: Option<ndk_sys::AChoreographerPostCallbackFn> = lib.get_symbol("AChoreographer_postVsyncCallback").ok();
+            CHOREOGRAPHER_POST_CALLBACK_FN = func;
+        } else if sdk_version >= 29 {
+            CHOREOGRAPHER_POST_CALLBACK_FN = Some(ndk_sys::AChoreographer_postFrameCallback64 as _);
+        } else {
+            init_simple_render_loop(device_refresh_rate);
+        }
         post_vsync_callback();
     }
 }
@@ -217,13 +211,41 @@ unsafe extern "C" fn vsync_callback(
 
 #[cfg(not(no_android_choreographer))]
 pub unsafe fn post_vsync_callback() {
-    if !CHOREOGRAPHER.is_null() {
-        ndk_sys::AChoreographer_postVsyncCallback(
-            CHOREOGRAPHER,
-            Some(vsync_callback),
-            std::ptr::null_mut(),
-        );
+    if let Some(post_callback) = CHOREOGRAPHER_POST_CALLBACK_FN {
+        if !CHOREOGRAPHER.is_null() {
+            post_callback(
+                CHOREOGRAPHER,
+                Some(vsync_callback),
+                std::ptr::null_mut(),
+            );
+        }
     }
+}
+
+fn init_simple_render_loop(device_refresh_rate: f32) {
+    std::thread::spawn(move || {
+        let mut last_frame_time = std::time::Instant::now();
+        let target_frame_time = std::time::Duration::from_secs_f32(1.0 / device_refresh_rate);
+        loop {
+            let now = std::time::Instant::now();
+            let elapsed = now - last_frame_time;
+            
+            if elapsed >= target_frame_time {
+                let frame_start = std::time::Instant::now();
+                send_from_java_message(FromJavaMessage::RenderLoop);
+                let frame_duration = frame_start.elapsed();
+                
+                // Adaptive sleep: sleep less if the last frame took longer to process
+                if frame_duration < target_frame_time {
+                    std::thread::sleep(target_frame_time - frame_duration);
+                }
+                
+                last_frame_time = now;
+            } else {
+                std::thread::sleep(target_frame_time - elapsed);
+            }
+        }
+    });
 }
 
 #[no_mangle]

--- a/platform/src/os/linux/android/ndk_sys.rs
+++ b/platform/src/os/linux/android/ndk_sys.rs
@@ -61,10 +61,25 @@ pub type AChoreographer_vsyncCallback = unsafe extern "C" fn(
     data: *mut c_void,
 );
 
+/// The function type for posting callbacks to the AChoreographer
+pub type AChoreographerPostCallbackFn = unsafe extern "C" fn(
+    *mut AChoreographer,
+    Option<unsafe extern "C" fn(*mut AChoreographerFrameCallbackData, *mut std::ffi::c_void)>,
+    *mut std::ffi::c_void,
+) -> i32;
+
 #[cfg(not(no_android_choreographer))]
 extern "C" {
     pub fn AChoreographer_getInstance() -> *mut AChoreographer;
+    // Android SDK >= 33
     pub fn AChoreographer_postVsyncCallback(
+        choreographer: *mut AChoreographer,
+        callback: Option<AChoreographer_vsyncCallback>,
+        data: *mut c_void,
+    ) -> i32;
+
+    // Android SDK < 33 && >= 29
+    pub fn AChoreographer_postFrameCallback64(
         choreographer: *mut AChoreographer,
         callback: Option<AChoreographer_vsyncCallback>,
         data: *mut c_void,

--- a/platform/src/os/linux/mod.rs
+++ b/platform/src/os/linux/mod.rs
@@ -11,6 +11,7 @@ pub mod egl_sys;
 pub mod gl_sys;
 pub mod libc_sys;
 pub mod opengl;
+pub mod module_loader;
 
 #[cfg(not(any(target_env="ohos", target_os="android")))]
 pub mod dma_buf;

--- a/platform/src/os/linux/module_loader.rs
+++ b/platform/src/os/linux/module_loader.rs
@@ -1,0 +1,41 @@
+use self::super::libc_sys::{dlclose, dlopen, dlsym, RTLD_LAZY, RTLD_LOCAL};
+use std::{ffi::CString, ptr::NonNull};
+
+/// A module loader for loading shared libraries.
+pub struct ModuleLoader(::std::ptr::NonNull<::std::os::raw::c_void>);
+
+impl ModuleLoader {
+    /// Load a shared library by its path.
+    pub fn load(path: &str) -> Result<Self, ()> {
+        let path = CString::new(path).unwrap();
+
+        // Open the shared library with lazy loading and local visibility.
+        let module = unsafe { dlopen(path.as_ptr(), RTLD_LAZY | RTLD_LOCAL) };
+        if module.is_null() {
+            Err(())
+        } else {
+            Ok(ModuleLoader(unsafe { NonNull::new_unchecked(module) }))
+        }
+    }
+
+    /// Get a symbol from the loaded module.
+    pub fn get_symbol<F: Sized>(&self, name: &str) -> Result<F, ()> {
+        let name = CString::new(name).unwrap();
+
+        let symbol = unsafe { dlsym(self.0.as_ptr(), name.as_ptr()) };
+
+        if symbol.is_null() {
+            return Err(());
+        }
+
+        // Transmute the symbol to the desired type.
+        Ok(unsafe { std::mem::transmute_copy::<_, F>(&symbol) })
+    }
+}
+
+impl Drop for ModuleLoader {
+    fn drop(&mut self) {
+        // When the module loader is dropped, close the shared library.
+        unsafe { dlclose(self.0.as_ptr()) };
+    }
+}

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -290,6 +290,7 @@ MidiManager.OnDeviceOpenedListener{
         String androidVersion = Build.VERSION.RELEASE;
         String buildNumber = Build.DISPLAY;
         String kernelVersion = this.getKernelVersion();
+        int sdkVersion = Build.VERSION.SDK_INT;
 
         MakepadNative.onAndroidParams(cache_path, density, isEmulator, androidVersion, buildNumber, kernelVersion);
 
@@ -297,7 +298,7 @@ MidiManager.OnDeviceOpenedListener{
         setVolumeControlStream(AudioManager.STREAM_MUSIC);
 
         float refreshRate = getDeviceRefreshRate();
-        MakepadNative.initChoreographer(refreshRate);
+        MakepadNative.initChoreographer(refreshRate, sdkVersion);
         //% MAIN_ACTIVITY_ON_CREATE
     }
 

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
@@ -17,7 +17,7 @@ public class MakepadNative {
     public static native void onAndroidParams(String cache_path, float dentify, boolean isEmulator, String androidVersion, String buildNumber,
         String kernelVersion);
 
-    public native static void initChoreographer(float deviceRefreshRate);
+    public native static void initChoreographer(float deviceRefreshRate, int sdkVersion);
 
     public native static void onBackPressed();
 


### PR DESCRIPTION
Adds fallback to earlier Choreographer methods on Android SDK < 33 (and > 29).
Also programatically fetching the `AChoreographer_postVsyncCallback` symbol to avoid crashes on lower SDKs.

Tested on physical and emulated SDK 34, and emulated SDK 32, 31 and 30.