### PR TITLE
Add `PortalList::was_scrolling()` method

### DIFF
--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -621,17 +621,22 @@ impl FingerMoveEvent {
 #[derive(Clone, Debug)]
 pub struct FingerUpEvent {
     pub window_id: WindowId,
+    /// The absolute position of the original finger-down event.
     pub abs: DVec2,
+    /// The absolute position of this finger-up event.
+    pub abs_start: DVec2,
+    /// The time at which the original finger-down event occurred.
     pub capture_time: f64,
+    /// The time at which this finger-up event occurred.
+    pub time: f64,
     
     pub digit_id: DigitId,
     pub device: DigitDevice,
     
     pub tap_count: u32,
     pub modifiers: KeyModifiers,
-    pub time: f64,
-    pub abs_start: DVec2,
     pub rect: Rect,
+    /// Whether this finger-up event (`abs`) occurred within the hits area.
     pub is_over: bool,
     pub is_sweep: bool
 }

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -1030,6 +1030,15 @@ impl PortalListRef {
         inner.visible_items()
     }
 
+    /// Returns whether this PortalList is currently scrolling.
+    ///
+    /// This returns true if the PortalList's scroll state is not `ScrollState::Stopped`.
+    pub fn is_scrolling(&self) -> bool {
+        self.borrow().is_some_and(|inner|
+            !matches!(inner.scroll_state, ScrollState::Stopped)
+        )
+    }
+
     /// Returns whether the given `actions` contain an action indicating that this PortalList was scrolled.
     pub fn scrolled(&self, actions: &Actions) -> bool {
         if let PortalListAction::Scroll = actions.find_widget_action(self.widget_uid()).cast() {

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -690,7 +690,6 @@ impl PortalList {
         if self.first_id == self.range_start {
             self.first_scroll = self.first_scroll.min(self.max_pull_down);
             if transition_to_pulldown && self.first_scroll > 0.0 {
-                log!("Transitioning to PullDown");
                 self.scroll_state = ScrollState::Pulldown {next_frame: cx.new_next_frame()};
             }
         }
@@ -791,7 +790,6 @@ impl Widget for PortalList {
                         cx.widget_action(uid, &scope.path, PortalListAction::Scroll);
                         self.area.redraw(cx);
                     } else {
-                        log!("ScrollingTo DONE");
                         self.was_scrolling = false;
                         self.scroll_state = ScrollState::Stopped;
                         cx.widget_action(uid, &scope.path, PortalListAction::SmoothScrollReached);
@@ -808,7 +806,6 @@ impl Widget for PortalList {
                         cx.widget_action(uid, &scope.path, PortalListAction::Scroll);
                         self.area.redraw(cx);
                     } else {
-                        log!("FLICK DONE");
                         self.was_scrolling = false;
                         self.scroll_state = ScrollState::Stopped;
                     }
@@ -822,7 +819,6 @@ impl Widget for PortalList {
                         if self.first_scroll < 1.0 {
                             self.first_scroll = 0.0;
                             // the pulldown animation is finished
-                            log!("PULLDOWN DONE");
                             self.was_scrolling = false;
                             self.scroll_state = ScrollState::Stopped;
                         }
@@ -833,7 +829,6 @@ impl Widget for PortalList {
                         self.area.redraw(cx);
                     }
                     else {
-                        log!("PULLDOWN HERE");
                         self.was_scrolling = false;
                         self.scroll_state = ScrollState::Stopped;
                     }
@@ -851,7 +846,6 @@ impl Widget for PortalList {
                 Hit::FingerScroll(e) => {
                     self.tail_range = false;
                     self.detect_tail_in_draw = true;
-                    log!("Finger scroll complete!");
                     self.was_scrolling = false;
                     self.scroll_state = ScrollState::Stopped;
                     self.delta_top_scroll(cx, -e.scroll.index(vi), false, true);
@@ -931,7 +925,6 @@ impl Widget for PortalList {
                         ScrollState::Stopped => false,
                         _ => true,
                     };
-                    log!("Set was_scrolling to {}", self.was_scrolling);
                     if self.drag_scrolling && fe.is_primary_hit() {
                         self.scroll_state = ScrollState::Drag {
                             samples: vec![ScrollSample{abs: fe.abs.index(vi), time: fe.time}]
@@ -1199,7 +1192,6 @@ impl PortalListRef {
 
         // First, if the target_id was too far away, jump directly to a closer starting_id.
         if let Some(start) = starting_id {
-            log!("smooth_scroll_to(): jumping from first ID {} to start ID {}", inner.first_id, start);
             inner.first_id = start;
         }
         // Then, we kick off the actual smooth scroll process.


### PR DESCRIPTION
which returns whether the PortalList was scrolling on the last FingerDown/Up action, which enables a user to determine whether a given click/press should be treated as a click on the underlying list items, or as a scroll-defining action (like a drag or tap-to-stop).