### PR TITLE
Ignore makepad_state0.ron etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ Cargo.lock
 *.bat
 mandelbrot_presets.json
 makepad_settings.ron
-makepad_state.ron
+makepad_state*.ron
 key.ron
 .vscode
 rustc*.txt


### PR DESCRIPTION
Before this I was getting
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	makepad_state0.ron
```
after running or building (?) an example.