### PR TITLE
Reimplement `PortalList::smooth_scroll_to()`. Support backwards navigation via Android back gesture or Escape key

### DIFF
--- a/widgets/src/modal.rs
+++ b/widgets/src/modal.rs
@@ -57,9 +57,10 @@ impl Widget for Modal {
         self.content.handle_event(cx, event, scope);
         cx.sweep_lock(self.draw_bg.area());
 
-        let is_finger_up_in_bg = || {
+        // A closure to check if a finger up event occurred in the modal's background area.
+        let mut is_finger_up_in_bg = || {
             if let Hit::FingerUp(fe) = event.hits_with_sweep_area(cx, self.draw_bg.area(), self.draw_bg.area()) {
-                !content_rec.contains(fe.abs)
+                !self.content.area().rect(cx).contains(fe.abs)
             } else {
                 false
             }
@@ -69,7 +70,7 @@ impl Widget for Modal {
         // * If the Escape key was pressed
         // * If the back navigational action/gesture on Android was triggered
         // * If there was a click/press in the background area outside of the inner content
-        if event == Event::BackPressed
+        if matches!(event, Event::BackPressed)
             || matches!(event, Event::KeyUp(KeyEvent { key_code: KeyCode::Escape, .. }))
             || is_finger_up_in_bg()
         {

--- a/widgets/src/modal.rs
+++ b/widgets/src/modal.rs
@@ -1,6 +1,7 @@
 use crate::{
     makepad_derive_widget::*,
     makepad_draw::*,
+    makepad_platform::{KeyCode, KeyEvent},
     view::*,
     widget::*
 };
@@ -56,16 +57,25 @@ impl Widget for Modal {
         self.content.handle_event(cx, event, scope);
         cx.sweep_lock(self.draw_bg.area());
 
-        // Check if there was a click outside of the content (bg), then close if true.
-        let content_rec = self.content.area().rect(cx);
-        if let Hit::FingerUp(fe) =
-            event.hits_with_sweep_area(cx, self.draw_bg.area(), self.draw_bg.area())
-        {
-            if !content_rec.contains(fe.abs) {
-                self.close(cx);
-                let widget_uid = self.content.widget_uid();
-                cx.widget_action(widget_uid, &scope.path, ModalAction::Dismissed);
+        let is_finger_up_in_bg = || {
+            if let Hit::FingerUp(fe) = event.hits_with_sweep_area(cx, self.draw_bg.area(), self.draw_bg.area()) {
+                !content_rec.contains(fe.abs)
+            } else {
+                false
             }
+        };
+
+        // Close the modal if any of the following conditions occur:
+        // * If the Escape key was pressed
+        // * If the back navigational action/gesture on Android was triggered
+        // * If there was a click/press in the background area outside of the inner content
+        if event == Event::BackPressed
+            || matches!(event, Event::KeyUp(KeyEvent { key_code: KeyCode::Escape, .. }))
+            || is_finger_up_in_bg()
+        {
+            self.close(cx);
+            let widget_uid = self.content.widget_uid();
+            cx.widget_action(widget_uid, &scope.path, ModalAction::Dismissed);
         }
     }
 

--- a/widgets/src/stack_navigation.rs
+++ b/widgets/src/stack_navigation.rs
@@ -110,9 +110,9 @@ impl StackNavigationView {
                 Event::MouseUp(mouse) => mouse.button == 3, // the "back" button on the mouse
                 _ => false,
             };
-            
+
             // TODO: in the future, a swipe right gesture on touchscreen, or two-finger swipe on trackpad
-            if back_mouse_button_released || event == Event::BackPressed {
+            if back_mouse_button_released || matches!(event, Event::BackPressed) {
                 self.hide_stack_view(cx);
             }
         }

--- a/widgets/src/stack_navigation.rs
+++ b/widgets/src/stack_navigation.rs
@@ -103,16 +103,16 @@ impl StackNavigationView {
         // If the back button was clicked, it will be handled there.
         self.widget_match_event(cx, event, scope);
 
-        // Clicking the "back" button on the mouse must also hide the active stack view.
+        // Hide the active stack view if the "back" button on the mouse is clicked,
+        // or if the Android back navigation "action"/gesture occurred.
         if self.state == StackNavigationViewState::Active {
             let back_mouse_button_released = match event {
                 Event::MouseUp(mouse) => mouse.button == 3, // the "back" button on the mouse
                 _ => false,
             };
-
+            
             // TODO: in the future, a swipe right gesture on touchscreen, or two-finger swipe on trackpad
-
-            if back_mouse_button_released {
+            if back_mouse_button_released || event == Event::BackPressed {
                 self.hide_stack_view(cx);
             }
         }


### PR DESCRIPTION
There are two unrelated fixes in this PR, but they've been combined because I needed both of them simultaneously to fix some behaviors in Robrix.

## PortalList
* Make `PortalList::smooth_scroll_to()` only include a specified maximum number of items in its scrolling animation
  * This maximum number of items can be set via an optional parameter; the default is 20 items maximum.
* Also, simplify and document the APIs for `smooth_scroll_to()` and `smooth_scroll_to_end()`

## Backwards navigation / cancel-like actions
So far, I've only added this to stack navigation and modals, but we can also add this to other widgets as desired.
Eventually it'd probably be a good idea to have a general event variant or a convenience function implemented for the `Event` type called something like `is_go_back()` which would quickly & easily check the various conditions for you. Another related (but slightly different) one could be `is_cancel()`, which would be a superset of `is_go_back()` that also includes events like pressing <kbd>Esc</kbd> and other things that aren't always strictly navigation related.