### PR TITLE
Example of Chinese characters breaking in Markdown

### DIFF
--- a/examples/simple/src/app.rs
+++ b/examples/simple/src/app.rs
@@ -33,6 +33,17 @@ live_design!{
                     <Rotary>{
                         text:"Slide"
                     }
+                    md = <Markdown> {
+                        body: "
+                        ## This character 是 does not break in headings
+                        but it does on regular text 是
+                         - and in lists 是
+                         also inline code blocks `是`
+                         ```
+                         // and full code blocks 是
+                         ```
+                        "
+                    }
                     button_1 = <Button> {
                         text: "Click 福 me 😊"
                         draw_text:{text_style:{font_size:18}}


### PR DESCRIPTION
<img width="395" alt="image" src="https://github.com/user-attachments/assets/ca139e73-9b44-407f-b0b5-fab098345b8a" />
