### PR TITLE
[Proposal] UiRunner integration

### DIFF
--- a/platform/src/app_main.rs
+++ b/platform/src/app_main.rs
@@ -1,9 +1,14 @@
 
 use crate::event::Event;
 use crate::cx::Cx;
+use crate::ui_runner::UiRunner;
 
 pub trait AppMain{
     fn handle_event(&mut self, cx: &mut Cx, event: &Event);
+    fn ui_runner(&self) -> UiRunner<Self> where Self: Sized + 'static {
+        // This assumes there is only one `AppMain`, and that `0` is reserved for it.
+        UiRunner::new(0)
+    }
 }
 
 #[macro_export]

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -53,6 +53,8 @@ pub mod file_dialogs;
 
 mod media_api;
 
+pub mod ui_runner;
+
 #[macro_use]
 mod app_main;
 
@@ -276,7 +278,8 @@ pub use {
             GeometryRef,
             Geometry,
         },
-        gpu_info::GpuPerformance,       
+        gpu_info::GpuPerformance,     
+        ui_runner::*,  
     },
 };
 

--- a/platform/src/ui_runner.rs
+++ b/platform/src/ui_runner.rs
@@ -1,0 +1,109 @@
+use crate::*;
+use std::sync::Mutex;
+use std::marker::PhantomData;
+
+/// Run code on the UI thread from another thread.
+///
+/// Allows you to mix non-blocking threaded code, with code that reads and updates
+/// your widget in the UI thread.
+/// 
+/// This can be copied and passed around.
+pub struct UiRunner<T> {
+    /// Trick to later distinguish actions sent globally thru `Cx::post_action`.
+    key: usize,
+    /// Enforce a consistent `target` type across `handle` and `defer`.
+    /// 
+    /// `fn() -> W` is used instead of `W` because, in summary, these:
+    /// - https://stackoverflow.com/a/50201389
+    /// - https://doc.rust-lang.org/nomicon/phantom-data.html#table-of-phantomdata-patterns
+    /// - https://doc.rust-lang.org/std/marker/struct.PhantomData.html
+    target: PhantomData<fn() -> T>
+}
+
+impl<T> Copy for UiRunner<T> {}
+
+impl<T> Clone for UiRunner<T> {
+    fn clone(&self) -> Self {
+        Self { key: self.key, target: PhantomData }
+    }
+}
+
+impl<T> std::fmt::Debug for UiRunner<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UiRunner")
+            .field("key", &self.key)
+            .finish()
+    }
+}
+impl<T> PartialEq for UiRunner<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
+}
+
+impl<T: 'static> UiRunner<T> {
+    /// Create a new `UiRunner` that dispatches functions as global actions but
+    /// differentiates them by the provided `key`.
+    /// 
+    /// If used in a widget, prefer using `your_widget.ui_runner()`.
+    /// If used in your app main, prefer using `your_app_main.ui_runner()`.
+    pub fn new(key: usize) -> Self {
+        Self { key, target: PhantomData }
+    }
+
+    /// Handle all functions scheduled with the `key` of this `UiRunner`.
+    ///
+    /// You should call this once from your `handle_event` method, like:
+    ///
+    /// ```rust
+    /// fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+    ///    // ... handle other stuff ...
+    ///    self.ui_runner().handle(cx, event, scope, self);
+    /// }
+    /// ```
+    ///
+    /// Once a function has been handled, it will never run again.
+    pub fn handle(self, cx: &mut Cx, event: &Event, scope: &mut Scope, target: &mut T) {
+        if let Event::Actions(actions) = event {
+            for action in actions {
+                if let Some(action) = action.downcast_ref::<UiRunnerAction<T>>() {
+                    if action.key != self.key {
+                        continue;
+                    }
+
+                    if let Some(f) = action.f.lock().unwrap().take() {
+                        (f)(target, cx, scope);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Schedule the provided closure to run on the UI thread.
+    pub fn defer(self, f: impl DeferCallback<T>) {
+        let action = UiRunnerAction {
+            f: Mutex::new(Some(Box::new(f))),
+            key: self.key,
+        };
+
+        Cx::post_action(action);
+    }
+}
+
+/// Private message that is sent to the ui thread with the closure to run.
+struct UiRunnerAction<T> {
+    f: Mutex<Option<Box<dyn DeferCallback<T>>>>,
+    key: usize,
+}
+
+impl<T> std::fmt::Debug for UiRunnerAction<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UiRunnerAction")
+            .field("key", &self.key)
+            .field("f", &"...")
+            .finish()
+    }
+}
+
+pub trait DeferCallback<T>: FnOnce(&mut T, &mut Cx, &mut Scope) + Send + 'static {}
+impl<T, F: FnOnce(&mut T, &mut Cx, &mut Scope) + Send + 'static> DeferCallback<T> for F {}

--- a/widgets/src/defer_with_redraw.rs
+++ b/widgets/src/defer_with_redraw.rs
@@ -1,0 +1,18 @@
+use makepad_draw::ui_runner::{UiRunner, DeferCallback};
+use crate::Widget;
+
+
+/// Extension only aviailable when the `UiRunner` is used with a `Widget`.
+pub trait DeferWithRedraw<T: 'static> {
+    /// Same as `defer` but calls `redraw` on the widget after the closure is run.
+    fn defer_with_redraw(self, f: impl DeferCallback<T>);
+}
+
+impl<W: Widget + 'static> DeferWithRedraw<W> for UiRunner<W> {
+    fn defer_with_redraw(self, f: impl DeferCallback<W>) {
+        self.defer(|widget, cx, scope| {
+            f(widget, cx, scope);
+            widget.redraw(cx);
+        });
+    }
+}

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -84,6 +84,8 @@ pub mod designer_outline;
 pub mod designer_data;
 pub mod designer_toolbox;
 
+pub mod defer_with_redraw;
+
 pub use crate::{
     data_binding::{DataBindingStore, DataBindingMap},
     button::*,
@@ -123,6 +125,7 @@ pub use crate::{
     slides_view::{SlidesView},
     widget_match_event::WidgetMatchEvent,
     toggle_panel::*,
+    defer_with_redraw::*,
     widget::{
         WidgetSet,
         WidgetUid,

--- a/widgets/src/widget.rs
+++ b/widgets/src/widget.rs
@@ -138,6 +138,10 @@ pub trait Widget: WidgetNode {
     {
         LiveType::of::<Self>()
     }
+
+    fn ui_runner(&self) -> UiRunner<Self> where Self: Sized + 'static {
+        UiRunner::new(self.widget_uid().0 as usize)
+    }
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
# Description

Provides an abstraction to run code in the UI thread from other running threads, and provides some basic helpers for widgets and app main.

# Examples

- [From a widget](https://github.com/noxware/makepad/blob/ui_runner_widget/examples/hello_widgets/src/ui.rs)
- [From app main](https://github.com/noxware/makepad/blob/ui_runner_app_main/examples/hello_widgets/src/app.rs)
- [block_on example](https://github.com/noxware/makepad/blob/ui_runner_block_on/examples/hello_widgets/src/ui.rs) (able to communicate a value back)
- [async example](https://github.com/noxware/makepad/blob/ui_runner_async/examples/hello_widgets/src/ui.rs) (PokeAPI + Tokio)

In summary, you can do:

```rust
let ui = self.ui_runner();
std::thread::spawn(move || {
  // ... do blocking stuff ...
  ui.defer(|me, cx, scope| {
    // ... update your widget or app main ...
  });
  // ... continue doing blocking stuff ...
});
```

```rust
// ... handle other events ...
self.ui_runner().handle(cx, event, scope, self);
```

# Details
- `UiRunner` is added to the platform module cause it's implementation is not dependent on widgets.
- The only thing that depends on widgets is the `defer_with_redraw` method, which is added as an extension trait on the widgets module, and is automatically implemented for all `UiRunner<W>` where `W` is a `Widget`.
- The `ui_runner()` method has been added to widget to automatically get a `UiRunner` using the widget uid as key.
- The `ui_runner()` method has been added to app main to mirror the widget helper.
  - I would personally not use this in app main as I normally keep as much as I can in the widgets dimension, but that's a personal preference and in apps like Moly the app main hold the store, which is something you could possibly want to access from other threads. That's why I generalized the base implementation and added this method.
  