### PR TITLE
Wasm bindgen tiny fixes and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,11 +300,29 @@ issue.
 
 To enable wasm-bindgen integration you should build like this:
 
-```bash
-# Ensure wasm-bindgen CLI is installed.
-cargo install -f wasm-bindgen-cli
+1. Ensure wasm-bindgen CLI is installed.
 
-# Run with `--bindgen` option
+```bash
+cargo install -f wasm-bindgen-cli
+```
+
+2. Add `wasm-bindgen` dependency to your `Cargo.toml` file.
+
+```bash
+cargo add wasm-bindgen
+```
+
+3. Ensure you are using the crate somewhere like in `main.rs`.
+
+```rust
+use wasm_bindgen::prelude::*;
+```
+
+> **Note:** If you forget this, you may see a compile error like `failed to find __wbindgen_malloc`.
+
+4. Now, run with the `--bindgen` option.
+
+```bash
 cargo makepad wasm --bindgen run -p makepad-example-hello-widgets --release
 ```
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,26 @@ cargo makepad wasm install-toolchain
 cargo makepad wasm run -p makepad-example-simple --release
 ```
 
+### If you need `wasm-bindgen` compatibility
+
+By default, Makepad uses it's own bridge. Web crates outside of Makepad
+usually depend on `wasm-bindgen` for web integration so they will fail
+at runtime if added to your project.
+
+However, we can build with opt-in `wasm-bindgen` support to solve this
+issue.
+
+To enable wasm-bindgen integration you should build like this:
+
+```bash
+# Ensure wasm-bindgen CLI is installed.
+cargo install -f wasm-bindgen-cli
+
+# Run with `--bindgen` option
+cargo makepad wasm --bindgen run -p makepad-example-hello-widgets --release
+```
+
+
 ---
 
 ## Makepad Commands Quick Reference

--- a/tools/cargo_makepad/src/wasm/compile.rs
+++ b/tools/cargo_makepad/src/wasm/compile.rs
@@ -41,7 +41,7 @@ pub fn generate_html(wasm:&str, config: &WasmConfig)->String{
             wasm._has_thread_support = true;
             wasm._memory = wasm.exports.memory;
             wasm._module = module;
-            use {{WasmWebGL}} from './makepad_platform/web_gl.js'
+            import {{WasmWebGL}} from './makepad_platform/web_gl.js'
             ")
     } else {
         format!("


### PR DESCRIPTION
# Changes
- Fix a tiny syntax error in the generated JS when using the `--bindgen` option.
- Document this opt-in feature to the README.