### PR TITLE
Fix `Timer` error on linux

### DIFF
--- a/examples/simple/src/app.rs
+++ b/examples/simple/src/app.rs
@@ -1,4 +1,6 @@
 
+use std::time::Instant;
+
 use makepad_widgets::*;
 
 live_design!{
@@ -48,6 +50,12 @@ app_main!(App);
 pub struct App {
     #[live] ui: WidgetRef,
     #[rust] counter: usize,
+    #[rust] timer: Timer,
+    #[rust] timer1: Timer,
+    #[rust] timer2: Timer,
+    #[rust] 
+    time_elapsed: Option<Instant>,
+
  }
  
 impl LiveRegister for App {
@@ -60,6 +68,11 @@ impl MatchEvent for App{
     fn handle_actions(&mut self, cx: &mut Cx, actions:&Actions){
         if self.ui.button(id!(button1)).clicked(&actions) {
             self.counter += 1;
+            // self.timer = cx.start_timeout(3.0);
+            // self.timer1 = cx.start_timeout(2.0);
+            // self.timer2 = cx.start_timeout(3.0);
+            self.timer = cx.start_interval(1.0);
+            self.time_elapsed = Some(Instant::now());
         }
     }
 }
@@ -68,5 +81,20 @@ impl AppMain for App {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event) {
         self.match_event(cx, event);
         self.ui.handle_event(cx, event, &mut Scope::empty());
+
+        if self.timer.is_event(event).is_some() {
+            log!("this timer run correct! ");
+            log!("Timer took {:?} seconds", self.time_elapsed.unwrap().elapsed());
+        }
+
+        if self.timer1.is_event(event).is_some() {
+            log!("this timer111 run correct! ");
+            log!("Timer took {:?} seconds", self.time_elapsed.unwrap().elapsed());
+        }
+
+        if self.timer2.is_event(event).is_some() {
+            log!("this timer222 run correct! ");
+            log!("Timer took {:?} seconds", self.time_elapsed.unwrap().elapsed());
+        }
     }
 }

--- a/examples/simple/src/app.rs
+++ b/examples/simple/src/app.rs
@@ -1,6 +1,4 @@
 
-use std::time::Instant;
-
 use makepad_widgets::*;
 
 live_design!{
@@ -50,12 +48,6 @@ app_main!(App);
 pub struct App {
     #[live] ui: WidgetRef,
     #[rust] counter: usize,
-    #[rust] timer: Timer,
-    #[rust] timer1: Timer,
-    #[rust] timer2: Timer,
-    #[rust] 
-    time_elapsed: Option<Instant>,
-
  }
  
 impl LiveRegister for App {
@@ -68,11 +60,6 @@ impl MatchEvent for App{
     fn handle_actions(&mut self, cx: &mut Cx, actions:&Actions){
         if self.ui.button(id!(button1)).clicked(&actions) {
             self.counter += 1;
-            // self.timer = cx.start_timeout(3.0);
-            // self.timer1 = cx.start_timeout(2.0);
-            // self.timer2 = cx.start_timeout(3.0);
-            self.timer = cx.start_interval(1.0);
-            self.time_elapsed = Some(Instant::now());
         }
     }
 }
@@ -81,20 +68,5 @@ impl AppMain for App {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event) {
         self.match_event(cx, event);
         self.ui.handle_event(cx, event, &mut Scope::empty());
-
-        if self.timer.is_event(event).is_some() {
-            log!("this timer run correct! ");
-            log!("Timer took {:?} seconds", self.time_elapsed.unwrap().elapsed());
-        }
-
-        if self.timer1.is_event(event).is_some() {
-            log!("this timer111 run correct! ");
-            log!("Timer took {:?} seconds", self.time_elapsed.unwrap().elapsed());
-        }
-
-        if self.timer2.is_event(event).is_some() {
-            log!("this timer222 run correct! ");
-            log!("Timer took {:?} seconds", self.time_elapsed.unwrap().elapsed());
-        }
     }
 }

--- a/platform/src/os/linux/select_timer.rs
+++ b/platform/src/os/linux/select_timer.rs
@@ -1,6 +1,5 @@
 use std::{collections::VecDeque, mem, os::raw::c_int, ptr, time::Instant};
 
-use crate::log;
 
 use self::super::libc_sys;
 

--- a/platform/src/os/linux/select_timer.rs
+++ b/platform/src/os/linux/select_timer.rs
@@ -151,12 +151,14 @@ impl SelectTimers {
         
         // Remove the timer from the list.
         let delta_timeout = self.timers.remove(index).unwrap().delta_timeout;
+
+        // self.timers.remove(index);
         
         // The timer succeeding the removed timer now has a different timer preceding it, so we need
         // to adjust its `delta timeout`.
-        if index < self.timers.len() {
-            self.timers[index].delta_timeout += delta_timeout;
-        }
+        // if index < self.timers.len() {
+        //     self.timers[index].delta_timeout += delta_timeout;
+        // }
     }
     
 }

--- a/platform/src/os/linux/select_timer.rs
+++ b/platform/src/os/linux/select_timer.rs
@@ -1,5 +1,7 @@
 use std::{collections::VecDeque, mem, os::raw::c_int, ptr, time::Instant};
 
+use crate::log;
+
 use self::super::libc_sys;
 
 
@@ -149,16 +151,9 @@ impl SelectTimers {
             return;
         };
         
-        // Remove the timer from the list.
-        let delta_timeout = self.timers.remove(index).unwrap().delta_timeout;
-
-        // self.timers.remove(index);
-        
-        // The timer succeeding the removed timer now has a different timer preceding it, so we need
-        // to adjust its `delta timeout`.
-        // if index < self.timers.len() {
-        //     self.timers[index].delta_timeout += delta_timeout;
-        // }
+        // Remove the timer from the list. 
+        // The timer being removed is always the first one in the queue, so it can just be removed directly.
+        self.timers.remove(index);
     }
     
 }


### PR DESCRIPTION
According to the timer `VecDeque` update method, the timer that's always released is the first one in the `VecDeque`. When the timer at `index=0` is released, its subsequent timers shouldn't have their `delta_timeout` increased. The error seems to be caused by this, because the trigger time of the timer is much longer than the set time. During the execution of the `stop_timer` method, unnecessary time was added to the `delta_timeout `of the second timer, causing the delay to be too long. I set up a timer in the simple module for testing purposes.I tested it on my computer, and it works fine.