### PR TITLE
Persistent and restoration of Window State

### DIFF
--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -66,14 +66,15 @@ impl MetalWindow {
         metal_cx: &MetalCx,
         inner_size: DVec2,
         position: Option<DVec2>,
-        title: &str
+        title: &str,
+        is_fullscreen: bool,
     ) -> MetalWindow {
         
         let ca_layer: ObjcId = unsafe {msg_send![class!(CAMetalLayer), new]};
         
         let mut cocoa_window = Box::new(MacosWindow::new(window_id));
         
-        cocoa_window.init(title, inner_size, position);
+        cocoa_window.init(title, inner_size, position, is_fullscreen);
         unsafe {
             let () = msg_send![ca_layer, setDevice: metal_cx.device];
             let () = msg_send![ca_layer, setPixelFormat: MTLPixelFormat::BGRA8Unorm];
@@ -457,7 +458,8 @@ impl Cx {
                         &metal_cx,
                         window.create_inner_size.unwrap_or(dvec2(800., 600.)),
                         window.create_position,
-                        &window.create_title
+                        &window.create_title,
+                        window.is_fullscreen
                     );
                     window.window_geom = metal_window.window_geom.clone();
                     metal_windows.push(metal_window);

--- a/platform/src/os/apple/macos/macos_window.rs
+++ b/platform/src/os/apple/macos/macos_window.rs
@@ -75,7 +75,7 @@ impl MacosWindow {
     }
     
     // complete window initialization with pointers to self
-    pub fn init(&mut self, title: &str, size: DVec2, position: Option<DVec2>) {
+    pub fn init(&mut self, title: &str, size: DVec2, position: Option<DVec2>, is_fullscreen: bool) {
         unsafe {
             let pool: ObjcId = msg_send![class!(NSAutoreleasePool), new];
             
@@ -147,11 +147,11 @@ impl MacosWindow {
             
             let input_context: ObjcId = msg_send![self.view, inputContext];
             let () = msg_send![input_context, invalidateCharacterCoordinates];
-            
+            if is_fullscreen {
+                self.maximize();
+            }
             // lets add an mtk_view object to our view
-            
-            
-            
+
             let () = msg_send![pool, drain];
         }
     }

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -269,6 +269,7 @@ impl Cx {
                         window.create_inner_size.unwrap_or(dvec2(800., 600.)),
                         window.create_position,
                         &window.create_title,
+                        window.is_fullscreen
                     );
                     window.window_geom = opengl_window.window_geom.clone();
                     opengl_windows.push(opengl_window);

--- a/platform/src/os/linux/x11/opengl_x11.rs
+++ b/platform/src/os/linux/x11/opengl_x11.rs
@@ -424,7 +424,8 @@ impl OpenglWindow {
         opengl_cx: &OpenglCx,
         inner_size: DVec2,
         position: Option<DVec2>,
-        title: &str
+        title: &str,
+        is_fullscreen: bool,
     ) -> OpenglWindow {
         // Checked "downcast" of the EGL platform display to a X11 display.
         assert_eq!(opengl_cx.egl_platform, egl_sys::EGL_PLATFORM_X11_EXT);
@@ -466,7 +467,7 @@ impl OpenglWindow {
         };
 
         let custom_window_chrome = false;
-        xlib_window.init(title, inner_size, position, visual_info, custom_window_chrome);
+        xlib_window.init(title, inner_size, position, is_fullscreen, visual_info, custom_window_chrome);
 
         let egl_surface = unsafe {
             (opengl_cx.libegl.eglCreateWindowSurface.unwrap())(

--- a/platform/src/os/linux/x11/xlib_window.rs
+++ b/platform/src/os/linux/x11/xlib_window.rs
@@ -67,7 +67,7 @@ impl XlibWindow {
         }
     }
     
-    pub fn init(&mut self, title: &str, size: DVec2, position: Option<DVec2>, visual_info: x11_sys::XVisualInfo, custom_window_chrome: bool) {
+    pub fn init(&mut self, title: &str, size: DVec2, position: Option<DVec2>, is_fullscreen: bool, visual_info: x11_sys::XVisualInfo, custom_window_chrome: bool) {
         unsafe {
             let display = get_xlib_app_global().display;
             
@@ -213,6 +213,9 @@ impl XlibWindow {
                     new_geom: new_geom
                 })
             );
+            if is_fullscreen {
+                self.maximize();
+            }
         }
     }
     

--- a/platform/src/os/windows/d3d11.rs
+++ b/platform/src/os/windows/d3d11.rs
@@ -523,11 +523,11 @@ pub struct D3d11Window {
 }
 
 impl D3d11Window {
-    pub fn new(window_id: WindowId, d3d11_cx: &D3d11Cx, inner_size: DVec2, position: Option<DVec2>, title: &str) -> D3d11Window {
+    pub fn new(window_id: WindowId, d3d11_cx: &D3d11Cx, inner_size: DVec2, position: Option<DVec2>, title: &str, is_fullscreen: bool) -> D3d11Window {
 
         // create window, and then initialize it; this is needed because
         // GWLP_USERDATA needs to reference a stable and existing window
-        let mut win32_window = Box::new(Win32Window::new(window_id, title, position));
+        let mut win32_window = Box::new(Win32Window::new(window_id, title, position, is_fullscreen));
         win32_window.init(inner_size);
         
         let wg = win32_window.get_window_geom();

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -306,6 +306,7 @@ pub struct Win32Window {
     pub ignore_wmsize: usize,
     pub hwnd: HWND,
     pub track_mouse_event: bool,
+    pub is_fullscreen: bool,
 }
 
 impl Win32Window {
@@ -313,7 +314,7 @@ impl Win32Window {
     // 2-stage initialization (new and init) to connect GWLP_USERDATA 
 
     // create window structure and register drag/drop
-    pub fn new(window_id: WindowId,title: &str, position: Option<DVec2>) -> Win32Window {
+    pub fn new(window_id: WindowId,title: &str, position: Option<DVec2>, is_fullscreen: bool) -> Win32Window {
 
         let title = encode_wide(title);
         
@@ -366,6 +367,7 @@ impl Win32Window {
             ignore_wmsize: 0,
             hwnd,
             track_mouse_event: false,
+            is_fullscreen
         }
     }
 
@@ -376,7 +378,9 @@ impl Win32Window {
 
         with_win32_app(|app| app.dpi_functions.enable_non_client_dpi_scaling(self.hwnd));
         with_win32_app(|app| app.all_windows.push(self.hwnd));
-
+        if self.is_fullscreen {
+            self.maximize();
+        }
         self.set_outer_size(size);
     }
     

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -378,10 +378,10 @@ impl Win32Window {
 
         with_win32_app(|app| app.dpi_functions.enable_non_client_dpi_scaling(self.hwnd));
         with_win32_app(|app| app.all_windows.push(self.hwnd));
+        self.set_outer_size(size);
         if self.is_fullscreen {
             self.maximize();
         }
-        self.set_outer_size(size);
     }
     
     pub unsafe extern "system" fn window_class_proc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: LPARAM,) -> LRESULT {

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -310,7 +310,8 @@ impl Cx {
                         &d3d11_cx,
                         window.create_inner_size.unwrap_or(dvec2(800., 600.)),
                         window.create_position,
-                        &window.create_title
+                        &window.create_title,
+                        window.is_fullscreen
                     );
                     
                     window.window_geom = d3d11_window.window_geom.clone();

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -329,6 +329,7 @@ impl Cx {
                         d3d11_windows[index].win32_window.close_window();
                         d3d11_windows.remove(index);
                         if d3d11_windows.len() == 0 {
+                            self.call_event_handler(&Event::Shutdown);
                             ret = EventFlow::Exit
                         }
                     }

--- a/platform/src/window.rs
+++ b/platform/src/window.rs
@@ -181,16 +181,12 @@ impl WindowHandle {
         cx.windows[self.window_id()].main_pass_id = Some(pass.pass_id());
         cx.passes[pass.pass_id()].parent = CxPassParent::Window(self.window_id());
     }
-    pub fn create_window(&mut self, cx: &mut Cx, inner_size: DVec2, position: DVec2, is_fullscreen: bool, title: String) {
-        let window = &cx.windows[self.window_id()];
+    pub fn configure_window(&mut self, cx: &mut Cx, inner_size: DVec2, position: DVec2, is_fullscreen: bool, title: String) {
+        let window = &mut cx.windows[self.window_id()];
         window.create_title = title;
         window.create_position = Some(position);
         window.create_inner_size = Some(inner_size);
-        window.is_created = true;
-        cx.push_unique_platform_op(CxOsOp::CreateWindow(self.window_id()));
-        if is_fullscreen && self.can_fullscreen(cx){
-            self.fullscreen(cx);
-        }
+        window.is_fullscreen = is_fullscreen;
     }
     pub fn get_inner_size(&self, cx: &Cx) -> DVec2 {
         cx.windows[self.window_id()].get_inner_size()
@@ -268,6 +264,7 @@ pub struct CxWindow {
     pub is_created: bool,
     pub window_geom: WindowGeom,
     pub main_pass_id: Option<PassId>,
+    pub is_fullscreen: bool,
 }
 
 impl CxWindow {

--- a/platform/src/window.rs
+++ b/platform/src/window.rs
@@ -182,10 +182,11 @@ impl WindowHandle {
         cx.passes[pass.pass_id()].parent = CxPassParent::Window(self.window_id());
     }
     pub fn create_window(&mut self, cx: &mut Cx, inner_size: DVec2, position: DVec2, is_fullscreen: bool, title: String) {
-        cx.windows[self.window_id()].create_title = title;
-        cx.windows[self.window_id()].create_position = Some(position);
-        cx.windows[self.window_id()].create_inner_size = Some(inner_size);
-        cx.windows[self.window_id()].is_created = true;
+        let window = &cx.windows[self.window_id()];
+        window.create_title = title;
+        window.create_position = Some(position);
+        window.create_inner_size = Some(inner_size);
+        window.is_created = true;
         cx.push_unique_platform_op(CxOsOp::CreateWindow(self.window_id()));
         if is_fullscreen && self.can_fullscreen(cx){
             self.fullscreen(cx);

--- a/platform/src/window.rs
+++ b/platform/src/window.rs
@@ -181,7 +181,16 @@ impl WindowHandle {
         cx.windows[self.window_id()].main_pass_id = Some(pass.pass_id());
         cx.passes[pass.pass_id()].parent = CxPassParent::Window(self.window_id());
     }
-    
+    pub fn create_window(&mut self, cx: &mut Cx, inner_size: DVec2, position: DVec2, is_fullscreen: bool, title: String) {
+        cx.windows[self.window_id()].create_title = title;
+        cx.windows[self.window_id()].create_position = Some(position);
+        cx.windows[self.window_id()].create_inner_size = Some(inner_size);
+        cx.windows[self.window_id()].is_created = true;
+        cx.push_unique_platform_op(CxOsOp::CreateWindow(self.window_id()));
+        if is_fullscreen && self.can_fullscreen(cx){
+            self.fullscreen(cx);
+        }
+    }
     pub fn get_inner_size(&self, cx: &Cx) -> DVec2 {
         cx.windows[self.window_id()].get_inner_size()
     }
@@ -271,24 +280,13 @@ impl CxWindow {
     }
     
     pub fn get_inner_size(&self) -> DVec2 {
-        if !self.is_created {
-            Default::default()
-            //panic!();
-        }
-        else {
-            self.window_geom.inner_size
-        }
+        self.window_geom.inner_size
     }
     
     pub fn get_position(&self) -> DVec2 {
-        if !self.is_created {
-            Default::default()
-            //panic!();
-        }
-        else {
-            self.window_geom.position
-        }
+        self.window_geom.position
     }
+
     /*
     pub fn get_dpi_factor(&mut self) -> Option<f32> {
         if self.is_created {

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -326,6 +326,17 @@ impl WindowRef{
             inner.set_fullscreen(cx);
         }
     }
+    /// Configure the window's size and position, and whether it's fullscreen or not.
+    ///
+    /// If `fullscreen` is `true`, the window will be set to the monitor's size and the
+    /// `inner_size` and `position` arguments will be ignored.
+    ///
+    /// If `fullscreen` is `false`, the window will be set to the specified `inner_size`
+    /// and positioned at `position` on the screen.
+    ///
+    /// The `title` argument sets the window's title bar text.
+    /// 
+    /// This only works in app startup. 
     pub fn configure_window(&self, cx: &mut Cx, inner_size: DVec2, position: DVec2, fullscreen: bool, title: String) {
         if let Some(mut inner) = self.borrow_mut() {
             inner.configure_window(cx, inner_size, position, fullscreen, title);

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -279,8 +279,8 @@ impl Window {
     pub fn set_fullscreen(&mut self, cx: &mut Cx) {
         self.window.fullscreen(cx);
     }
-    pub fn create_window(&mut self, cx: &mut Cx, inner_size: DVec2, position: DVec2, fullscreen: bool, title: String) {
-        self.window.create_window(cx, inner_size, position, fullscreen, title);
+    pub fn configure_window(&mut self, cx: &mut Cx, inner_size: DVec2, position: DVec2, is_fullscreen: bool, title: String) {
+        self.window.configure_window(cx, inner_size, position, is_fullscreen, title);
     }
 }
 
@@ -321,10 +321,14 @@ impl WindowRef{
             inner.reposition(cx, size);
         }
     }
-
-    pub fn create_window(&self, cx: &mut Cx, inner_size: DVec2, position: DVec2, fullscreen: bool, title: String) {
+    pub fn fullscreen(&self, cx: &mut Cx) {
         if let Some(mut inner) = self.borrow_mut() {
-            inner.create_window(cx, inner_size, position, fullscreen, title);
+            inner.set_fullscreen(cx);
+        }
+    }
+    pub fn configure_window(&self, cx: &mut Cx, inner_size: DVec2, position: DVec2, fullscreen: bool, title: String) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.configure_window(cx, inner_size, position, fullscreen, title);
         }
     }
 }

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -279,7 +279,9 @@ impl Window {
     pub fn set_fullscreen(&mut self, cx: &mut Cx) {
         self.window.fullscreen(cx);
     }
-    
+    pub fn create_window(&mut self, cx: &mut Cx, inner_size: DVec2, position: DVec2, fullscreen: bool, title: String) {
+        self.window.create_window(cx, inner_size, position, fullscreen, title);
+    }
 }
 
 impl WindowRef{
@@ -320,6 +322,11 @@ impl WindowRef{
         }
     }
 
+    pub fn create_window(&self, cx: &mut Cx, inner_size: DVec2, position: DVec2, fullscreen: bool, title: String) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.create_window(cx, inner_size, position, fullscreen, title);
+        }
+    }
 }
 
 impl Widget for Window {


### PR DESCRIPTION
- Allow creation of window using function instead of using live_design.
- Remove is_created check inside get_inner_size and get_position function
