### PR TITLE
fix(ui): remove unnecessary unwrap from image list item retrieval in …

### DIFF
--- a/experiments/image_viewer/src/ui.rs
+++ b/experiments/image_viewer/src/ui.rs
@@ -64,7 +64,7 @@ impl Widget for Ui {
 
                 while let Some(index) = img_list.next_visible_item(cx) {
                     if index < range_end {
-                        let item = img_list.item(cx, index, live_id!(img_btn)).unwrap();
+                        let item = img_list.item(cx, index, live_id!(img_btn));
                         item.set_text(&filenames[index]);
                         item.draw_all(cx, scope);
                     }


### PR DESCRIPTION
…src/ui.rs
E01: \\?\C:\working\rust\demos\makepad\experiments\image_viewer\src\ui.rs:67:80 no method named `unwrap` found for struct `makepad_widgets::WidgetRef` in the current scope: let item = img_list.item(cx, index, live_id!(img_btn)).unwrap();