### PR TITLE
Add translation capabilities to Cx

### DIFF
--- a/platform/live_compiler/src/live_registry.rs
+++ b/platform/live_compiler/src/live_registry.rs
@@ -39,12 +39,12 @@ pub struct LiveFile {
 #[derive(Default)]
 pub struct LiveLinkTarget{
     targets: Vec<LiveFileId>,
-    combined_exports: Option<HashMap<LiveId, LiveFileId>>
+    pub combined_exports: Option<HashMap<LiveId, LiveFileId>>
 }
 
 pub struct LiveRegistry {
     pub (crate) file_ids: BTreeMap<String, LiveFileId>,
-    pub (crate) link_targets: BTreeMap<LiveId, LiveLinkTarget>,
+    pub link_targets: BTreeMap<LiveId, LiveLinkTarget>,
     pub (crate) link_connections: BTreeMap<LiveId, LiveId>,
     
     pub module_id_to_file_id: BTreeMap<LiveModuleId, LiveFileId>,

--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -1,51 +1,17 @@
 use {
-    makepad_futures::{executor, executor::{Executor, Spawner}},
-    std::{
-        collections::{
+    crate::{
+        action::{ActionSendSync, ActionsBuf, ACTION_SENDER_GLOBAL}, area::Area, cx_api::CxOsOp, debug::Debug, display_context::DisplayContext, draw_list::CxDrawListPool, draw_matrix::CxDrawMatrixPool, draw_shader::CxDrawShaders, event::{
+            CxDragDrop, CxFingers, CxKeyboard, DrawEvent, Event, NextFrame, Trigger
+        }, geometry::{
+            CxGeometryPool, Geometry, GeometryFingerprint
+        }, gpu_info::GpuInfo, makepad_live_compiler::{
+            LiveFileChange, LiveRegistry
+        }, makepad_shader_compiler::ShaderRegistry, os::CxOs, pass::CxPassPool, performance_stats::PerformanceStats, texture::{CxTexturePool, Texture, TextureFormat, TextureUpdated}, translator::Translator, web_socket::WebSocket, window::CxWindowPool
+    }, makepad_futures::executor::{self, Executor, Spawner}, std::{
+        any::{Any, TypeId}, cell::RefCell, collections::{
             HashMap,
             HashSet,
-        },
-        any::{Any, TypeId},
-        rc::Rc,
-        rc::Weak,
-        cell::RefCell,
-    },
-    crate::{
-        action::{ActionSendSync,ACTION_SENDER_GLOBAL},
-        makepad_live_compiler::{
-            LiveRegistry,
-            LiveFileChange
-        },
-        makepad_shader_compiler::ShaderRegistry,
-        draw_shader::CxDrawShaders,
-        draw_matrix::CxDrawMatrixPool,
-        os::CxOs,
-        debug::Debug,
-        display_context::DisplayContext,
-        performance_stats::PerformanceStats,
-        event::{
-            DrawEvent,
-            CxFingers,
-            CxDragDrop,
-            Event,
-            Trigger,
-            CxKeyboard,
-            NextFrame,
-        },
-        action::ActionsBuf,
-        cx_api::CxOsOp,
-        area::Area,
-        gpu_info::GpuInfo,
-        window::CxWindowPool,
-        draw_list::CxDrawListPool,
-        web_socket::WebSocket,
-        pass::CxPassPool,
-        texture::{CxTexturePool,TextureFormat,Texture,TextureUpdated},
-        geometry::{
-            Geometry,
-            CxGeometryPool,
-            GeometryFingerprint
-        },
+        }, rc::{Rc, Weak}
     }
 };
 
@@ -124,6 +90,8 @@ pub struct Cx {
     pub(crate) studio_http: String,
     
     pub performance_stats: PerformanceStats,
+
+    pub translator: Translator,
 
     /// Event ID that triggered a widget query cache invalidation.
     /// When Some(event_id), indicates that widgets should clear their query caches
@@ -311,6 +279,8 @@ impl Cx {
             performance_stats: Default::default(),
 
             display_context: Default::default(),
+
+            translator: Translator::new("en"),
 
             widget_query_invalidation_event: None,
         }

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -639,6 +639,16 @@ impl Cx {
     pub fn event_id(&self) -> u64 {
         self.event_id
     }
+
+    /// Translate a string
+    pub fn tr(&self, key: LiveId) -> String {
+        self.translator.tr(self, key)
+    }
+
+    /// Translate a string with arguments
+    pub fn tr_with_args(&self, key: LiveId, args: &[&str]) -> String {
+        self.translator.tr_with_args(self, key, args)
+    }
 }
 
 #[macro_export]

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -57,6 +57,8 @@ pub mod ui_runner;
 
 pub mod display_context;
 
+pub mod translator;
+
 #[macro_use]
 mod app_main;
 

--- a/platform/src/translator.rs
+++ b/platform/src/translator.rs
@@ -1,0 +1,156 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::error::Error;
+
+use crate::{LiveId, LiveFileId, Cx};
+use crate::makepad_live_compiler::LiveScopeTarget;
+use crate::makepad_live_compiler::live_registry;
+
+#[derive(Debug, Clone)]
+pub struct Translator {
+    current_language: String,
+    translations: HashMap<String, LiveFileId>,
+}
+
+impl Translator {
+    pub fn new(default_lang: &str) -> Self {
+        Translator {
+            current_language: default_lang.to_string(),
+            translations: HashMap::new(),
+        }
+    }
+
+    /// Create a new translator using the convention of having a `translations` directory
+    /// with a file for each language, e.g. `translations/en.rs` for English.
+    /// 
+    /// Example usage:
+    /// ```rust
+    /// let translator = Translator::discover_translations(&cx, "en")?;
+    /// ```
+    /// 
+    pub fn discover_translations(cx: &Cx, default_lang: &str) -> Self {
+        let mut translator = Self::new(default_lang);
+        
+        let live_registry = cx.live_registry.borrow();
+        let mut translations = Vec::new();
+        
+        // Look for translation files in the conventional location
+        for (file_path, _) in live_registry.file_ids() {
+            if file_path.contains("/translations/") && file_path.ends_with(".rs") {
+                // Extract language code from filename (e.g., "en.rs" -> "en")
+                if let Some(file_name) = Path::new(file_path).file_stem() {
+                    if let Some(lang_code) = file_name.to_str() {
+                        translations.push((lang_code, file_path.as_str()));
+                    }
+                }
+            }
+        }
+
+        if translations.is_empty() {
+            error!("No translation files found in /translations/ directory");
+        }
+
+        let _ = translator.set_translations(cx, &translations);
+        translator
+    }
+
+    /// Set the translations for the translator
+    /// 
+    /// Example usage:
+    /// ```rust
+    /// let mut translator = Translator::new("en");
+    ///     translator.set_translations(cx, &[
+    ///         ("en", "src/translations/en.rs"),
+    ///         ("es", "src/translations/es.rs"),
+    ///     ])?;
+    /// ```
+    pub fn set_translations(&mut self, cx: &Cx, translations: &[(&str, &str)]) -> Result<(), Box<dyn Error>> {
+        let mut lang_map = HashMap::new();
+        
+        for (lang, file_name) in translations {
+            let live_registry_ref = cx.live_registry.borrow();
+            let file_id = live_registry_ref.file_name_to_file_id(file_name)
+                .ok_or_else(|| format!("Failed to find file: {}", file_name))?;
+            
+            lang_map.insert(lang.to_string(), file_id);
+        }
+
+        if !lang_map.contains_key(&self.current_language) {
+            return Err("Default language not found in translations".into());
+        }
+
+        self.translations = lang_map;
+        Ok(())
+    }
+
+    pub fn add_translations(&mut self, lang: &str, file_name: &str, cx: &Cx) -> Result<(), Box<dyn Error>> {
+        let live_registry_ref = cx.live_registry.borrow();
+        let file_id = live_registry_ref.file_name_to_file_id(file_name)
+            .ok_or_else(|| format!("Failed to find file: {}", file_name))?;
+        
+        self.translations.insert(lang.to_string(), file_id);
+        Ok(())
+    }
+
+    /// Translate a string
+    pub fn tr(&self, cx: &Cx, tr_live_id: LiveId) -> String {
+        let file_id = self.translations.get(&self.current_language).expect("Failed to find translation file");
+
+        let live_registry_ref = cx.live_registry.borrow();
+
+        let live_file = live_registry_ref.file_id_to_file(*file_id);
+        // All the nodes in the file
+        let nodes = &live_file.expanded.nodes;
+
+        // Find the target node
+        let target = live_registry_ref.find_scope_target(tr_live_id, nodes).expect("Failed to find target");
+        match target {
+            // The target is a local pointer to a node in the same file
+            live_registry::LiveScopeTarget::LocalPtr(local_ptr) => {
+                let live_node = nodes.get(local_ptr).expect("Failed to find node");
+                let value = live_registry_ref.live_node_as_string(live_node);
+                value.expect("Translation not found")
+            }
+            // The target is a live pointer to a node in another file 
+            live_registry::LiveScopeTarget::LivePtr(live_ptr) => {
+                let node = live_registry_ref.ptr_to_node(live_ptr);
+                let value = live_registry_ref.live_node_as_string(node);
+                value.expect("Translation not found")
+            }
+        }
+    }
+
+    /// Translate a string with arguments
+    pub fn tr_with_args(
+        &self,
+        cx: &Cx,
+        tr_live_id: LiveId,
+        args: &[&str],
+    ) -> String {
+        // Fetch the translation
+        let translation = self.tr(cx, tr_live_id);
+        // Replace placeholders with arguments
+        self.format_with_args(&translation, args)
+    }
+
+    // Helper method to format placeholders
+    fn format_with_args(&self, template: &str, args: &[&str]) -> String {
+        let mut result = template.to_string();
+        for (i, arg) in args.iter().enumerate() {
+            let placeholder = format!("{{{}}}", i);
+            result = result.replace(&placeholder, arg);
+        }
+        result
+    }
+
+    /// Set the current language
+    pub fn set_language(&mut self, language: &str) -> Result<(), String> {
+        if self.translations.contains_key(language) {
+            self.current_language = language.to_string();
+            Ok(())
+        } else {
+            Err(format!("Language not available: {}", language))
+        }
+    }
+}


### PR DESCRIPTION
This PR adds translation support to Makepad applications using the link and Live Registry systems. 

It introduces a new Translator struct that manages translations and integrates with the existing DSL/link system.

### Key Changes
- Added Translator struct to manage language state and file mappings
- Added convenience method discover_translations for automatic translation file discovery
- Added translation methods to Cx for easy access

### Usage

Create translation files in your project:
```rs
// transalations/en.rs
live_design! {
    link translator_en;
    
    WELCOME_MESSAGE = "Welcome to our app"
    DELETE_PROMPT = "Are you sure you want to delete {0}?"
}
```

Simple initialization using convention:
```rs
fn init_translator(&mut self, cx: &mut Cx) {
    // Automatically discovers files in src/translations/
    cx.translator = Translator::discover_translations(cx, "en");
}
```
Or with explicit paths:
```rs
fn init_translator(&mut self, cx: &mut Cx) {
    let mut translator = Translator::new("en");
    translator.set_translations(cx, &[
        ("en", "src/translations/en.rs"),
        ("es", "src/translations/es.rs"),
    ])?;
    cx.translator = translator;
}
```
In `live_register`, link the right translation before calling live_design on your app's components, example from Moly:
(This will be handled within the Translator so that it becomes unnecessary)
```rs
impl LiveRegister for App {
    fn live_register(cx: &mut Cx) {
        makepad_widgets::live_design(cx);
        makepad_code_editor::live_design(cx);

        cx.link(live_id!(translator), live_id!(translator_en));

        crate::shared::live_design(cx);
        crate::landing::live_design(cx);
       // ...   
```

Usage in code:
```rs
// Simple translation
let message = cx.tr(live_id!(WELCOME_MESSAGE));

// Translation with arguments
let prompt = cx.tr_with_args(live_id!(DELETE_PROMPT), &["my_file.txt"]);

// Change language at runtime, not fully supported yet. (need a way to live reload the app at runtime to remap DSL)
cx.translator.set_language("es")?;
```

## Work in progress

We plan to implement a more efficient get_value_by_path feature in Cx that would allow direct access to any value in the live registry using path notation (e.g., "translator.WELCOME_MESSAGE"). This would simplify the translation setup process and potentially remove the need for explicit language file management.

TODO:
- [ ] Fix discover_translations panic
- [ ] Replace `live_id!()` usage with `id!()`
- [ ] Currently calling `cx.link(live_id!(translator), live_id!(translator_en));` after calling `live_design` on the app components, takes no effect since the whole app needs to be live reloaded. Once we have a function call for that in Cx, we should handle this automatically for the app developers both during initialization, but also whenever language needs to be switched. Doing `translator.set_language` should internally call `cx.link`.