### PR TITLE
Fix cargo_makepad-generated Java file

### DIFF
--- a/tools/cargo_makepad/src/android/compile.rs
+++ b/tools/cargo_makepad/src/android/compile.rs
@@ -94,7 +94,7 @@ fn manifest_xml(label:&str, class_name:&str, url:&str, sdk_version: usize)->Stri
 fn main_java(url:&str)->String{
     format!(r#"
         package {url};
-        use dev.makepad.android.MakepadActivity;
+        import dev.makepad.android.MakepadActivity;
         public class MakepadApp extends MakepadActivity{{
         }}
     "#)


### PR DESCRIPTION
This was probably a find/replace error during the migration from `import` to `use` in the DSL syntax.
Java still requires `import`.