### PR TITLE
Breaking change: allow app logic to mark a `Hit` event as [un]handled

### DIFF
--- a/audio_graph/audio_widgets/src/piano.rs
+++ b/audio_graph/audio_widgets/src/piano.rs
@@ -209,14 +209,14 @@ impl PianoKey {
             self.draw_key.area().redraw(cx);
         }
         match event.hits_with_sweep_area(cx, self.draw_key.area(), sweep_area) {
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 cx.set_cursor(MouseCursor::Hand);
                 self.animator_play(cx, id!(hover.on));
             }
             Hit::FingerHoverOut(_) => {
                 self.animator_play(cx, id!(hover.off));
             }
-            Hit::FingerDown(_) => {
+            Hit::FingerDown(..) => {
                 self.animator_play(cx, id!(hover.on));
                 self.animator_play(cx, id!(pressed.on));
                 actions.push((key_id, PianoKeyAction::Pressed(127)));

--- a/code_editor/src/code_editor.rs
+++ b/code_editor/src/code_editor.rs
@@ -928,17 +928,20 @@ impl CodeEditor {
                     keyboard_moved_cursor = true;
                 }
             }
-            Hit::FingerDown(FingerDownEvent {
-                abs,
-                tap_count,
-                modifiers:
-                    KeyModifiers {
-                        alt: false,
-                        shift: false,
-                        ..
-                    },
-                ..
-            }) => {
+            Hit::FingerDown(
+                FingerDownEvent {
+                    abs,
+                    tap_count,
+                    modifiers:
+                        KeyModifiers {
+                            alt: false,
+                            shift: false,
+                            ..
+                        },
+                    ..
+                },
+                _,
+            ) => {
                 self.animator_play(cx, id!(focus.on));
                 cx.set_key_focus(self.scroll_bars.area());
                 let ((cursor, affinity), is_in_gutter) = self.pick(session, abs);
@@ -961,17 +964,20 @@ impl CodeEditor {
                 self.keep_cursor_in_view = KeepCursorInView::Always(abs, cx.new_next_frame());
                 self.redraw(cx);
             }
-            Hit::FingerDown(FingerDownEvent {
-                abs,
-                tap_count,
-                modifiers:
-                    KeyModifiers {
-                        alt: true,
-                        shift: false,
-                        ..
-                    },
-                ..
-            }) => {
+            Hit::FingerDown(
+                FingerDownEvent {
+                    abs,
+                    tap_count,
+                    modifiers:
+                        KeyModifiers {
+                            alt: true,
+                            shift: false,
+                            ..
+                        },
+                    ..
+                },
+                _,
+            ) => {
                 self.animator_play(cx, id!(focus.on));
                 cx.set_key_focus(self.scroll_bars.area());
                 let ((cursor, affinity), is_in_gutter) = self.pick(session, abs);
@@ -997,15 +1003,18 @@ impl CodeEditor {
                 self.reset_cursor_blinker(cx);
                 self.keep_cursor_in_view = KeepCursorInView::Off;
             }
-            Hit::FingerHoverIn(_) | Hit::FingerHoverOver(_) => {
+            Hit::FingerHoverIn(..) | Hit::FingerHoverOver(..) => {
                 cx.set_cursor(MouseCursor::Text);
             }
-            Hit::FingerDown(FingerDownEvent {
-                abs,
-                modifiers: KeyModifiers { shift: true, .. },
-                ..
-            })
-            | Hit::FingerMove(FingerMoveEvent { abs, .. }) => {
+            Hit::FingerDown(
+                FingerDownEvent {
+                    abs,
+                    modifiers: KeyModifiers { shift: true, .. },
+                    ..
+                },
+                _,
+            ) 
+            | Hit::FingerMove(FingerMoveEvent { abs, .. }, _) => {
                 self.reset_cursor_blinker(cx);
                 if let KeepCursorInView::Always(old_abs, _) = &mut self.keep_cursor_in_view {
                     *old_abs = abs;

--- a/code_editor/src/test.rs
+++ b/code_editor/src/test.rs
@@ -435,11 +435,14 @@ impl CodeEditor {
                 session.redo();
                 cx.redraw_all();
             }
-            Hit::FingerDown(FingerDownEvent {
-                abs,
-                modifiers: KeyModifiers { alt, .. },
-                ..
-            }) => {
+            Hit::FingerDown(
+                FingerDownEvent {
+                    abs,
+                    modifiers: KeyModifiers { alt, .. },
+                    ..
+                },
+                _,
+            ) => {
                 cx.set_key_focus(self.scroll_bars.area());
                 if let Some((cursor, affinity)) = self.pick(session, abs) {
                     if alt {
@@ -450,7 +453,7 @@ impl CodeEditor {
                     cx.redraw_all();
                 }
             }
-            Hit::FingerMove(FingerMoveEvent { abs, .. }) => {
+            Hit::FingerMove(FingerMoveEvent { abs, .. }, _) => {
                 if let Some((cursor, affinity)) = self.pick(session, abs) {
                     session.move_to(cursor, affinity);
                     cx.redraw_all();
@@ -4453,11 +4456,14 @@ impl CodeEditor {
                 session.redo();
                 cx.redraw_all();
             }
-            Hit::FingerDown(FingerDownEvent {
-                abs,
-                modifiers: KeyModifiers { alt, .. },
-                ..
-            }) => {
+            Hit::FingerDown(
+                FingerDownEvent {
+                    abs,
+                    modifiers: KeyModifiers { alt, .. },
+                    ..
+                },
+                _,
+            ) => {
                 cx.set_key_focus(self.scroll_bars.area());
                 if let Some((cursor, affinity)) = self.pick(session, abs) {
                     if alt {
@@ -4468,7 +4474,7 @@ impl CodeEditor {
                     cx.redraw_all();
                 }
             }
-            Hit::FingerMove(FingerMoveEvent { abs, .. }) => {
+            Hit::FingerMove(FingerMoveEvent { abs, .. }, _) => {
                 if let Some((cursor, affinity)) = self.pick(session, abs) {
                     session.move_to(cursor, affinity);
                     cx.redraw_all();
@@ -8471,11 +8477,14 @@ impl CodeEditor {
                 session.redo();
                 cx.redraw_all();
             }
-            Hit::FingerDown(FingerDownEvent {
-                abs,
-                modifiers: KeyModifiers { alt, .. },
-                ..
-            }) => {
+            Hit::FingerDown(
+                FingerDownEvent {
+                    abs,
+                    modifiers: KeyModifiers { alt, .. },
+                    ..
+                },
+                _,
+            ) => {
                 cx.set_key_focus(self.scroll_bars.area());
                 if let Some((cursor, affinity)) = self.pick(session, abs) {
                     if alt {
@@ -8486,7 +8495,7 @@ impl CodeEditor {
                     cx.redraw_all();
                 }
             }
-            Hit::FingerMove(FingerMoveEvent { abs, .. }) => {
+            Hit::FingerMove(FingerMoveEvent { abs, .. }, _) => {
                 if let Some((cursor, affinity)) = self.pick(session, abs) {
                     session.move_to(cursor, affinity);
                     cx.redraw_all();
@@ -12489,11 +12498,14 @@ impl CodeEditor {
                 session.redo();
                 cx.redraw_all();
             }
-            Hit::FingerDown(FingerDownEvent {
-                abs,
-                modifiers: KeyModifiers { alt, .. },
-                ..
-            }) => {
+            Hit::FingerDown(
+                FingerDownEvent {
+                    abs,
+                    modifiers: KeyModifiers { alt, .. },
+                    ..
+                },
+                _,
+            ) => {
                 cx.set_key_focus(self.scroll_bars.area());
                 if let Some((cursor, affinity)) = self.pick(session, abs) {
                     if alt {
@@ -12504,7 +12516,7 @@ impl CodeEditor {
                     cx.redraw_all();
                 }
             }
-            Hit::FingerMove(FingerMoveEvent { abs, .. }) => {
+            Hit::FingerMove(FingerMoveEvent { abs, .. }, _) => {
                 if let Some((cursor, affinity)) = self.pick(session, abs) {
                     session.move_to(cursor, affinity);
                     cx.redraw_all();
@@ -16507,11 +16519,14 @@ impl CodeEditor {
                 session.redo();
                 cx.redraw_all();
             }
-            Hit::FingerDown(FingerDownEvent {
-                abs,
-                modifiers: KeyModifiers { alt, .. },
-                ..
-            }) => {
+            Hit::FingerDown(
+                FingerDownEvent {
+                    abs,
+                    modifiers: KeyModifiers { alt, .. },
+                    ..
+                },
+                _,
+            ) => {
                 cx.set_key_focus(self.scroll_bars.area());
                 if let Some((cursor, affinity)) = self.pick(session, abs) {
                     if alt {
@@ -16522,7 +16537,7 @@ impl CodeEditor {
                     cx.redraw_all();
                 }
             }
-            Hit::FingerMove(FingerMoveEvent { abs, .. }) => {
+            Hit::FingerMove(FingerMoveEvent { abs, .. }, _) => {
                 if let Some((cursor, affinity)) = self.pick(session, abs) {
                     session.move_to(cursor, affinity);
                     cx.redraw_all();

--- a/examples/fractal_zoom/src/mandelbrot.rs
+++ b/examples/fractal_zoom/src/mandelbrot.rs
@@ -504,7 +504,7 @@ impl Widget for Mandelbrot {
         // in this mode we get fingerdown events for each finger.
         
         match event.hits(cx, self.view_area) {
-            Hit::FingerDown(fe) => {
+            Hit::FingerDown(fe, _) => {
                 // ok so we get multiple finger downs
                 self.is_zooming = true;
                 self.finger_abs = fe.abs;
@@ -528,7 +528,7 @@ impl Widget for Mandelbrot {
                                         
                 }
             }
-            Hit::FingerMove(fe) => {
+            Hit::FingerMove(fe, _) => {
             //if fe.digit.index == 0 { // only respond to digit 0
                 self.finger_abs = fe.abs;
                 //}

--- a/examples/ironfish/src/sequencer.rs
+++ b/examples/ironfish/src/sequencer.rs
@@ -156,14 +156,14 @@ impl SeqButton {
             self.draw_button.area(),
             HitOptions::new().with_sweep_area(sweep_area)
         ) {
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 cx.set_cursor(MouseCursor::Hand);
                 self.animator_play(cx, id!(hover.on));
             }
             Hit::FingerHoverOut(_) => {
                 self.animator_play(cx, id!(hover.off));
             }
-            Hit::FingerDown(_) => {
+            Hit::FingerDown(..) => {
                 self.animator_play(cx, id!(hover.on));
                 if self.animator_in_state(cx, id!(active.on)) {
                     self.animator_play(cx, id!(active.off));

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -10,3 +10,6 @@ metadata.makepad-auto-version = "db3R5Gxh5Njhx8E-8kuZ2plQ1AI="
 [dependencies]
 makepad-widgets = { path = "../../widgets", version = "0.6.0" }
 
+[target.'cfg(target_env = "ohos")'.dependencies]
+napi-derive-ohos = "0.0.9"  ## now at 1.0.4
+napi-ohos = "0.1.3"         ## now at 1.0.4

--- a/experiments/bigfish/src/block_connector_button.rs
+++ b/experiments/bigfish/src/block_connector_button.rs
@@ -170,7 +170,7 @@ impl Widget for BlockConnectorButton {
         let uid = self.widget_uid();
         self.animator_handle_event(cx, event);
         match event.hits(cx, self.draw_bg.area()) {
-            Hit::FingerMove(fe) => {
+            Hit::FingerMove(fe, _) => {
                 if self.dragging {
                     cx.widget_action(
                         uid,
@@ -183,7 +183,7 @@ impl Widget for BlockConnectorButton {
                     );
                 }
             }
-            Hit::FingerDown(fe) => {
+            Hit::FingerDown(fe, _) => {
                 if self.grab_key_focus {
                     cx.set_key_focus(self.draw_bg.area());
                 }
@@ -201,7 +201,7 @@ impl Widget for BlockConnectorButton {
                 cx.widget_action(uid, &scope.path, BlockConnectorButtonAction::Pressed);
                 self.animator_play(cx, id!(hover.pressed));
             }
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 cx.set_cursor(MouseCursor::Hand);
                 self.animator_play(cx, id!(hover.on));
             }

--- a/experiments/bigfish/src/block_delete_button.rs
+++ b/experiments/bigfish/src/block_delete_button.rs
@@ -154,8 +154,8 @@ impl Widget for BlockDeleteButton {
         let uid = self.widget_uid();
         self.animator_handle_event(cx, event);
         match event.hits(cx, self.draw_bg.area()) {
-            Hit::FingerMove(_fe) => if self.dragging {},
-            Hit::FingerDown(_fe) => {
+            Hit::FingerMove(..) => if self.dragging {},
+            Hit::FingerDown(..) => {
                 if self.grab_key_focus {
                     cx.set_key_focus(self.draw_bg.area());
                 }
@@ -164,7 +164,7 @@ impl Widget for BlockDeleteButton {
                 cx.widget_action(uid, &scope.path, BlockDeleteButtonAction::Pressed);
                 self.animator_play(cx, id!(hover.pressed));
             }
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 cx.set_cursor(MouseCursor::Hand);
                 self.animator_play(cx, id!(hover.on));
             }

--- a/experiments/bigfish/src/block_header_button.rs
+++ b/experiments/bigfish/src/block_header_button.rs
@@ -160,7 +160,7 @@ impl Widget for BlockHeaderButton {
         let uid = self.widget_uid();
         self.animator_handle_event(cx, event);
         match event.hits(cx, self.draw_bg.area()) {
-            Hit::FingerMove(fe) => {
+            Hit::FingerMove(fe, _) => {
                 if self.dragging {
                     cx.widget_action(
                         uid,
@@ -174,7 +174,7 @@ impl Widget for BlockHeaderButton {
                     self.draglast = fe.abs;
                 }
             }
-            Hit::FingerDown(fe) => {
+            Hit::FingerDown(fe, _) => {
                 if self.grab_key_focus {
                     cx.set_key_focus(self.draw_bg.area());
                 }
@@ -189,7 +189,7 @@ impl Widget for BlockHeaderButton {
                 );
                 self.animator_play(cx, id!(hover.pressed));
             }
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 cx.set_cursor(MouseCursor::Hand);
                 self.animator_play(cx, id!(hover.on));
             }

--- a/experiments/bigfish/src/fish_connection_widget.rs
+++ b/experiments/bigfish/src/fish_connection_widget.rs
@@ -113,14 +113,14 @@ impl Widget for FishConnectionWidget {
         return;
 /*
         match event.hits(cx, self.draw_line.area()) {
-            Hit::FingerDown(_fe) => {
+            Hit::FingerDown(..) => {
                 if self.grab_key_focus {
                     cx.set_key_focus(self.draw_line.area());
                 }
                 cx.widget_action(uid, &scope.path, ButtonAction::Pressed);
                 self.animator_play(cx, id!(hover.pressed));
             }
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 cx.set_cursor(MouseCursor::Hand);
                 self.animator_play(cx, id!(hover.on));
             }

--- a/experiments/bigfish/src/fish_patch_editor.rs
+++ b/experiments/bigfish/src/fish_patch_editor.rs
@@ -198,7 +198,7 @@ impl Widget for FishPatchEditor {
 
         match event.hits(cx, self.draw_bg.area()) {
             
-            Hit::FingerDown(fe) => {
+            Hit::FingerDown(fe, _) => {
 //                if  fe.digit_id == live_id!(0).into() {
                     self.selecting = true;              
                     let patch = &mut scope.data.get_mut::<FishDoc>().unwrap().patches[0];
@@ -212,7 +212,7 @@ impl Widget for FishPatchEditor {
                 self.animator_play(cx, id!(hover.pressed));
             }
             
-            Hit::FingerMove(fe) =>{
+            Hit::FingerMove(fe, _) =>{
                 if 
                 //fe.digit_id == live_id!(0).into() &&
                  self.selecting
@@ -224,13 +224,11 @@ impl Widget for FishPatchEditor {
                 }
                 
             }
-            Hit::FingerHoverIn(_) => {
-
+            Hit::FingerHoverIn(..) => {
                 cx.set_cursor(MouseCursor::Hand);
                 self.animator_play(cx, id!(hover.on));
             }
             Hit::FingerHoverOut(_) => {
-
                 self.animator_play(cx, id!(hover.off));
             }
             Hit::FingerUp(fe) => {

--- a/libs/shell/src/shell.rs
+++ b/libs/shell/src/shell.rs
@@ -31,6 +31,7 @@ pub fn shell_env(env: &[(&str, &str)], cwd: &Path, cmd: &str, args: &[&str]) -> 
     for (key, value) in env {
         cmd_build.env(key, value);
     }
+    println!("### RUNNING COMMAND ###\nenv: {:?}\n\n{:?}\n", cmd_build.get_envs().collect::<Vec<_>>(), cmd_build);
     let mut child = cmd_build.spawn().map_err( | e | format!("Error starting {} in dir {:?} - {:?}", cmd, cwd, e)) ?;
     
     let r = child.wait().map_err( | e | format!("Process {} in dir {:?} returned error {:?} ", cmd, cwd, e)) ?;

--- a/platform/src/event/event.rs
+++ b/platform/src/event/event.rs
@@ -387,7 +387,7 @@ impl Event{
 
 
 #[derive(Debug)]
-pub enum Hit{
+pub enum Hit {
     KeyFocus(KeyFocusEvent),
     KeyFocusLost(KeyFocusEvent),
     KeyDown(KeyEvent),
@@ -398,10 +398,10 @@ pub enum Hit{
     TextCut(TextClipboardEvent),
 
     FingerScroll(FingerScrollEvent),
-    FingerDown(FingerDownEvent),
-    FingerMove(FingerMoveEvent),
-    FingerHoverIn(FingerHoverEvent),
-    FingerHoverOver(FingerHoverEvent),
+    FingerDown(FingerDownEvent, EventHandled),
+    FingerMove(FingerMoveEvent, EventHandled),
+    FingerHoverIn(FingerHoverEvent, EventHandled),
+    FingerHoverOver(FingerHoverEvent, EventHandled),
     FingerHoverOut(FingerHoverEvent),
     FingerUp(FingerUpEvent),
     FingerLongPress(FingerLongPressEvent),

--- a/platform/src/log.rs
+++ b/platform/src/log.rs
@@ -120,7 +120,7 @@ pub fn log_with_level(file_name:&str, line_start:u32, column_start:u32, line_end
                 LogLevel::Log => {hilog_sys::LogLevel::LOG_INFO}
                 _=> {hilog_sys::LogLevel::LOG_INFO}
             };
-            unsafe {hilog_sys::OH_LOG_Print(hilog_sys::LogType::LOG_APP,hilevel, 0x03D00, "makepad-ohos\0".as_ptr(), "%{public}s\0".as_ptr(),msg.as_ptr())};
+            unsafe {hilog_sys::OH_LOG_Print(hilog_sys::LogType::LOG_APP,hilevel, 0x03D00, "makepad-ohos\0".as_ptr().cast(), "%{public}s\0".as_ptr().cast(), msg.as_ptr())};
        }
     }
     else{

--- a/platform/src/os/apple/ios/ios_app.rs
+++ b/platform/src/os/apple/ios/ios_app.rs
@@ -1,6 +1,7 @@
 use {
     std::{
         cell::{Cell,RefCell},
+        rc::Rc,
         time::Instant,
     },
     crate::{
@@ -258,7 +259,7 @@ impl IosApp {
                 rotation_angle: 0.0,
                 force: 0.0,
                 radius: dvec2(0.0, 0.0),
-                handled: Cell::new(Area::Empty),
+                handled: Rc::new(Cell::new(Area::Empty)),
                 sweep_lock: Cell::new(Area::Empty)
             })
         }

--- a/platform/src/os/apple/macos/macos_window.rs
+++ b/platform/src/os/apple/macos/macos_window.rs
@@ -357,7 +357,7 @@ impl MacosWindow {
             window_id: self.window_id,
             abs: self.last_mouse_pos,
             time: self.time_now(),
-            handled: Cell::new(Area::Empty),
+            handled: Rc::new(Cell::new(Area::Empty)),
         }));
     }
     
@@ -379,9 +379,9 @@ impl MacosWindow {
         self.do_callback(MacosEvent::MouseMove(MouseMoveEvent {
             window_id: self.window_id,
             abs: pos,
-            modifiers: modifiers,
+            modifiers,
             time: self.time_now(),
-            handled: Cell::new(Area::Empty),
+            handled: Rc::new(Cell::new(Area::Empty)),
         }));
         
         //get_macos_app_global().ns_event = ptr::null_mut();

--- a/platform/src/os/cx_stdin.rs
+++ b/platform/src/os/cx_stdin.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 use {
-    std::cell::Cell,
-    std::collections::HashMap,
+    std::{cell::Cell, collections::HashMap, rc::Rc},
     crate::{
         cx::Cx,
         cursor::MouseCursor,
@@ -353,7 +352,7 @@ impl StdinMouseDown {
             window_id,
             modifiers: self.modifiers.into_key_modifiers(),
             time: self.time,
-            handled: Cell::new(Area::Empty),
+            handled: Rc::new(Cell::new(Area::Empty)),
         }
     }
 }
@@ -368,12 +367,12 @@ pub struct StdinMouseMove{
 
 impl StdinMouseMove {
     pub fn into_event(self, window_id: WindowId, pos: DVec2) -> MouseMoveEvent {
-        MouseMoveEvent{
+        MouseMoveEvent {
             abs: dvec2(self.x - pos.x, self.y - pos.y),
             window_id,
             modifiers: self.modifiers.into_key_modifiers(),
             time: self.time,
-            handled: Cell::new(Area::Empty),
+            handled: Rc::new(Cell::new(Area::Empty)),
         }
     }
 }

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -3,7 +3,7 @@ use crate::module_loader::ModuleLoader;
 
 use {
     std::sync::Mutex,
-    std::{cell::Cell, ffi::CString, sync::mpsc::{self, Sender}},
+    std::{cell::Cell, ffi::CString, rc::Rc, sync::mpsc::{self, Sender}},
     self::super::{
         ndk_sys,
         ndk_utils,
@@ -427,7 +427,7 @@ pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_surfaceOnTouch(
             rotation_angle,
             force,
             radius: dvec2(1.0, 1.0),
-            handled: Cell::new(Area::Empty),
+            handled: Rc::new(Cell::new(Area::Empty)),
             sweep_lock: Cell::new(Area::Empty),
             abs: dvec2(x as f64, y as f64),
             time: time as f64 / 1000.0,

--- a/platform/src/os/linux/direct/raw_input.rs
+++ b/platform/src/os/linux/direct/raw_input.rs
@@ -15,6 +15,7 @@ use {
         cell::Cell,
         fs::File,
         io::Read,
+        rc::Rc,
         sync::mpsc, 
     }
 };
@@ -752,7 +753,7 @@ impl RawInput {
             window_id,
             modifiers: self.modifiers,
             time,
-            handled: Cell::new(Area::Empty),
+            handled: Rc::new(Cell::new(Area::Empty)),
         }))
     }
 
@@ -778,7 +779,7 @@ impl RawInput {
             window_id,
             modifiers: self.modifiers,
             time,
-            handled: Cell::new(Area::Empty),
+            handled: Rc::new(Cell::new(Area::Empty)),
         }))
     }
 
@@ -910,7 +911,7 @@ impl RawInput {
                             window_id,
                             modifiers: self.modifiers,
                             time,
-                            handled: Cell::new(Area::Empty),
+                            handled: Rc::new(Cell::new(Area::Empty)),
                         }))
                     },
                     EvKeyCodes::BTN_TOUCH => {
@@ -920,7 +921,7 @@ impl RawInput {
                             window_id,
                             modifiers: self.modifiers,
                             time,
-                            handled: Cell::new(Area::Empty),
+                            handled: Rc::new(Cell::new(Area::Empty)),
                         }))
                     },
                     _ => {

--- a/platform/src/os/linux/open_harmony/oh_callbacks.rs
+++ b/platform/src/os/linux/open_harmony/oh_callbacks.rs
@@ -12,6 +12,7 @@ use ohos_sys::xcomponent::{
 use std::cell::{Cell, RefCell};
 use std::mem::MaybeUninit;
 use std::os::raw::c_void;
+use std::rc::Rc;
 use std::sync::mpsc;
 
 use super::raw_file::RawFileMgr;
@@ -142,7 +143,7 @@ extern "C" fn on_dispatch_touch_event_cb(component: *mut OH_NativeXComponent, wi
             rotation_angle: 0.0,
             force: point.force as f64,
             radius: dvec2(1.0, 1.0),
-            handled: Cell::new(Area::Empty),
+            handled: Rc::new(Cell::new(Area::Empty)),
             sweep_lock: Cell::new(Area::Empty),
         })
 

--- a/platform/src/os/linux/x11/xlib_window.rs
+++ b/platform/src/os/linux/x11/xlib_window.rs
@@ -460,7 +460,7 @@ impl XlibWindow {
             window_id: self.window_id,
             abs: self.last_mouse_pos,
             time: self.time_now(),
-            handled: Cell::new(Area::Empty),
+            handled: Rc::new(Cell::new(Area::Empty)),
         }));
     }
     
@@ -481,7 +481,7 @@ impl XlibWindow {
             abs: pos,
             modifiers,
             time: self.time_now(),
-            handled: Cell::new(Area::Empty),
+            handled: Rc::new(Cell::new(Area::Empty)),
         }));
         
     }

--- a/platform/src/os/web/to_wasm.rs
+++ b/platform/src/os/web/to_wasm.rs
@@ -1,5 +1,5 @@
 use {
-    std::cell::Cell,
+    std::{cell::Cell, rc::Rc},
     crate::{
         makepad_live_id::*,
         makepad_wasm_bridge::*,
@@ -186,7 +186,7 @@ impl From<WTouchPoint> for TouchPoint {
             radius: dvec2(v.radius_x, v.radius_y),
             rotation_angle: v.rotation_angle,
             sweep_lock: Cell::new(Area::Empty),
-            handled: Cell::new(Area::Empty),
+            handled: Rc::new(Cell::new(Area::Empty)),
         }
     }
 }
@@ -253,7 +253,7 @@ impl From<ToWasmMouseDown> for MouseDownEvent {
             button: wmouse_to_mouse_button(v.mouse.button),
             window_id: CxWindowPool::id_zero(),
             modifiers: unpack_key_modifier(v.mouse.modifiers),
-            handled: Cell::new(Area::Empty),
+            handled: Rc::new(Cell::new(Area::Empty)),
             time: v.mouse.time
         }
     }
@@ -271,7 +271,7 @@ impl From<ToWasmMouseMove> for MouseMoveEvent {
             abs: dvec2(v.mouse.x, v.mouse.y),
             window_id: CxWindowPool::id_zero(),
             modifiers: unpack_key_modifier(v.mouse.modifiers),
-            handled: Cell::new(Area::Empty),
+            handled: Rc::new(Cell::new(Area::Empty)),
             time: v.mouse.time
         }
     }

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -1026,7 +1026,7 @@ impl Win32Window {
             window_id: self.window_id,
             abs: self.last_mouse_pos,
             time: self.time_now(),
-            handled: Cell::new(Area::Empty),
+            handled: Rc::new(Cell::new(Area::Empty)),
         }));
     }
     
@@ -1052,9 +1052,9 @@ impl Win32Window {
         self.do_callback(Win32Event::MouseMove(MouseMoveEvent {
             window_id: self.window_id,
             abs: pos,
-            modifiers: modifiers,
+            modifiers,
             time: self.time_now(),
-            handled: Cell::new(Area::Empty),
+            handled: Rc::new(Cell::new(Area::Empty)),
         }));
     }
 
@@ -1063,9 +1063,9 @@ impl Win32Window {
         self.do_callback(Win32Event::MouseLeave(MouseLeaveEvent {
             window_id: self.window_id,
             abs: pos,
-            modifiers: modifiers,
+            modifiers,
             time: self.time_now(),
-            handled: Cell::new(Area::Empty),
+            handled: Rc::new(Cell::new(Area::Empty)),
         }));
     }
     

--- a/platform/src/window.rs
+++ b/platform/src/window.rs
@@ -106,7 +106,7 @@ impl LiveNew for WindowHandle {
         let window = cx.windows.alloc();
         let cxwindow = &mut cx.windows[window.window_id()];
         cxwindow.is_created = false;
-        cxwindow.create_title = "Makepad".to_string();
+        cxwindow.create_title = "Kevin Test".to_string();
         cxwindow.create_inner_size = None;
         cxwindow.create_position = None;
         cx.platform_ops.push(CxOsOp::CreateWindow(window.window_id()));

--- a/studio/src/profiler.rs
+++ b/studio/src/profiler.rs
@@ -184,12 +184,12 @@ impl Widget for ProfilerEventChart {
         
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, _scope: &mut Scope){
         match event.hits(cx, self.draw_bg.area()) {
-            Hit::FingerDown(_fe) => {
+            Hit::FingerDown(..) => {
                 // ok so we get multiple finger downs
                 cx.set_key_focus(self.draw_bg.area());
                 self.time_drag = Some(self.time_range.clone());
             },
-            Hit::FingerMove(fe) => {
+            Hit::FingerMove(fe, _) => {
                 if let Some(start) = &self.time_drag{
                     // ok so how much did we move?
                     let moved = fe.abs_start.x - fe.abs.x;

--- a/studio/src/run_view.rs
+++ b/studio/src/run_view.rs
@@ -327,7 +327,7 @@ impl Widget for RunView {
         self.animator_handle_event(cx, event);
         // lets send mouse events
         match event.hits(cx, self.draw_app.area()) {
-            Hit::FingerDown(_) => {
+            Hit::FingerDown(..) => {
                 cx.set_key_focus(self.draw_app.area());
             }
             Hit::TextInput(e) => {

--- a/tools/cargo_makepad/src/main.rs
+++ b/tools/cargo_makepad/src/main.rs
@@ -90,6 +90,7 @@ fn show_help(err: &str){
     println!("");
     println!("    [options]:");
     println!("");
+    println!("       --arch=\"aarch64\"                        The target architecture for the OHOS target device (defaultsto the current architecture).");
     println!("       --deveco-home=\"deveco_path\"             The path of DevEco program, this parameter can also be specified by environment variable \"DEVECO_HOME\"");
     println!("       --remote=\"<hdcip:port>\"                 Remote hdc service, this parameter can also be specified by environment variable \"HDC_REMOTE\"");
     println!();

--- a/tools/cargo_makepad/src/open_harmony/mod.rs
+++ b/tools/cargo_makepad/src/open_harmony/mod.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 mod compile;
 mod sdk;
 
@@ -10,15 +12,39 @@ pub enum HostOs {
     Unsupported
 }
 
-#[allow(non_camel_case_types)]
 pub enum OpenHarmonyTarget {
-    aarch64,
+    Aarch64,
+    X86_64,
 }
-
 impl OpenHarmonyTarget {
-    fn toolchain(&self) ->&'static str{
+    fn target_triple_str(&self) -> &'static str {
         match self {
-            Self::aarch64 => "aarch64-unknown-linux-ohos"
+            Self::Aarch64 => "aarch64-unknown-linux-ohos",
+            Self::X86_64 => "x86_64-unknown-linux-ohos",
+        }
+    }
+}
+impl FromStr for OpenHarmonyTarget {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "aarch64" => Ok(OpenHarmonyTarget::Aarch64),
+            "x86_64" => Ok(OpenHarmonyTarget::X86_64),
+            _ => Err(())
+        }
+    }
+}
+impl OpenHarmonyTarget {
+    fn from_current_target_arch() -> Result<Self, ()> {
+        #[cfg(target_arch = "aarch64")] {
+            Ok(Self::Aarch64)
+        }
+        #[cfg(target_arch = "x86_64")] {
+            Ok(Self::X86_64)
+        }
+        #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))] {
+            Err(())
         }
     }
 }
@@ -27,7 +53,7 @@ pub fn handle_open_harmony(mut args: &[String]) -> Result<(), String> {
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))] let host_os = HostOs::WindowsX64;
     #[cfg(all(target_os = "macos"))] let host_os = HostOs::MacOS;
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))] let host_os = HostOs::LinuxX64;
-    let targets = vec![OpenHarmonyTarget::aarch64];
+    let mut targets = Vec::new();
     let mut deveco_home = None;
     let mut hdc_remote = None;
 
@@ -35,6 +61,12 @@ pub fn handle_open_harmony(mut args: &[String]) -> Result<(), String> {
         let v = &args[i];
         if let Some(opt) = v.strip_prefix("--deveco-home=") {
             deveco_home = Some(opt.to_string());
+        }
+        else if let Some(opt) = v.strip_prefix("--arch=") {
+            targets.push(
+                OpenHarmonyTarget::from_str(opt.trim())
+                    .map_err(|_| format!("Invalid --arch argument: '{}'", opt))?
+            );
         }
         else if let Some(remote) = v.strip_prefix("--remote=") {
             hdc_remote = Some(remote.to_string());
@@ -55,6 +87,14 @@ pub fn handle_open_harmony(mut args: &[String]) -> Result<(), String> {
         if let Ok(v) = std::env::var("HDC_REMOTE") {
             hdc_remote = Some(v);
         }
+    }
+
+    if targets.is_empty() {
+        targets.push(
+            OpenHarmonyTarget::from_current_target_arch()
+                .inspect(|target| println!("Using current target arch: '{}'", target.target_triple_str()))
+                .map_err(|_| format!("Current target arch is unsupported. Try passing in the '--arch' argument"))?
+        );
     }
 
     if args.len() < 1 {

--- a/tools/cargo_makepad/src/open_harmony/sdk.rs
+++ b/tools/cargo_makepad/src/open_harmony/sdk.rs
@@ -2,21 +2,27 @@ use crate::makepad_shell::*;
 use crate::open_harmony::OpenHarmonyTarget;
 
 pub fn rustup_toolchain_install(openharmoy_targets:&[OpenHarmonyTarget]) -> Result<(), String> {
-    println!("[Begin] Installing Rust toolchains for OpenHarmony devices");
     shell_env(&[],&std::env::current_dir().unwrap(), "rustup", &[
         "install",
         "nightly"
-    ]) ?;
+    ])?;
 
     for target in openharmoy_targets{
-        shell_env(&[],&std::env::current_dir().unwrap(), "rustup", &[
-            "target",
-            "add",
-            target.toolchain(),
-            "--toolchain",
-            "nightly"
-            ]) ?
+        let target_triple = target.target_triple_str();
+        println!("Installing Rust nightly toolchain for '{target_triple}'...");
+        shell_env(
+            &[],
+            &std::env::current_dir().unwrap(),
+            "rustup",
+            &[
+                "target",
+                "add",
+                target.target_triple_str(),
+                "--toolchain",
+                "nightly"
+            ],
+        )?;
     }
-    println!("[Finished] OpenHarmony Rust toolchains installed");
+    println!("Finished installing OpenHarmony (ohos) Rust toolchains.");
     Ok(())
 }

--- a/tools/open_harmony/README.md
+++ b/tools/open_harmony/README.md
@@ -58,7 +58,7 @@ cargo makepad ohos --deveco-home=<path-to-deveco> deveco -p makepad-example-simp
 DEVECO_HOME=<$HOME/command-line-tools> cargo makepad ohos deveco -p makepad-example-simple --release
 ```
 
-After this command, it would generates a DevEco Project in `target/makepad-open-haromony/makepad_example_simple`
+After this command, it would generates a DevEco Project in `target/makepad-open-harmony/makepad_example_simple`
 
 ## Signing With DevEco
 Use `DevEco studio` to sign the project, for the Linux user, please copy the project to Windows/MacOS, then sign it with `DevEco studio`
@@ -73,7 +73,7 @@ Click `File` -> `Project Structure` -> `Signing Configs` -> `Sign in`
 
 After signing
 
-`target/makepad-open-haromony/makepad_example_simple/build-profile.json5`
+`target/makepad-open-harmony/makepad_example_simple/build-profile.json5`
 ```json
 {
   "app": {
@@ -143,7 +143,7 @@ cargo makepad ohos --deveco-home=<path-to-deveco> run -p makepad-example-simple 
 DEVECO_HOME=<$HOME/command-line-tools> cargo makepad ohos run -p makepad-example-simple --release
 ```
 
-After this command, it would generates a Hap file  in `target/makepad-open-haromony/makepad_example_simple/entry/build/outputs/default/makepad-default-signed.hap`
+After this command, it would generates a Hap file  in `target/makepad-open-harmony/makepad_example_simple/entry/build/outputs/default/makepad-default-signed.hap`
 
 
 ## HDC Remote

--- a/tools/open_harmony/cmd/x86_64-unknown-linux-ohos-clang++.cmd
+++ b/tools/open_harmony/cmd/x86_64-unknown-linux-ohos-clang++.cmd
@@ -1,0 +1,14 @@
+@echo off
+setlocal
+
+set "SOURCE=%~dp0"
+if "%SOURCE:~-1%"=="\" set "SOURCE=%SOURCE:~0,-1%"
+
+"%SOURCE%\clang++.exe" ^
+  -target x86_64-linux-ohos ^
+  --sysroot="%SOURCE%\..\..\sysroot" ^
+  -D__MUSL__ ^
+  %*
+
+endlocal
+exit /b

--- a/tools/open_harmony/cmd/x86_64-unknown-linux-ohos-clang.cmd
+++ b/tools/open_harmony/cmd/x86_64-unknown-linux-ohos-clang.cmd
@@ -1,0 +1,14 @@
+@echo off
+setlocal
+
+set "SOURCE=%~dp0"
+if "%SOURCE:~-1%"=="\" set "SOURCE=%SOURCE:~0,-1%"
+
+"%SOURCE%\clang.exe" ^
+  -target x86_64-linux-ohos ^
+  --sysroot="%SOURCE%\..\..\sysroot" ^
+  -D__MUSL__ ^
+  %*
+
+endlocal
+exit /b

--- a/widgets/src/button.rs
+++ b/widgets/src/button.rs
@@ -377,14 +377,14 @@ impl Widget for Button {
             // If it's not enabled, we still show the button, but we set
             // the NotAllowed mouse cursor upon hover instead of the Hand cursor.
             match event.hits(cx, self.draw_bg.area()) {
-                Hit::FingerDown(fe) if self.enabled && fe.is_primary_hit() => {
+                Hit::FingerDown(fe, _) if self.enabled && fe.is_primary_hit() => {
                     if self.grab_key_focus {
                         cx.set_key_focus(self.draw_bg.area());
                     }
                     cx.widget_action_with_data(&self.action_data, uid, &scope.path, ButtonAction::Pressed(fe.modifiers));
                     self.animator_play(cx, id!(hover.pressed));
                 }
-                Hit::FingerHoverIn(_) => {
+                Hit::FingerHoverIn(..) => {
                     if self.enabled {
                         cx.set_cursor(MouseCursor::Hand);
                         self.animator_play(cx, id!(hover.on));

--- a/widgets/src/check_box.rs
+++ b/widgets/src/check_box.rs
@@ -382,14 +382,14 @@ impl Widget for CheckBox {
         self.animator_handle_event(cx, event);
                 
         match event.hits(cx, self.draw_check.area()) {
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 cx.set_cursor(MouseCursor::Hand);
                 self.animator_play(cx, id!(hover.on));
             }
             Hit::FingerHoverOut(_) => {
                 self.animator_play(cx, id!(hover.off));
             },
-            Hit::FingerDown(fe) if fe.is_primary_hit() => {
+            Hit::FingerDown(fe, _) if fe.is_primary_hit() => {
                 if self.animator_in_state(cx, id!(selected.on)) {
                     self.animator_play(cx, id!(selected.off));
                     cx.widget_action_with_data(&self.action_data, uid, &scope.path, CheckBoxAction::Change(false));
@@ -402,7 +402,7 @@ impl Widget for CheckBox {
             Hit::FingerUp(_fe) => {
                                 
             }
-            Hit::FingerMove(_fe) => {
+            Hit::FingerMove(..) => {
                                 
             }
             _ => ()

--- a/widgets/src/color_picker.rs
+++ b/widgets/src/color_picker.rs
@@ -225,13 +225,13 @@ impl Widget for ColorPicker {
         self.animator_handle_event(cx, event);
                 
         match event.hits(cx, self.draw_wheel.area()) {
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 self.animator_play(cx, id!(hover.on));
             }
             Hit::FingerHoverOut(_) => {
                 self.animator_play(cx, id!(hover.off));
             },
-            Hit::FingerDown(fe) => {
+            Hit::FingerDown(fe, _) => {
                 self.animator_play(cx, id!(hover.pressed));
                 let rsize = (self.size * 0.28) / 2.0f64.sqrt();
                 let rel = fe.abs - fe.rect.pos;
@@ -260,7 +260,7 @@ impl Widget for ColorPicker {
                 let uid = self.widget_uid();
                 cx.widget_action(uid, &scope.path, ColorPickerAction::DoneChanging);
             }
-            Hit::FingerMove(fe) => {
+            Hit::FingerMove(fe, _) => {
                 let rel = fe.abs - fe.rect.pos;
                 return self.handle_finger(cx, rel, scope)
                                 

--- a/widgets/src/designer_outline_tree.rs
+++ b/widgets/src/designer_outline_tree.rs
@@ -466,18 +466,18 @@ impl DesignerOutlineTreeNode {
         }
         
         match event.hits(cx, self.draw_bg.area()) {
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                self.animator_play(cx, id!(hover.on));
             }
             Hit::FingerHoverOut(_) => {
                 self.animator_play(cx, id!(hover.off));
             }
-            Hit::FingerMove(f) => {
+            Hit::FingerMove(f, _) => {
                 if f.abs.distance(&f.abs_start) >= self.min_drag_distance {
                     actions_out.push((node_id, OutlineTreeNodeAction::ShouldStartDrag));
                 }
             }
-            Hit::FingerDown(e) => {
+            Hit::FingerDown(e, _) => {
                 self.animator_play(cx, id!(select.on));
                 actions_out.push((node_id, OutlineTreeNodeAction::Selected(e.modifiers)));
                 /*

--- a/widgets/src/designer_view.rs
+++ b/widgets/src/designer_view.rs
@@ -451,7 +451,7 @@ impl Widget for DesignerView {
         // 
         let data = scope.data.get_mut::<DesignerData>().unwrap();
         match event.hits(cx, self.area) {
-            Hit::FingerHoverOver(fe) =>{
+            Hit::FingerHoverOver(fe, _) =>{
                 // lets poll our widget structure with a special event
                 // alright so we hover over. lets determine the mouse cursor
                 //let corner_inner:f64  = 10.0 * self.zoom;
@@ -541,7 +541,7 @@ impl Widget for DesignerView {
             }
             Hit::FingerHoverOut(_fh)=>{
             }
-            Hit::FingerDown(fe) => {
+            Hit::FingerDown(fe, _) => {
                 self.undo_group += 1;
                 if !fe.modifiers.shift{
                     if fe.modifiers.control && fe.modifiers.alt{
@@ -614,7 +614,7 @@ impl Widget for DesignerView {
                 self.sync_zoom_pan(cx);
                 self.redraw(cx);
             }
-            Hit::FingerMove(fe) => {
+            Hit::FingerMove(fe, _) => {
                 match self.finger_move.as_ref().unwrap(){
                     FingerMove::DragSubComponentOrder(cs)=>{
                         // ok how do we do this.

--- a/widgets/src/desktop_button.rs
+++ b/widgets/src/desktop_button.rs
@@ -143,11 +143,11 @@ impl Widget for DesktopButton{
         self.animator_handle_event(cx, event);
         
         match event.hits(cx, self.draw_bg.area()) {
-            Hit::FingerDown(fe) => {
+            Hit::FingerDown(fe, _) => {
                 cx.widget_action(uid, &scope.path, ButtonAction::Pressed(fe.modifiers));
                 self.animator_play(cx, id!(hover.pressed));
             },
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 cx.set_cursor(MouseCursor::Hand);
                 self.animator_play(cx, id!(hover.on));
             }

--- a/widgets/src/drop_down.rs
+++ b/widgets/src/drop_down.rs
@@ -477,12 +477,12 @@ impl Widget for DropDown {
                 },
                 _ => ()
             }
-            Hit::FingerDown(fe) if fe.is_primary_hit() => {
+            Hit::FingerDown(fe, _) if fe.is_primary_hit() => {
                 cx.set_key_focus(self.draw_bg.area());
                 self.set_open(cx);
                 self.animator_play(cx, id!(hover.pressed));
             },
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 cx.set_cursor(MouseCursor::Hand);
                 self.animator_play(cx, id!(hover.on));
             }

--- a/widgets/src/file_tree.rs
+++ b/widgets/src/file_tree.rs
@@ -417,18 +417,18 @@ impl FileTreeNode {
             self.draw_bg.redraw(cx);
         }
         match event.hits(cx, self.draw_bg.area()) {
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 self.animator_play(cx, id!(hover.on));
             }
             Hit::FingerHoverOut(_) => {
                 self.animator_play(cx, id!(hover.off));
             }
-            Hit::FingerMove(f) => {
+            Hit::FingerMove(f, _) => {
                 if f.abs.distance(&f.abs_start) >= self.min_drag_distance {
                     actions.push((node_id, FileTreeNodeAction::ShouldStartDrag));
                 }
             }
-            Hit::FingerDown(_) => {
+            Hit::FingerDown(..) => {
                 self.animator_play(cx, id!(select.on));
                 if self.is_folder {
                     if self.animator_in_state(cx, id!(open.on)) {

--- a/widgets/src/flat_list.rs
+++ b/widgets/src/flat_list.rs
@@ -221,7 +221,7 @@ impl Widget for FlatList {
                     self.area.redraw(cx);
                 },
                 
-                Hit::FingerDown(e) => {
+                Hit::FingerDown(e, _) => {
                     if self.grab_key_focus {
                         cx.set_key_focus(self.area);
                     }
@@ -231,7 +231,7 @@ impl Widget for FlatList {
                         };
                     }
                 }
-                Hit::FingerMove(e) => {
+                Hit::FingerMove(e, _) => {
                     //log!("Finger move {} {}", e.time, e.abs);
                     cx.set_cursor(MouseCursor::Default);
                     match &mut self.scroll_state {

--- a/widgets/src/fold_button.rs
+++ b/widgets/src/fold_button.rs
@@ -167,7 +167,7 @@ impl Widget for FoldButton {
         };
                 
         match event.hits(cx, self.draw_bg.area()) {
-            Hit::FingerDown(_fe) => {
+            Hit::FingerDown(_fe, _) => {
                 if self.animator_in_state(cx, id!(open.on)) {
                     self.animator_play(cx, id!(open.off));
                     cx.widget_action(uid, &scope.path, FoldButtonAction::Closing)
@@ -178,7 +178,7 @@ impl Widget for FoldButton {
                 }
                 self.animator_play(cx, id!(hover.on));
             },
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 cx.set_cursor(MouseCursor::Hand);
                 self.animator_play(cx, id!(hover.on));
             }

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -706,7 +706,7 @@ impl Widget for HtmlLink {
 
         for area in self.drawn_areas.clone().into_iter() {
             match event.hits(cx, area) {
-                Hit::FingerDown(fe) => {
+                Hit::FingerDown(fe, _) => {
                     if fe.is_primary_hit() {
                         if self.grab_key_focus {
                             cx.set_key_focus(self.area());
@@ -725,7 +725,7 @@ impl Widget for HtmlLink {
                         );
                     }
                 }
-                Hit::FingerHoverIn(_) => {
+                Hit::FingerHoverIn(..) => {
                     cx.set_cursor(MouseCursor::Hand);
                     self.animator_play(cx, id!(hover.on));
                 }

--- a/widgets/src/label.rs
+++ b/widgets/src/label.rs
@@ -244,7 +244,7 @@ impl Widget for Label {
         if self.hover_actions_enabled {
             
             match event.hits_with_capture_overload(cx, self.area, true) {
-                Hit::FingerHoverIn(fh) => {
+                Hit::FingerHoverIn(fh, _) => {
                     cx.widget_action(uid, &scope.path, LabelAction::HoverIn(fh.rect));
                 }
                 Hit::FingerHoverOut(_) => {

--- a/widgets/src/popup_menu.rs
+++ b/widgets/src/popup_menu.rs
@@ -240,13 +240,13 @@ impl PopupMenuItem {
             self.draw_bg.area(),
             HitOptions::new().with_sweep_area(sweep_area)
         ) {
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 self.animator_play(cx, id!(hover.on));
             }
             Hit::FingerHoverOut(_) => {
                 self.animator_play(cx, id!(hover.off));
             }
-            Hit::FingerDown(fe) if fe.is_primary_hit() => {
+            Hit::FingerDown(fe, _) if fe.is_primary_hit() => {
                 dispatch_action(cx, PopupMenuItemAction::WasSweeped);
                 self.animator_play(cx, id!(hover.on));
                 self.animator_play(cx, id!(select.on));

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -911,7 +911,7 @@ impl Widget for PortalList {
                     },
                     _ => ()
                 }
-                Hit::FingerDown(fe) => {
+                Hit::FingerDown(fe, _) => {
                     // We allow other mouse buttons to grab key focus and stop the tail range behavior,
                     // but we only want the primary button (or touch) to actually scroll via dragging.
 
@@ -931,7 +931,7 @@ impl Widget for PortalList {
                         };
                     }
                 }
-                Hit::FingerMove(e) => {
+                Hit::FingerMove(e, _) => {
                     //log!("Finger move {} {}", e.time, e.abs);
                     cx.set_cursor(MouseCursor::Default);
                     match &mut self.scroll_state {

--- a/widgets/src/radio_button.rs
+++ b/widgets/src/radio_button.rs
@@ -409,7 +409,7 @@ impl Widget for RadioButton {
         self.animator_handle_event(cx, event);
                 
         match event.hits(cx, self.draw_radio.area()) {
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 cx.set_cursor(MouseCursor::Hand);
                 self.animator_play(cx, id!(hover.on));
             }
@@ -417,7 +417,7 @@ impl Widget for RadioButton {
                 cx.set_cursor(MouseCursor::Arrow);
                 self.animator_play(cx, id!(hover.off));
             },
-            Hit::FingerDown(fe) if fe.is_primary_hit() => {
+            Hit::FingerDown(fe, _) if fe.is_primary_hit() => {
                 if self.animator_in_state(cx, id!(selected.off)) {
                     self.animator_play(cx, id!(selected.on));
                     cx.widget_action(uid, &scope.path, RadioButtonAction::Clicked);
@@ -426,7 +426,7 @@ impl Widget for RadioButton {
             Hit::FingerUp(_fe) => {
                                 
             }
-            Hit::FingerMove(_fe) => {
+            Hit::FingerMove(_fe, _) => {
                                 
             }
             _ => ()

--- a/widgets/src/scroll_bar.rs
+++ b/widgets/src/scroll_bar.rs
@@ -431,7 +431,7 @@ impl ScrollBar {
             }
             
             match event.hits(cx, self.draw_bar.area()) {
-                Hit::FingerDown(fe) if fe.is_primary_hit() => {
+                Hit::FingerDown(fe, _) if fe.is_primary_hit() => {
                     self.animator_play(cx, id!(hover.pressed));
                     let rel = fe.abs - fe.rect.pos;
                     let rel = match self.axis {
@@ -451,7 +451,7 @@ impl ScrollBar {
                         self.drag_point = Some(rel - bar_start); // store the drag delta
                     }
                 },
-                Hit::FingerHoverIn(_) => {
+                Hit::FingerHoverIn(..) => {
                     self.animator_play(cx, id!(hover.on));
                 },
                 Hit::FingerHoverOut(_) => {
@@ -467,7 +467,7 @@ impl ScrollBar {
                     }
                     return;
                 },
-                Hit::FingerMove(fe) => {
+                Hit::FingerMove(fe, _) => {
                     let rel = fe.abs - fe.rect.pos;
                     // helper called by event code to scroll from a finger
                     if self.drag_point.is_none() {

--- a/widgets/src/slider.rs
+++ b/widgets/src/slider.rs
@@ -1767,7 +1767,7 @@ impl Widget for Slider {
 
         if self.hover_actions_enabled {
             match event.hits_with_capture_overload(cx, self.label_area, true) {
-                Hit::FingerHoverIn(fh) => {
+                Hit::FingerHoverIn(fh, _) => {
                     cx.widget_action(uid, &scope.path, SliderAction::LabelHoverIn(fh.rect));
                 }
                 Hit::FingerHoverOut(_) => {
@@ -1778,21 +1778,24 @@ impl Widget for Slider {
         }
 
         match event.hits(cx, self.draw_slider.area()) {
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 self.animator_play(cx, id!(hover.on));
             },
             Hit::FingerHoverOut(_) => {
                 self.animator_play(cx, id!(hover.off));
             },
-            Hit::FingerHoverOver(_) => {
+            Hit::FingerHoverOver(..) => {
                 cx.set_cursor(MouseCursor::Grab);
             },
-            Hit::FingerDown(FingerDownEvent {
-                // abs,
-                // rect,
-                device,
-                ..
-            }) if device.is_primary_hit() => {
+            Hit::FingerDown(
+                FingerDownEvent {
+                    // abs,
+                    // rect,
+                    device,
+                    ..
+                },
+                _,
+            ) if device.is_primary_hit() => {
                 // cx.set_key_focus(self.slider.area());
                 // self.relative_value = ((abs.x - rect.pos.x) / rect.size.x ).max(0.0).min(1.0);
                 self.update_text_input(cx);
@@ -1822,7 +1825,7 @@ impl Widget for Slider {
                 cx.widget_action(uid, &scope.path, SliderAction::EndSlide);
                 cx.set_cursor(MouseCursor::Grab);
             }
-            Hit::FingerMove(fe) => {
+            Hit::FingerMove(fe, _) => {
                 let rel = fe.abs - fe.abs_start;
                 if let Some(start_pos) = self.dragging {
                     if let DragAxis::Horizontal = self.axis {

--- a/widgets/src/slides_view.rs
+++ b/widgets/src/slides_view.rs
@@ -194,7 +194,7 @@ impl Widget for SlidesView {
                 let uid = self.widget_uid();
                 cx.widget_action(uid, &scope.path, SlidesViewAction::Flipped(self.goal_slide as usize));
             }
-            Hit::FingerDown(_fe) => {
+            Hit::FingerDown(..) => {
                 cx.set_key_focus(self.area);
             },
             _ => ()

--- a/widgets/src/splitter.rs
+++ b/widgets/src/splitter.rs
@@ -184,7 +184,7 @@ impl Widget for Splitter {
         
         self.animator_handle_event(cx, event);
         match event.hits_with_options(cx, self.draw_splitter.area(), HitOptions::new().with_margin(self.margin())) {
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 match self.axis {
                     SplitterAxis::Horizontal => cx.set_cursor(MouseCursor::ColResize),
                     SplitterAxis::Vertical => cx.set_cursor(MouseCursor::RowResize),
@@ -194,7 +194,7 @@ impl Widget for Splitter {
             Hit::FingerHoverOut(_) => {
                 self.animator_play(cx, id!(hover.off));
             },
-            Hit::FingerDown(_) => {
+            Hit::FingerDown(..) => {
                 match self.axis {
                     SplitterAxis::Horizontal => cx.set_cursor(MouseCursor::ColResize),
                     SplitterAxis::Vertical => cx.set_cursor(MouseCursor::RowResize),
@@ -211,7 +211,7 @@ impl Widget for Splitter {
                     self.animator_play(cx, id!(hover.off));
                 }
             }
-            Hit::FingerMove(f) => {
+            Hit::FingerMove(f, _) => {
                 if let Some(drag_start_align) = self.drag_start_align {
                     let delta = match self.axis {
                         SplitterAxis::Horizontal => f.abs.x - f.abs_start.x,

--- a/widgets/src/tab.rs
+++ b/widgets/src/tab.rs
@@ -273,13 +273,13 @@ impl Tab {
         };
         
         match event.hits(cx, self.draw_bg.area()) {
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 self.animator_play(cx, id!(hover.on));
             }
             Hit::FingerHoverOut(_) => if !block_hover_out {
                 self.animator_play(cx, id!(hover.off));
             }
-            Hit::FingerMove(e) => {
+            Hit::FingerMove(e, _) => {
                 if !self.is_dragging && (e.abs - e.abs_start).length() > self.min_drag_dist {
                     self.is_dragging = true;
                     dispatch_action(cx, TabAction::ShouldTabStartDrag);
@@ -291,7 +291,7 @@ impl Tab {
                     self.is_dragging = false;
                 }
             }
-            Hit::FingerDown(fde) => {
+            Hit::FingerDown(fde, _) => {
                 // A primary click/touch selects the tab, but a middle click closes it.
                 if fde.is_primary_hit() {
                     dispatch_action(cx, TabAction::WasPressed);

--- a/widgets/src/tab_close_button.rs
+++ b/widgets/src/tab_close_button.rs
@@ -80,7 +80,7 @@ impl TabCloseButton {
     ) -> TabCloseButtonAction {
         self.animator_handle_event(cx, event);
         match event.hits(cx, self.draw_button.area()) {
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 self.animator_play(cx, id!(hover.on));
                 return TabCloseButtonAction::HoverIn;
             }
@@ -90,7 +90,7 @@ impl TabCloseButton {
             }
             // Pressing the tab close button with a primary button/touch
             // or the middle mouse button are both recognized as a close tab action.
-            Hit::FingerDown(fe) 
+            Hit::FingerDown(fe, _)
                 if fe.is_primary_hit() || fe.mouse_button().is_some_and(|b| b.is_middle()) =>
             {
                 return TabCloseButtonAction::WasPressed;

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -795,7 +795,7 @@ impl Widget for TextFlowLink {
         
         for area in self.drawn_areas.clone().into_iter() {
             match event.hits(cx, area) {
-                Hit::FingerDown(fe) => {
+                Hit::FingerDown(fe, _) => {
                     if self.grab_key_focus {
                         cx.set_key_focus(self.area());
                     }
@@ -821,7 +821,7 @@ impl Widget for TextFlowLink {
                         );
                     }
                 }
-                Hit::FingerHoverIn(_) => {
+                Hit::FingerHoverIn(..) => {
                     cx.set_cursor(MouseCursor::Hand);
                     self.animator_play(cx, id!(hover.on));
                 }

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -701,19 +701,22 @@ impl Widget for TextInput {
                     cx.widget_action(uid, &scope.path, TextInputAction::Change(self.text.clone()));
                 }
             }
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(..) => {
                 cx.set_cursor(MouseCursor::Text);
                 self.animator_play(cx, id!(hover.on));
             }
             Hit::FingerHoverOut(_) => {
                 self.animator_play(cx, id!(hover.off));
             },
-            Hit::FingerDown(FingerDownEvent {
-                abs,
-                tap_count,
-                device,
-                ..
-            }) => {
+            Hit::FingerDown(
+                FingerDownEvent {
+                    abs,
+                    tap_count,
+                    device,
+                    ..
+                },
+                _,
+            ) => {
                 let event = DrawEvent::default();
                 let mut cx = Cx2d::new(cx, &event);
                 let index_affinity = self.position_to_index_affinity(
@@ -732,11 +735,14 @@ impl Widget for TextInput {
                 }
                 self.draw_bg.redraw(&mut *cx);
             }
-            Hit::FingerMove(FingerMoveEvent {
-                abs,
-                tap_count,
-                ..
-            }) => {
+            Hit::FingerMove(
+                FingerMoveEvent {
+                    abs,
+                    tap_count,
+                    ..
+                },
+                _,
+            ) => {
                 let event: DrawEvent = DrawEvent::default();
                 let mut cx = Cx2d::new(cx, &event);
                 let index_affinity = self.position_to_index_affinity(

--- a/widgets/src/tooltip.rs
+++ b/widgets/src/tooltip.rs
@@ -81,6 +81,10 @@ pub struct Tooltip {
 
 impl Widget for Tooltip {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        if !self.opened {
+            return;
+        }
+
         self.content.handle_event(cx, event, scope);
 
         match event.hits_with_capture_overload(cx, self.content.area(), true) {

--- a/widgets/src/touch_gesture.rs
+++ b/widgets/src/touch_gesture.rs
@@ -177,14 +177,14 @@ impl TouchGesture {
         }
 
         match event.hits_with_capture_overload(cx, area, true) {
-            Hit::FingerDown(e) => {
+            Hit::FingerDown(e, _) => {
                 self.scroll_state = ScrollState::Drag {
                     samples: vec![ScrollSample{abs: e.abs.y, time: e.time}]
                 };
 
                 return TouchMotionChange::ScrollStateChanged
             }
-            Hit::FingerMove(e) => {
+            Hit::FingerMove(e, _) => {
                 cx.set_cursor(MouseCursor::Default);
                 match &mut self.scroll_state {
                     ScrollState::Drag {samples}=>{

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -504,12 +504,12 @@ impl Video {
 
     fn handle_gestures(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         match event.hits(cx, self.draw_bg.area()) {
-            Hit::FingerDown(fe) if fe.is_primary_hit() => {
+            Hit::FingerDown(fe, _) if fe.is_primary_hit() => {
                 if self.hold_to_pause {
                     self.pause_playback(cx);
                 }
             }
-            Hit::FingerDown(fe) if fe.mouse_button().is_some_and(|mb| mb.is_secondary()) => {
+            Hit::FingerDown(fe, _) if fe.mouse_button().is_some_and(|mb| mb.is_secondary()) => {
                 self.handle_secondary_click(cx, scope, fe.abs, fe.modifiers);
             }
             Hit::FingerLongPress(lp) => {

--- a/widgets/src/widget.rs
+++ b/widgets/src/widget.rs
@@ -383,7 +383,7 @@ impl WidgetRef {
     ///         self.draw_button.redraw(cx);
     ///     }
     ///     match event.hits_with_options(cx, self.draw_button.area(), HitOptions::new().with_sweep_area(sweep_area) ) {
-    ///         Hit::FingerDown(f_down) => {
+    ///         Hit::FingerDown(f_down, _) => {
     ///             if self.grab_key_focus {
     ///                  cx.set_key_focus(self.sweep_area);
     ///             }


### PR DESCRIPTION
(This PR depends on / includes changes from #670, so merge that one in first before trying to review this)

This commit adds a new paradigm that allows the app dev to control whether the act of handling hits from a given event (when calling `event.hits()`) will or will not mark that event as handled.

The default is that the `Hit` *does* mark the causing event as handled, such that it won't be handle-able by other widgets duplicately unless of course they enable `capture_overload`).
This commit still preserves that historical behavior in order to not surprise any users further; however, I do believe that the default should be that an event is *not* considered to be handled unless the app logic explicitly marks it as handled.

This currently only applies to four `Hit` variants:
* `Hit::FingerDown`
* `Hit::FingerMove`
* `Hit::FingerHoverIn`
* `Hit::FingerHoverOver`

because those are the four `Hit`s that previously set their event's `handled` Area unconditionally (internal to the `hits()` API).

Any code that matches on one of those four `Hit` variants will need to be updated. It's very simple to do so, you can just ignore the extra `EventHandled` parameter when matching on those variants.
```rust
pub enum Hit {
    ...
    FingerDown(FingerDownEvent, EventHandled),
    FingerMove(FingerMoveEvent, EventHandled),
    FingerHoverIn(FingerHoverEvent, EventHandled),
    FingerHoverOver(FingerHoverEvent, EventHandled),
    ...
```

In addition, all of these Hit handlers within the base `View` widget now explicitly mark those events as *not* handled, which ensures they are also able to handled by other widgets.
This makes sense because the base `View` should not "consume" any hits, since most app devs would not expect that a blank empty space view would consume a mouse click or something.