### PR TITLE
faster wasm websockets

### DIFF
--- a/platform/src/os/web/web.js
+++ b/platform/src/os/web/web.js
@@ -496,6 +496,15 @@ export class WasmWebBrowser extends WasmBridge {
             return
         }
         worker.postMessage(this.alloc_thread_stack(args.context_ptr, args.timer));
+        worker.onmessage = (e) => {
+            // try to preemptively send a signal to ui to read from the websocket
+            setTimeout(() => {
+                if (this.exports.wasm_check_signal() == 1) {
+                    this.to_wasm.ToWasmSignal();
+                    this.do_wasm_pump();
+                }
+            }, 1);
+        }
         
         this.workers.push(worker);
     }

--- a/platform/src/os/web/web_worker.js
+++ b/platform/src/os/web/web_worker.js
@@ -68,6 +68,7 @@ onmessage = async function(e) {
                 wasm.exports.wasm_web_socket_error(id, err.ptr, err.len);
             }
             web_socket.onmessage = e => {
+                postMessage("SignalToUI");  // preemptively sends the signal to ui to read from the websocket
                 if(typeof e.data == "string"){
                     let data = string_to_u8("" + e.data);
                     wasm.exports.wasm_web_socket_string(id, data.ptr, data.len);

--- a/platform/src/web_socket.rs
+++ b/platform/src/web_socket.rs
@@ -77,7 +77,7 @@ impl Cx{
         let mut thread_sender = WEB_SOCKET_THREAD_SENDER.lock().unwrap();
         *thread_sender = Some(rx_sender);
         let sockets = Mutex::new(RefCell::new(HashMap::new()));
-        self.spawn_timer_thread(16, move ||{ 
+        self.spawn_timer_thread(1, move ||{ 
             let mut app_to_studio = AppToStudioVec(Vec::new());
             while let Ok(msg) = rx_receiver.try_recv(){
                 match msg{


### PR DESCRIPTION
16ms -> 1 change should not be controversial.

but i also added code that notifies the main js thread immediately after receiving websocket msg in js worker, which then preemptively (1ms later) checks whether the rust worker has already processed the message.

can you think of a cleaner way to remove 'rust -> js -> rust' round trip? feel free to do not merge this part.