### PR TITLE
TextInput: expose current keyboard modifiers in `Return` action

### DIFF
--- a/widgets/src/slider.rs
+++ b/widgets/src/slider.rs
@@ -181,8 +181,8 @@ impl Widget for Slider {
                 TextInputAction::KeyFocusLost => {
                     self.animator_play(cx, id!(focus.off));
                 }
-                TextInputAction::Return(value) => {
-                    if let Ok(v) = value.parse::<f64>() {
+                TextInputAction::Return { text, .. } => {
+                    if let Ok(v) = text.parse::<f64>() {
                         self.set_internal(v.max(self.min).min(self.max));
                     }
                     self.update_text_input_and_redraw(cx);


### PR DESCRIPTION
This is necessary for applications that wish to handle the `Return` key being pressed in different ways, based on the active modifier keys.

Also adds new `returned_with_modifiers()` function to make it easier for users to query this info from the `TextInput` widget.