### PR TITLE
Missing handling of shaders that use time: OpenGL, WebGL, d3d11

### DIFF
--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -59,6 +59,9 @@ impl Cx {
                 if sh.os_shader_id.is_none() { // shader didnt compile somehow
                     continue;
                 }
+                if sh.mapping.uses_time {
+                    self.demo_time_repaint = true;
+                }
                 let shp = &mut self.draw_shaders.os_shaders[sh.os_shader_id.unwrap()];
                 
                 if shp.gl_shader.is_none(){

--- a/platform/src/os/web/web_gl.rs
+++ b/platform/src/os/web/web_gl.rs
@@ -355,6 +355,10 @@ impl Cx {
                 }
                 if cx_shader.os_shader_id.is_none() {
                     let shp = CxOsDrawShader::new(vertex.clone(), pixel.clone());
+                    if cx_shader.mapping.uses_time {
+                        self.demo_time_repaint = true;
+                    }
+
                     self.os.from_wasm(FromWasmCompileWebGLShader{
                         shader_id: item.draw_shader_id,
                         vertex: shp.vertex.clone(), 

--- a/platform/src/os/windows/d3d11.rs
+++ b/platform/src/os/windows/d3d11.rs
@@ -173,8 +173,11 @@ impl Cx {
                 if sh.os_shader_id.is_none() { // shader didnt compile somehow
                     continue;
                 }
+                if sh.mapping.uses_time {
+                    self.demo_time_repaint = true;
+                }
                 let shp = &self.draw_shaders.os_shaders[sh.os_shader_id.unwrap()];
-                
+
                 if draw_call.instance_dirty {
                     draw_call.instance_dirty = false;
                     if draw_item.instances.as_ref().unwrap().len() == 0 {


### PR DESCRIPTION
Currently running makepad-example-simple in Linux results in the background shader not redrawing unless user events happen. I noticed that the `demo_time_repaint` flag is only being set in Metal but not in other platforms.
I've added the same handling to OpenGl, D3D11 and WebGL as in metal. This fixes the issue for Linux but it seems not enough to fix the same issue on Windows and WASM builds (I just noticed it happens on those platforms as well.