### PR TITLE
Update old `windows-targets` dep version to reduce lockfile duplicates

### DIFF
--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -110,5 +110,7 @@ features = [
     "implement"
 ]
 
+## The vast majority of the Rust ecosystem is currently on
+## `windows-targets` v0.52.*, so we use that version to avoid duplicates.
 [target.'cfg(windows)'.dependencies.windows-targets]
-version = "0.48.3"
+version = "0.52"

--- a/widgets/src/adaptive_view.rs
+++ b/widgets/src/adaptive_view.rs
@@ -235,11 +235,11 @@ impl Widget for AdaptiveView {
 }
 
 impl WidgetMatchEvent for AdaptiveView {
-    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
         for action in actions {
             // Window geometry has changed, reapply the selector. 
             // Will use the most recent parent size, might be updated on next draw call.
-            if let WindowAction::WindowGeomChange(ce) = action.as_widget_action().cast() {
+            if let WindowAction::WindowGeomChange(_ce) = action.as_widget_action().cast() {
                 self.apply_selector(cx);
             }
         }


### PR DESCRIPTION
All other crates in the Rust ecosystem depend on `windows-targets` v0.52.*, so this small change vastly reduces the number of duplicate `windows-*` crate dependencies that cargo must download and track in the lockfile.

Also address minor compiler warnings in AdaptiveView.