### PR TITLE
Explicitly position windows on linux

### DIFF
--- a/platform/src/os/linux/x11/x11_sys.rs
+++ b/platform/src/os/linux/x11/x11_sys.rs
@@ -357,6 +357,13 @@ extern "C" {
     ) -> c_int;
     
     pub fn XMapWindow(arg1: *mut Display, arg2: Window) -> c_int;
+
+    pub fn XMoveWindow(
+        display: *mut Display,
+        window: Window,
+        x: c_int,
+        y: c_int,
+    );
     
     pub fn XFlush(arg1: *mut Display) -> c_int;
     

--- a/platform/src/os/linux/x11/xlib_window.rs
+++ b/platform/src/os/linux/x11/xlib_window.rs
@@ -177,6 +177,14 @@ impl XlibWindow {
             // Map the window to the screen
             x11_sys::XMapWindow(display, window);
             x11_sys::XFlush(display);
+
+            // Explicitly set the window position after mapping
+            // This is necessary because some window managers might ignore the initial position
+            // and override it with their own heuristics.
+            if let Some(pos) = position {
+                x11_sys::XMoveWindow(display, window, pos.x as i32, pos.y as i32);
+                x11_sys::XFlush(display);
+            }
             
             let xic = x11_sys::XCreateIC(
                 get_xlib_app_global().xim,


### PR DESCRIPTION
Fixes https://github.com/makepad/makepad/issues/560

The problem seems to be that some window managers ignore the initial position in `XCreateWindow` and position the window based on their own Heuristics. To make the position in the DSL work, these changes re-position the window right after mapping.

I think more generally we might want to do this only if there is a window position set by the user, otherwise instead of hardcoding a position just let the window manager set a default / decide positioning.