### PR TITLE
Android Manifest: ensure COARSE location permissions are specified

### DIFF
--- a/tools/cargo_makepad/src/android/compile.rs
+++ b/tools/cargo_makepad/src/android/compile.rs
@@ -77,6 +77,7 @@ fn manifest_xml(label:&str, class_name:&str, url:&str, sdk_version: usize)->Stri
         <uses-permission android:name="android.permission.BLUETOOTH"/>
         <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
         <uses-permission android:name="android.permission.CAMERA"/>
+        <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
         <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
         <uses-permission android:name="android.permission.USE_BIOMETRIC" />
         <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:ignore="QueryAllPackagesPermission" />


### PR DESCRIPTION
According to the Android developer docs, if FINE location permissions are specified in the manifest, COARSE location permissions must *also* be specified too.

See <https://developer.android.com/develop/sensors-and-location/location/permissions#foreground>

Screenshot of the relevant Manifest excerpt:
<img width="935" alt="image" src="https://github.com/user-attachments/assets/f11d98c2-6dbf-41bd-8aff-6d58ce421486">
