### PR TITLE
Add KeyModifiers parameter to `TextInputAction::Returned`

### DIFF
--- a/widgets/src/slider.rs
+++ b/widgets/src/slider.rs
@@ -2742,7 +2742,7 @@ impl Widget for Slider {
                 TextInputAction::KeyFocusLost => {
                     self.animator_play(cx, id!(focus.off));
                 }
-                TextInputAction::Returned(value) => {
+                TextInputAction::Returned(value, _modifiers) => {
                     if let Ok(v) = value.parse::<f64>() {
                         self.set_internal(v.max(self.min).min(self.max));
                     }

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -1528,14 +1528,21 @@ impl Widget for TextInput {
             }
             Hit::KeyDown(KeyEvent {
                 key_code: KeyCode::ReturnKey,
-                modifiers: KeyModifiers {
+                modifiers: mods @ KeyModifiers {
                     shift: false,
                     ..
                 },
                 ..
             }) => {
                 cx.hide_text_ime();
-                cx.widget_action(uid, &scope.path, TextInputAction::Returned(self.text.clone()));
+                cx.widget_action(
+                    uid,
+                    &scope.path,
+                    TextInputAction::Returned(
+                        self.text.clone(),
+                        mods,
+                    ),
+                );
             },
 
             Hit::KeyDown(KeyEvent {
@@ -1808,10 +1815,10 @@ impl TextInputRef {
         }
     }
 
-    pub fn returned(&self, actions: &Actions) -> Option<String> {
+    pub fn returned(&self, actions: &Actions) -> Option<(String, KeyModifiers)> {
         for action in actions.filter_widget_actions_cast::<TextInputAction>(self.widget_uid()){
-            if let TextInputAction::Returned(text) = action{
-                return Some(text);
+            if let TextInputAction::Returned(text, modifiers) = action {
+                return Some((text, modifiers));
             }
         }
         None
@@ -1850,7 +1857,7 @@ pub enum TextInputAction {
     None,
     KeyFocus,
     KeyFocusLost,
-    Returned(String),
+    Returned(String, KeyModifiers),
     Escaped,
     Changed(String),
     KeyDownUnhandled(KeyEvent),


### PR DESCRIPTION
This change is necessary in order for an entity handling a `TextInputAction::Returned` variant to be able to determine whether a particular key modifier was held down while the ReturnKey was pressed. This is needed by Robrix and probably many other future apps as well.