### PR TITLE
Allow apply_over for image_scale and image_pan using Mouse event.

### DIFF
--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -293,8 +293,6 @@ impl Image {
                 (w,h)
             }
             else{
-                self.draw_bg.image_scale = vec2(1.0,1.0);
-                self.draw_bg.image_pan = vec2(0.0,0.0);
                 (width as f64 * self.width_scale, height as f64)
             }
         }


### PR DESCRIPTION
#785 

Currently image_scale and image_pan is being reset to default, hence applying over image_scale and image_pan using mouse event does not work.