### PR TITLE
Add `Dock::replace_tab()`. Fix StackNavigation to forward non-visibility events to all subviews

### DIFF
--- a/widgets/src/stack_navigation.rs
+++ b/widgets/src/stack_navigation.rs
@@ -1,12 +1,5 @@
 use crate::{
-    makepad_derive_widget::*,
-    makepad_draw::*,
-    widget::*,
-    label::*,
-    button::*,
-    view::*,
-    WidgetMatchEvent,
-    WindowAction,
+    button::*, label::*, makepad_derive_widget::*, makepad_draw::*, view::*, widget::*, WidgetMatchEvent, WindowAction
 };
 
 live_design!{
@@ -319,7 +312,17 @@ impl LiveHook for StackNavigation {
 
 impl Widget for StackNavigation {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        for widget_ref in self.get_active_views(cx).iter() {
+        // If the event requires visibility, only forward it to the visible views.
+        // If the event does not require visibility, forward it to all views,
+        // ensuring that we don't forward it to the root view twice.
+        let mut visible_views = self.get_visible_views(cx);
+        if !event.requires_visibility() {
+            let root_view = self.view.widget(id!(root_view));
+            if !visible_views.contains(&root_view) {
+                visible_views.insert(0, root_view);
+            }
+        }
+        for widget_ref in visible_views {
             widget_ref.handle_event(cx, event, scope);
         }
 
@@ -330,7 +333,7 @@ impl Widget for StackNavigation {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep  {
-        for widget_ref in self.get_active_views(cx.cx).iter() {
+        for widget_ref in self.get_visible_views(cx.cx).iter() {
             widget_ref.draw_walk(cx, scope, walk) ?;
         }
         DrawStep::done()
@@ -344,7 +347,7 @@ impl WidgetNode for StackNavigation {
     fn area(&self)->Area{self.view.area()}
     
     fn redraw(&mut self, cx: &mut Cx) {
-        for widget_ref in self.get_active_views(cx).iter() {
+        for widget_ref in self.get_visible_views(cx).iter() {
             widget_ref.redraw(cx);
         }
     }
@@ -399,7 +402,13 @@ impl StackNavigation {
         }
     }
 
-    fn get_active_views(&mut self, cx: &mut Cx) -> Vec<WidgetRef> {
+    /// Returns the views that are currently visible.
+    ///
+    /// This includes up to two views, in this order:
+    /// 1. The root_view, if it is animating and partially showing,
+    /// 2. The active stack view, if it exists and is partially or fully showing.
+    ///   or if there is no active stack view at all.
+    fn get_visible_views(&mut self, cx: &mut Cx) -> Vec<WidgetRef> {
         match self.active_stack_view {
             ActiveStackView::None => {
                 vec![self.view.widget(id!(root_view))]


### PR DESCRIPTION
The new `Dock::replace_tab()` function allows a user to replace the inner content of a tab without closing or recreating that tab. 

See docs copied below:
```rust
    /// Performs an in-place replacement of the inner widget (within an existing tab)
    /// with a completely new widget of a different kind.
    /// The type of the tab itself is not changed, but the widget inside of it is.
    ///
    /// Optionally, you can give the tab a new name and select it.
    ///
    /// ## Arguments
    /// * `cx`: A mutable reference to the Cx context.
    /// * `tab_item_id`: The ID of the tab to be replaced.
    /// * `new_kind`: The new widget that should be shown inside of the tab.
    /// * `new_name`: An optional new name for the tab.
    /// * `select`: A boolean indicating whether to select the new tab after replacement.
    ///   If `false`, the tab will be not be explicitly selected, but of course
    ///   if it was already selected, it will remain selected.
    ///
    /// ## Return
    /// * Returns `None` if the `tab_item_id` does not exist in the dock
    ///   or if the `new_kind` template was not listed in the Dock's live DSL.
    /// * Returns `Some((new_widget, true))` if the existing tab's inner widget
    ///   was successfully replaced with the new one. 
    ///   * Returns `Some((existing_widget, false))`` if the `new_kind` is the same
    ///     as existing tab's inner widget kind, meaning that no replacement occurred.
    fn replace_tab(
        &mut self,
        cx: &mut Cx,
        tab_item_id: LiveId,
        new_kind: LiveId,
        new_name: Option<String>,
        select: bool,
    ) -> Option<(WidgetRef, bool)> {
```