### PR TITLE
Emit a `Hit::BackPressed` for an area that has key focus

### DIFF
--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -797,6 +797,11 @@ impl Event {
                     return Hit::TextCut(tc.clone());
                 }
             },
+            Event::BackPressed => {
+                if cx.keyboard.has_key_focus(area) {
+                    return Hit::BackPressed;
+                }
+            },
             Event::Scroll(e) => {
                 if cx.fingers.test_sweep_lock(options.sweep_area) {
                     // log!("Skipping Scroll sweep_area: {:?}", options.sweep_area);


### PR DESCRIPTION
Allows for the `event.hits()` API to be used to test for `BackPressed`