### PR TITLE
Fix websockets drop panic

### DIFF
--- a/platform/src/web_socket.rs
+++ b/platform/src/web_socket.rs
@@ -59,12 +59,7 @@ pub (crate) static HAS_STUDIO_WEB_SOCKET: AtomicBool = AtomicBool::new(false);
 
 impl Drop for WebSocket{
     fn drop(&mut self){
-        let sender = WEB_SOCKET_THREAD_SENDER.lock().unwrap();
-        if let Some(sender) = &*sender{
-            sender.send(WebSocketThreadMsg::Close{
-                socket_id: self.socket_id,
-            }).unwrap();
-        }
+        self.close();
     }
 }
 impl Cx{
@@ -244,6 +239,15 @@ impl Cx{
 
 impl WebSocket{    
     
+    pub fn close(&mut self){
+        if let Ok(sender) = WEB_SOCKET_THREAD_SENDER.lock(){
+            if let Some(sender) = &*sender{
+                let _ = sender.send(WebSocketThreadMsg::Close{
+                    socket_id: self.socket_id,
+                });
+            }
+        }
+    }
     
     pub fn open(request:HttpRequest)->WebSocket {
         let (rx_sender, rx_receiver) = channel();


### PR DESCRIPTION
### Changes

Prevents Makepad from panicking whenever a websocket is dropped, by not unwrapping locks on `WEB_SOCKET_THREAD_SENDER`. It seems like websocket implementation in general doesn't not properly consider closing connections, this is a quick fix just to prevent panics but the websocket management probably needs a refactor.