### PR TITLE
Improve Markdown heading scaling and general spacing

### DIFF
--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -225,18 +225,14 @@ impl DrawText {
         } else {
             None
         };
-        let wrap_width_in_lpxs = if cx.turtle().layout().flow == Flow::RightWrap {
-            max_width_in_lpxs
-        } else {
-            None
-        };
+        let wrap = cx.turtle().layout().flow == Flow::RightWrap;
 
         let text = self.layout(
             cx,
             first_row_indent_in_lpxs,
             row_height as f32,
-            wrap_width_in_lpxs,
-            false,
+            max_width_in_lpxs,
+            wrap,
             Align::default(),
             text,
         );

--- a/widgets/src/markdown.rs
+++ b/widgets/src/markdown.rs
@@ -142,6 +142,7 @@ live_design!{
         pre_code_spacing: 8,
         inline_code_padding: <THEME_MSPACE_1> {},
         inline_code_margin: <THEME_MSPACE_1> {},
+        heading_base_scale: 1.8,
                 
         draw_normal: {
             text_style: <THEME_FONT_REGULAR> {
@@ -306,7 +307,8 @@ pub struct Markdown{
     #[live(false)] use_code_block_widget:bool,
     #[rust] in_code_block: bool,
     #[rust] code_block_string: String,
-    #[rust] auto_id: u64
+    #[rust] auto_id: u64,
+    #[live] heading_base_scale: f64,
 }
 
 impl Widget for Markdown {
@@ -339,22 +341,27 @@ impl Markdown {
         let tf = &mut self.text_flow;
         // Track state for nested formatting
         let mut list_stack = Vec::new();
+        let mut is_first_block = true;
 
         let parser = Parser::new_ext(self.body.as_ref(), Options::ENABLE_TABLES);        
         
         for event in parser.into_iter() {
             match event {
                 MdEvent::Start(Tag::Heading { level, .. }) => {
-                    cx.turtle_new_line_with_spacing(self.paragraph_spacing);
-                    let levelf64 = match level {
-                        HeadingLevel::H1 => 1.0,
-                        HeadingLevel::H2 => 2.0,
-                        HeadingLevel::H3 => 3.0,
-                        HeadingLevel::H4 => 4.0,
-                        HeadingLevel::H5 => 5.0,
-                        HeadingLevel::H6 => 6.0,
+                    if !is_first_block {
+                        cx.turtle_new_line_with_spacing(self.paragraph_spacing);
+                    }
+                    is_first_block = false; 
+                    let heading_base = self.heading_base_scale;
+                    let scale = match level {
+                        HeadingLevel::H1 => heading_base,
+                        HeadingLevel::H2 => heading_base * 0.75,
+                        HeadingLevel::H3 => heading_base * 0.58,
+                        HeadingLevel::H4 => heading_base * 0.5, 
+                        HeadingLevel::H5 => heading_base * 0.42,
+                        HeadingLevel::H6 => heading_base * 0.33,
                     };
-                    tf.push_size_abs_scale(4.5 / levelf64);
+                    tf.push_size_abs_scale(scale);
                     tf.bold.push();
                 }
                 MdEvent::End(TagEnd::Heading(_level)) => {
@@ -363,13 +370,19 @@ impl Markdown {
                     cx.turtle_new_line();
                 }
                 MdEvent::Start(Tag::Paragraph) => {
-                    cx.turtle_new_line_with_spacing(self.paragraph_spacing);
+                    if !is_first_block {
+                         cx.turtle_new_line_with_spacing(self.paragraph_spacing);
+                    }
+                    is_first_block = false;
                 }
                 MdEvent::End(TagEnd::Paragraph) => {
-                    // No special handling needed
+                    // No special handling needed, turtle position is managed by content/following blocks
                 }
                 MdEvent::Start(Tag::BlockQuote(_)) => {
-                    cx.turtle_new_line_with_spacing(self.paragraph_spacing);
+                     if !is_first_block {
+                        cx.turtle_new_line_with_spacing(self.paragraph_spacing);
+                    }
+                    is_first_block = false;
                     tf.begin_quote(cx);
                 }
                 MdEvent::End(TagEnd::BlockQuote(_quote_kind)) => {
@@ -382,7 +395,10 @@ impl Markdown {
                     list_stack.pop();
                 }
                 MdEvent::Start(Tag::Item) => {
-                    cx.turtle_new_line();
+                     if !is_first_block {
+                         cx.turtle_new_line();
+                     }
+                     is_first_block = false;
                     let marker = if let Some(Some(n)) = list_stack.last() {
                         format!("{}.", n)
                     } else {
@@ -428,10 +444,13 @@ impl Markdown {
                     tf.draw_text(cx, "]");
                 }
                 MdEvent::Start(Tag::CodeBlock(_kind)) => {
+                    if !is_first_block {
+                         cx.turtle_new_line_with_spacing(self.pre_code_spacing);
+                    }
+                    is_first_block = false;
                     if self.use_code_block_widget {
                         self.in_code_block = true;
                         self.code_block_string.clear();
-                        cx.turtle_new_line_with_spacing(self.pre_code_spacing);
                         
                         // TODO: Handle language info if available for syntax highlighting
                         // if let CodeBlockKind::Fenced(lang) = kind {
@@ -439,8 +458,6 @@ impl Markdown {
                     } else {
                         const FIXED_FONT_SIZE_SCALE: f64 = 0.85;
                         tf.push_size_rel_scale(FIXED_FONT_SIZE_SCALE);
-                        // alright lets check if we need to use a widget
-                        cx.turtle_new_line_with_spacing(self.paragraph_spacing);
                         tf.combine_spaces.push(false);
                         tf.fixed.push();
                                 
@@ -491,19 +508,29 @@ impl Markdown {
                     if self.in_code_block {
                         self.code_block_string.push('\n');
                     } else {
-                        cx.turtle_new_line();
+                        // Soft break should typically render as a space or wrap, not a full newline.
+                        // TextFlow handles wrapping, so we might not need to do anything specific here,
+                        // or perhaps just ensure a space if the rendering context needs it.
+                        // For now, let's treat it like a space.
+                        tf.draw_text(cx, " ");
                     }
                 }
                 MdEvent::HardBreak => {
                     if self.in_code_block {
                         self.code_block_string.push('\n');
                     } else {
-                        cx.turtle_new_line_with_spacing(self.paragraph_spacing);
+                        // Internal break within a block, do not add spacing
+                         cx.turtle_new_line();
                     }
                 }
                 MdEvent::Rule => {
-                    cx.turtle_new_line_with_spacing(self.paragraph_spacing);
+                     if !is_first_block {
+                        cx.turtle_new_line_with_spacing(self.paragraph_spacing);
+                    }
+                     is_first_block = false;
                     tf.sep(cx);
+                    // Add spacing after the separator rule as well
+                    cx.turtle_new_line_with_spacing(self.paragraph_spacing);
                 }
                 MdEvent::TaskListMarker(_) => {
                     // TODO: Implement task list markers


### PR DESCRIPTION
### Changes

- Fixes a bug where paragraph spacing was being applied at the top of some elements regardless of not having another element above
- Fixed some other minor spacing issues
- Improved heading sizing (similar logic to the HTML widget)