### PR TITLE
MouseCursor::Hand on x11 platform

### DIFF
--- a/platform/src/os/linux/x11/xlib_app.rs
+++ b/platform/src/os/linux/x11/xlib_app.rs
@@ -700,7 +700,7 @@ impl XlibApp {
 
             MouseCursor::Default => self.load_first_cursor(&[b"left_ptr\0"]),
             MouseCursor::Crosshair => self.load_first_cursor(&[b"crosshair\0"]),
-            MouseCursor::Hand => self.load_first_cursor(&[b"hand\0", b"left_ptr\0"]),
+            MouseCursor::Hand => self.load_first_cursor(&[b"hand2\0", b"left_ptr\0"]),
             MouseCursor::Arrow => self.load_first_cursor(&[b"left_ptr\0\0"]),
             MouseCursor::Move => self.load_first_cursor(&[b"move\0"]),
             MouseCursor::NotAllowed => self.load_first_cursor(&[b"crossed_circle\0"]),

--- a/platform/src/os/linux/x11/xlib_app.rs
+++ b/platform/src/os/linux/x11/xlib_app.rs
@@ -700,7 +700,7 @@ impl XlibApp {
 
             MouseCursor::Default => self.load_first_cursor(&[b"left_ptr\0"]),
             MouseCursor::Crosshair => self.load_first_cursor(&[b"crosshair\0"]),
-            MouseCursor::Hand => self.load_first_cursor(&[b"hand1\0", b"left_ptr\0"]),
+            MouseCursor::Hand => self.load_first_cursor(&[b"hand\0", b"left_ptr\0"]),
             MouseCursor::Arrow => self.load_first_cursor(&[b"left_ptr\0\0"]),
             MouseCursor::Move => self.load_first_cursor(&[b"move\0"]),
             MouseCursor::NotAllowed => self.load_first_cursor(&[b"crossed_circle\0"]),

--- a/platform/src/os/linux/x11/xlib_app.rs
+++ b/platform/src/os/linux/x11/xlib_app.rs
@@ -700,7 +700,7 @@ impl XlibApp {
 
             MouseCursor::Default => self.load_first_cursor(&[b"left_ptr\0"]),
             MouseCursor::Crosshair => self.load_first_cursor(&[b"crosshair\0"]),
-            MouseCursor::Hand => self.load_first_cursor(&[b"left_ptr\0", b"hand1\0"]),
+            MouseCursor::Hand => self.load_first_cursor(&[b"hand1\0", b"left_ptr\0"]),
             MouseCursor::Arrow => self.load_first_cursor(&[b"left_ptr\0\0"]),
             MouseCursor::Move => self.load_first_cursor(&[b"move\0"]),
             MouseCursor::NotAllowed => self.load_first_cursor(&[b"crossed_circle\0"]),


### PR DESCRIPTION
The function `load_first_cursor() `returns the first valid cursor input. Adjusting the order of the array input and returns the `hand1` cursor.