### PR TITLE
Expose more `TextFlow` fields. Make math pub functions `const`

### DIFF
--- a/libs/math/src/complex.rs
+++ b/libs/math/src/complex.rs
@@ -11,8 +11,8 @@ impl ComplexF32{
     pub fn magnitude(self)->f32{(self.re*self.re + self.im *self.im).sqrt()}
 }
 
-pub fn cf64(re: f64, im: f64) -> ComplexF64 {ComplexF64 {re, im}}
-pub fn cf32(re: f32, im: f32) -> ComplexF32 {ComplexF32 {re, im}}
+pub const fn cf64(re: f64, im: f64) -> ComplexF64 {ComplexF64 {re, im}}
+pub const fn cf32(re: f32, im: f32) -> ComplexF32 {ComplexF32 {re, im}}
 
 impl From<ComplexF32> for ComplexF64 {
     fn from(v: ComplexF32) -> Self {

--- a/libs/math/src/math_f32.rs
+++ b/libs/math/src/math_f32.rs
@@ -197,9 +197,9 @@ impl fmt::Display for Vec3 {
     }
 }
 
-pub fn vec2(x: f32, y: f32) -> Vec2 {Vec2 {x, y}}
-pub fn vec3(x: f32, y: f32, z: f32) -> Vec3 {Vec3 {x, y, z}}
-pub fn vec4(x: f32, y: f32, z: f32, w: f32) -> Vec4 {Vec4 {x, y, z, w}}
+pub const fn vec2(x: f32, y: f32) -> Vec2 {Vec2 {x, y}}
+pub const fn vec3(x: f32, y: f32, z: f32) -> Vec3 {Vec3 {x, y, z}}
+pub const fn vec4(x: f32, y: f32, z: f32, w: f32) -> Vec4 {Vec4 {x, y, z, w}}
 
 const TORAD: f32 = 0.017453292;
 const TODEG: f32 = 57.29578;
@@ -233,11 +233,11 @@ impl Vec3 {
         self.z = 0.0;
     }
     
-    pub fn all(x: f32) -> Vec3 {
+    pub const fn all(x: f32) -> Vec3 {
         Vec3 {x, y: x, z: x}
     }
     
-    pub fn to_vec2(&self) -> Vec2 {
+    pub const fn to_vec2(&self) -> Vec2 {
         Vec2 {x: self.x, y: self.y}
     }
     
@@ -342,11 +342,11 @@ impl Vec4 {
     pub const B: Vec4 = Vec4 {x: 0.0, y: 0.0, z: 1.0, w: 1.0};
 
     
-    pub fn all(v: f32) -> Self {
+    pub const fn all(v: f32) -> Self {
         Self {x: v, y: v, z: v, w: v}
     }
     
-    pub fn to_vec3(&self) -> Vec3 {
+    pub const fn to_vec3(&self) -> Vec3 {
         Vec3 {x: self.x, y: self.y, z: self.z}
     }
     
@@ -426,11 +426,11 @@ impl Vec4 {
         (r<<24)|(g<<16)|(b<<8)|a
     }
 
-    pub fn xy(&self) -> Vec2 {
+    pub const fn xy(&self) -> Vec2 {
         Vec2{x:self.x, y:self.y}
     }
 
-    pub fn zw(&self) -> Vec2 {
+    pub const fn zw(&self) -> Vec2 {
         Vec2{x:self.z, y:self.w}
     }
 
@@ -514,7 +514,7 @@ pub fn vec4(x:f32, y:f32, z:f32, w:f32)->Vec4{
 
 
 impl Mat4 {
-    pub fn identity() -> Mat4 {
+    pub const fn identity() -> Mat4 {
         Mat4 {v: [
             1.0,
             0.0,
@@ -660,7 +660,7 @@ impl Mat4 {
         ]}
     }
     
-    pub fn translation(x: f32, y: f32, z: f32) -> Mat4 {
+    pub const fn translation(x: f32, y: f32, z: f32) -> Mat4 {
         Mat4 {v: [
             1.0,
             0.0,
@@ -682,7 +682,7 @@ impl Mat4 {
         
     }
     
-    pub fn scaled_translation(s: f32, x: f32, y: f32, z: f32) -> Mat4 {
+    pub const fn scaled_translation(s: f32, x: f32, y: f32, z: f32) -> Mat4 {
         Mat4 {v: [
             s,
             0.0,

--- a/libs/math/src/math_f64.rs
+++ b/libs/math/src/math_f64.rs
@@ -216,8 +216,8 @@ impl std::convert::From<(DVec2, DVec2)> for Rect {
 }
 
 impl DVec2 {
-    pub fn new() -> DVec2 {
-        DVec2::default()
+    pub const fn new() -> DVec2 {
+        DVec2 {x: 0.0, y: 0.0}
     }
 
     pub fn zero(&mut self) {
@@ -233,11 +233,11 @@ impl DVec2 {
         }
     }
     
-    pub fn all(x: f64) -> DVec2 {
+    pub const fn all(x: f64) -> DVec2 {
         DVec2 {x, y: x}
     }
     
-    pub fn index(&self, index:Vec2Index)->f64{
+    pub const fn index(&self, index:Vec2Index)->f64{
         match index{
             Vec2Index::X=>self.x,
             Vec2Index::Y=>self.y
@@ -251,14 +251,14 @@ impl DVec2 {
         }
     }
     
-    pub fn from_index_pair(index:Vec2Index, a: f64, b:f64)->Self{
+    pub const fn from_index_pair(index:Vec2Index, a: f64, b:f64)->Self{
         match index{
             Vec2Index::X=>{Self{x:a,y:b}},
             Vec2Index::Y=>{Self{x:b,y:a}}
         }
     }
     
-    pub fn into_vec2(self) -> Vec2 {
+    pub const fn into_vec2(self) -> Vec2 {
         Vec2 {x: self.x as f32, y: self.y as f32}
     }
     
@@ -349,9 +349,9 @@ impl fmt::Display for DVec2 {
     }
 }
 
-pub fn dvec2(x: f64, y: f64) -> DVec2 {DVec2 {x, y}}
+pub const fn dvec2(x: f64, y: f64) -> DVec2 {DVec2 {x, y}}
 
-pub fn rect(x: f64, y: f64, w:f64, h:f64) -> Rect {Rect{pos:DVec2 {x, y}, size:DVec2{x:w, y:h}}}
+pub const fn rect(x: f64, y: f64, w:f64, h:f64) -> Rect {Rect{pos:DVec2 {x, y}, size:DVec2{x:w, y:h}}}
 
 
 //------ Vec2 operators

--- a/libs/math/src/math_usize.rs
+++ b/libs/math/src/math_usize.rs
@@ -7,11 +7,11 @@ pub struct RectUsize {
 }
 
 impl RectUsize {
-    pub fn new(origin: PointUsize, size: SizeUsize) -> Self {
+    pub const fn new(origin: PointUsize, size: SizeUsize) -> Self {
         Self { origin, size }
     }
 
-    pub fn min(self) -> PointUsize {
+    pub const fn min(self) -> PointUsize {
         self.origin
     }
 
@@ -33,7 +33,7 @@ pub struct PointUsize {
 }
 
 impl PointUsize {
-    pub fn new(x: usize, y: usize) -> Self {
+    pub const fn new(x: usize, y: usize) -> Self {
         Self { x, y }
     }
 
@@ -75,7 +75,7 @@ pub struct SizeUsize {
 }
 
 impl SizeUsize {
-    pub fn new(width: usize, height: usize) -> Self {
+    pub const fn new(width: usize, height: usize) -> Self {
         Self { width, height }
     }
 }

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -251,12 +251,12 @@ pub enum FlowBlockType {
 #[repr(C)]
 pub struct DrawFlowBlock {
     #[deref] draw_super: DrawQuad,
-    #[live] line_color: Vec4,
-    #[live] sep_color: Vec4,
-    #[live] code_color: Vec4,
-    #[live] quote_bg_color: Vec4,
-    #[live] quote_fg_color: Vec4,
-    #[live] block_type: FlowBlockType
+    #[live] pub line_color: Vec4,
+    #[live] pub sep_color: Vec4,
+    #[live] pub code_color: Vec4,
+    #[live] pub quote_bg_color: Vec4,
+    #[live] pub quote_fg_color: Vec4,
+    #[live] pub block_type: FlowBlockType
 }
 
 #[derive(Default)]
@@ -281,18 +281,17 @@ impl StackCounter{
 // this widget has a retained and an immediate mode api
 #[derive(Live, Widget)]
 pub struct TextFlow {
-    #[live] draw_normal: DrawText,
-    #[live] draw_italic: DrawText,
-    #[live] draw_bold: DrawText,
-    #[live] draw_bold_italic: DrawText,
-    #[live] draw_fixed: DrawText,
-    
-    #[live] draw_block: DrawFlowBlock,
+    #[live] pub draw_normal: DrawText,
+    #[live] pub draw_italic: DrawText,
+    #[live] pub draw_bold: DrawText,
+    #[live] pub draw_bold_italic: DrawText,
+    #[live] pub draw_fixed: DrawText,
+    #[live] pub draw_block: DrawFlowBlock,
     
     /// The default font size used for all text if not otherwise specified.
-    #[live] font_size: f64,
+    #[live] pub font_size: f64,
     /// The default font color used for all text if not otherwise specified.
-    #[live] font_color: Vec4,
+    #[live] pub font_color: Vec4,
     #[walk] walk: Walk,
     
     #[rust] area_stack: SmallVec<[Area;4]>,
@@ -322,8 +321,8 @@ pub struct TextFlow {
     #[live] sep_walk: Walk, 
     #[live] list_item_layout: Layout,
     #[live] list_item_walk: Walk,
-    #[live] inline_code_padding: Padding,
-    #[live] inline_code_margin: Margin,
+    #[live] pub inline_code_padding: Padding,
+    #[live] pub inline_code_margin: Margin,
         
     #[redraw] #[rust] area:Area,
     #[rust] draw_state: DrawStateWrap<DrawState>,


### PR DESCRIPTION
This allows for external customization of `TextFlow`-based
draw formatting by app-level *custom* widgets, instead of just `Html`
or other Makepad-internal widgets.

--------------------------

Also: Make all possible math-related pub functions `const`

This allows you to define, for example, `Vec2`/`Vec3`/`Vec4`
constants or statics using the convenience functions,
which is useful for colors and such.