### PR TITLE
experiments/html_experiment app import path fixed

### DIFF
--- a/experiments/html_experiment/src/main.rs
+++ b/experiments/html_experiment/src/main.rs
@@ -2,5 +2,5 @@
 // as dll (mobile / wasm) and some require to be built as executable
 // unfortunately cargo doesn't facilitate this without a main.rs stub
 fn main(){
-    html_experiment::app::app_main()
+    makepad_experiment_html::app::app_main()
 }


### PR DESCRIPTION
Before this a compile error:
```
makepad/experiments/html_experiment on  makepad-studio_cargo-makepad_in-sync:master [?] is 📦 v0.1.0 via 🦀 v1.84.0-nightly 
❯ cargo build
   Compiling makepad-experiment-html v0.1.0 (/share/pkehl/GIT/makepad/experiments/html_experiment)
error[E0433]: failed to resolve: use of undeclared crate or module `html_experiment`
 --> experiments/html_experiment/src/main.rs:5:5
  |
5 |     html_experiment::app::app_main()
  |     ^^^^^^^^^^^^^^^ use of undeclared crate or module `html_experiment`
```