### PR TITLE
feat: Distinguish between mouse mode and keyboard model for CommandTextInput

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ CLAUDE_KEY
 *.fish
 experiments/websocket-windows/nodejs-websocketserver
 experiments/svgloader
+CLAUDE.md


### PR DESCRIPTION
Distinguish between mouse mode and keyboard model, so that only one option in the list is highlighted uniquely.

Previous effect:
![demo](https://github.com/user-attachments/assets/2232f0af-d009-4615-892e-e64b0b596ae3)

Current effect:
![mention](https://github.com/user-attachments/assets/96ead576-d7a8-4ec3-bf7b-8db183079a8c)
