### PR TITLE
Implement data directory handling for mobile platforms

### DIFF
--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -146,12 +146,20 @@ pub struct CxDependency {
 #[derive(Clone, Debug)]
 pub struct AndroidParams {
     pub cache_path: String,
+    pub data_path: String,
     pub density: f64,
     pub is_emulator: bool,
     pub has_xr_mode: bool,
     pub android_version: String,
     pub build_number: String,
     pub kernel_version: String
+}
+
+#[derive(Clone, Debug)]
+pub struct IosParams {
+    pub data_path: String,
+    pub device_model: String,
+    pub system_version: String,
 }
 
 #[derive(Clone, Debug)]
@@ -184,7 +192,7 @@ pub enum OsType {
     Unknown,
     Windows,
     Macos,
-    Ios,
+    Ios(IosParams),
     Android(AndroidParams),
     OpenHarmony(OpenHarmonyParams),
     LinuxWindow (LinuxWindowParams),
@@ -202,7 +210,7 @@ impl OsType {
     pub fn is_single_window(&self)->bool{
         match self{
             OsType::Web(_) => true,
-            OsType::Ios=>true,
+            OsType::Ios(_)=>true,
             OsType::Android(_) => true,
             OsType::LinuxDirect=> true,
             _=> false
@@ -228,6 +236,21 @@ impl OsType {
         }
         else if let OsType::OpenHarmony(params) = self {
             Some(params.cache_dir.clone())
+        }
+        else {
+            None
+        }
+    }
+    
+    pub fn get_data_dir(&self)->Option<String>{
+        if let OsType::Android(params) = self {
+            Some(params.data_path.clone())
+        }
+        else if let OsType::Ios(params) = self {
+            Some(params.data_path.clone())
+        }
+        else if let OsType::OpenHarmony(params) = self {
+            Some(params.files_dir.clone())
         }
         else {
             None

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -233,6 +233,19 @@ impl Cx {
     pub fn os_type(&self) -> &OsType {
         &self.os_type
     }
+    
+    /// Returns the app's writable data directory path.
+    /// 
+    /// On Android, this is the directory returned by Activity's getFilesDir().
+    /// On iOS, this is the Application Support directory.
+    /// Returns None on unsupported platforms (e.g. wasm).
+    /// 
+    /// Note that this path is not guaranteed to exist (it doesn't by default on iOS simulators),
+    /// so you might need to create it.
+    pub fn get_data_dir(&self) -> Option<String> {
+        self.os_type.get_data_dir()
+    }
+
     pub fn in_makepad_studio(&self) -> bool {
         self.in_makepad_studio
     }

--- a/platform/src/os/apple/apple_sys.rs
+++ b/platform/src/os/apple/apple_sys.rs
@@ -357,6 +357,11 @@ pub const NSTrackingCursorUpdate: u64 = 0x04;
 
 pub const UTF8_ENCODING: usize = 4;
 
+// NSSearchPathDirectory constants for iOS
+pub const NSApplicationSupportDirectory: u64 = 14;
+pub const NSCachesDirectory: u64 = 13;
+pub const NSUserDomainMask: u64 = 1;
+
 #[repr(u64)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum NSWindowTitleVisibility {

--- a/platform/src/os/apple/ios/ios_app.rs
+++ b/platform/src/os/apple/ios/ios_app.rs
@@ -1,16 +1,24 @@
 use {
+    std::{
+        cell::{Cell,RefCell},
+        time::Instant,
+    },
     crate::{
-        area::Area, event::{
-            KeyCode, KeyEvent, KeyModifiers, LongPressEvent, TextInputEvent, TimerEvent, TouchPoint, TouchState, TouchUpdateEvent, VirtualKeyboardEvent, WindowGeom, WindowGeomChangeEvent
-        }, makepad_math::*, os::{
-            apple::{apple_sys::*, apple_util::str_to_nsstring}, cx_native::EventFlow, ios::{
+        event::*,
+        os::{
+            apple::{
+                apple_sys::*,
+                apple_util::*,
+            },
+            cx_native::EventFlow,
+            ios::{
                 ios_delegates::*,
                 ios_event::*,
             }
-        }, window::CxWindowPool
-    }, std::{
-        cell::{Cell,RefCell},
-        time::Instant,
+        },
+        area::Area,
+        window::CxWindowPool,
+        makepad_math::*,
     }
 };
 
@@ -434,6 +442,24 @@ impl IosApp {
             let nsstring = str_to_nsstring(content);
             let pasteboard: ObjcId = self.pasteboard;
             let _: () = msg_send![pasteboard, setString: nsstring];
+        }
+    }
+
+    pub fn get_ios_directory_paths() -> String {
+        unsafe {
+            let file_manager: ObjcId = msg_send![class!(NSFileManager), defaultManager];
+            
+            // Get application support directory
+            let app_support_dir: ObjcId = msg_send![
+                file_manager,
+                URLsForDirectory: NSApplicationSupportDirectory
+                inDomains: NSUserDomainMask
+            ];
+            let app_support_url: ObjcId = msg_send![app_support_dir, firstObject];
+            let app_support_path: ObjcId = msg_send![app_support_url, path];
+            let data_path = nsstring_to_string(app_support_path);
+        
+            data_path
         }
     }
 }

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -283,6 +283,7 @@ pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onAndroidParams(
     env: *mut jni_sys::JNIEnv,
     _: jni_sys::jclass,
     cache_path: jni_sys::jstring,
+    data_path: jni_sys::jstring,
     density: jni_sys::jfloat,
     is_emulator: jni_sys::jboolean,
     android_version: jni_sys::jstring,
@@ -291,6 +292,7 @@ pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onAndroidParams(
 ) {
     send_from_java_message(FromJavaMessage::Init(AndroidParams {
         cache_path: jstring_to_string(env, cache_path),
+        data_path: jstring_to_string(env, data_path),
         density: density as f64,
         is_emulator: is_emulator != 0,
         android_version: jstring_to_string(env, android_version),

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -336,6 +336,7 @@ public class MakepadActivity
 
 
         String cache_path = this.getCacheDir().getAbsolutePath();
+        String data_path = this.getFilesDir().getAbsolutePath();
         float density = getResources().getDisplayMetrics().density;
         boolean isEmulator = this.isEmulator();
         String androidVersion = Build.VERSION.RELEASE;
@@ -343,7 +344,7 @@ public class MakepadActivity
         String kernelVersion = this.getKernelVersion();
         int sdkVersion = Build.VERSION.SDK_INT;
 
-        MakepadNative.onAndroidParams(cache_path, density, isEmulator, androidVersion, buildNumber, kernelVersion);
+        MakepadNative.onAndroidParams(cache_path, data_path, density, isEmulator, androidVersion, buildNumber, kernelVersion);
 
         // Set volume keys to control music stream, we might want make this flexible for app devs
         setVolumeControlStream(AudioManager.STREAM_MUSIC);

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
@@ -12,7 +12,7 @@ public class MakepadNative {
     public native static void activityOnStop();
     public native static void activityOnDestroy();
     public native static void activityOnWindowFocusChanged(boolean has_focus);
-    public static native void onAndroidParams(String cache_path, float dentify, boolean isEmulator, String androidVersion, String buildNumber,
+    public static native void onAndroidParams(String cache_path, String data_path, float density, boolean isEmulator, String androidVersion, String buildNumber,
         String kernelVersion);
 
     public native static void initChoreographer(float deviceRefreshRate, int sdkVersion);


### PR DESCRIPTION
Enables mobile apps to persist data between sessions in platform-appropriate locations.

### Changes
- Adds `get_data_dir` method to `Cx` for retrieving writable data directory paths on mobile platforms.
  - **iOS**: Uses Application Support directory (`NSApplicationSupportDirectory`)
  - **Android**: Uses `getFilesDir()`  
  - **API**: `cx.get_data_dir()` returns writable app data directory path

### Platform Support:
- ✅ iOS (Application Support directory)
- ✅ Android (Internal files directory) 
- ❌ Desktop/WASM (returns None)