### PR TITLE
Add  `Ctrl + Z `shortcut to the input.

### DIFF
--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -640,7 +640,15 @@ impl Widget for TextInput {
                     ..
                 },
                 ..
-            }) if !self.is_read_only => {
+            }) | Hit::KeyDown(KeyEvent { 
+                key_code: KeyCode::KeyZ, 
+                modifiers: KeyModifiers {
+                    control: true,
+                    shift: false,
+                    ..
+                },
+                ..
+            }) if !self.is_read_only => { 
                 self.undo();
                 self.draw_bg.redraw(cx);
                 cx.widget_action(uid, &scope.path, TextInputAction::Change(self.text.clone()));
@@ -649,6 +657,14 @@ impl Widget for TextInput {
                 key_code: KeyCode::KeyZ,
                 modifiers: KeyModifiers {
                     logo: true,
+                    shift: true,
+                    ..
+                },
+                ..
+            }) | Hit::KeyDown(KeyEvent {
+                key_code: KeyCode::KeyZ,
+                modifiers: KeyModifiers {
+                    control: true,
                     shift: true,
                     ..
                 },

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -634,42 +634,18 @@ impl Widget for TextInput {
             },
             Hit::KeyDown(KeyEvent {
                 key_code: KeyCode::KeyZ,
-                modifiers: KeyModifiers {
-                    logo: true,
-                    shift: false,
-                    ..
-                },
+                modifiers,
                 ..
-            }) | Hit::KeyDown(KeyEvent { 
-                key_code: KeyCode::KeyZ, 
-                modifiers: KeyModifiers {
-                    control: true,
-                    shift: false,
-                    ..
-                },
-                ..
-            }) if !self.is_read_only => { 
+            }) if modifiers.is_primary() && !modifiers.shift && !self.is_read_only => {
                 self.undo();
                 self.draw_bg.redraw(cx);
                 cx.widget_action(uid, &scope.path, TextInputAction::Change(self.text.clone()));
             }
             Hit::KeyDown(KeyEvent {
                 key_code: KeyCode::KeyZ,
-                modifiers: KeyModifiers {
-                    logo: true,
-                    shift: true,
-                    ..
-                },
+                modifiers,
                 ..
-            }) | Hit::KeyDown(KeyEvent {
-                key_code: KeyCode::KeyZ,
-                modifiers: KeyModifiers {
-                    control: true,
-                    shift: true,
-                    ..
-                },
-                ..
-            }) if !self.is_read_only => {
+            }) if modifiers.is_primary() && modifiers.shift && !self.is_read_only => {
                 self.redo();
                 self.draw_bg.redraw(cx);
                 cx.widget_action(uid, &scope.path, TextInputAction::Change(self.text.clone()));


### PR DESCRIPTION
After some investigation, I found that on many platforms, the shortcuts for undo and redo are `Ctrl + Z` and `Ctrl + Shift + Z`. So far, I haven’t seen any platform (I tested on Windows, Linux, and Web) that supports` Logo + Z` or `Logo + Shift + Z`. Should we still keep the `Logo + Z` shortcut? Also, I noticed that on some apps or platforms (especially on the Web), `Ctrl + Y` is used for redo. Should Makepad also support the `Ctrl + Y` shortcut?