### PR TITLE
Support real OpenHarmony hardware

### DIFF
--- a/platform/src/os/linux/egl_sys.rs
+++ b/platform/src/os/linux/egl_sys.rs
@@ -515,8 +515,7 @@ pub unsafe  fn create_egl_context(
 
     let config = available_cfgs[0];
 
-    // TODO FIXME: these attributes were required to make the OpenHarmony emulator work.
-    //             They may not be necessary on real hardware or on other platforms.
+    #[cfg(ohos_sim)]
     let ctx_attributes = vec![
         EGL_CONTEXT_MAJOR_VERSION, 2, // version 1 and 3 also work
         EGL_CONTEXT_MINOR_VERSION_KHR , 0,
@@ -525,6 +524,14 @@ pub unsafe  fn create_egl_context(
         EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT, // allows use of deprecated features
         EGL_NONE, 0, 0, 0,
     ];
+
+    #[cfg(not(ohos_sim))]
+    let ctx_attributes = vec![
+        EGL_CONTEXT_MAJOR_VERSION, 2, // version 1 and 3 also work
+        EGL_CONTEXT_MINOR_VERSION_KHR , 0,
+        EGL_NONE,
+    ];
+
     let context = (egl.eglCreateContext.unwrap())(
         display,
         config,

--- a/tools/open_harmony/README.md
+++ b/tools/open_harmony/README.md
@@ -56,9 +56,13 @@ Click `File` -> `Project Structure` -> `Signing Configs` -> `Sign in`
 
 ![](./pic/signing.png)
 
-After signing
+After signing in, make sure to click the "Apply" button on the bottom right of the `Signing Configs` pane.
 
+Then, the DevEco IDE will auto-populate the `signingConfigs` array within the `build-profile.json5` file,
+which should be located at the path:
 `target/makepad-open-harmony/makepad_example_simple/build-profile.json5`
+
+The contents of that file will look something like this (we have redacted the paths and password fields):
 ```json
 {
   "app": {


### PR DESCRIPTION
Fix OpenGL configuration on real OHOS devices, which is different than what is required for OHOS simulators.

Clarify the instructions for building and signing a real `.hap` app bundle on a real device.

Ensure that all combinations of Windows, macOS, x86_64, and aarch64 work when building across different hosts and target architectures for OpenHarmony.