### PR TITLE
inline search for command text input

### DIFF
--- a/widgets/src/command_text_input.rs
+++ b/widgets/src/command_text_input.rs
@@ -321,13 +321,11 @@ impl CommandTextInput {
 
         let text = self.text();
         let end = get_head(&self.text_input_ref());
-        let Some(start) = end.checked_sub(graphemes(&to_remove).count()) else {
+        let Some(start) = end.checked_sub(to_remove.len()) else {
             return;
         };
 
-        let text = graphemes_with_pos(&text)
-            .filter_map(|(p, g)| if p < start || p >= end { Some(g) } else { None })
-            .collect::<String>();
+        let text = text[..start].to_string() + &text[end..];
 
         self.text_input_ref().set_cursor(start, start);
         self.set_text(cx, &text);
@@ -588,14 +586,6 @@ impl CommandTextInputRef {
 
 fn graphemes(text: &str) -> impl DoubleEndedIterator<Item = &str> {
     text.graphemes(true)
-}
-
-fn graphemes_with_pos(text: &str) -> impl DoubleEndedIterator<Item = (usize, &str)> {
-    text.grapheme_indices(true)
-}
-
-fn inserted_grapheme_with_pos(text: &str, cursor_pos: usize) -> Option<(usize, &str)> {
-    graphemes_with_pos(text).rfind(|(i, _)| *i < cursor_pos)
 }
 
 fn get_head(text_input: &TextInputRef) -> usize {

--- a/widgets/src/command_text_input.rs
+++ b/widgets/src/command_text_input.rs
@@ -158,6 +158,32 @@ impl Widget for CommandTextInput {
     }
 
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        if cx.has_key_focus(self.key_controller_text_input_ref().area()) {
+            if let Event::KeyDown(key_event) = event {
+                let mut eat_the_event = true;
+
+                match key_event.key_code {
+                    KeyCode::ArrowDown => self.on_keyboard_move(cx, 1),
+                    KeyCode::ArrowUp => self.on_keyboard_move(cx, -1),
+                    KeyCode::ReturnKey => {
+                        self.on_keyboard_controller_input_submit(cx, scope);
+                    }
+                    KeyCode::Escape => {
+                        self.is_text_input_focus_pending = true;
+                        self.hide_popup(cx);
+                        self.redraw(cx);
+                    }
+                    _ => {
+                        eat_the_event = false;
+                    }
+                };
+
+                if eat_the_event {
+                    return;
+                }
+            }
+        }
+
         self.deref.handle_event(cx, event, scope);
 
         if cx.has_key_focus(self.text_input_ref().area()) {
@@ -182,24 +208,6 @@ impl Widget for CommandTextInput {
                         );
                     }
                 }
-            }
-        }
-
-        if cx.has_key_focus(self.key_controller_text_input_ref().area()) {
-            if let Event::KeyDown(key_event) = event {
-                match key_event.key_code {
-                    KeyCode::ArrowDown => self.on_keyboard_move(cx, 1),
-                    KeyCode::ArrowUp => self.on_keyboard_move(cx, -1),
-                    KeyCode::ReturnKey => {
-                        self.on_keyboard_controller_input_submit(cx, scope);
-                    }
-                    KeyCode::Escape => {
-                        self.is_text_input_focus_pending = true;
-                        self.hide_popup(cx);
-                        self.redraw(cx);
-                    }
-                    _ => {}
-                };
             }
         }
 


### PR DESCRIPTION
# Changes

- Added a `inline_search` flag that gets rid of the separate search text input field and handles filtering along the main text.
  - When using inline search, not only the trigger but also the search leftover will be removed, setting the cursor back to where you began. This gives you the chance to insert text right there upon selection. 
  - When using inline search, cursor position will be used to determine the search text. This matches Discord behavior.
- If an event is meant to perform keyboard controlling of the options, it's not propagated further.

# Try it

Put this on `examples/hello_widgets/src/ui.rs`.

```rust
use makepad_widgets::*;

live_design!(
    use link::theme::*;
    use link::widgets::*;

    pub Ui = {{Ui}} {
        item_template: <View> {
            height: 40,
            label = <Label> {}
        }

        body = <View> {
            flow: Down,
            align: {x: 0.5, y: 0.5}
            prompt = <CommandTextInput> {
                trigger: "@",
                inline_search: true
            }
            <TextInput> {width: 100, text: "to lose focus"}
        }
    }
);

#[derive(Live, LiveHook, Widget)]
pub struct Ui {
    #[deref]
    deref: View,

    #[live]
    item_template: Option<LivePtr>,
}

impl Widget for Ui {
    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
        self.deref.draw_walk(cx, scope, walk)
    }

    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
        self.deref.handle_event(cx, event, scope);

        let Event::Actions(actions) = event else {
            return;
        };

        let mut prompt = self.command_text_input(id!(prompt));

        if let Some(selected) = prompt.item_selected(actions) {
            let text = selected.label(id!(label)).text();
            println!("Selected: {}", text);
        }

        if prompt.should_build_items(actions) {
            prompt.clear_items();

            let search = prompt.search_text().to_lowercase();

            for fruit in ["Apple", "Banana", "Orange", "火火火"] {
                if fruit.to_lowercase().contains(&search) {
                    let widget = WidgetRef::new_from_ptr(cx, self.item_template);
                    widget.label(id!(label)).set_text(cx, fruit);
                    prompt.add_item(widget);
                }
            }
        }
    }
}
```

If you want to test text insertion, you could update selection handling to the following:

```rust
if let Some(selected) = prompt.item_selected(actions) {
    let selected_text = selected.label(id!(label)).text();
    let head_before = prompt.text_input_ref().borrow().unwrap().get_cursor().head.index;
    let head_after = head_before + selected_text.len();

    let mut prompt_text = prompt.text();
    prompt_text.insert_str(head_before, &selected_text);

    prompt.set_text(cx, &prompt_text);
    prompt.text_input_ref().set_cursor(head_after, head_after);
}
```