### PR TITLE
Modal: allow querying whether the modal `is_open()`

### DIFF
--- a/widgets/src/modal.rs
+++ b/widgets/src/modal.rs
@@ -119,6 +119,14 @@ impl Modal {
 }
 
 impl ModalRef {
+    pub fn is_open(&self) -> bool {
+        if let Some(inner) = self.borrow() {
+            inner.opened
+        } else {
+            false
+        }
+    }
+
     pub fn open(&self, cx: &mut Cx) {
         if let Some(mut inner) = self.borrow_mut() {
             inner.open(cx);


### PR DESCRIPTION
very tiny PR just to expose this inner state, since there are some use cases where a parent widget would need to know whether a modal is already open in order to influence its behavior.