### PR TITLE
Add `PortalList::is_filling_viewport()`

### DIFF
--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -110,5 +110,7 @@ features = [
     "implement"
 ]
 
+## The vast majority of the Rust ecosystem is currently on
+## `windows-targets` v0.52.*, so we use that version to avoid duplicates.
 [target.'cfg(windows)'.dependencies.windows-targets]
-version = "0.48.3"
+version = "0.52"

--- a/widgets/src/adaptive_view.rs
+++ b/widgets/src/adaptive_view.rs
@@ -235,11 +235,11 @@ impl Widget for AdaptiveView {
 }
 
 impl WidgetMatchEvent for AdaptiveView {
-    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
         for action in actions {
             // Window geometry has changed, reapply the selector. 
             // Will use the most recent parent size, might be updated on next draw call.
-            if let WindowAction::WindowGeomChange(ce) = action.as_widget_action().cast() {
+            if let WindowAction::WindowGeomChange(_ce) = action.as_widget_action().cast() {
                 self.apply_selector(cx);
             }
         }

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -781,9 +781,13 @@ impl PortalList {
     ///    If `None`, the default value of 20 is used.
     pub fn smooth_scroll_to_end(&mut self, cx: &mut Cx, speed: f64, max_items_to_show: Option<usize>) {
         if self.items.is_empty() { return };
+        let speed = speed * self.range_end as f64;
+        self.smooth_scroll_to(cx, self.range_end, speed, max_items_to_show);
+    }
 
-	let speed = speed * self.range_end as f64;
-	self.smooth_scroll_to(cx, self.range_end, speed, max_items_to_show);
+    /// Returns whether this PortalList is currently filling the viewport.
+    pub fn is_filling_viewport(&self) -> bool {
+        !self.not_filling_viewport
     }
 }
 
@@ -1234,7 +1238,7 @@ impl PortalListRef {
     /// ```
     pub fn smooth_scroll_to(&self, cx: &mut Cx, target_id: usize, speed: f64, max_items_to_show: Option<usize>) {
         let Some(mut inner) = self.borrow_mut() else { return };
-	inner.smooth_scroll_to(cx, target_id, speed, max_items_to_show);
+	    inner.smooth_scroll_to(cx, target_id, speed, max_items_to_show);
     }
 
     /// Returns the ID of the item that is currently being smoothly scrolled to, if any.
@@ -1267,8 +1271,13 @@ impl PortalListRef {
     ///    If `None`, the default value of 20 is used.
     pub fn smooth_scroll_to_end(&self, cx: &mut Cx, speed: f64, max_items_to_show: Option<usize>) {
         let Some(mut inner) = self.borrow_mut() else { return };
+	    inner.smooth_scroll_to_end(cx, speed, max_items_to_show);
+    }
 
-	inner.smooth_scroll_to_end(cx, speed, max_items_to_show);
+    /// Returns whether this PortalList is currently filling the viewport.
+    pub fn is_filling_viewport(&self) -> bool {
+        let Some(inner) = self.borrow() else { return false };
+        inner.is_filling_viewport()
     }
 
     /// It indicates if we have items not displayed towards the end of the list (below)


### PR DESCRIPTION
This is needed in order for an app to be able to take action upon a portal list's viewport not being completely full.

For example, if you're showing a chat room, you can fetch older events until there is enough history to fill the entire viewport.

Merge this after #780.