### PR TITLE
Only trigger actions for most widgets upon a primary mouse button/touch hit

### DIFF
--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -1,11 +1,32 @@
 #![allow(unused)]
 #![allow(dead_code)]
 use {
+    std::{cell::Cell, ops::Deref},
     crate::{
-        area::Area, cx::Cx, event::event::{Event, Hit}, live_traits::{Apply, LiveApply, LiveApplyReset, LiveApplyValue, LiveHook, LiveHookDeref, LiveNew, LiveRegister}, makepad_derive_live::*, makepad_live_compiler::{
-            LiveFieldKind, LiveId, LiveModuleId, LiveNode, LiveNodeSliceApi, LivePropType, LiveType, LiveTypeField, LiveTypeInfo
-        }, makepad_live_id::{live_id, live_id_num, FromLiveId}, makepad_live_tokenizer::{live_error_origin, LiveErrorOrigin}, makepad_math::*, makepad_micro_serde::*, window::WindowId
-    }, std::{cell::Cell, ops::Deref}
+        makepad_micro_serde::*,
+        makepad_live_tokenizer::{LiveErrorOrigin, live_error_origin},
+        makepad_live_compiler::{
+            LivePropType,
+            LiveType,
+            LiveTypeField,
+            LiveFieldKind,
+            LiveNode,
+            LiveId,
+            LiveModuleId,
+            LiveTypeInfo,
+            LiveNodeSliceApi
+        },
+        live_traits::{LiveNew, LiveHook, LiveRegister, LiveHookDeref, LiveApplyValue, LiveApply,LiveApplyReset, Apply},
+        makepad_derive_live::*,
+        makepad_math::*,
+        makepad_live_id::{FromLiveId, live_id, live_id_num},
+        event::{
+            event::{Event, Hit}
+        },
+        window::WindowId,
+        cx::Cx,
+        area::Area,
+    },
 };
 
 // Mouse events

--- a/widgets/src/check_box.rs
+++ b/widgets/src/check_box.rs
@@ -389,7 +389,7 @@ impl Widget for CheckBox {
             Hit::FingerHoverOut(_) => {
                 self.animator_play(cx, id!(hover.off));
             },
-            Hit::FingerDown(_fe) => {
+            Hit::FingerDown(fe) if fe.is_primary_hit() => {
                 if self.animator_in_state(cx, id!(selected.on)) {
                     self.animator_play(cx, id!(selected.off));
                     cx.widget_action_with_data(&self.action_data, uid, &scope.path, CheckBoxAction::Change(false));

--- a/widgets/src/drop_down.rs
+++ b/widgets/src/drop_down.rs
@@ -477,7 +477,7 @@ impl Widget for DropDown {
                 },
                 _ => ()
             }
-            Hit::FingerDown(_fe) => {
+            Hit::FingerDown(fe) if fe.is_primary_hit() => {
                 cx.set_key_focus(self.draw_bg.area());
                 self.set_open(cx);
                 self.animator_play(cx, id!(hover.pressed));
@@ -489,7 +489,7 @@ impl Widget for DropDown {
             Hit::FingerHoverOut(_) => {
                 self.animator_play(cx, id!(hover.off));
             }
-            Hit::FingerUp(fe) => {
+            Hit::FingerUp(fe) if fe.is_primary_hit() => {
                 if fe.is_over {
                     if fe.device.has_hovers() {
                         self.animator_play(cx, id!(hover.on));

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -703,7 +703,7 @@ impl Widget for HtmlLink {
 
         for area in self.drawn_areas.clone().into_iter() {
             match event.hits(cx, area) {
-                Hit::FingerDown(_fe) => {
+                Hit::FingerDown(fe) if fe.is_primary_hit() => {
                     if self.grab_key_focus {
                         cx.set_key_focus(self.area());
                     }

--- a/widgets/src/popup_menu.rs
+++ b/widgets/src/popup_menu.rs
@@ -246,12 +246,12 @@ impl PopupMenuItem {
             Hit::FingerHoverOut(_) => {
                 self.animator_play(cx, id!(hover.off));
             }
-            Hit::FingerDown(_) => {
+            Hit::FingerDown(fe) if fe.is_primary_hit() => {
                 dispatch_action(cx, PopupMenuItemAction::WasSweeped);
                 self.animator_play(cx, id!(hover.on));
                 self.animator_play(cx, id!(select.on));
             }
-            Hit::FingerUp(se) => {
+            Hit::FingerUp(se) if se.is_primary_hit() => {
                 if !se.is_sweep {
                     //if se.was_tap() { // ok this only goes for the first time
                     //    dispatch_action(cx, PopupMenuItemAction::MightBeSelected);

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -880,7 +880,10 @@ impl Widget for PortalList {
                     },
                     _ => ()
                 }
-                Hit::FingerDown(e) => {
+                Hit::FingerDown(fe) => {
+                    // We allow other mouse buttons to grab key focus and stop the tail range behavior,
+                    // but we only want the primary button (or touch) to actually scroll via dragging.
+
                     //log!("Finger down {} {}", e.time, e.abs);
                     if self.grab_key_focus {
                         cx.set_key_focus(self.area);
@@ -889,9 +892,9 @@ impl Widget for PortalList {
                     if self.tail_range {
                         self.tail_range = false;
                     }
-                    if self.drag_scrolling{
+                    if self.drag_scrolling && fe.is_primary_hit() {
                         self.scroll_state = ScrollState::Drag {
-                            samples: vec![ScrollSample{abs:e.abs.index(vi),time:e.time}]
+                            samples: vec![ScrollSample{abs: fe.abs.index(vi), time: fe.time}]
                         };
                     }
                 }
@@ -912,7 +915,7 @@ impl Widget for PortalList {
                         _=>()
                     }
                 }
-                Hit::FingerUp(_e) => {
+                Hit::FingerUp(fe) if fe.is_primary_hit() => {
                     //log!("Finger up {} {}", e.time, e.abs);
                     match &mut self.scroll_state {
                         ScrollState::Drag {samples}=>{

--- a/widgets/src/radio_button.rs
+++ b/widgets/src/radio_button.rs
@@ -417,7 +417,7 @@ impl Widget for RadioButton {
                 cx.set_cursor(MouseCursor::Arrow);
                 self.animator_play(cx, id!(hover.off));
             },
-            Hit::FingerDown(_fe) => {
+            Hit::FingerDown(fe) if fe.is_primary_hit() => {
                 if self.animator_in_state(cx, id!(selected.off)) {
                     self.animator_play(cx, id!(selected.on));
                     cx.widget_action(uid, &scope.path, RadioButtonAction::Clicked);

--- a/widgets/src/scroll_bar.rs
+++ b/widgets/src/scroll_bar.rs
@@ -431,7 +431,7 @@ impl ScrollBar {
             }
             
             match event.hits(cx, self.draw_bar.area()) {
-                Hit::FingerDown(fe) => {
+                Hit::FingerDown(fe) if fe.is_primary_hit() => {
                     self.animator_play(cx, id!(hover.pressed));
                     let rel = fe.abs - fe.rect.pos;
                     let rel = match self.axis {
@@ -457,7 +457,7 @@ impl ScrollBar {
                 Hit::FingerHoverOut(_) => {
                     self.animator_play(cx, id!(hover.off));
                 },
-                Hit::FingerUp(fe) => {
+                Hit::FingerUp(fe) if fe.is_primary_hit() => {
                     self.drag_point = None;
                     if fe.is_over && fe.device.has_hovers() {
                         self.animator_play(cx, id!(hover.on));

--- a/widgets/src/slider.rs
+++ b/widgets/src/slider.rs
@@ -1005,8 +1005,9 @@ impl Widget for Slider {
             Hit::FingerDown(FingerDownEvent {
                 abs,
                 rect,
+                device,
                 ..
-            }) => {
+            }) if device.is_primary_hit() => {
                 // cx.set_key_focus(self.slider.area());
                 self.relative_value = ((abs.x - rect.pos.x) / rect.size.x ).max(0.0).min(1.0);
                 self.update_text_input(cx);
@@ -1021,7 +1022,7 @@ impl Widget for Slider {
                 cx.widget_action(uid, &scope.path, SliderAction::StartSlide);
                 cx.set_cursor(MouseCursor::Grabbing);
             },
-            Hit::FingerUp(fe) => {
+            Hit::FingerUp(fe) if fe.is_primary_hit() => {
                 self.text_input.is_read_only = false;
                 // if the finger hasn't moved further than X we jump to edit-all on the text thing
                 self.text_input.force_new_edit_group();

--- a/widgets/src/tab.rs
+++ b/widgets/src/tab.rs
@@ -291,8 +291,13 @@ impl Tab {
                     self.is_dragging = false;
                 }
             }
-            Hit::FingerDown(_) => {
-                dispatch_action(cx, TabAction::WasPressed);
+            Hit::FingerDown(fde) => {
+                // A primary click/touch selects the tab, but a middle click closes it.
+                if fde.is_primary_hit() {
+                    dispatch_action(cx, TabAction::WasPressed);
+                } else if fde.mouse_button().is_some_and(|b| b.is_middle()) {
+                    dispatch_action(cx, TabAction::CloseWasPressed);
+                }
             }
             _ => {}
         }

--- a/widgets/src/tab_close_button.rs
+++ b/widgets/src/tab_close_button.rs
@@ -88,7 +88,13 @@ impl TabCloseButton {
                 self.animator_play(cx, id!(hover.off));
                 return TabCloseButtonAction::HoverOut;
             }
-            Hit::FingerDown(_) => return TabCloseButtonAction::WasPressed,
+            // Pressing the tab close button with a primary button/touch
+            // or the middle mouse button are both recognized as a close tab action.
+            Hit::FingerDown(fe) 
+                if fe.is_primary_hit() || fe.mouse_button().is_some_and(|b| b.is_middle()) =>
+            {
+                return TabCloseButtonAction::WasPressed;
+            }
             _ => {}
         }
         TabCloseButtonAction::None

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -792,12 +792,12 @@ impl Widget for TextFlowLink {
         
         for area in self.drawn_areas.clone().into_iter() {
             match event.hits(cx, area) {
-                Hit::FingerDown(fe) => {
+                Hit::FingerDown(fe) if fe.is_primary_hit() => {
                     if self.grab_key_focus {
                         cx.set_key_focus(self.area());
                     }
                     self.animator_play(cx, id!(hover.pressed));
-                    if self. click_on_down{
+                    if self.click_on_down{
                         cx.widget_action_with_data(
                             &self.action_data,
                             self.widget_uid(),
@@ -815,7 +815,7 @@ impl Widget for TextFlowLink {
                 Hit::FingerHoverOut(_) => {
                     self.animator_play(cx, id!(hover.off));
                 }
-                Hit::FingerUp(fe) => {
+                Hit::FingerUp(fe) if fe.is_primary_hit() => {
                     if fe.is_over {
                         if !self.click_on_down{
                             cx.widget_action_with_data(

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -711,6 +711,7 @@ impl Widget for TextInput {
             Hit::FingerDown(FingerDownEvent {
                 abs,
                 tap_count,
+                device,
                 ..
             }) => {
                 let event = DrawEvent::default();
@@ -721,12 +722,14 @@ impl Widget for TextInput {
                     abs - padded_rect.pos
                 );
                 self.move_cursor_to(index_affinity, false);
-                if tap_count == 2 {
-                    self.select_word();
-                } else if tap_count == 3 {
-                    self.select_all();
+                if device.is_primary_hit() {
+                    if tap_count == 2 {
+                        self.select_word();
+                    } else if tap_count == 3 {
+                        self.select_all();
+                    }
+                    self.set_key_focus(&mut *cx);
                 }
-                self.set_key_focus(&mut *cx);
                 self.draw_bg.redraw(&mut *cx);
             }
             Hit::FingerMove(FingerMoveEvent {

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -499,17 +499,16 @@ impl Video {
 
     fn handle_gestures(&mut self, cx: &mut Cx, event: &Event) {
         match event.hits(cx, self.draw_bg.area()) {
-            Hit::FingerDown(_fe) => {
+            Hit::FingerDown(fe) if fe.is_primary_hit() => {
                 if self.hold_to_pause {
                     self.pause_playback(cx);
                 }
             }
-            Hit::FingerUp(_fe) => {
+            Hit::FingerUp(fe) if fe.is_primary_hit() => {
                 if self.hold_to_pause {
                     self.resume_playback(cx);
                 }
             }
-            
             _ => (),
         }
     }


### PR DESCRIPTION
Many widgets that can be clicked have previously treated *any* click as if it were a primary mouse button click (or touch). This has led to unexpected results, such as activating a button upon a right click or a back/forward button click, which is generally non-standard behavior.

This changeset ensures that many widget actions only occur if a regular touch press or a primary mouse button click occurs. To make this easy, we add the `is_primary_hit()` function which can be conveniently added to a branch when matching on `hits()`:
```rust
match event.hits(...) {
    Hit::FingerDown(fe) if fe.is_primary_hit() => { ... }
    Hit::FingerUp(fe) if fe.is_primary_hit() => { ... }
}
```

This also makes very minor changes to certain widgets that should have special behavior based on which mouse button is pressed.
For example, if a `Tab` or its tab close button is middle-clicked, the tab should be closed, not selected.

------ 

One specific widget that I did not change the click behavior for is the FileTree. In my opinion, a file tree should only be expanded upon a primary click, but considering that secondary (right-clicks) currently don't have any effect on a FileTree node, I figured it was better to continue treating right-click as primary clicks.