### PR TITLE
feat(texture): add swap_vec_u32 method and refactor mandelbrot.rs for…

### DIFF
--- a/examples/fractal_zoom/Cargo.toml
+++ b/examples/fractal_zoom/Cargo.toml
@@ -15,3 +15,4 @@ makepad-widgets = {path="../../widgets", version="0.6.0"}
 
 
 
+[workspace]

--- a/examples/fractal_zoom/src/mandelbrot.rs
+++ b/examples/fractal_zoom/src/mandelbrot.rs
@@ -173,7 +173,7 @@ impl TileCache {
     
     fn tile_completed(&mut self, cx: &mut Cx, mut tile: Tile) {
         self.tiles_in_flight -= 1;
-        self.textures[tile.texture_index].put_back_vec_u32(cx, &mut tile.buffer, None);
+        self.textures[tile.texture_index].put_back_vec_u32(cx, tile.buffer.clone(), None);
         self.next.push(tile)
     }
     

--- a/platform/src/texture.rs
+++ b/platform/src/texture.rs
@@ -569,6 +569,29 @@ impl Texture {
         *data = Some(new_data);
         *updated = updated.update(dirty_rect);
     }
+        /// Swaps the internal u32 image data with the provided vector.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the texture format is not `VecBGRAu8_32`
+    /// or if the internal image data is not available (i.e. has not been taken).
+    pub fn swap_vec_u32(&self, cx: &mut Cx, other: &mut Vec<u32>) {
+        // Retrieve a mutable reference to the texture from Cx.
+        let cx_texture = &mut cx.textures[self.texture_id()];
+        let (data, updated) = match &mut cx_texture.format {
+            TextureFormat::VecBGRAu8_32 { data, updated, .. } => (data, updated),
+            _ => panic!("incorrect texture format for u32 image data in swap_vec_u32"),
+        };
+
+        // Get the internal vector. This expects that the image data is currently available (i.e. Some(_))
+        let mut current = data.take().expect("image data not available for swapping");
+        // Swap the contents with `other`
+        std::mem::swap(&mut current, other);
+        // Put the new (swapped) vector back into the texture.
+        *data = Some(current);
+        // Update the texture’s dirty state.
+        *updated = updated.update(None);
+    }
 }
 
 #[derive(Default)]


### PR DESCRIPTION
… buffer cloning

chore(fractal_zoom): update workspace dependencies in Cargo.toml


```
E01: src\mandelbrot.rs:176:64 mismatched types: self.textures[tile.texture_index].put_back_vec_u32(cx, &mut tile.buffer, None);
E02: src\mandelbrot.rs:211:47 no method named `swap_vec_u32` found for struct `makepad_widgets::Texture` in the current scope: self.textures[tile.texture_index].swap_vec_u32(cx, &mut tile.buffer);
E03: src\mandelbrot.rs:218:47 no method named `swap_vec_u32` found for struct `makepad_widgets::Texture` in the current scope: self.textures[tile.texture_index].swap_vec_u32(cx, &mut tile.buffer);
```
i dont know what the story is on this swap method being used and not being implemented, same with the mut ref interface changing.

these changes make a working sample.
