### PR TITLE
Create PageFlip child widget within `set_active_page()`

### DIFF
--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -598,7 +598,7 @@ impl PortalList {
                 }
             }
         } else {
-            warning!("Template not found: {template}. Did you add it to the <PortalList> instance in `live_design!{{}}`?");
+            error!("Template not found: {template}. Did you add it to the <PortalList> instance in `live_design!{{}}`?");
             (WidgetRef::empty(), false)
         }
     }


### PR DESCRIPTION
This allows an app dev/user to create and populate a new widget within the PageFlip parent widget *before* waiting for it to be drawn. Previously, the child widgets within PageFlip were either created upon app load (which is inefficient) or upon draw (which is too late).