### PR TITLE
add-CxOsOpShowTextIME

### DIFF
--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -319,6 +319,17 @@ impl Cx {
                 CxOsOp::StopTimer(timer_id) => {
                     xlib_app.stop_timer(timer_id);
                 },
+                CxOsOp::ShowTextIME(area, pos) => {
+                    let pos = area.clipped_rect(self).pos + pos;
+                    opengl_windows.iter_mut().for_each(|w| {
+                        w.xlib_window.set_ime_spot(pos);
+                    });
+                },
+                CxOsOp::HideTextIME => {
+                    opengl_windows.iter_mut().for_each(|w| {
+                        w.xlib_window.set_ime_spot(dvec2(0.0,0.0));
+                    });
+                },
                 e=>{
                     crate::error!("Not implemented on this platform: CxOsOp::{:?}", e);
                 }


### PR DESCRIPTION
This fix only solves the error `Not implemented on this platform: CxOsOp::ShowTextIME` that happened when typing or focusing the `textInput`. Input method still doesn't work on Linux, so that probably needs to be fixed in another PR.