### PR TITLE
Make `HtmlLink` public so a foreign crate can access its text/URL

### DIFF
--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -632,7 +632,7 @@ pub enum HtmlLinkAction {
 }
 
 #[derive(Live, Widget)]
-struct HtmlLink {
+pub struct HtmlLink {
     #[animator] animator: Animator,
 
     // TODO: this is unusued; just here to invalidly satisfy the area provider.


### PR DESCRIPTION
Without this, the `pub text` and `pub url` fields cannot actually be accessed/named due to Rust's private typing restrictions.