### PR TITLE
Link CachedWidget to widgets

### DIFF
--- a/widgets/src/cached_widget.rs
+++ b/widgets/src/cached_widget.rs
@@ -7,7 +7,9 @@ use crate::{
 };
 
 live_design! {
-    CachedWidgetBase = {{CachedWidget}} {}
+    link widgets;
+    
+    pub CachedWidget = {{CachedWidget}} {}
 }
 
 /// A Singleton wrapper widget that caches and reuses its child widget across multiple instances.


### PR DESCRIPTION
`CachedWidget` is currently not being exported/linked into `link::widgets`.
Added the missing `link widgets` and `pub` prefix.