### PR TITLE
Introduce new `MouseButton` bitmask/bitflags to represent pressed mouse buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,19 @@ cargo run -p makepad-example-simple
 
 And there should be a desktop application window now running (may need to click on the icon on MacOS's Dock to show it)
 
+### Building for the Linux direct target
+
+To build and run for the Linux direct target (which bypasses X11), first install the following dependencies:
+```shell
+sudo apt-get install libinput-dev libgbm-dev libdrm-dev
+```
+
+and then run the same cargo command with the `MAKEPAD` environment variable set:
+```shell
+MAKEPAD=linux_direct cargo run -p makepad-example-simple
+```
+
+
 ## 4. Android Build
 
 ### Install Android toolchain (First time)

--- a/examples/simple/src/app.rs
+++ b/examples/simple/src/app.rs
@@ -7,39 +7,36 @@ live_design!{
     use link::widgets::*;
     
     App = {{App}} {
-        ui: <Root>{
-            main_window = <Window>{
-                body = <View>{
-                    flow: Down,
-                    spacing: 10,
-                    align: {
-                        x: 0.5,
-                        y: 0.5
+        ui: <Window> {
+            show_bg: true
+            width: Fill,
+            height: Fill
+
+            body = <ScrollXYView> {
+                flow: Down,
+                spacing: 20,
+                align: {
+                    x: 0.5,
+                    y: 0.5
+                },
+                draw_bg: {
+                    fn pixel(self) -> vec4 {
+                        return mix(#7, #3, self.pos.y);
+                    }
+                }
+                button1 = <Button> {
+                    text: "Click me!"
+                    draw_text:{
+                        color:#fff,
+                        text_style: { font_size: 14 }
+                    }
+                }
+                label1 = <Label> {
+                    draw_text: {
+                        color: #f
+                        text_style: { font_size: 14 }
                     },
-                    show_bg: true,
-                    draw_bg:{
-                        fn pixel(self) -> vec4 {
-                            let center = vec2(0.5, 0.5);
-                            let uv = self.pos - center;
-                            let radius = length(uv);
-                            let angle = atan(uv.y, uv.x);
-                            let color1 = mix(#f00, #00f, 0.5 + 10.5 * cos(angle + self.time));
-                            let color2 = mix(#0f0, #ff0, 0.5 + 0.5 * sin(angle + self.time));
-                            return mix(color1, color2, radius);
-                        }
-                    }
-                    b0= <Button> {
-                        text: "Click me 123"
-                        draw_text:{color:#fff}
-                    }
-                    button1 = <Button> {
-                        text: "Click me 123"
-                        draw_text:{color:#fff}
-                    }
-                    button2 = <Button> {
-                        text: "Click me 345"
-                        draw_text:{color:#fff}
-                    }
+                    text: "Counter: 0"
                 }
             }
         }
@@ -60,17 +57,27 @@ impl LiveRegister for App {
     }
 }
 
-impl MatchEvent for App{
-    fn handle_actions(&mut self, _cx: &mut Cx, actions:&Actions){
-        if self.ui.button(id!(button1)).clicked(&actions) {
-            self.counter += 1;
-        }
-    }
-}
-
 impl AppMain for App {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event) {
-        self.match_event(cx, event);
+        if let Event::Actions(actions) = event {
+            if self.ui.button(id!(button1)).clicked(&actions) {
+                log!("BUTTON CLICKED {}", self.counter); 
+                self.counter += 1;
+                let label = self.ui.label(id!(label1));
+                label.set_text(cx,&format!("Counter: {}", self.counter));
+            }
+        }
+
+        match event.hits(cx, self.ui.area()) {
+            Hit::FingerDown(fe) => {
+                log!("FingerDown: button {:?}", fe.device.mouse_button());
+            },
+            Hit::FingerUp(fe) => {
+                log!("FingerUp: button {:?}", fe.device.mouse_button());
+            },
+            _ => ()
+        }
+
         self.ui.handle_event(cx, event, &mut Scope::empty());
     }
 }

--- a/examples/simple/src/app.rs
+++ b/examples/simple/src/app.rs
@@ -7,36 +7,39 @@ live_design!{
     use link::widgets::*;
     
     App = {{App}} {
-        ui: <Window> {
-            show_bg: true
-            width: Fill,
-            height: Fill
-
-            body = <ScrollXYView> {
-                flow: Down,
-                spacing: 20,
-                align: {
-                    x: 0.5,
-                    y: 0.5
-                },
-                draw_bg: {
-                    fn pixel(self) -> vec4 {
-                        return mix(#7, #3, self.pos.y);
-                    }
-                }
-                button1 = <Button> {
-                    text: "Click me!"
-                    draw_text:{
-                        color:#fff,
-                        text_style: { font_size: 14 }
-                    }
-                }
-                label1 = <Label> {
-                    draw_text: {
-                        color: #f
-                        text_style: { font_size: 14 }
+        ui: <Root>{
+            main_window = <Window>{
+                body = <View>{
+                    flow: Down,
+                    spacing: 10,
+                    align: {
+                        x: 0.5,
+                        y: 0.5
                     },
-                    text: "Counter: 0"
+                    show_bg: true,
+                    draw_bg:{
+                        fn pixel(self) -> vec4 {
+                            let center = vec2(0.5, 0.5);
+                            let uv = self.pos - center;
+                            let radius = length(uv);
+                            let angle = atan(uv.y, uv.x);
+                            let color1 = mix(#f00, #00f, 0.5 + 10.5 * cos(angle + self.time));
+                            let color2 = mix(#0f0, #ff0, 0.5 + 0.5 * sin(angle + self.time));
+                            return mix(color1, color2, radius);
+                        }
+                    }
+                    b0= <Button> {
+                        text: "Click me 123"
+                        draw_text:{color:#fff}
+                    }
+                    button1 = <Button> {
+                        text: "Click me 123"
+                        draw_text:{color:#fff}
+                    }
+                    button2 = <Button> {
+                        text: "Click me 345"
+                        draw_text:{color:#fff}
+                    }
                 }
             }
         }
@@ -57,27 +60,17 @@ impl LiveRegister for App {
     }
 }
 
+impl MatchEvent for App{
+    fn handle_actions(&mut self, _cx: &mut Cx, actions:&Actions){
+        if self.ui.button(id!(button1)).clicked(&actions) {
+            self.counter += 1;
+        }
+    }
+}
+
 impl AppMain for App {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event) {
-        if let Event::Actions(actions) = event {
-            if self.ui.button(id!(button1)).clicked(&actions) {
-                log!("BUTTON CLICKED {}", self.counter); 
-                self.counter += 1;
-                let label = self.ui.label(id!(label1));
-                label.set_text(cx,&format!("Counter: {}", self.counter));
-            }
-        }
-
-        match event.hits(cx, self.ui.area()) {
-            Hit::FingerDown(fe) => {
-                log!("FingerDown: button {:?}", fe.device.mouse_button());
-            },
-            Hit::FingerUp(fe) => {
-                log!("FingerUp: button {:?}", fe.device.mouse_button());
-            },
-            _ => ()
-        }
-
+        self.match_event(cx, event);
         self.ui.handle_event(cx, event, &mut Scope::empty());
     }
 }

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -13,7 +13,8 @@ metadata.makepad-auto-version = "ue5pTU0e_KaMiNqLQpo2CaD-WeQ="
 makepad-futures = { path = "../libs/futures", version = "0.4.0" }
 makepad-shader-compiler = { path = "./shader_compiler", version = "0.5.0" }
 makepad-http = { path = "../libs/http", version="0.4.0" }
-smallvec = {version ="1.11.2"}
+smallvec = "1.11.2"
+bitflags = "2"
 
 [target.wasm32-unknown-unknown.dependencies]
 makepad-wasm-bridge = { path = "../libs/wasm_bridge", version = "0.4.0" }

--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -59,14 +59,78 @@ impl KeyModifiers{
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+
+bitflags::bitflags! {
+    /// A bit mask of all mouse buttons that were pressed
+    /// during a given mouse event.
+    ///
+    /// This is a bit mask because it is possible for multiple buttons
+    /// to be pressed simultaneously during a given input event.
+    #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+    pub struct MouseButton: u32 {
+        /// The primary mouse button, typically the left-click button.
+        const PRIMARY =   1 << 0;
+        /// The secondary mouse button, typically the right-click button.
+        const SECONDARY = 1 << 1;
+        /// The middle mouse button, typically the scroll-wheel click button.
+        const MIDDLE =    1 << 2;
+        /// The fourth mouse button, typically used for back navigation.
+        const BACK =      1 << 3;
+        /// The fifth mouse button, typically used for forward navigation.
+        const FORWARD =   1 << 4;
+
+        // Ensure that all bit values are valid flags and will not be truncated.
+        const _ = !0;
+    }
+}
+impl MouseButton {
+    /// Returns true if the primary mouse button is pressed.
+    pub fn is_primary(&self) -> bool {
+        self.contains(MouseButton::PRIMARY)
+    }
+    /// Returns true if the secondary mouse button is pressed.
+    pub fn is_secondary(&self) -> bool {
+        self.contains(MouseButton::SECONDARY)
+    }
+    /// Returns true if the middle mouse button is pressed.
+    pub fn is_middle(&self) -> bool {
+        self.contains(MouseButton::MIDDLE)
+    }
+    /// Returns true if the back mouse button is pressed.
+    pub fn is_back(&self) -> bool {
+        self.contains(MouseButton::BACK)
+    }
+    /// Returns true if the forward mouse button is pressed.
+    pub fn is_forward(&self) -> bool {
+        self.contains(MouseButton::FORWARD)
+    }
+    /// Returns true if the `n`-th button is pressed.
+    pub fn is_other_button(&self, n: u8) -> bool {
+        self.bits() & (1 << n) != 0
+    }
+    /// Returns a `MouseButton` bit mask based on the raw button value: `1 << raw`.
+    ///
+    /// A raw button value is a number that represents a mouse button, like so:
+    /// * 0: MouseButton::PRIMARY
+    /// * 1: MouseButton::SECONDARY
+    /// * 2: MouseButton::MIDDLE
+    /// * 3: MouseButton::BACK
+    /// * 4: MouseButton::FORWARD
+    /// * etc.
+    pub fn from_raw_button(raw: usize) -> MouseButton {
+        MouseButton::from_bits_retain(1 << raw)
+    }
+}
+
+
+#[derive(Clone, Debug)]
 pub struct MouseDownEvent {
     pub abs: DVec2,
-    pub button: usize,
+    pub button: MouseButton,
     pub window_id: WindowId,
     pub modifiers: KeyModifiers,
     pub handled: Cell<Area>,
-    pub time: f64
+    pub time: f64,
 }
 
 
@@ -82,7 +146,7 @@ pub struct MouseMoveEvent {
 #[derive(Clone, Debug)]
 pub struct MouseUpEvent {
     pub abs: DVec2,
-    pub button: usize,
+    pub button: MouseButton,
     pub window_id: WindowId,
     pub modifiers: KeyModifiers,
     pub time: f64
@@ -231,7 +295,7 @@ pub struct CxDigitHover {
 
 #[derive(Default, Clone)]
 pub struct CxFingers {
-    pub first_mouse_button: Option<(usize, WindowId)>,
+    pub first_mouse_button: Option<(MouseButton, WindowId)>,
     captures: Vec<CxDigitCapture>,
     tap: CxDigitTap,
     hovers: Vec<CxDigitHover>,
@@ -403,9 +467,9 @@ impl CxFingers {
         self.switch_captures();
     }
     
-    pub (crate) fn mouse_down(&mut self, button: usize, window_id:WindowId) {
+    pub (crate) fn mouse_down(&mut self, button: MouseButton, window_id: WindowId) {
         if self.first_mouse_button.is_none() {
-            self.first_mouse_button = Some((button,window_id));
+            self.first_mouse_button = Some((button, window_id));
         }
     }
     
@@ -418,11 +482,14 @@ impl CxFingers {
         }
     }
     
-    pub (crate) fn mouse_up(&mut self, button: usize) {
-        if self.first_mouse_button.is_some() && self.first_mouse_button.unwrap().0 == button {
-            self.first_mouse_button = None;
-            let digit_id = live_id!(mouse).into();
-            self.release_digit(digit_id);
+    pub (crate) fn mouse_up(&mut self, button: MouseButton) {
+        match self.first_mouse_button {
+            Some((fmb, _)) if fmb == button => {
+                self.first_mouse_button = None;
+                let digit_id = live_id!(mouse).into();
+                self.release_digit(digit_id);
+            }
+            _ => { }
         }
     }
     
@@ -452,7 +519,7 @@ impl CxFingers {
 #[derive(Clone, Debug)]
 pub enum DigitDevice {
     Mouse {
-        button: usize
+        button: MouseButton,
     },
     Touch {
         uid: u64
@@ -467,7 +534,7 @@ impl DigitDevice {
     
     pub fn has_hovers(&self) -> bool {self.is_mouse() || self.is_xr()}
     
-    pub fn mouse_button(&self) -> Option<usize> {if let DigitDevice::Mouse {button} = self {Some(*button)}else {None}}
+    pub fn mouse_button(&self) -> Option<MouseButton> {if let DigitDevice::Mouse {button} = self {Some(*button)}else {None}}
     pub fn touch_uid(&self) -> Option<u64> {if let DigitDevice::Touch {uid} = self {Some(*uid)}else {None}}
     // pub fn xr_input(&self) -> Option<usize> {if let DigitDevice::XR(input) = self {Some(*input)}else {None}}
 }
@@ -696,7 +763,7 @@ impl Event {
                 if hit_test(e.abs, &rect, &options.margin) {
                     //fe.handled = true;
                     let device = DigitDevice::Mouse {
-                        button: 0,
+                        button: MouseButton::PRIMARY,
                     };
                     return Hit::FingerScroll(FingerScrollEvent {
                         abs: e.abs,
@@ -944,7 +1011,7 @@ impl Event {
                 }
                 else {
                     let device = DigitDevice::Mouse {
-                        button: 0,
+                        button: MouseButton::PRIMARY,
                     };
                     
                     let handled_area = e.handled.get();
@@ -1064,7 +1131,7 @@ impl Event {
                 if cx.fingers.test_sweep_lock(options.sweep_area) {
                     return Hit::Nothing;
                 }
-                let device = DigitDevice::Mouse { button: 0 };
+                let device = DigitDevice::Mouse { button: MouseButton::empty() };
                 let digit_id = live_id!(mouse).into();
                 let rect = area.clipped_rect(&cx);
                 let hover_last = cx.fingers.find_hover_area(digit_id);

--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -61,7 +61,7 @@ impl KeyModifiers{
 
 
 bitflags::bitflags! {
-    /// A bit mask of all mouse buttons that were pressed
+    /// A `u32` bit mask of all mouse buttons that were pressed
     /// during a given mouse event.
     ///
     /// This is a bit mask because it is possible for multiple buttons

--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -67,19 +67,23 @@ bitflags::bitflags! {
     /// This is a bit mask because it is possible for multiple buttons
     /// to be pressed simultaneously during a given input event.
     #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+    #[doc(alias = "click")]
     pub struct MouseButton: u32 {
         /// The primary mouse button, typically the left-click button.
+        #[doc(alias("left", "left-click"))]
         const PRIMARY =   1 << 0;
         /// The secondary mouse button, typically the right-click button.
+        #[doc(alias("right", "right-click"))]
         const SECONDARY = 1 << 1;
         /// The middle mouse button, typically the scroll-wheel click button.
+        #[doc(alias("scroll", "wheel"))]
         const MIDDLE =    1 << 2;
         /// The fourth mouse button, typically used for back navigation.
         const BACK =      1 << 3;
         /// The fifth mouse button, typically used for forward navigation.
         const FORWARD =   1 << 4;
 
-        // Ensure that all bit values are valid flags and will not be truncated.
+        // Ensure that all bits are valid, such that no bits get truncated.
         const _ = !0;
     }
 }
@@ -104,7 +108,15 @@ impl MouseButton {
     pub fn is_forward(&self) -> bool {
         self.contains(MouseButton::FORWARD)
     }
-    /// Returns true if the `n`-th button is pressed.
+    /// Returns true if the `n`th button is pressed.
+    ///
+    /// The button values are:
+    /// * n = 0: PRIMARY
+    /// * n = 1: SECONDARY
+    /// * n = 2: MIDDLE
+    /// * n = 3: BACK
+    /// * n = 4: FORWARD
+    /// * n > 4: other/custom
     pub fn is_other_button(&self, n: u8) -> bool {
         self.bits() & (1 << n) != 0
     }

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -177,6 +177,7 @@ pub use {
             KeyModifiers,
             DrawEvent,
             DigitDevice,
+            MouseButton,
             MouseDownEvent,
             MouseMoveEvent,
             MouseUpEvent,

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -38,6 +38,7 @@ use {
         window::WindowId,
         event::{
             WindowGeom,
+            MouseButton,
             MouseUpEvent,
             Event,
             NetworkResponseChannel
@@ -396,14 +397,14 @@ impl Cx {
                 // TODO! make this more resilient
                 self.call_event_handler(&Event::MouseUp(MouseUpEvent {
                     abs: dvec2(-100000.0, -100000.0),
-                    button: 0,
+                    button: MouseButton::PRIMARY,
                     window_id: CxWindowPool::id_zero(),
                     modifiers: Default::default(),
                     time: 0.0
                 }));
-                self.fingers.mouse_up(0);
+                self.fingers.mouse_up(MouseButton::PRIMARY);
                 self.fingers.cycle_hover_area(live_id!(mouse).into());
-                
+
                 self.call_event_handler(&Event::DragEnd);
                 self.drag_drop.cycle_drag();
             }

--- a/platform/src/os/apple/macos/macos_delegates.rs
+++ b/platform/src/os/apple/macos/macos_delegates.rs
@@ -1,5 +1,3 @@
-use crate::apple_util::get_event_mouse_button;
-
 use {
     std::{
         sync::Arc,
@@ -24,6 +22,7 @@ use {
             apple_util::{
                 nsstring_to_string,
                 get_event_key_modifier,
+                get_event_mouse_button,
                 superclass,
                 load_mouse_cursor
             },
@@ -33,7 +32,8 @@ use {
             DragEvent,
             DropEvent,
             DragItem,
-            DragResponse
+            DragResponse,  
+            finger::MouseButton,
         },
     }
 };
@@ -357,40 +357,40 @@ pub fn define_cocoa_view_class() -> *const Class {
             }
         }
         let modifiers = get_event_key_modifier(event);
-        cw.send_mouse_down(0, modifiers);
+        cw.send_mouse_down(MouseButton::PRIMARY, modifiers);
     }
     
     
     extern fn mouse_up(this: &Object, _sel: Sel, event: ObjcId) {
         let cw = get_cocoa_window(this);
         let modifiers = get_event_key_modifier(event);
-        cw.send_mouse_up(0, modifiers);
+        cw.send_mouse_up(MouseButton::PRIMARY, modifiers);
     }
     
     extern fn right_mouse_down(this: &Object, _sel: Sel, event: ObjcId) {
         let cw = get_cocoa_window(this);
         let modifiers = get_event_key_modifier(event);
-        cw.send_mouse_down(1, modifiers);
+        cw.send_mouse_down(MouseButton::SECONDARY, modifiers);
     }
     
     extern fn right_mouse_up(this: &Object, _sel: Sel, event: ObjcId) {
         let cw = get_cocoa_window(this);
         let modifiers = get_event_key_modifier(event);
-        cw.send_mouse_up(1, modifiers);
+        cw.send_mouse_up(MouseButton::SECONDARY, modifiers);
     }
     
     extern fn other_mouse_down(this: &Object, _sel: Sel, event: ObjcId) {
         let cw = get_cocoa_window(this);
         let modifiers = get_event_key_modifier(event);
-        let button = get_event_mouse_button(event);
-        cw.send_mouse_down(button, modifiers);
+        let raw_button = get_event_mouse_button(event);
+        cw.send_mouse_down(MouseButton::from_raw_button(raw_button), modifiers);
     }
     
     extern fn other_mouse_up(this: &Object, _sel: Sel, event: ObjcId) {
         let cw = get_cocoa_window(this);
         let modifiers = get_event_key_modifier(event);
-        let button = get_event_mouse_button(event);
-        cw.send_mouse_up(button, modifiers);
+        let raw_button = get_event_mouse_button(event);
+        cw.send_mouse_up(MouseButton::from_raw_button(raw_button), modifiers);
     }
     
     fn mouse_pos_from_event(view: &Object, event: ObjcId) -> DVec2 {

--- a/platform/src/os/apple/macos/macos_stdin.rs
+++ b/platform/src/os/apple/macos/macos_stdin.rs
@@ -168,10 +168,11 @@ impl Cx {
                         dvec2(e.x, e.y),
                         e.time
                     );
-                    // lets log the window_id we mousedowned on
+                    // store the window_id we mousedowned on
                     let (window_id,pos) = self.windows.window_id_contains(dvec2(e.x, e.y));
-                    self.fingers.mouse_down(e.button, window_id);
-                    self.call_event_handler(&Event::MouseDown(e.into_event(window_id, pos)));
+                    let mouse_down_event = e.into_event(window_id, pos);
+                    self.fingers.mouse_down(mouse_down_event.button, window_id);
+                    self.call_event_handler(&Event::MouseDown(mouse_down_event));
                 }
                 HostToStdin::MouseMove(e) => {
                     let (window_id, pos) = if let Some((_, window_id)) = self.fingers.first_mouse_button{
@@ -185,14 +186,15 @@ impl Cx {
                     self.fingers.switch_captures();
                 }
                 HostToStdin::MouseUp(e) => {
-                    let button = e.button;
                     let (window_id, pos) = if let Some((_, window_id)) = self.fingers.first_mouse_button{
                         (window_id, self.windows[window_id].window_geom.position)
                     }
                     else{
                         self.windows.window_id_contains(dvec2(e.x, e.y))
                     };
-                    self.call_event_handler(&Event::MouseUp(e.into_event(window_id, pos)));
+                    let mouse_up_event = e.into_event(window_id, pos);
+                    let button = mouse_up_event.button;
+                    self.call_event_handler(&Event::MouseUp(mouse_up_event));
                     self.fingers.mouse_up(button);
                     self.fingers.cycle_hover_area(live_id!(mouse).into());
                 }

--- a/platform/src/os/apple/macos/macos_window.rs
+++ b/platform/src/os/apple/macos/macos_window.rs
@@ -17,6 +17,7 @@ use {
         },
         area::Area,
         event::{
+            finger::MouseButton,
             ScrollEvent,
             MouseUpEvent,
             MouseDownEvent,
@@ -348,7 +349,7 @@ impl MacosWindow {
         }
     }
     
-    pub fn send_mouse_down(&mut self, button: usize, modifiers: KeyModifiers) {
+    pub fn send_mouse_down(&mut self, button: MouseButton, modifiers: KeyModifiers) {
         let () = unsafe {msg_send![self.window, makeFirstResponder: self.view]};
         self.do_callback(MacosEvent::MouseDown(MouseDownEvent {
             button,
@@ -360,7 +361,7 @@ impl MacosWindow {
         }));
     }
     
-    pub fn send_mouse_up(&mut self, button: usize, modifiers: KeyModifiers) {
+    pub fn send_mouse_up(&mut self, button: MouseButton, modifiers: KeyModifiers) {
         self.do_callback(MacosEvent::MouseUp(MouseUpEvent {
             button,
             modifiers,

--- a/platform/src/os/cx_stdin.rs
+++ b/platform/src/os/cx_stdin.rs
@@ -7,7 +7,7 @@ use {
         cursor::MouseCursor,
         makepad_micro_serde::*,
         makepad_math::{dvec2,DVec2},
-        window::{WindowId},
+        window::WindowId,
         area::Area,
         event::{
             KeyModifiers,
@@ -16,6 +16,7 @@ use {
             TimerEvent,
             KeyEvent,
             ScrollEvent,
+            MouseButton,
             MouseDownEvent,
             MouseUpEvent,
             MouseMoveEvent,
@@ -337,7 +338,7 @@ impl StdinKeyModifiers{
 
 #[derive(Clone, Copy, Debug, Default, SerBin, DeBin, SerJson, DeJson, PartialEq)]
 pub struct StdinMouseDown{
-   pub button: usize,
+   pub raw_button: usize,
    pub x: f64,
    pub y: f64,
    pub time: f64,
@@ -348,8 +349,8 @@ impl StdinMouseDown {
     pub fn into_event(self, window_id: WindowId, pos: DVec2) -> MouseDownEvent {
         MouseDownEvent{
             abs: dvec2(self.x - pos.x, self.y - pos.y),
-            button: self.button,
-            window_id: window_id,
+            button: MouseButton::from_raw_button(self.raw_button),
+            window_id,
             modifiers: self.modifiers.into_key_modifiers(),
             time: self.time,
             handled: Cell::new(Area::Empty),
@@ -369,7 +370,7 @@ impl StdinMouseMove {
     pub fn into_event(self, window_id: WindowId, pos: DVec2) -> MouseMoveEvent {
         MouseMoveEvent{
             abs: dvec2(self.x - pos.x, self.y - pos.y),
-            window_id: window_id,
+            window_id,
             modifiers: self.modifiers.into_key_modifiers(),
             time: self.time,
             handled: Cell::new(Area::Empty),
@@ -380,7 +381,7 @@ impl StdinMouseMove {
 #[derive(Clone, Copy, Debug, Default, SerBin, DeBin, SerJson, DeJson, PartialEq)]
 pub struct StdinMouseUp{
    pub time: f64,
-   pub button: usize,
+   pub raw_button: usize,
    pub x: f64,
    pub y: f64,
    pub modifiers: StdinKeyModifiers
@@ -390,7 +391,7 @@ pub struct StdinMouseUp{
 pub struct StdinTextInput{
     pub time: f64,
     pub window_id: usize,
-    pub button: usize,
+    pub raw_button: usize,
     pub x: f64,
     pub y: f64
 }
@@ -399,8 +400,8 @@ impl StdinMouseUp {
    pub fn into_event(self, window_id: WindowId, pos: DVec2) -> MouseUpEvent {
         MouseUpEvent{
             abs: dvec2(self.x - pos.x, self.y - pos.y),
-            button: self.button,
-            window_id: window_id,
+            button: MouseButton::from_raw_button(self.raw_button),
+            window_id,
             modifiers: self.modifiers.into_key_modifiers(),
             time: self.time,
         }

--- a/platform/src/os/cx_stdin.rs
+++ b/platform/src/os/cx_stdin.rs
@@ -337,8 +337,8 @@ impl StdinKeyModifiers{
 
 
 #[derive(Clone, Copy, Debug, Default, SerBin, DeBin, SerJson, DeJson, PartialEq)]
-pub struct StdinMouseDown{
-   pub raw_button: usize,
+pub struct StdinMouseDown {
+   pub button_raw_bits: u32,
    pub x: f64,
    pub y: f64,
    pub time: f64,
@@ -347,9 +347,9 @@ pub struct StdinMouseDown{
 
 impl StdinMouseDown {
     pub fn into_event(self, window_id: WindowId, pos: DVec2) -> MouseDownEvent {
-        MouseDownEvent{
+        MouseDownEvent {
             abs: dvec2(self.x - pos.x, self.y - pos.y),
-            button: MouseButton::from_raw_button(self.raw_button),
+            button: MouseButton::from_bits_retain(self.button_raw_bits),
             window_id,
             modifiers: self.modifiers.into_key_modifiers(),
             time: self.time,
@@ -379,9 +379,9 @@ impl StdinMouseMove {
 }
 
 #[derive(Clone, Copy, Debug, Default, SerBin, DeBin, SerJson, DeJson, PartialEq)]
-pub struct StdinMouseUp{
+pub struct StdinMouseUp {
    pub time: f64,
-   pub raw_button: usize,
+   pub button_raw_bits: u32,
    pub x: f64,
    pub y: f64,
    pub modifiers: StdinKeyModifiers
@@ -398,9 +398,9 @@ pub struct StdinTextInput{
 
 impl StdinMouseUp {
    pub fn into_event(self, window_id: WindowId, pos: DVec2) -> MouseUpEvent {
-        MouseUpEvent{
+        MouseUpEvent {
             abs: dvec2(self.x - pos.x, self.y - pos.y),
-            button: MouseButton::from_raw_button(self.raw_button),
+            button: MouseButton::from_bits_retain(self.button_raw_bits),
             window_id,
             modifiers: self.modifiers.into_key_modifiers(),
             time: self.time,

--- a/platform/src/os/linux/direct/raw_input.rs
+++ b/platform/src/os/linux/direct/raw_input.rs
@@ -903,9 +903,9 @@ impl RawInput {
                     _ => ()
                 };
                 match code {
-                    EvKeyCodes::BTN_LEFT | EvKeyCodes::BTN_RIGHT | EvKeyCodes::BTN_MIDDLE => {
+                    EvKeyCodes::BTN_LEFT | EvKeyCodes::BTN_RIGHT | EvKeyCodes::BTN_MIDDLE | EvKeyCodes::BTN_SIDE | EvKeyCodes::BTN_EXTRA => {
                         dir_evts.push(DirectEvent::MouseDown(MouseDownEvent {
-                            button: (evt.code - EvKeyCodes::BTN_LEFT as u16) as usize,
+                            button: MouseButton::from_raw_button((evt.code - EvKeyCodes::BTN_LEFT as u16) as usize),
                             abs: self.abs,
                             window_id,
                             modifiers: self.modifiers,
@@ -915,7 +915,7 @@ impl RawInput {
                     },
                     EvKeyCodes::BTN_TOUCH => {
                         dir_evts.push(DirectEvent::MouseDown(MouseDownEvent {
-                            button: 0usize,
+                            button: MouseButton::PRIMARY,
                             abs: self.abs,
                             window_id,
                             modifiers: self.modifiers,
@@ -954,9 +954,9 @@ impl RawInput {
                     _ => ()
                 };
                 match code {
-                    EvKeyCodes::BTN_LEFT | EvKeyCodes::BTN_RIGHT | EvKeyCodes::BTN_MIDDLE => {
+                    EvKeyCodes::BTN_LEFT | EvKeyCodes::BTN_RIGHT | EvKeyCodes::BTN_MIDDLE | EvKeyCodes::BTN_SIDE | EvKeyCodes::BTN_EXTRA => {
                         dir_evts.push(DirectEvent::MouseUp(MouseUpEvent {
-                            button: (evt.code - EvKeyCodes::BTN_LEFT as u16) as usize,
+                            button: MouseButton::from_raw_button((evt.code - EvKeyCodes::BTN_LEFT as u16) as usize),
                             abs: self.abs,
                             window_id,
                             modifiers: self.modifiers,
@@ -965,7 +965,7 @@ impl RawInput {
                     },
                     EvKeyCodes::BTN_TOUCH => {
                         dir_evts.push(DirectEvent::MouseUp(MouseUpEvent {
-                            button: 0usize,
+                            button: MouseButton::PRIMARY,
                             abs: self.abs,
                             window_id,
                             modifiers: self.modifiers,

--- a/platform/src/os/linux/x11/linux_x11_stdin.rs
+++ b/platform/src/os/linux/x11/linux_x11_stdin.rs
@@ -117,10 +117,7 @@ impl Cx {
                     );
                     let (window_id,pos) = self.windows.window_id_contains(dvec2(e.x, e.y));
                     let mouse_down_event = e.into_event(window_id, pos);
-                    self.fingers.mouse_down(
-                        mouse_down_event.button,
-                        window_id,
-                    );
+                    self.fingers.mouse_down(mouse_down_event.button, window_id);
                     self.call_event_handler(&Event::MouseDown(mouse_down_event));
                 }
                 HostToStdin::MouseMove(e) => {

--- a/platform/src/os/linux/x11/linux_x11_stdin.rs
+++ b/platform/src/os/linux/x11/linux_x11_stdin.rs
@@ -1,25 +1,7 @@
 use {
-    std::{
-        io,
-        io::prelude::*,
-        io::BufReader,
-    },
     crate::{
-        makepad_live_id::*,
-        makepad_math::*,
-        makepad_micro_serde::*,
-        event::Event,
-        CxOsApi,
-        window::CxWindowPool,
-        event::WindowGeom,
-        texture::{Texture, TextureFormat},
-        thread::SignalToUI,
-        os::cx_stdin::{aux_chan, HostToStdin, PresentableDraw, StdinToHost, Swapchain, PollTimer},
-        pass::{CxPassParent, PassClearColor, CxPassColorTexture},
-        cx_api::CxOsOp,
-        cx::Cx,
-        gl_sys,
-    } 
+        cx::Cx, cx_api::CxOsOp, event::{Event, WindowGeom}, gl_sys, makepad_live_id::*, makepad_math::*, makepad_micro_serde::*, os::cx_stdin::{aux_chan, HostToStdin, PollTimer, PresentableDraw, StdinToHost, Swapchain}, pass::{CxPassColorTexture, CxPassParent, PassClearColor}, texture::{Texture, TextureFormat}, thread::SignalToUI, window::CxWindowPool, CxOsApi,
+    }, std::io::{self, prelude::*, BufReader} 
 };
 
 #[derive(Default)]
@@ -134,8 +116,12 @@ impl Cx {
                         e.time
                     );
                     let (window_id,pos) = self.windows.window_id_contains(dvec2(e.x, e.y));
-                    self.fingers.mouse_down(e.button, window_id);
-                    self.call_event_handler(&Event::MouseDown(e.into_event(window_id,pos)));
+                    let mouse_down_event = e.into_event(window_id, pos);
+                    self.fingers.mouse_down(
+                        mouse_down_event.button,
+                        window_id,
+                    );
+                    self.call_event_handler(&Event::MouseDown(mouse_down_event));
                 }
                 HostToStdin::MouseMove(e) => {
                     let (window_id, pos) = if let Some((_, window_id)) = self.fingers.first_mouse_button{
@@ -149,14 +135,15 @@ impl Cx {
                     self.fingers.switch_captures();
                 }
                 HostToStdin::MouseUp(e) => {
-                    let button = e.button;
                     let (window_id, pos) = if let Some((_, window_id)) = self.fingers.first_mouse_button{
                         (window_id, self.windows[window_id].window_geom.position)
                     }
                     else{
                         self.windows.window_id_contains(dvec2(e.x, e.y))
                     };
-                    self.call_event_handler(&Event::MouseUp(e.into_event(window_id,pos)));
+                    let mouse_up_event = e.into_event(window_id, pos);
+                    let button = mouse_up_event.button;
+                    self.call_event_handler(&Event::MouseUp(mouse_up_event));
                     self.fingers.mouse_up(button);
                     self.fingers.cycle_hover_area(live_id!(mouse).into());
                 }

--- a/platform/src/os/linux/x11/xlib_app.rs
+++ b/platform/src/os/linux/x11/xlib_app.rs
@@ -326,6 +326,7 @@ impl XlibApp {
                 },
                 x11_sys::ButtonPress => { // mouse down
                     let button = event.xbutton;
+                    println!("x11_sys ButtonPress: {:?}", button.button);
                     let time_now = self.time_now();
                     if let Some(window_ptr) = self.window_map.get(&button.window) {
                         let window = &mut (**window_ptr);
@@ -403,7 +404,10 @@ impl XlibApp {
                                 }
                             }
                             else {
-                                window.send_mouse_down(button.button as usize, self.xkeystate_to_modifiers(button.state))
+                                window.send_mouse_down(
+                                    self.xbutton_to_mouse_button(button.button),
+                                    self.xkeystate_to_modifiers(button.state)
+                                );
                             }
                         }
                     }
@@ -414,7 +418,10 @@ impl XlibApp {
                     let button = event.xbutton;
                     if let Some(window_ptr) = self.window_map.get(&button.window) {
                         let window = &mut (**window_ptr);
-                        window.send_mouse_up(button.button as usize, self.xkeystate_to_modifiers(button.state))
+                        window.send_mouse_up(
+                            self.xbutton_to_mouse_button(button.button),
+                            self.xkeystate_to_modifiers(button.state),
+                        );
                     }
                 },
                 x11_sys::KeyPress => {
@@ -725,6 +732,20 @@ impl XlibApp {
                 }
                 x11_sys::XFreeCursor(self.display, x11_cursor);
             }
+        }
+    }
+
+    fn xbutton_to_mouse_button(&self, button: u32) -> MouseButton {
+        match button {
+            0 => MouseButton::empty(), 
+            1 => MouseButton::PRIMARY,
+            2 => MouseButton::MIDDLE,
+            3 => MouseButton::SECONDARY,
+            // Button values 4, 5, 6, 7 are scroll directions
+            4..=7 => MouseButton::empty(), 
+            8 => MouseButton::BACK,
+            9 => MouseButton::FORWARD,
+            10.. => MouseButton::from_raw_button(button as usize - 4),
         }
     }
 

--- a/platform/src/os/linux/x11/xlib_app.rs
+++ b/platform/src/os/linux/x11/xlib_app.rs
@@ -326,7 +326,6 @@ impl XlibApp {
                 },
                 x11_sys::ButtonPress => { // mouse down
                     let button = event.xbutton;
-                    println!("x11_sys ButtonPress: {:?}", button.button);
                     let time_now = self.time_now();
                     if let Some(window_ptr) = self.window_map.get(&button.window) {
                         let window = &mut (**window_ptr);

--- a/platform/src/os/linux/x11/xlib_window.rs
+++ b/platform/src/os/linux/x11/xlib_window.rs
@@ -453,7 +453,7 @@ impl XlibWindow {
         self.do_callback(XlibEvent::AppLostFocus);
     }
     
-    pub fn send_mouse_down(&mut self, button: usize, modifiers: KeyModifiers) {
+    pub fn send_mouse_down(&mut self, button: MouseButton, modifiers: KeyModifiers) {
         self.do_callback(XlibEvent::MouseDown(MouseDownEvent {
             button,
             modifiers,
@@ -464,7 +464,7 @@ impl XlibWindow {
         }));
     }
     
-    pub fn send_mouse_up(&mut self, button: usize, modifiers: KeyModifiers) {
+    pub fn send_mouse_up(&mut self, button: MouseButton, modifiers: KeyModifiers) {
         self.do_callback(XlibEvent::MouseUp(MouseUpEvent {
             button,
             modifiers,
@@ -479,7 +479,7 @@ impl XlibWindow {
         self.do_callback(XlibEvent::MouseMove(MouseMoveEvent {
             window_id: self.window_id,
             abs: pos,
-            modifiers: modifiers,
+            modifiers,
             time: self.time_now(),
             handled: Cell::new(Area::Empty),
         }));
@@ -500,9 +500,9 @@ impl XlibWindow {
     
     pub fn send_text_input(&mut self, input: String, replace_last: bool) {
         self.do_callback(XlibEvent::TextInput(TextInputEvent {
-            input: input,
+            input,
             was_paste: false,
-            replace_last: replace_last
+            replace_last,
         }))
     }
     

--- a/platform/src/os/web/to_wasm.rs
+++ b/platform/src/os/web/to_wasm.rs
@@ -14,6 +14,7 @@ use {
             XRUpdateEvent,
             KeyCode,
             KeyModifiers,
+            MouseButton,
             MouseDownEvent,
             MouseMoveEvent,
             MouseUpEvent,
@@ -229,6 +230,16 @@ pub struct WMouse {
     pub time: f64,
 }
 
+/// Convert a raw Web mouse button code to a Makepad `MouseButton`.
+fn wmouse_to_mouse_button(button: u32) -> MouseButton {
+    match button {
+        0 => MouseButton::PRIMARY,
+        1 => MouseButton::MIDDLE,
+        2 => MouseButton::SECONDARY,
+        n => MouseButton::from_raw_button(n as usize),
+    }
+}
+
 #[derive(ToWasm)]
 pub struct ToWasmMouseDown {
     pub mouse: WMouse,
@@ -236,9 +247,10 @@ pub struct ToWasmMouseDown {
 
 impl From<ToWasmMouseDown> for MouseDownEvent {
     fn from(v:ToWasmMouseDown) -> Self {
+        crate::log!("ToWasmMouseDown: button: {:?}", v.mouse.button);
         Self {
             abs: dvec2(v.mouse.x, v.mouse.y),
-            button: v.mouse.button as usize,
+            button: wmouse_to_mouse_button(v.mouse.button),
             window_id: CxWindowPool::id_zero(),
             modifiers: unpack_key_modifier(v.mouse.modifiers),
             handled: Cell::new(Area::Empty),
@@ -273,9 +285,10 @@ pub struct ToWasmMouseUp {
 
 impl From<ToWasmMouseUp> for MouseUpEvent {
     fn from(v:ToWasmMouseUp) -> Self {
+        crate::log!("ToWasmMouseUp: button: {:?}", v.mouse.button);
         Self {
             abs: dvec2(v.mouse.x, v.mouse.y),
-            button: v.mouse.button as usize,
+            button: wmouse_to_mouse_button(v.mouse.button),
             window_id: CxWindowPool::id_zero(),
             modifiers: unpack_key_modifier(v.mouse.modifiers),
             time: v.mouse.time

--- a/platform/src/os/web/to_wasm.rs
+++ b/platform/src/os/web/to_wasm.rs
@@ -247,7 +247,6 @@ pub struct ToWasmMouseDown {
 
 impl From<ToWasmMouseDown> for MouseDownEvent {
     fn from(v:ToWasmMouseDown) -> Self {
-        crate::log!("ToWasmMouseDown: button: {:?}", v.mouse.button);
         Self {
             abs: dvec2(v.mouse.x, v.mouse.y),
             button: wmouse_to_mouse_button(v.mouse.button),
@@ -285,7 +284,6 @@ pub struct ToWasmMouseUp {
 
 impl From<ToWasmMouseUp> for MouseUpEvent {
     fn from(v:ToWasmMouseUp) -> Self {
-        crate::log!("ToWasmMouseUp: button: {:?}", v.mouse.button);
         Self {
             abs: dvec2(v.mouse.x, v.mouse.y),
             button: wmouse_to_mouse_button(v.mouse.button),

--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -776,7 +776,7 @@ pub unsafe extern "C" fn wasm_check_signal() -> u32 {
 
 #[export_name = "wasm_init_panic_hook"]
 pub unsafe extern "C" fn init_panic_hook() {
-    pub fn panic_hook(info: &panic::PanicInfo) {
+    pub fn panic_hook(info: &panic::PanicHookInfo) {
         crate::error!("{}", info)
     }
     panic::set_hook(Box::new(panic_hook));

--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -776,7 +776,7 @@ pub unsafe extern "C" fn wasm_check_signal() -> u32 {
 
 #[export_name = "wasm_init_panic_hook"]
 pub unsafe extern "C" fn init_panic_hook() {
-    pub fn panic_hook(info: &panic::PanicHookInfo) {
+    pub fn panic_hook(info: &panic::PanicInfo) {
         crate::error!("{}", info)
     }
     panic::set_hook(Box::new(panic_hook));

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -1,281 +1,47 @@
 use {
-    std::{
-        cell::{
-            RefCell,
-            Cell,
-        },
-        sync::Arc,
-        sync::Mutex,
-        rc::Rc,
-        ffi::OsStr,
-        os::windows::ffi::OsStrExt,
-        mem,
-    },
-    
     crate::{
-        windows::{
+        area::Area, cursor::MouseCursor, event::*, makepad_math::*, os::windows::{
+            droptarget::*, win32_app::{
+                encode_wide, get_win32_app_global, Win32App, FALSE
+            }, win32_event::*
+        }, window::WindowId, windows::{
             core::PCWSTR,
             //core::IntoParam,
             //core::Result as coreResult,
             //core::HRESULT,
             Win32::{
                 Foundation::{
-                    HWND,
-                    HANDLE,
-                    HGLOBAL,
-                    WPARAM,
-                    LPARAM,
-                    LRESULT,
-                    RECT,
-                    POINT,
-                    POINTL,
-                },
-                System::{
-                    Memory::{
-                        GlobalLock,
-                        GlobalAlloc,
-                        GlobalSize,
-                        GlobalUnlock,
-                        GLOBAL_ALLOC_FLAGS,
-                    },
-                    Ole::{
-                        CF_UNICODETEXT,
-                        RegisterDragDrop,
-                        IDropTarget,
-                        DROPEFFECT,
-                        DROPEFFECT_COPY,
-                        DROPEFFECT_MOVE,
-                        DROPEFFECT_LINK,
-                    },
-                    SystemServices::{
-                        MODIFIERKEYS_FLAGS,
-                        MK_CONTROL,
-                        MK_SHIFT,
-                    },
-                    WindowsProgramming::GMEM_DDESHARE,
+                    HANDLE, HGLOBAL, HWND, LPARAM, LRESULT, POINT, POINTL, RECT, WPARAM
+                }, Graphics::{
+                    Dwm::DwmExtendFrameIntoClientArea,
+                    Gdi::ScreenToClient,
+                }, System::{
                     DataExchange::{
-                        OpenClipboard,
-                        EmptyClipboard,
-                        GetClipboardData,
-                        SetClipboardData,
-                        CloseClipboard,
-                    },
-                    LibraryLoader::GetModuleHandleW,
-                },
-                UI::{
-                    WindowsAndMessaging::{
-                        CreateWindowExW,
-                        SetWindowLongPtrW,
-                        GetWindowLongPtrW,
-                        DefWindowProcW,
-                        ShowWindow,
-                        PostMessageW,
-                        GetWindowRect,
-                        DestroyWindow,
-                        SetWindowPos,
-                        GetWindowPlacement,
-                        WINDOWPLACEMENT,
-                        GetClientRect,
-                        MoveWindow,
-                        GWL_EXSTYLE,
-                        HWND_TOPMOST,
-                        HWND_NOTOPMOST,
-                        WS_SIZEBOX,
-                        WS_MAXIMIZEBOX,
-                        WS_MINIMIZEBOX,
-                        WS_POPUP,
-                        WS_CLIPSIBLINGS,
-                        WS_CLIPCHILDREN,
-                        WS_SYSMENU,
-                        WS_EX_WINDOWEDGE,
-                        WS_EX_APPWINDOW,
-                        WS_EX_ACCEPTFILES,
-                        WS_EX_TOPMOST,
-                        CW_USEDEFAULT,
-                        GWLP_USERDATA,
-                        SW_SHOW,
-                        SW_RESTORE,
-                        SW_MAXIMIZE,
-                        SW_MINIMIZE,
-                        SWP_NOMOVE,
-                        SWP_NOSIZE,
-                        WM_ACTIVATE,
-                        WM_NCCALCSIZE,
-                        WM_NCHITTEST,
-                        WA_ACTIVE,
-                        WM_ERASEBKGND,
-                        WM_MOUSEMOVE,
-                        WM_MOUSEWHEEL,
-                        WM_LBUTTONDOWN,
-                        WM_LBUTTONUP,
-                        WM_RBUTTONDOWN,
-                        WM_RBUTTONUP,
-                        WM_MBUTTONDOWN,
-                        WM_MBUTTONUP,
-                        WM_KEYDOWN,
-                        WM_SYSKEYDOWN,
-                        WM_CLOSE,
-                        WM_KEYUP,
-                        WM_SYSKEYUP,
-                        WM_CHAR,
-                        WM_ENTERSIZEMOVE,
-                        WM_EXITSIZEMOVE,
-                        WM_SIZE,
-                        WM_DPICHANGED,
-                        WM_DESTROY,
-                        HTTOPLEFT,
-                        HTBOTTOMLEFT,
-                        HTLEFT,
-                        HTTOPRIGHT,
-                        HTBOTTOMRIGHT,
-                        HTRIGHT,
-                        HTTOP,
-                        HTBOTTOM,
-                        HTCLIENT,
-                        HTCAPTION,
-                        HTSYSMENU
-                    },
+                        CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, SetClipboardData
+                    }, LibraryLoader::GetModuleHandleW, Memory::{
+                        GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock, GLOBAL_ALLOC_FLAGS
+                    }, Ole::{
+                        IDropTarget, RegisterDragDrop, CF_UNICODETEXT, DROPEFFECT, DROPEFFECT_COPY, DROPEFFECT_LINK, DROPEFFECT_MOVE
+                    }, SystemServices::{
+                        MK_CONTROL, MK_SHIFT, MODIFIERKEYS_FLAGS
+                    }, WindowsProgramming::GMEM_DDESHARE
+                }, UI::{
                     Controls::{
                         MARGINS,
                         WM_MOUSELEAVE
-                    },
-                    Input::KeyboardAndMouse::{
-                        VIRTUAL_KEY,
-                        ReleaseCapture,
-                        SetCapture,
-                        TrackMouseEvent,
-                        GetKeyState,
-                        TRACKMOUSEEVENT,
-                        TME_LEAVE,
-                        VK_CONTROL,
-                        VK_SHIFT,
-                        VK_MENU,
-                        VK_LWIN,
-                        VK_RWIN,
-                        VK_ESCAPE,
-                        VK_OEM_3,
-                        VK_0,
-                        VK_1,
-                        VK_2,
-                        VK_3,
-                        VK_4,
-                        VK_5,
-                        VK_6,
-                        VK_7,
-                        VK_8,
-                        VK_9,
-                        VK_OEM_MINUS,
-                        VK_OEM_PLUS,
-                        VK_BACK,
-                        VK_TAB,
-                        VK_Q,
-                        VK_W,
-                        VK_E,
-                        VK_R,
-                        VK_T,
-                        VK_Y,
-                        VK_U,
-                        VK_I,
-                        VK_O,
-                        VK_P,
-                        VK_OEM_4,
-                        VK_OEM_6,
-                        VK_RETURN,
-                        VK_A,
-                        VK_S,
-                        VK_D,
-                        VK_F,
-                        VK_G,
-                        VK_H,
-                        VK_J,
-                        VK_K,
-                        VK_L,
-                        VK_OEM_1,
-                        VK_OEM_7,
-                        VK_OEM_5,
-                        VK_Z,
-                        VK_X,
-                        VK_C,
-                        VK_V,
-                        VK_B,
-                        VK_N,
-                        VK_M,
-                        VK_OEM_COMMA,
-                        VK_OEM_PERIOD,
-                        VK_OEM_2,
-                        VK_LCONTROL,
-                        VK_RCONTROL,
-                        VK_LMENU,
-                        VK_RMENU,
-                        VK_LSHIFT,
-                        VK_RSHIFT,
-                        VK_SPACE,
-                        VK_CAPITAL,
-                        VK_F1,
-                        VK_F2,
-                        VK_F3,
-                        VK_F4,
-                        VK_F5,
-                        VK_F6,
-                        VK_F7,
-                        VK_F8,
-                        VK_F9,
-                        VK_F10,
-                        VK_F11,
-                        VK_F12,
-                        VK_SNAPSHOT,
-                        VK_SCROLL,
-                        VK_PAUSE,
-                        VK_INSERT,
-                        VK_DELETE,
-                        VK_HOME,
-                        VK_END,
-                        VK_PRIOR,
-                        VK_NEXT,
-                        VK_NUMPAD0,
-                        VK_NUMPAD1,
-                        VK_NUMPAD2,
-                        VK_NUMPAD3,
-                        VK_NUMPAD4,
-                        VK_NUMPAD5,
-                        VK_NUMPAD6,
-                        VK_NUMPAD7,
-                        VK_NUMPAD8,
-                        VK_NUMPAD9,
-                        VK_SUBTRACT,
-                        VK_ADD,
-                        VK_DECIMAL,
-                        VK_MULTIPLY,
-                        VK_DIVIDE,
-                        VK_NUMLOCK,
-                        VK_UP,
-                        VK_DOWN,
-                        VK_LEFT,
-                        VK_RIGHT,
-                    },
-                },
-                Graphics::{
-                    Dwm::DwmExtendFrameIntoClientArea,
-                    Gdi::ScreenToClient,
-                },
+                    }, Input::KeyboardAndMouse::{
+                        GetKeyState, ReleaseCapture, SetCapture, TrackMouseEvent, TME_LEAVE, TRACKMOUSEEVENT, VIRTUAL_KEY, VK_0, VK_1, VK_2, VK_3, VK_4, VK_5, VK_6, VK_7, VK_8, VK_9, VK_A, VK_ADD, VK_B, VK_BACK, VK_C, VK_CAPITAL, VK_CONTROL, VK_D, VK_DECIMAL, VK_DELETE, VK_DIVIDE, VK_DOWN, VK_E, VK_END, VK_ESCAPE, VK_F, VK_F1, VK_F10, VK_F11, VK_F12, VK_F2, VK_F3, VK_F4, VK_F5, VK_F6, VK_F7, VK_F8, VK_F9, VK_G, VK_H, VK_HOME, VK_I, VK_INSERT, VK_J, VK_K, VK_L, VK_LCONTROL, VK_LEFT, VK_LMENU, VK_LSHIFT, VK_LWIN, VK_M, VK_MENU, VK_MULTIPLY, VK_N, VK_NEXT, VK_NUMLOCK, VK_NUMPAD0, VK_NUMPAD1, VK_NUMPAD2, VK_NUMPAD3, VK_NUMPAD4, VK_NUMPAD5, VK_NUMPAD6, VK_NUMPAD7, VK_NUMPAD8, VK_NUMPAD9, VK_O, VK_OEM_1, VK_OEM_2, VK_OEM_3, VK_OEM_4, VK_OEM_5, VK_OEM_6, VK_OEM_7, VK_OEM_COMMA, VK_OEM_MINUS, VK_OEM_PERIOD, VK_OEM_PLUS, VK_P, VK_PAUSE, VK_PRIOR, VK_Q, VK_R, VK_RCONTROL, VK_RETURN, VK_RIGHT, VK_RMENU, VK_RSHIFT, VK_RWIN, VK_S, VK_SCROLL, VK_SHIFT, VK_SNAPSHOT, VK_SPACE, VK_SUBTRACT, VK_T, VK_TAB, VK_U, VK_UP, VK_V, VK_W, VK_X, VK_Y, VK_Z
+                    }, WindowsAndMessaging::{
+                        CreateWindowExW, DefWindowProcW, DestroyWindow, GetClientRect, GetWindowLongPtrW, GetWindowPlacement, GetWindowRect, MoveWindow, PostMessageW, SetWindowLongPtrW, SetWindowPos, ShowWindow, CW_USEDEFAULT, GWLP_USERDATA, GWL_EXSTYLE, HTBOTTOM, HTBOTTOMLEFT, HTBOTTOMRIGHT, HTCAPTION, HTCLIENT, HTLEFT, HTRIGHT, HTSYSMENU, HTTOP, HTTOPLEFT, HTTOPRIGHT, HWND_NOTOPMOST, HWND_TOPMOST, SWP_NOMOVE, SWP_NOSIZE, SW_MAXIMIZE, SW_MINIMIZE, SW_RESTORE, SW_SHOW, WA_ACTIVE, WINDOWPLACEMENT, WM_ACTIVATE, WM_CHAR, WM_CLOSE, WM_DESTROY, WM_DPICHANGED, WM_ENTERSIZEMOVE, WM_ERASEBKGND, WM_EXITSIZEMOVE, WM_KEYDOWN, WM_KEYUP, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_NCCALCSIZE, WM_NCHITTEST, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SIZE, WM_SYSKEYDOWN, WM_SYSKEYUP, WS_CLIPCHILDREN, WS_CLIPSIBLINGS, WS_EX_ACCEPTFILES, WS_EX_APPWINDOW, WS_EX_TOPMOST, WS_EX_WINDOWEDGE, WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_POPUP, WS_SIZEBOX, WS_SYSMENU
+                    }
+                }
             },
-        },
-        event::*,
-        area::Area,
-        os::windows::{
-            win32_app::{
-                Win32App,
-                encode_wide,
-                FALSE,
-                get_win32_app_global,
-            },
-            win32_event::*,
-            droptarget::*,
-        },
-        window::WindowId,
-        makepad_math::*,
-        cursor::MouseCursor,
-    },
+        }
+    }, std::{
+        cell::{
+            Cell, RefCell
+        }, ffi::OsStr, mem, os::windows::ffi::OsStrExt, rc::Rc, sync::{Arc, Mutex}
+    }, windows::Win32::UI::WindowsAndMessaging::{WM_XBUTTONDOWN, WM_XBUTTONUP}
 };
 /*
 // Copied from Microsoft so it refers to the right IDropTarget
@@ -516,13 +282,26 @@ impl Win32Window {
             WM_LBUTTONDOWN => {
                 // hack for drag/drop: save which window was last clicked on in win32_app
                 get_win32_app_global().currently_clicked_window_id = Some(window.window_id);
-                window.send_mouse_down(0, Self::get_key_modifiers());
+                window.send_mouse_down(MouseButton::PRIMARY, Self::get_key_modifiers());
             },
-            WM_LBUTTONUP => window.send_mouse_up(0, Self::get_key_modifiers()),
-            WM_RBUTTONDOWN => window.send_mouse_down(1, Self::get_key_modifiers()),
-            WM_RBUTTONUP => window.send_mouse_up(1, Self::get_key_modifiers()),
-            WM_MBUTTONDOWN => window.send_mouse_down(2, Self::get_key_modifiers()),
-            WM_MBUTTONUP => window.send_mouse_up(2, Self::get_key_modifiers()),
+            WM_LBUTTONUP => window.send_mouse_up(MouseButton::PRIMARY, Self::get_key_modifiers()),
+            WM_RBUTTONDOWN => window.send_mouse_down(MouseButton::SECONDARY, Self::get_key_modifiers()),
+            WM_RBUTTONUP => window.send_mouse_up(MouseButton::SECONDARY, Self::get_key_modifiers()),
+            WM_MBUTTONDOWN => window.send_mouse_down(MouseButton::MIDDLE, Self::get_key_modifiers()),
+            WM_MBUTTONUP => window.send_mouse_up(MouseButton::MIDDLE, Self::get_key_modifiers()),
+            // All other mouse buttons are handled as "XBUTTON"s.
+            // Their specific button value is obtained via the "hiword" (bits 16..32) of the `wparam` value.
+            // The back mosue button is XBUTTON1 (value 0x1); the forward button is XBUTTON2 (value 0x2).
+            WM_XBUTTONDOWN => {
+                let wparam_hiword = (wparam.0 >> 16) & 0xFFFF;
+                let raw_button = wparam_hiword + 2; // MouseButton::BACK is 3, MouseButton::FORWARD is 4.
+                window.send_mouse_down(MouseButton::from_raw_button(raw_button), Self::get_key_modifiers());
+            }
+            WM_XBUTTONUP => {
+                let wparam_hiword = (wparam.0 >> 16) & 0xFFFF;
+                let raw_button = wparam_hiword + 2; // MouseButton::BACK is 3, MouseButton::FORWARD is 4.
+                window.send_mouse_up(MouseButton::from_raw_button(raw_button), Self::get_key_modifiers());
+            }   
             WM_KEYDOWN | WM_SYSKEYDOWN => {
                 // detect control/cmd - c / v / x
                 let modifiers = Self::get_key_modifiers();
@@ -997,7 +776,7 @@ impl Win32Window {
         self.do_callback(Win32Event::AppLostFocus);
     }
     
-    pub fn send_mouse_down(&mut self, button: usize, modifiers: KeyModifiers) {
+    pub fn send_mouse_down(&mut self, button: MouseButton, modifiers: KeyModifiers) {
         if self.mouse_buttons_down == 0 {
             unsafe {SetCapture(self.hwnd);}
         }
@@ -1012,7 +791,7 @@ impl Win32Window {
         }));
     }
     
-    pub fn send_mouse_up(&mut self, button: usize, modifiers: KeyModifiers) {
+    pub fn send_mouse_up(&mut self, button: MouseButton, modifiers: KeyModifiers) {
         if self.mouse_buttons_down > 1 {
             self.mouse_buttons_down -= 1;
         }

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -291,15 +291,16 @@ impl Win32Window {
             WM_MBUTTONUP => window.send_mouse_up(MouseButton::MIDDLE, Self::get_key_modifiers()),
             // All other mouse buttons are handled as "XBUTTON"s.
             // Their specific button value is obtained via the "hiword" (bits 16..32) of the `wparam` value.
-            // The back mosue button is XBUTTON1 (value 0x1); the forward button is XBUTTON2 (value 0x2).
+            // The back mouse button is XBUTTON1 (value 0x1); the forward button is XBUTTON2 (value 0x2).
+            // Thus, we add `2` to the XBUTTON value in order to get the `MouseButton` value of `3` for BACK and `4` for FORWARD.
             WM_XBUTTONDOWN => {
                 let wparam_hiword = (wparam.0 >> 16) & 0xFFFF;
-                let raw_button = wparam_hiword + 2; // MouseButton::BACK is 3, MouseButton::FORWARD is 4.
+                let raw_button = wparam_hiword + 2;
                 window.send_mouse_down(MouseButton::from_raw_button(raw_button), Self::get_key_modifiers());
             }
             WM_XBUTTONUP => {
                 let wparam_hiword = (wparam.0 >> 16) & 0xFFFF;
-                let raw_button = wparam_hiword + 2; // MouseButton::BACK is 3, MouseButton::FORWARD is 4.
+                let raw_button = wparam_hiword + 2;
                 window.send_mouse_up(MouseButton::from_raw_button(raw_button), Self::get_key_modifiers());
             }   
             WM_KEYDOWN | WM_SYSKEYDOWN => {

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -206,12 +206,12 @@ impl Cx {
                 // send MouseUp
                 self.call_event_handler(&Event::MouseUp(MouseUpEvent {
                     abs: dvec2(-100000.0, -100000.0),
-                    button: 0,
+                    button: MouseButton::PRIMARY,
                     window_id: CxWindowPool::id_zero(),
                     modifiers: Default::default(),
                     time: 0.0
                 }));
-                self.fingers.mouse_up(0);
+                self.fingers.mouse_up(MouseButton::PRIMARY);
                 self.fingers.cycle_hover_area(live_id!(mouse).into());
             }
             Win32Event::KeyDown(e) => {

--- a/platform/src/os/windows/windows_stdin.rs
+++ b/platform/src/os/windows/windows_stdin.rs
@@ -143,9 +143,10 @@ impl Cx {
                         dvec2(e.x, e.y),
                         e.time
                     );
-                    let  (window_id,pos) = self.windows.window_id_contains(dvec2(e.x, e.y));
-                    self.fingers.mouse_down(e.button, window_id);
-                    self.call_event_handler(&Event::MouseDown(e.into_event(window_id, pos)));
+                    let (window_id, pos) = self.windows.window_id_contains(dvec2(e.x, e.y));
+                    let mouse_down_event = e.into_event(window_id, pos);
+                    self.fingers.mouse_down(mouse_down_event.button, window_id);
+                    self.call_event_handler(&Event::MouseDown(mouse_down_event));
                 }
                 HostToStdin::MouseMove(e) => {
                     let (window_id, pos) = if let Some((_, window_id)) = self.fingers.first_mouse_button{
@@ -159,14 +160,15 @@ impl Cx {
                     self.fingers.switch_captures();
                 }
                 HostToStdin::MouseUp(e) => {
-                    let button = e.button;
                     let (window_id, pos) = if let Some((_, window_id)) = self.fingers.first_mouse_button{
                         (window_id, self.windows[window_id].window_geom.position)
                     }
                     else{
                         self.windows.window_id_contains(dvec2(e.x, e.y))
                     };
-                    self.call_event_handler(&Event::MouseUp(e.into_event(window_id, pos)));
+                    let mouse_up_event = e.into_event(window_id, pos);
+                    let button = mouse_up_event.button;
+                    self.call_event_handler(&Event::MouseUp(mouse_up_event));
                     self.fingers.mouse_up(button);
                     self.fingers.cycle_hover_area(live_id!(mouse).into());
                 }

--- a/studio/src/build_manager/build_manager.rs
+++ b/studio/src/build_manager/build_manager.rs
@@ -372,7 +372,7 @@ impl BuildManager {
                                         time: e.time,
                                         x: e.abs.x,
                                         y: e.abs.y,
-                                        button: e.button,
+                                        raw_button: e.button,
                                         modifiers: StdinKeyModifiers::from_key_modifiers(
                                             &e.modifiers,
                                         ),
@@ -397,7 +397,7 @@ impl BuildManager {
             Event::MouseUp(e) => {
                 self.broadcast_to_stdin(HostToStdin::MouseUp(StdinMouseUp {
                     time: e.time,
-                    button: e.button,
+                    raw_button: e.button,
                     x: e.abs.x,
                     y: e.abs.y,
                     modifiers: StdinKeyModifiers::from_key_modifiers(&e.modifiers),

--- a/studio/src/build_manager/build_manager.rs
+++ b/studio/src/build_manager/build_manager.rs
@@ -372,7 +372,7 @@ impl BuildManager {
                                         time: e.time,
                                         x: e.abs.x,
                                         y: e.abs.y,
-                                        raw_button: e.button,
+                                        button_raw_bits: e.button.bits(),
                                         modifiers: StdinKeyModifiers::from_key_modifiers(
                                             &e.modifiers,
                                         ),
@@ -397,7 +397,7 @@ impl BuildManager {
             Event::MouseUp(e) => {
                 self.broadcast_to_stdin(HostToStdin::MouseUp(StdinMouseUp {
                     time: e.time,
-                    raw_button: e.button,
+                    button_raw_bits: e.button.bits(),
                     x: e.abs.x,
                     y: e.abs.y,
                     modifiers: StdinKeyModifiers::from_key_modifiers(&e.modifiers),

--- a/tools/cargo_makepad/src/wasm/compile.rs
+++ b/tools/cargo_makepad/src/wasm/compile.rs
@@ -298,7 +298,7 @@ pub fn start_wasm_server(root:PathBuf, lan:bool, port: u16) {
     else{
         SocketAddr::new("127.0.0.1".parse().unwrap(), port)
     };
-    println!("Starting webserver on {:?}", addr);
+    println!("Starting webserver on http://{:?}", addr);
     let (tx_request, rx_request) = mpsc::channel::<HttpServerRequest> ();
             
     start_http_server(HttpServer {

--- a/widgets/src/stack_navigation.rs
+++ b/widgets/src/stack_navigation.rs
@@ -217,7 +217,7 @@ impl StackNavigationView {
         // or if the Android back navigation "action"/gesture occurred.
         if self.state == StackNavigationViewState::Active {
             let back_mouse_button_released = match event {
-                Event::MouseUp(mouse) => mouse.button == 3, // the "back" button on the mouse
+                Event::MouseUp(mouse) => mouse.button.is_back(),
                 _ => false,
             };
 


### PR DESCRIPTION
**All good and ready to merge!**

~~Not yet ready to merge~~

---------------------

The `MouseButton` type is intended to provide a multi-platform abstraction for the 5 common mouse buttons, as well as support for arbitrary button numbers. These 5 buttons are:
1. The primary mouse button, typically the left-click button.
2. The secondary mouse button, typically the right-click button.
3. The middle mouse button, typically the scroll-wheel click button.
4. The fourth mouse button, typically used for back navigation.
5. The fifth mouse button, typically used for forward navigation.


It also supports the notion of multiple mouse buttons being pressed simultaneously, e.g., left-clicking while the right-click button is held down (though many platforms don't actually support emitting those events).

Platforms currently supported:
- [x] macOS
- [x] windows 
- [x] Linux X11
-  ~~Android~~ no specific mouse support
- [x] iOS
- [x] Linux direct
- [x] web
- ~~ohos~~ (build is broken) 