### PR TITLE
Rik cleanup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,104 @@
+# From https://github.com/gitattributes/gitattributes/blob/master/Rust.gitattributes
+# Auto detect text files and perform normalization
+*          text=auto
+
+*.rs       text diff=rust
+*.toml     text diff=toml
+Cargo.lock text
+# Taken from https://github.com/gitattributes/gitattributes/blob/master/Common.gitattributes
+# Common settings that generally should always be used with your language specific settings
+
+
+#
+# The above will handle all files NOT found below
+#
+
+# Documents
+*.bibtex   text diff=bibtex
+*.doc      diff=astextplain
+*.DOC      diff=astextplain
+*.docx     diff=astextplain
+*.DOCX     diff=astextplain
+*.dot      diff=astextplain
+*.DOT      diff=astextplain
+*.pdf      diff=astextplain
+*.PDF      diff=astextplain
+*.rtf      diff=astextplain
+*.RTF      diff=astextplain
+*.md       text diff=markdown
+*.mdx      text diff=markdown
+*.tex      text diff=tex
+*.adoc     text
+*.textile  text
+*.mustache text
+*.csv      text eol=crlf
+*.tab      text
+*.tsv      text
+*.txt      text
+*.sql      text
+*.epub     diff=astextplain
+
+# Graphics
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.gif      binary
+*.tif      binary
+*.tiff     binary
+*.ico      binary
+# SVG treated as text by default.
+*.svg      text
+# If you want to treat it as binary,
+# use the following line instead.
+# *.svg    binary
+*.eps      binary
+
+# Scripts
+*.bash     text eol=lf
+*.fish     text eol=lf
+*.ksh      text eol=lf
+*.sh       text eol=lf
+*.zsh      text eol=lf
+# These are explicitly windows files and should use crlf
+*.bat      text eol=crlf
+*.cmd      text eol=crlf
+*.ps1      text eol=crlf
+
+# Serialisation
+*.json     text
+*.toml     text
+*.xml      text
+*.yaml     text
+*.yml      text
+
+# Archives
+*.7z       binary
+*.bz       binary
+*.bz2      binary
+*.bzip2    binary
+*.gz       binary
+*.lz       binary
+*.lzma     binary
+*.rar      binary
+*.tar      binary
+*.taz      binary
+*.tbz      binary
+*.tbz2     binary
+*.tgz      binary
+*.tlz      binary
+*.txz      binary
+*.xz       binary
+*.Z        binary
+*.zip      binary
+*.zst      binary
+
+# Text files where line endings should be preserved
+*.patch    -text
+
+#
+# Exclude files from exporting
+#
+
+.gitattributes export-ignore
+.gitignore     export-ignore
+.gitkeep       export-ignore

--- a/libs/zune-png/src/lib.rs
+++ b/libs/zune-png/src/lib.rs
@@ -162,6 +162,7 @@ extern crate alloc;
 extern crate core;
 
 #[cfg(feature = "std")]
+pub use apng::ActlChunk;
 pub use apng::post_process_image;
 pub use apng::{BlendOp, DisposeOp};
 pub use decoder::{ItxtChunk, PngDecoder, PngInfo, TextChunk, TimeInfo, ZtxtChunk};

--- a/libs/zune-png/src/lib.rs
+++ b/libs/zune-png/src/lib.rs
@@ -162,8 +162,8 @@ extern crate alloc;
 extern crate core;
 
 #[cfg(feature = "std")]
-pub use apng::ActlChunk;
 pub use apng::post_process_image;
+pub use apng::ActlChunk;
 pub use apng::{BlendOp, DisposeOp};
 pub use decoder::{ItxtChunk, PngDecoder, PngInfo, TextChunk, TimeInfo, ZtxtChunk};
 pub use encoder::PngEncoder;


### PR DESCRIPTION
This pull request:
- Cleans up code in `image_cache.rs` to make it more readable
- Adds `.gitattributes` to normalize file line endings properly
- fixes bug where previous assertion about `from_png` changed causing any images that were not pngs passed in to panic.
    - Previous assertion was that passed in images that are not png will result in an Err being returned