### PR TITLE
Tooltip: dismiss on click/press

### DIFF
--- a/widgets/src/tooltip.rs
+++ b/widgets/src/tooltip.rs
@@ -82,6 +82,13 @@ pub struct Tooltip {
 impl Widget for Tooltip {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         self.content.handle_event(cx, event, scope);
+
+        match event.hits_with_capture_overload(cx, self.content.area(), true) {
+            Hit::FingerUp(fue) if fue.is_over => {
+                self.hide(cx);
+            }
+            _ => { }
+        }
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, _walk: Walk) -> DrawStep {


### PR DESCRIPTION
When displaying a tooltip on mobile devices without hover events, the tooltip won't be automatically hidden after it has been shown (e.g., on a long-press event).
Ideally the app dev will choose to hide it upon a different user interaction, such as clicking elsewhere, but that can be quite difficult to implement consistently.

This is a very localized change that allows the user to just click on a tooltip to hide it, which works in all cases that the app dev inadvertently forgets to otherwise handle.