### PR TITLE
Allow saving/restoring the state of the `TextInput` widget

### DIFF
--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -1843,6 +1843,42 @@ impl TextInputRef {
         }
         None
     }
+
+    /// Saves the internal state of this text input widget
+    /// to a new `TextInputState` object.
+    pub fn save_state(&self) -> TextInputState {
+        if let Some(inner) = self.borrow() {
+            TextInputState {
+                text: inner.text.clone(),
+                password_text: inner.password_text.clone(),
+                selection: inner.selection.clone(),
+                history: inner.history.clone(),
+            }
+        } else {
+            TextInputState::default()
+        }
+    }
+
+    /// Restores the internal state of this text input widget
+    /// from the given `TextInputState` object.
+    pub fn restore_state(&self, state: TextInputState) {
+        if let Some(mut inner) = self.borrow_mut() {
+            // Don't use `set_text()` here, as it has other side effects.
+            inner.text = state.text;
+            inner.password_text = state.password_text;
+            inner.selection = state.selection;
+            inner.history = state.history;
+        }
+    }
+}
+
+/// The saved (checkpointed) state of a text input widget.
+#[derive(Clone, Debug, Default)]
+pub struct TextInputState {
+    text: String,
+    password_text: String,
+    selection: Selection,
+    history: History,
 }
 
 #[derive(Clone, Debug, DefaultNone)]

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -1861,13 +1861,12 @@ impl TextInputRef {
 
     /// Restores the internal state of this text input widget
     /// from the given `TextInputState` object.
-    pub fn restore_state(&self, state: TextInputState) {
+    pub fn restore_state(&self, cx: &mut Cx, state: TextInputState) {
         if let Some(mut inner) = self.borrow_mut() {
-            // Don't use `set_text()` here, as it has other side effects.
-            inner.text = state.text;
+            inner.set_text(cx, &state.text);
             inner.password_text = state.password_text;
-            inner.selection = state.selection;
             inner.history = state.history;
+            inner.set_selection(cx, state.selection);
         }
     }
 }


### PR DESCRIPTION
This redoes the changes introduced in #533, but modified for the new version of TextInput