### PR TITLE
Allow saving and restoring the state of a `TextInput` widget

### DIFF
--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -1869,6 +1869,48 @@ impl TextInputRef {
         }
         None
     }
+
+    /// Saves the internal state of this text input widget
+    /// to a new `TextInputState` object.
+    pub fn save_state(&self) -> TextInputState {
+        if let Some(inner) = self.borrow() {
+            TextInputState {
+                text: inner.text.clone(),
+                password_text: inner.password_text.clone(),
+                laidout_text: inner.laidout_text.clone(),
+                text_area: inner.text_area,
+                selection: inner.selection.clone(),
+                history: inner.history.clone(),
+            }
+        } else {
+            TextInputState::default()
+        }
+    }
+
+    /// Restores the internal state of this text input widget
+    /// from the given `TextInputState` object.
+    pub fn restore_state(&self, state: TextInputState) {
+        if let Some(mut inner) = self.borrow_mut() {
+            // Don't use `set_text()` here, as it has other side effects.
+            inner.text = state.text;
+            inner.password_text = state.password_text;
+            inner.laidout_text = state.laidout_text;
+            inner.text_area = state.text_area;
+            inner.selection = state.selection;
+            inner.history = state.history;
+        }
+    }
+}
+
+/// The saved (checkpointed) state of a text input widget.
+#[derive(Clone, Debug, Default)]
+pub struct TextInputState {
+    text: String,
+    password_text: String,
+    laidout_text: Option<Rc<LaidoutText>>,
+    text_area: Area,
+    selection: Selection,
+    history: History,
 }
 
 #[derive(Clone, Debug, DefaultNone)]

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -1877,8 +1877,6 @@ impl TextInputRef {
             TextInputState {
                 text: inner.text.clone(),
                 password_text: inner.password_text.clone(),
-                laidout_text: inner.laidout_text.clone(),
-                text_area: inner.text_area,
                 selection: inner.selection.clone(),
                 history: inner.history.clone(),
             }
@@ -1894,8 +1892,6 @@ impl TextInputRef {
             // Don't use `set_text()` here, as it has other side effects.
             inner.text = state.text;
             inner.password_text = state.password_text;
-            inner.laidout_text = state.laidout_text;
-            inner.text_area = state.text_area;
             inner.selection = state.selection;
             inner.history = state.history;
         }
@@ -1907,8 +1903,6 @@ impl TextInputRef {
 pub struct TextInputState {
     text: String,
     password_text: String,
-    laidout_text: Option<Rc<LaidoutText>>,
-    text_area: Area,
     selection: Selection,
     history: History,
 }


### PR DESCRIPTION
This redoes the changes introduced in #533, but modified for the new version of `TextInput`

I'm not sure if we absolutely need to include `laidout_text` and `text_area`, since those are new additions to the widget.