### PR TITLE
Redesign `Event::BackPressed` to contain a `handled` bool

### DIFF
--- a/draw/src/match_event.rs
+++ b/draw/src/match_event.rs
@@ -55,7 +55,14 @@ pub trait MatchEvent{
     fn handle_draw_2d(&mut self, _cx: &mut Cx2d){}
     fn handle_key_down(&mut self, _cx: &mut Cx, _e:&KeyEvent){}
     fn handle_key_up(&mut self, _cx: &mut Cx, _e:&KeyEvent){}
-    fn handle_back_pressed(&mut self, _cx: &mut Cx){}
+    /// Handles the [`Event::BackPressed`] event.
+    ///
+    /// This will only be called if this event was not already handled.
+    ///
+    /// Returns `true` if the event was handled, `false` otherwise.
+    /// Returning `true` will mark this as handled, meaning that
+    /// no other widgets will receive this event.
+    fn handle_back_pressed(&mut self, _cx: &mut Cx) -> bool { false }
 
     fn match_event(&mut self, cx:&mut Cx, event:&Event){
         match event{
@@ -78,7 +85,10 @@ pub trait MatchEvent{
             Event::NetworkResponses(e)=>self.handle_network_responses(cx, e),
             Event::KeyDown(e)=>self.handle_key_down(cx, e),
             Event::KeyUp(e)=>self.handle_key_up(cx, e),
-            Event::BackPressed=>self.handle_back_pressed(cx),
+            Event::BackPressed { handled } if !handled.get() => {
+                let was_handled = self.handle_back_pressed(cx);
+                handled.set(was_handled);
+            }
             _=>()
         }
     }

--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -838,11 +838,6 @@ impl Event {
                     return Hit::TextCut(tc.clone());
                 }
             },
-            Event::BackPressed => {
-                if cx.keyboard.has_key_focus(area) {
-                    return Hit::BackPressed;
-                }
-            },
             Event::Scroll(e) => {
                 if cx.fingers.test_sweep_lock(options.sweep_area) {
                     // log!("Skipping Scroll sweep_area: {:?}", options.sweep_area);

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -1,3 +1,5 @@
+use std::cell::Cell;
+
 #[allow(unused)]
 use makepad_jni_sys as jni_sys;
 use crate::event::LongPressEvent;
@@ -125,7 +127,7 @@ impl Cx {
                 // This should not happen here, as it's handled in the main loop
             },
             FromJavaMessage::BackPressed => {
-                self.call_event_handler(&Event::BackPressed);
+                self.call_event_handler(&Event::BackPressed { handled: Cell::new(false)});
             }
             FromJavaMessage::SurfaceCreated {window} => unsafe {
                 self.os.display.as_mut().unwrap().update_surface(window);
@@ -251,7 +253,7 @@ impl Cx {
                         }
                     } else {
                         if makepad_keycode == KeyCode::Back {
-                            self.call_event_handler(&Event::BackPressed);
+                            self.call_event_handler(&Event::BackPressed { handled: Cell::new(false)});
                         }
 
                         e = Event::KeyDown(

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -348,9 +348,7 @@ public class MakepadActivity
     @Override
     @SuppressWarnings("deprecation")
     public void onBackPressed() {
-        Log.w("SAPP", "onBackPressed");
         super.onBackPressed();
-        // TODO: here is the place to handle request_quit/order_quit/cancel_quit
         MakepadNative.onBackPressed();
     }
 

--- a/widgets/src/modal.rs
+++ b/widgets/src/modal.rs
@@ -102,7 +102,7 @@ impl Widget for Modal {
         // * If the back navigational action/gesture was triggered (e.g., on Android)
         // * If the Escape key was pressed
         // * If there was a click/press in the background area, outside of the inner `content` view
-        let should_close = matches!(event, Event::BackPressed)
+        let should_close = event.back_pressed()
             || matches!(event, Event::KeyUp(KeyEvent { key_code: KeyCode::Escape, .. }))
             || match consumed_hit {
                 Hit::FingerUp(fe) => !self.content.area().rect(cx).contains(fe.abs),


### PR DESCRIPTION
The main idea is that a `BackPressed` event should only be handled *once* by a single widget.
You can use the new `Event::back_pressed()` event to automatically handle this.

This also removes the `Hit::BackPressed` variant, as it doesn't make sense to have area-based hits for a `BackPressed` event because that event is not associated with an area-based or focus-based event.

Adjust StackNavigation widget's event handling order to ensure that the child view's event handler is called first, which allows child widgets to consume the `BackPressed` event before the `StackNavigation` widget can consume the `BackPressed` event itself.