### PR TITLE
CommandTextInput widget

### DIFF
--- a/widgets/src/command_text_input.rs
+++ b/widgets/src/command_text_input.rs
@@ -15,8 +15,8 @@ live_design! {
         flow: Down,
         height: Fit,
 
-        keyboard_focus_color: #ffffff3a,
-        pointer_hover_color: #ffffff23,
+        keyboard_focus_color: (THEME_COLOR_CTRL_HOVER),
+        pointer_hover_color: (THEME_COLOR_CTRL_HOVER * 0.85),
 
         popup = <RoundedView> {
             flow: Down,

--- a/widgets/src/command_text_input.rs
+++ b/widgets/src/command_text_input.rs
@@ -1,0 +1,610 @@
+use crate::*;
+
+live_design! {
+    link widgets;
+    use link::widgets::*;
+    use link::theme::*;
+
+    List = {{List}} {
+        flow: Down,
+        width: Fill,
+        height: Fill,
+    }
+
+    pub CommandTextInput = {{CommandTextInput}} {
+        flow: Down,
+        height: Fit,
+
+        keyboard_focus_color: #ffffff3a,
+        pointer_hover_color: #ffffff23,
+
+        popup = <RoundedView> {
+            flow: Down,
+            height: Fit,
+            visible: false,
+            search_input = <TextInput> {
+                width: Fill,
+                height: Fit,
+            }
+
+            list = <List> {
+                height: Fit
+            }
+        }
+
+        persistent = <RoundedView> {
+            flow: Down,
+            height: Fit,
+            top = <View> { height: Fit }
+            center = <RoundedView> {
+                height: Fit,
+                // `left` and `right` seems to not work with `height: Fill`.
+                left = <View> { width: Fit, height: Fit }
+                text_input = <TextInput> { width: Fill }
+                right = <View> { width: Fit, height: Fit }
+            }
+            bottom = <View> { height: Fit }
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, DefaultNone)]
+enum InternalAction {
+    ShouldBuildItems,
+    ItemSelected,
+    None,
+}
+
+/// `TextInput` wrapper glued to a popup list of options that is shown when a
+/// trigger character is typed.
+///
+/// Limitation: Selectable items are expected to be `View`s.
+#[derive(Widget, Live)]
+pub struct CommandTextInput {
+    #[deref]
+    deref: View,
+
+    /// The character that triggers the popup.
+    ///
+    /// If not set, popup can't be triggerd by keyboard.
+    ///
+    /// `char` type is not "live", so String is used instead.
+    /// Behavior is undefined if this string contains anything other than a
+    /// single character.
+    #[live]
+    pub trigger: Option<String>,
+
+    /// Strong color to highlight the item that would be submitted if `Return` is pressed.
+    #[live]
+    pub keyboard_focus_color: Vec4,
+
+    /// Weak color to highlight the item that the pointer is hovering over.
+    #[live]
+    pub pointer_hover_color: Vec4,
+
+    /// Just used to detect `trigger`` insertion.
+    #[rust]
+    previous: String,
+
+    /// To deal with focus requesting issues.
+    #[rust]
+    is_search_input_focus_pending: bool,
+
+    /// To deal with focus requesting issues.
+    #[rust]
+    is_text_input_focus_pending: bool,
+
+    /// Index from `selectable_widgets` that would be submitted if `Return` is pressed.
+    /// `None` if there are no selectable widgets.
+    #[rust]
+    keyboard_focus_index: Option<usize>,
+
+    /// Index from `selectable_widgets` that the pointer is hovering over.
+    /// `None` if there are no selectable widgets.
+    #[rust]
+    pointer_hover_index: Option<usize>,
+
+    /// Convenience copy of the selectable widgets on the popup list.
+    #[rust]
+    selectable_widgets: Vec<WidgetRef>,
+
+    /// To deal with widgets not being `Send`.
+    #[rust]
+    last_selected_widget: WidgetRef,
+}
+
+impl Widget for CommandTextInput {
+    fn set_text(&mut self, v: &str) {
+        self.text_input_ref().set_text(v);
+    }
+
+    fn text(&self) -> String {
+        self.text_input_ref().text()
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.update_highlights(cx);
+
+        while !self.deref.draw_walk(cx, scope, walk).is_done() {}
+
+        if self.is_search_input_focus_pending {
+            self.is_search_input_focus_pending = false;
+            self.search_input_ref().set_key_focus(cx);
+        }
+
+        if self.is_text_input_focus_pending {
+            self.is_text_input_focus_pending = false;
+            self.text_input_ref().set_key_focus(cx);
+        }
+
+        DrawStep::done()
+    }
+
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.deref.handle_event(cx, event, scope);
+
+        // since popup is hidden on blur, this is enough
+        if self.view(id!(popup)).visible() {
+            if let Event::KeyDown(key_event) = event {
+                let delta = match key_event.key_code {
+                    KeyCode::ArrowDown => 1,
+                    KeyCode::ArrowUp => -1,
+                    _ => 0,
+                };
+
+                if delta != 0 {
+                    self.on_keyboard_move(cx, delta);
+                }
+            }
+        }
+
+        if let Event::Actions(actions) = event {
+            let mut selected_by_click = None;
+            let mut should_redraw = false;
+
+            for (idx, item) in self.selectable_widgets.iter().enumerate() {
+                let item = item.as_view();
+
+                if item
+                    .finger_down(actions)
+                    .map(|fe| fe.tap_count == 1)
+                    .unwrap_or(false)
+                {
+                    selected_by_click = Some((&*item).clone());
+                }
+
+                if item.finger_hover_out(actions).is_some() && Some(idx) == self.pointer_hover_index
+                {
+                    self.pointer_hover_index = None;
+                    should_redraw = true;
+                }
+
+                if item.finger_hover_in(actions).is_some() {
+                    self.pointer_hover_index = Some(idx);
+                    should_redraw = true;
+                }
+            }
+
+            if should_redraw {
+                self.redraw(cx);
+            }
+
+            if let Some(selected) = selected_by_click {
+                self.select_item(cx, scope, selected);
+            }
+
+            let text_input = self.text_input_ref();
+            let search_input = self.search_input_ref();
+
+            for action in actions.iter().filter_map(|a| a.as_widget_action()) {
+                if action.widget_uid == text_input.widget_uid() {
+                    match action.cast::<TextInputAction>() {
+                        TextInputAction::Change(_) => {
+                            self.on_text_input_changed(cx, scope);
+                        }
+                        _ => {}
+                    }
+                }
+
+                if action.widget_uid == search_input.widget_uid() {
+                    match action.cast::<TextInputAction>() {
+                        TextInputAction::Change(search) => {
+                            // disallow multiline input
+                            search_input.set_text(search.lines().next().unwrap_or_default());
+
+                            cx.widget_action(
+                                self.widget_uid(),
+                                &scope.path,
+                                InternalAction::ShouldBuildItems,
+                            );
+                        }
+                        TextInputAction::Return(_) => {
+                            self.on_search_input_submit(cx, scope);
+                        }
+                        TextInputAction::Escape => {
+                            self.is_text_input_focus_pending = true;
+                            self.hide_popup();
+                            self.redraw(cx);
+                        }
+                        TextInputAction::KeyFocusLost => {
+                            self.hide_popup();
+                            self.redraw(cx);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl CommandTextInput {
+    fn on_text_input_changed(&mut self, cx: &mut Cx, scope: &mut Scope) {
+        if self.was_trigger_inserted() {
+            self.show_popup(cx);
+            self.is_search_input_focus_pending = true;
+            cx.widget_action(
+                self.widget_uid(),
+                &scope.path,
+                InternalAction::ShouldBuildItems,
+            );
+        }
+
+        let current = self.text_input_ref().text();
+        self.previous = current;
+    }
+
+    fn on_search_input_submit(&mut self, cx: &mut Cx, scope: &mut Scope) {
+        let Some(idx) = self.keyboard_focus_index else {
+            return;
+        };
+
+        self.select_item(cx, scope, self.selectable_widgets[idx].clone());
+    }
+
+    fn select_item(&mut self, cx: &mut Cx, scope: &mut Scope, selected: WidgetRef) {
+        self.last_selected_widget = selected;
+        cx.widget_action(self.widget_uid(), &scope.path, InternalAction::ItemSelected);
+        self.hide_popup();
+        self.is_text_input_focus_pending = true;
+        self.try_remove_trigger_char();
+        self.redraw(cx);
+    }
+
+    fn try_remove_trigger_char(&mut self) {
+        let text_input = self.text_input_ref();
+        let cursor_pos = text_input.borrow().map_or(0, |p| p.get_cursor().head.index);
+        if cursor_pos > 0 {
+            let last_char_pos = cursor_pos - 1;
+            let last_char = text_input.text().chars().nth(last_char_pos);
+
+            if last_char == self.trigger_char() {
+                let at_removed = text_input
+                    .text()
+                    .chars()
+                    .enumerate()
+                    .filter_map(|(i, c)| if i == last_char_pos { None } else { Some(c) })
+                    .collect::<String>();
+
+                text_input.set_text(&at_removed);
+                self.previous = at_removed;
+            }
+        }
+    }
+
+    fn show_popup(&mut self, cx: &mut Cx) {
+        self.view(id!(popup)).set_visible(true);
+        self.view(id!(popup)).redraw(cx);
+    }
+
+    fn hide_popup(&mut self) {
+        self.clear_popup();
+        self.view(id!(popup)).set_visible(false);
+    }
+
+    /// Clear all text and hide the popup going back to initial state.
+    pub fn reset(&mut self) {
+        self.clear_popup();
+        self.hide_popup();
+        self.text_input_ref().set_text("");
+        self.previous = String::new();
+    }
+
+    fn clear_popup(&mut self) {
+        self.search_input_ref().set_text("");
+        self.search_input_ref().set_cursor(0, 0);
+        self.clear_items();
+    }
+
+    /// Empty the list of items.
+    ///
+    /// Normally called as response to `should_build_items`.
+    pub fn clear_items(&mut self) {
+        self.list(id!(list)).clear();
+        self.selectable_widgets.clear();
+        self.keyboard_focus_index = None;
+        self.pointer_hover_index = None;
+    }
+
+    /// Add a custom selectable item to the list.
+    ///
+    /// Normally called after clearing the previous items.
+    pub fn add_item(&mut self, widget: WidgetRef) {
+        self.list(id!(list)).add(widget.clone());
+        self.selectable_widgets.push(widget);
+        self.keyboard_focus_index = self.keyboard_focus_index.or(Some(0));
+    }
+
+    /// Add a custom unselectable item to the list.
+    ///
+    /// Ex: Headers, dividers, etc.
+    ///
+    /// Normally called after clearing the previous items.
+    pub fn add_unselectable_item(&mut self, widget: WidgetRef) {
+        self.list(id!(list)).add(widget);
+    }
+
+    /// Get the current search query.
+    ///
+    /// You probably want this for filtering purposes when updating the items.
+    pub fn search_text(&self) -> String {
+        self.search_input_ref().text()
+    }
+
+    /// Check if an item has been selected returning the widget reference.
+    pub fn item_selected(&self, actions: &Actions) -> Option<WidgetRef> {
+        actions
+            .iter()
+            .filter_map(|a| a.as_widget_action())
+            .filter(|a| a.widget_uid == self.widget_uid())
+            .find_map(|a| {
+                if let InternalAction::ItemSelected = a.cast() {
+                    Some(self.last_selected_widget.clone())
+                } else {
+                    None
+                }
+            })
+    }
+
+    /// If you should compute the items to display again.
+    ///
+    /// For ex: If trigger is typed, or if search filter changes.
+    pub fn should_build_items(&self, actions: &Actions) -> bool {
+        actions
+            .iter()
+            .filter_map(|a| a.as_widget_action())
+            .filter(|a| a.widget_uid == self.widget_uid())
+            .any(|a| matches!(a.cast(), InternalAction::ShouldBuildItems))
+    }
+
+    /// Exposed the internal main `TextInput` widget.
+    // `_ref` is added to avoid naming conflicts with Makepad's autogenerated methods.
+    pub fn text_input_ref(&self) -> TextInputRef {
+        self.text_input(id!(text_input))
+    }
+
+    /// Exposes the internal search `TextInput` widget.
+    // `_ref` is added for consistency with `text_input_ref`.
+    pub fn search_input_ref(&self) -> TextInputRef {
+        self.text_input(id!(search_input))
+    }
+
+    fn was_trigger_inserted(&self) -> bool {
+        let text_input = self.text_input_ref();
+        let prev = self.previous.as_str();
+        let current = &text_input.text();
+
+        if current.len() != prev.len() + 1 {
+            return false;
+        }
+
+        // not necessarily the cursor head, but works for this single character use case
+        let cursor_pos = text_input.borrow().map_or(0, |p| p.get_cursor().head.index);
+
+        if cursor_pos == 0 {
+            return false;
+        }
+
+        let inserted_char = current.chars().nth(cursor_pos - 1).unwrap_or_default();
+
+        let Some(trigger) = self.trigger_char() else {
+            return false;
+        };
+
+        inserted_char == trigger
+    }
+
+    fn trigger_char(&self) -> Option<char> {
+        self.trigger.as_ref().and_then(|t| t.chars().next())
+    }
+
+    fn on_keyboard_move(&mut self, cx: &mut Cx, delta: i32) {
+        let Some(idx) = self.keyboard_focus_index else {
+            return;
+        };
+
+        let new_index = idx
+            .saturating_add_signed(delta as isize)
+            .clamp(0, self.selectable_widgets.len() - 1);
+
+        if idx != new_index {
+            self.keyboard_focus_index = Some(new_index);
+        }
+
+        self.redraw(cx);
+    }
+
+    fn update_highlights(&mut self, cx: &mut Cx) {
+        for (idx, item) in self.selectable_widgets.iter().enumerate() {
+            item.apply_over(cx, live! { show_bg: true, cursor: Hand });
+
+            if Some(idx) == self.keyboard_focus_index {
+                item.apply_over(
+                    cx,
+                    live! {
+                        draw_bg: {
+                            color: (self.keyboard_focus_color),
+                        }
+                    },
+                );
+            } else if Some(idx) == self.pointer_hover_index {
+                item.apply_over(
+                    cx,
+                    live! {
+                        draw_bg: {
+                            color: (self.pointer_hover_color),
+                        }
+                    },
+                );
+            } else {
+                item.apply_over(
+                    cx,
+                    live! {
+                        draw_bg: {
+                            color: (Vec4::all(0.)),
+                        }
+                    },
+                );
+            }
+        }
+    }
+
+    /// Obtain focus in the main `TextInput` widget as soon as possible.
+    pub fn request_text_input_focus(&mut self) {
+        self.is_text_input_focus_pending = true;
+    }
+}
+
+impl LiveHook for CommandTextInput {}
+
+impl CommandTextInputRef {
+    /// Calls `should_build_items` on the inner widget. See docs there for more info.
+    pub fn should_build_items(&self, actions: &Actions) -> bool {
+        self.borrow()
+            .map_or(false, |inner| inner.should_build_items(actions))
+    }
+
+    /// Calls `clear_items` on the inner widget. See docs there for more info.
+    pub fn clear_items(&mut self) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.clear_items();
+        }
+    }
+
+    /// Calls `add_item` on the inner widget. See docs there for more info.
+    pub fn add_item(&mut self, widget: WidgetRef) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.add_item(widget);
+        }
+    }
+
+    /// Calls `add_unselectable_item` on the inner widget. See docs there for more info.
+    pub fn add_unselectable_item(&mut self, widget: WidgetRef) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.add_unselectable_item(widget);
+        }
+    }
+
+    /// Calls `item_selected` on the inner widget. See docs there for more info.
+    pub fn item_selected(&self, actions: &Actions) -> Option<WidgetRef> {
+        self.borrow().and_then(|inner| inner.item_selected(actions))
+    }
+
+    /// Calls `text_input_ref` on the inner widget. See docs there for more info.
+    pub fn text_input_ref(&self) -> TextInputRef {
+        self.borrow()
+            .map_or(WidgetRef::empty().as_text_input(), |inner| {
+                inner.text_input_ref()
+            })
+    }
+
+    /// Calls `search_input_ref` on the inner widget. See docs there for more info.
+    pub fn search_input_ref(&self) -> TextInputRef {
+        self.borrow()
+            .map_or(WidgetRef::empty().as_text_input(), |inner| {
+                inner.search_input_ref()
+            })
+    }
+
+    /// Calls `reset` on the inner widget. See docs there for more info.
+    pub fn reset(&mut self) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.reset();
+        }
+    }
+
+    /// Calls `request_text_input_focus` on the inner widget. See docs there for more info.
+    pub fn request_text_input_focus(&mut self) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.request_text_input_focus();
+        }
+    }
+
+    /// Calls `search_text` on the inner widget. See docs there for more info.
+    pub fn search_text(&self) -> String {
+        self.borrow()
+            .map_or(String::new(), |inner| inner.search_text())
+    }
+}
+
+/// Reduced and adapted copy of the `List` widget from Moly.
+#[derive(Live, Widget, LiveHook)]
+struct List {
+    #[walk]
+    walk: Walk,
+
+    #[layout]
+    layout: Layout,
+
+    #[redraw]
+    #[rust]
+    area: Area,
+
+    #[rust]
+    items: Vec<WidgetRef>,
+}
+
+impl Widget for List {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.items.iter().for_each(|item| {
+            item.handle_event(cx, event, scope);
+        });
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        cx.begin_turtle(walk, self.layout);
+        self.items.iter().for_each(|item| {
+            item.draw_all(cx, scope);
+        });
+        cx.end_turtle_with_area(&mut self.area);
+        DrawStep::done()
+    }
+}
+
+impl List {
+    fn clear(&mut self) {
+        self.items.clear();
+    }
+
+    fn add(&mut self, widget: WidgetRef) {
+        self.items.push(widget);
+    }
+}
+
+impl ListRef {
+    fn clear(&mut self) {
+        let Some(mut inner) = self.borrow_mut() else {
+            return;
+        };
+
+        inner.clear();
+    }
+
+    fn add(&mut self, widget: WidgetRef) {
+        let Some(mut inner) = self.borrow_mut() else {
+            return;
+        };
+
+        inner.add(widget);
+    }
+}

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -67,6 +67,7 @@ pub mod view_ui;
 pub mod widget;
 pub mod widget_match_event;
 pub mod toggle_panel;
+pub mod command_text_input;
 
 pub mod touch_gesture;
 
@@ -124,6 +125,7 @@ pub use crate::{
     dock::*,
     stack_navigation::*,
     expandable_panel::*,
+    command_text_input::*,
     window::*,
     multi_window::*,
     scroll_bars::{ScrollBars},
@@ -229,6 +231,7 @@ pub fn live_design(cx: &mut Cx) {
     crate::turtle_step::live_design(cx);
     crate::toggle_panel::live_design(cx);
     crate::cached_widget::live_design(cx);
+    crate::command_text_input::live_design(cx);
     
     crate::designer_theme::live_design(cx);
     crate::designer::live_design(cx);


### PR DESCRIPTION
# Description

A widget that displays a popup with a list of options when certain key is pressed in its wrapped text input.

Options may be something mentionable (like people or bots, typically by detecting `@`), or maybe actual commands to execute (typically by detecting `/`).

# Notes

This can't be considered an autocomplete widget because when the popup appears, focus is interrupted. This mimics ChatGPT `@` behavior. That's why it's just called `CommandTextInput` and not `AutocompleteTextInput`.

This is a reusable version of [Moly's prompt input](https://github.com/moxin-org/moly/blob/a77b7f0221f95eccb668fdc4ce3bb76a79363f5e/src/chat/prompt_input.rs).

Commit history has been squashed due to a lot of experimentation and `wip` commits on it. 

# Simple example

```rust
use makepad_widgets::*;

live_design!(
    use link::theme::*;
    use link::widgets::*;

    pub Ui = {{Ui}} {
        item_template: <View> {
            height: 40,
            label = <Label> {}
        }

        body = <View> {
            flow: Down,
            align: {x: 0.5, y: 0.5}
            prompt = <CommandTextInput> { trigger: "/" }
        }
    }
);

#[derive(Live, LiveHook, Widget)]
pub struct Ui {
    #[deref]
    deref: Window,

    #[live]
    item_template: Option<LivePtr>,
}

impl Widget for Ui {
    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
        self.deref.draw_walk(cx, scope, walk)
    }

    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
        self.deref.handle_event(cx, event, scope);

        let Event::Actions(actions) = event else {
            return;
        };

        let mut prompt = self.command_text_input(id!(prompt));

        if let Some(selected) = prompt.item_selected(actions) {
            let text = selected.label(id!(label)).text();
            println!("Selected: {}", text);
        }

        if prompt.should_build_items(actions) {
            prompt.clear_items();

            let search = prompt.search_text().to_lowercase();

            for fruit in ["Apple", "Banana", "Orange"] {
                if fruit.to_lowercase().contains(&search) {
                    let widget = WidgetRef::new_from_ptr(cx, self.item_template);
                    widget.label(id!(label)).set_text(fruit);
                    prompt.add_item(widget);
                }
            }
        }
    }
}
```

For more complex scenarios:
- Custom headings and grouping logic can be implemented by using `add_unselectable_item`.
- Since you are in control of the filtering, you can do something smarter than just comparing the lowercased strings.
- Usage in Moly can serve as a more [complex example](https://github.com/moxin-org/moly/pull/332).