### PR TITLE
AdaptiveView Improvements (some regression fixes)

### DIFF
--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -113,6 +113,7 @@ pub struct Cx {
     pub (crate) self_ref: Option<Rc<RefCell<Cx>>>,
     pub (crate) in_draw_event: bool,
 
+    /// Display context for the main window, used by AdaptiveView
     pub display_context: DisplayContext,
     
     pub debug: Debug,

--- a/platform/src/display_context.rs
+++ b/platform/src/display_context.rs
@@ -6,12 +6,18 @@ const DEFAULT_MIN_DESKTOP_WIDTH: f64 = 860.;
 /// Later to be expanded with more context data like platfrom information, accessibility settings, etc.
 #[derive(Clone, Debug, Default)]
 pub struct DisplayContext {
+    /// The event ID that last updated the display context
     pub updated_on_event_id: u64,
+    /// The current screen size
     pub screen_size: DVec2,
 }
 
 impl DisplayContext {
     pub fn is_desktop(&self) -> bool {
         self.screen_size.x >= DEFAULT_MIN_DESKTOP_WIDTH
+    }
+
+    pub fn is_screen_size_known(&self) -> bool {
+        self.screen_size.x != 0.0 && self.screen_size.y != 0.0
     }
 }

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -369,6 +369,11 @@ impl Widget for Window {
                         }
                         _ => ()
                     }
+
+                    // Update the display context if the screen size has changed
+                    cx.display_context.screen_size = ev.new_geom.inner_size;
+                    cx.display_context.updated_on_event_id = cx.event_id();
+
                     cx.widget_action(uid, &scope.path, WindowAction::WindowGeomChange(ev.clone()));
                     return
                 }


### PR DESCRIPTION
### Changes

- Fix DrawList warnings related to mismatch in overlay cleanup
Prevents "Drawlist id generation wrong index" errors when AdaptiveView
switches between variants by using checked_index() instead of direct
indexing to safely handle recycled DrawList IDs in overlay.end().
- Dispatch WindowGeomChange upon window creation on Web (same as other platforms)
- Move display context updates to Window (instead of AdaptiveView) to prevent some race conditions with event handling