### PR TITLE
  Add audio input permission handling and example project

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 workspace.members = [
     # === examples ===
+    "examples/audio",
     "examples/chatgpt",
     "examples/ironfish",
     "examples/teamtalk",

--- a/examples/audio/Cargo.toml
+++ b/examples/audio/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "makepad-example-audio"
+version = "1.0.0"
+authors = ["Makepad <info@makepad.nl>"]
+edition = "2018"
+description = "Makepad Audio"
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/makepad/makepad/"
+repository = "https://github.com/makepad/makepad/"
+metadata.makepad-auto-version = "Ywx5y_Q1A52NaelyQCiYcZ6m0Po="
+
+[dependencies]
+makepad-widgets = { path = "../../widgets", version = "1.0.0" }
+makepad-audio-graph = { path = "../../audio_graph", version = "1.0.0" }

--- a/examples/audio/src/app.rs
+++ b/examples/audio/src/app.rs
@@ -1,0 +1,726 @@
+use {
+    crate::{makepad_platform::live_atomic::*, makepad_widgets::*},
+    makepad_widgets::permission::{Permission, PermissionStatus},
+    std::sync::Arc,
+};
+
+live_design! {
+    use link::theme::*;
+    use link::shaders::*;
+    use link::widgets::*;
+
+    BoldLabel = <Label> {
+        draw_text: {
+            text_style: <THEME_FONT_BOLD> {}
+        }
+    }
+
+    DeviceSelector = <View> {
+        height: Fit
+        align: {x: 0.0, y: 0.5}
+        spacing: 5
+
+        label = <BoldLabel> {}
+
+        device_selector = <DropDown> {
+            draw_text: {
+                text_style: {font_size: 11}
+            }
+            popup_menu_position: BelowInput
+            popup_menu: {
+                width: 300, height: Fit,
+                menu_item: <PopupMenuItem> {
+                    width: Fill, height: Fit,
+                    align: { y: 0.5 }
+                    padding: {left: 15, right: 15, top: 10, bottom: 10}
+                }
+            }
+            margin: 5
+            labels: ["default"]
+            values: [default]
+        }
+    }
+
+    DevicesSelector = <View> {
+        height: Fit, width: Fill
+        flow: Down, spacing: 5
+        <View> {
+            height: Fit
+            mic_selector = <DeviceSelector> {
+                width: Fit
+                label = { text: "Mic:"}
+            }
+            // mute_control = <MuteControl> {}
+        }
+        speaker_selector = <DeviceSelector> {
+            label = { text: "Speaker:"}
+        }
+    }
+
+    MicStats = <View> {
+        height: Fit
+        flow: Down, spacing: 10
+        <BoldLabel> {
+            text: "🎤  Microphone Capture"
+            draw_text: {
+                text_style: {font_size: 12}
+            }
+        }
+
+        status_label = <BoldLabel> {
+            text: "Status: Not started"
+            draw_text: {
+                color: #f88
+            }
+        }
+
+        frames_label = <BoldLabel> {
+            text: "Frames: 0"
+            draw_text: {
+                color: #aaa
+            }
+        }
+
+        peak_label = <BoldLabel> {
+            text: "Peak: 0.0000"
+            draw_text: {
+                color: #aaa
+            }
+        }
+
+        samples_label = <BoldLabel> {
+            text: "Samples: [waiting...]"
+            draw_text: {
+                color: #aaa
+            }
+        }
+
+        level_bar = <View> {
+            width: Fill
+            height: 40
+            show_bg: true
+            draw_bg: {
+                fn pixel(self) -> vec4 {
+                    return #222;
+                }
+            }
+
+            level_fill = <View> {
+                width: 0
+                height: Fill
+                show_bg: true
+                draw_bg: {
+                    fn pixel(self) -> vec4 {
+                        let level = self.pos.x;
+                        if level < 0.5 {
+                            return mix(#0f0, #ff0, level * 2.0);
+                        } else {
+                            return mix(#ff0, #f00, (level - 0.5) * 2.0);
+                        }
+                    }
+                }
+            }
+        }
+
+        callback_label = <BoldLabel> {
+            text: "Callbacks: 0"
+            draw_text: {
+                color: #8f8
+            }
+        }
+    }
+
+    Playback = <View> {
+        height: Fit
+        flow: Down, spacing: 10
+        <BoldLabel> {
+            text: "🔊  Playback"
+            draw_text: {
+                text_style: {font_size: 12}
+            }
+        }
+
+        passthrough_toggle = <Toggle> {
+            draw_bg: {
+                size: 20.0;
+            }
+            label_walk: {
+                margin: <THEME_MSPACE_H_1> { left: (25.0 + THEME_SPACE_2) }
+            }
+            text: "Enable Mic Passthrough"
+            draw_text: {
+                text_style: {font_size: 12}
+            }
+        }
+
+        <View> {
+            height: Fit
+            spacing: 10
+            align: {x: 0.0, y: 0.5}
+
+            <BoldLabel> {
+                text: "Volume:"
+                draw_text: {
+                    text_style: {font_size: 11}
+                }
+            }
+
+            volume_slider = <Slider> {
+                width: 200
+                height: 30
+                min: 0.0
+                max: 1.0
+                step: 0.01
+                default: 0.3
+            }
+
+            volume_label = <BoldLabel> {
+                text: "30%"
+                draw_text: {
+                    text_style: {font_size: 11}
+                    color: #aaa
+                }
+            }
+        }
+
+        passthrough_status = <BoldLabel> {
+            text: "Status: Passthrough disabled"
+            draw_text: {
+                color: #f88
+                text_style: {font_size: 11}
+            }
+        }
+    }
+
+    Header = <View> {
+        align: {x: 0.5, y: 0.5}
+        height: Fit
+        <Label> {
+            text: "Makead Audio Test"
+            draw_text: {
+                color: #f9
+                text_style: <THEME_FONT_BOLD>{font_size: 15}
+            }
+        }
+    }
+
+    Separator = <View> {
+        height: 1
+        margin: 10
+        show_bg: true
+        draw_bg: {
+            color: #8
+        }
+    }
+
+    PermissionWarning = <View> {
+        visible: false
+        height: Fit
+        spacing: 10
+        flow: Down
+        permission_warning_label = <BoldLabel> {
+            text: "⚠️ Microphone access is required to use this app.
+Click on the button below to request permission."
+            draw_text: {
+                color: #f88
+            }
+        }
+        request_permission_button = <Button> {
+            visible: false
+            padding: 10
+            text: "Trigger Permission Request"
+        }
+    }
+
+    App = {{App}} {
+        ui: <Window>{
+            window: {inner_size: vec2(600, 800)},
+            padding: 10
+            show_bg: true
+            draw_bg: {
+                fn pixel(self) -> vec4 {
+                    return mix(#3, mix(#7, #3, self.pos.y),self.pos.x);
+                }
+            }
+
+            body = <View>{
+                padding:20
+                flow:Down
+                spacing: 10
+
+                <Header> {}
+                permission_warning = <PermissionWarning> {}
+                <DevicesSelector> {}
+                <Separator> {}
+                <MicStats> {}
+                <Separator> {}
+                <Playback> {}
+            }
+        }
+    }
+}
+
+app_main!(App);
+
+use std::sync::Mutex;
+
+#[derive(Live, LiveAtomic, LiveHook, LiveRead, LiveRegister)]
+#[live_ignore]
+pub struct Store {
+    #[live(0i64)]
+    frame_count: i64a,
+    #[live(0i64)]
+    callback_count: i64a,
+    #[live(0.0f64)]
+    peak_level: f64a,
+    #[live(0.0f64)]
+    avg_level: f64a,
+    #[live(0.3f64)]
+    passthrough_volume: f64a,
+    #[rust]
+    passthrough_enabled: Mutex<bool>,
+    #[rust]
+    samples: Mutex<Vec<f32>>,
+    #[rust]
+    passthrough_audio: Arc<Mutex<Vec<f32>>>,
+}
+
+#[derive(Live, LiveHook)]
+pub struct App {
+    #[live]
+    ui: WidgetRef,
+    #[live]
+    store: Arc<Store>,
+    #[rust]
+    audio_update_signal: SignalToUI,
+    #[rust]
+    audio_devices: Vec<AudioDeviceDesc>,
+}
+
+impl LiveRegister for App {
+    fn live_register(cx: &mut Cx) {
+        makepad_widgets::live_design(cx);
+        makepad_audio_graph::live_design(cx);
+    }
+}
+
+impl MatchEvent for App {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions) {
+        self.handle_device_selection(cx, actions);
+
+        // Handle passthrough toggle
+        if let Some(enabled) = self.ui.check_box(id!(passthrough_toggle)).changed(actions) {
+            if let Ok(mut passthrough_enabled) = self.store.passthrough_enabled.lock() {
+                *passthrough_enabled = enabled;
+            }
+
+            // Clear the buffer when toggling to prevent audio artifacts
+            if let Ok(mut buffer) = self.store.passthrough_audio.lock() {
+                buffer.clear();
+            }
+
+            if enabled {
+                self.setup_passthrough_output(cx);
+            }
+
+            self.update_passthrough_ui(cx);
+        }
+
+        // Handle volume slider
+        if let Some(volume) = self.ui.slider(id!(volume_slider)).slided(actions) {
+            self.store.passthrough_volume.set(volume);
+            self.update_volume_label(cx, volume);
+        }
+
+        if self
+            .ui
+            .button(id!(request_permission_button))
+            .clicked(actions)
+        {
+            cx.request_permission(Permission::AudioInput);
+        }
+    }
+
+    fn handle_startup(&mut self, cx: &mut Cx) {
+        cx.request_permission(Permission::AudioInput);
+    }
+
+    fn handle_signal(&mut self, cx: &mut Cx) {
+        if self.audio_update_signal.check_and_clear() {
+            self.update_audio_stats(cx);
+            self.update_samples_display(cx);
+
+            // Update passthrough UI occasionally to reduce processing
+            let callback_count = self.store.callback_count.get();
+            let is_enabled = self
+                .store
+                .passthrough_enabled
+                .try_lock()
+                .map(|guard| *guard)
+                .unwrap_or(false);
+            if is_enabled && callback_count % 20 == 0 {
+                self.update_passthrough_ui(cx);
+            }
+
+            self.ui.redraw(cx);
+        }
+    }
+
+    fn handle_audio_devices(&mut self, cx: &mut Cx, devices: &AudioDevicesEvent) {
+        let mut input_names = Vec::new();
+        let mut output_names = Vec::new();
+        let mut default_input_name = String::new();
+        let mut default_output_name = String::new();
+
+        devices
+            .descs
+            .iter()
+            .for_each(|desc| match desc.device_type {
+                AudioDeviceType::Input => {
+                    input_names.push(desc.name.clone());
+                    if desc.is_default {
+                        default_input_name = desc.name.clone();
+                    }
+                }
+                AudioDeviceType::Output => {
+                    output_names.push(desc.name.clone());
+                    if desc.is_default {
+                        default_output_name = desc.name.clone();
+                    }
+                }
+            });
+
+        let mic_dropdown = self.ui.drop_down(id!(mic_selector.device_selector));
+        mic_dropdown.set_labels(cx, input_names.clone());
+        mic_dropdown.set_selected_by_label(&default_input_name, cx);
+
+        let speaker_dropdown = self.ui.drop_down(id!(speaker_selector.device_selector));
+        speaker_dropdown.set_labels(cx, output_names.clone());
+        speaker_dropdown.set_selected_by_label(&default_output_name, cx);
+
+        // Automatically switch to default devices
+        // e.g. when a user connects headphones we assume they want to use them right away.
+        // Note: we do not want to automatically switch to default devices if the user has already selected a non-default device, unless
+        // the default device is new (wasn't present in the previous list)
+        let default_input = devices.default_input();
+        let default_output = devices.default_output();
+
+        // The default device is new, assume we want to use it
+        if !self
+            .audio_devices
+            .iter()
+            .any(|d| d.device_type == AudioDeviceType::Input && d.device_id == default_input[0])
+        {
+            cx.use_audio_inputs(&default_input);
+        }
+
+        // The default device is new, assume we want to use it
+        if !self
+            .audio_devices
+            .iter()
+            .any(|d| d.device_type == AudioDeviceType::Output && d.device_id == default_output[0])
+        {
+            cx.use_audio_outputs(&default_output);
+        }
+
+        self.audio_devices = devices.descs.clone();
+    }
+}
+
+impl AppMain for App {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event) {
+        self.match_event(cx, event);
+        self.ui.handle_event(cx, event, &mut Scope::empty());
+
+        if let Event::PermissionResult(pr) = event {
+            if pr.permission == Permission::AudioInput {
+                log!("Permission result: {:?}", pr);
+                match pr.status {
+                    PermissionStatus::Granted => {
+                        self.initialize(cx);
+                        self.ui.view(id!(permission_warning)).set_visible(cx, false);
+                    }
+                    PermissionStatus::DeniedPermanent => {
+                        self.ui.label(id!(permission_warning_label)).set_text(cx, "⚠️ Microphone permission denied.\nPlease enable microphone access in the system settings.");
+                        self.ui.view(id!(permission_warning)).set_visible(cx, true);
+                        self.ui.button(id!(request_permission_button)).set_visible(cx, false);
+                    }
+                    PermissionStatus::DeniedCanRetry => {
+                        self.ui.view(id!(permission_warning)).set_visible(cx, true);
+                        self.ui.button(id!(request_permission_button)).set_visible(cx, true);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+impl App {
+    fn initialize(&mut self, cx: &mut Cx) {
+        self.start_audio_test(cx);
+
+        // Initialize passthrough UI
+        self.update_passthrough_ui(cx);
+        self.update_volume_label(cx, self.store.passthrough_volume.get());
+
+        self.ui.redraw(cx);
+    }
+
+    fn handle_device_selection(&mut self, cx: &mut Cx, actions: &Actions) {
+        // Handle speaker selection
+        let speaker_dropdown = self.ui.drop_down(id!(speaker_selector.device_selector));
+        if let Some(_id) = speaker_dropdown.changed(actions) {
+            if let Some(device) = self.find_device_by_name(&speaker_dropdown.selected_label()) {
+                cx.use_audio_outputs(&[device.device_id]);
+            }
+        }
+
+        // Handle microphone selection
+        let microphone_dropdown = self.ui.drop_down(id!(mic_selector.device_selector));
+        if let Some(_id) = microphone_dropdown.changed(actions) {
+            if let Some(device) = self.find_device_by_name(&microphone_dropdown.selected_label()) {
+                cx.use_audio_inputs(&[device.device_id]);
+            }
+        }
+    }
+
+    fn find_device_by_name(&self, name: &str) -> Option<&AudioDeviceDesc> {
+        self.audio_devices.iter().find(|device| device.name == name)
+    }
+
+    pub fn start_audio_test(&mut self, cx: &mut Cx) {
+        self.ui
+            .label(id!(status_label))
+            .set_text(cx, "Status: Starting audio capture...");
+        self.ui.redraw(cx);
+
+        let store = self.store.clone();
+        let audio_signal = self.audio_update_signal.clone();
+        let mut frame_counter = 0i64;
+        let mut callback_counter = 0i64;
+        let mut update_counter = 0u32;
+
+        // Audio input capture
+        cx.audio_input(0, move |_info, input_buffer| {
+            frame_counter += input_buffer.frame_count as i64;
+            callback_counter += 1;
+
+            // Calculate audio statistics from first channel only
+            let channel_0 = input_buffer.channel(0);
+            let mut peak = 0.0f32;
+            let mut avg = 0.0f32;
+
+            for &sample in channel_0 {
+                let abs_val = sample.abs();
+                avg += abs_val;
+                if abs_val > peak {
+                    peak = abs_val;
+                }
+            }
+
+            if !channel_0.is_empty() {
+                avg /= channel_0.len() as f32;
+            }
+
+            // Update store values
+            store.frame_count.set(frame_counter);
+            store.callback_count.set(callback_counter);
+            store.peak_level.set(peak as f64);
+            store.avg_level.set(avg as f64);
+
+            // Store first few samples for display
+            if let Ok(mut samples) = store.samples.lock() {
+                samples.clear();
+                let channel_0 = input_buffer.channel(0);
+                for i in 0..20.min(channel_0.len()) {
+                    samples.push(channel_0[i]);
+                }
+            }
+
+            // Store audio data for passthrough if enabled
+            if let Ok(passthrough_enabled) = store.passthrough_enabled.try_lock() {
+                if *passthrough_enabled {
+                    if let Ok(mut passthrough_audio) = store.passthrough_audio.try_lock() {
+                        let channel_0 = input_buffer.channel(0);
+
+                        // Append new audio data to buffer
+                        passthrough_audio.extend_from_slice(channel_0);
+
+                        // Keep buffer size reasonable to prevent excessive latency
+                        const MAX_BUFFER_SIZE: usize = 1200; // ~25ms at 48kHz
+                        if passthrough_audio.len() > MAX_BUFFER_SIZE {
+                            let excess = passthrough_audio.len() - MAX_BUFFER_SIZE;
+                            passthrough_audio.drain(..excess);
+                        }
+                    }
+                }
+            }
+
+            update_counter += 1;
+
+            // Update UI every 5 callbacks (roughly 10Hz at typical rates)
+            if update_counter >= 5 {
+                update_counter = 0;
+                audio_signal.set();
+            }
+
+            // Also update immediately if we detect audio for the first time
+            if callback_counter == 1 || (callback_counter < 10 && peak > 0.01) {
+                audio_signal.set();
+            }
+        });
+    }
+
+    fn setup_passthrough_output(&mut self, cx: &mut Cx) {
+        let store = self.store.clone();
+
+        // Audio output callback for mic passthrough
+        cx.audio_output(0, move |_info, output_buffer| {
+            // Always start with silence
+            output_buffer.zero();
+
+            // Only play if passthrough is enabled (use try_lock to avoid blocking)
+            let is_enabled = if let Ok(passthrough_enabled) = store.passthrough_enabled.try_lock() {
+                *passthrough_enabled
+            } else {
+                false
+            };
+
+            if !is_enabled {
+                return;
+            }
+
+            // Get volume setting
+            let volume = store.passthrough_volume.get() as f32;
+
+            if let Ok(mut passthrough_audio) = store.passthrough_audio.try_lock() {
+                if !passthrough_audio.is_empty() {
+                    let frame_count = output_buffer.frame_count();
+                    let channel_count = output_buffer.channel_count();
+                    let samples_available = passthrough_audio.len().min(frame_count);
+
+                    // Fill each output channel with the same mono input data
+                    for frame_idx in 0..samples_available {
+                        let sample = passthrough_audio[frame_idx];
+                        // Apply volume scaling without extra reduction
+                        let scaled_sample = (sample * volume).clamp(-1.0, 1.0);
+
+                        // Write to all output channels (mono to stereo/multi-channel)
+                        for channel_idx in 0..channel_count {
+                            let channel = output_buffer.channel_mut(channel_idx);
+                            channel[frame_idx] = scaled_sample;
+                        }
+                    }
+
+                    // Remove consumed samples from the front of the buffer
+                    if samples_available > 0 {
+                        passthrough_audio.drain(..samples_available);
+                    }
+                }
+            }
+        });
+    }
+
+    fn update_passthrough_ui(&mut self, cx: &mut Cx) {
+        let is_enabled = if let Ok(passthrough_enabled) = self.store.passthrough_enabled.try_lock()
+        {
+            *passthrough_enabled
+        } else {
+            false
+        };
+
+        let (status_text, color) = if is_enabled {
+            (
+                "Status: ✅ Passthrough active".to_string(),
+                vec4(0.5, 1.0, 0.5, 1.0),
+            )
+        } else {
+            (
+                "Status: Passthrough disabled".to_string(),
+                vec4(1.0, 0.5, 0.5, 1.0),
+            )
+        };
+
+        self.ui
+            .label(id!(passthrough_status))
+            .set_text(cx, &status_text);
+        self.ui.label(id!(passthrough_status)).apply_over(
+            cx,
+            live! {
+                draw_text: { color: (color) }
+            },
+        );
+
+        self.ui.redraw(cx);
+    }
+
+    fn update_volume_label(&mut self, cx: &mut Cx, volume: f64) {
+        let percentage = (volume * 100.0) as i32;
+        self.ui
+            .label(id!(volume_label))
+            .set_text(cx, &format!("{}%", percentage));
+        self.ui.redraw(cx);
+    }
+
+    fn update_audio_stats(&mut self, cx: &mut Cx) {
+        let frame_count = self.store.frame_count.get();
+        let callback_count = self.store.callback_count.get();
+        let peak = self.store.peak_level.get();
+        let avg = self.store.avg_level.get();
+
+        // Update status label
+        let status = if callback_count == 0 {
+            "Status: ❌ No callbacks received!"
+        } else if peak > 0.001 {
+            "Status: ✅ AUDIO ACTIVE!"
+        } else {
+            "Status: ⚠️ Callbacks OK, but silent"
+        };
+        self.ui.label(id!(status_label)).set_text(cx, status);
+
+        // Update frames and peak labels
+        self.ui
+            .label(id!(frames_label))
+            .set_text(cx, &format!("Frames: {}", frame_count));
+        self.ui
+            .label(id!(peak_label))
+            .set_text(cx, &format!("Peak: {:.4} | Avg: {:.4}", peak, avg));
+
+        // Update callback counter with frequency
+        let frequency = if frame_count > 0 {
+            callback_count * 48000 / frame_count
+        } else {
+            0
+        };
+        self.ui.label(id!(callback_label)).set_text(
+            cx,
+            &format!("Callbacks: {} ({}Hz)", callback_count, frequency),
+        );
+
+        // Update level bar
+        let width = (peak.min(1.0) * 360.0) as f64;
+        self.ui
+            .view(id!(level_fill))
+            .apply_over(cx, live! {width: (width)});
+    }
+
+    fn update_samples_display(&mut self, cx: &mut Cx) {
+        if let Ok(samples) = self.store.samples.lock() {
+            if !samples.is_empty() {
+                let samples_str: Vec<String> = samples
+                    .iter()
+                    .take(10)
+                    .map(|s| format!("{:.3}", s))
+                    .collect();
+                self.ui
+                    .label(id!(samples_label))
+                    .set_text(cx, &format!("Samples: [{}]", samples_str.join(", ")));
+            } else {
+                self.ui
+                    .label(id!(samples_label))
+                    .set_text(cx, "Samples: [no data yet]");
+            }
+        }
+    }
+}

--- a/examples/audio/src/lib.rs
+++ b/examples/audio/src/lib.rs
@@ -1,0 +1,7 @@
+
+
+pub use makepad_widgets;
+pub use makepad_widgets::makepad_platform;
+pub use makepad_platform::makepad_micro_serde;
+pub use makepad_audio_graph;
+pub mod app;

--- a/examples/audio/src/main.rs
+++ b/examples/audio/src/main.rs
@@ -1,0 +1,3 @@
+fn main(){
+    makepad_example_audio::app::app_main()
+}

--- a/platform/src/audio.rs
+++ b/platform/src/audio.rs
@@ -15,7 +15,8 @@ pub struct AudioDeviceId(pub LiveId);
 #[derive(Clone, Copy, Debug)]
 pub struct AudioInfo{
     pub device_id: AudioDeviceId,
-    pub time: Option<AudioTime>
+    pub time: Option<AudioTime>,
+    pub sample_rate: f64,
 }
 
 #[derive(Clone, Debug)]

--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -79,7 +79,8 @@ pub struct Cx {
     pub (crate) event_id: u64,
     pub (crate) timer_id: u64,
     pub (crate) next_frame_id: u64,
-    
+    pub (crate) permissions_request_id: i32,
+
     pub keyboard: CxKeyboard,
     pub fingers: CxFingers,
     pub (crate) ime_area: Area,
@@ -306,6 +307,7 @@ impl Cx {
             repaint_id: 1,
             timer_id: 1,
             next_frame_id: 1,
+            permissions_request_id: 0,
             
             keyboard: Default::default(),
             fingers: Default::default(),

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -88,6 +88,15 @@ pub enum CxOsOp {
     ShowClipboardActions(String),
     CopyToClipboard(String),
 
+    CheckPermission {
+        permission: crate::permission::Permission,
+        request_id: i32,
+    },
+    RequestPermission {
+        permission: crate::permission::Permission,
+        request_id: i32,
+    },
+
     HttpRequest {
         request_id: LiveId,
         request: HttpRequest,
@@ -157,6 +166,8 @@ impl std::fmt::Debug for CxOsOp {
             Self::UpdateMacosMenu(..)=>write!(f, "UpdateMacosMenu"),
             Self::ShowClipboardActions(..)=>write!(f, "ShowClipboardActions"),
             Self::CopyToClipboard(..)=>write!(f, "CopyToClipboard"),
+            Self::CheckPermission{..}=>write!(f, "CheckPermission"),
+            Self::RequestPermission{..}=>write!(f, "RequestPermission"),
             
             Self::HttpRequest{..}=>write!(f, "HttpRequest"),
             Self::CancelHttpRequest{..}=>write!(f, "CancelHttpRequest"),
@@ -376,6 +387,14 @@ impl Cx {
         }
     }
 
+    pub fn request_permission(&mut self, permission: crate::permission::Permission) -> i32 {
+        self.permissions_request_id += 1;
+        self.platform_ops.push(CxOsOp::RequestPermission {
+            request_id: self.permissions_request_id,
+            permission,
+        });
+        self.permissions_request_id
+    }
 
     pub fn get_dpi_factor_of(&mut self, area: &Area) -> f64 {
         if let Some(draw_list_id) = area.draw_list_id() {

--- a/platform/src/event/event.rs
+++ b/platform/src/event/event.rs
@@ -26,6 +26,7 @@ use {
         midi::MidiPortsEvent,
         video::VideoInputsEvent,
         draw_list::DrawListId,
+        permission::{PermissionResult},
     },
 };
 
@@ -218,6 +219,10 @@ pub enum Event {
     BackPressed {
         handled: Cell<bool>,
     },
+    
+    /// Permission check or request result
+    PermissionResult(PermissionResult),
+    
     #[cfg(target_arch = "wasm32")]
     ToWasmMsg(ToWasmMsgEvent),
     
@@ -292,12 +297,13 @@ impl Event{
             49=>"MouseLeave",
             50=>"Actions",
             51=>"BackPressed",
+            52=>"PermissionResult",
 
             #[cfg(target_arch = "wasm32")]
-            52=>"ToWasmMsg",
+            55=>"ToWasmMsg",
             
-            53=>"DesignerPick",
-            54=>"XrLocal",
+            56=>"DesignerPick",
+            57=>"XrLocal",
             _=>panic!()
         }
     }
@@ -365,12 +371,13 @@ impl Event{
             Self::MouseLeave(_)=>49,
             Self::Actions(_)=>50,
             Self::BackPressed{..}=>51,
+            Self::PermissionResult(_)=>52,
             
             #[cfg(target_arch = "wasm32")]
-            Self::ToWasmMsg(_)=>52,
+            Self::ToWasmMsg(_)=>55,
             
-            Self::DesignerPick(_) =>53,
-            Self::XrLocal(_)=>54
+            Self::DesignerPick(_) =>56,
+            Self::XrLocal(_)=>57
         }
     }
 

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -31,6 +31,7 @@ mod draw_vars;
 
 mod id_pool;
 pub mod event;
+pub mod permission;
 mod area;
 mod window;
 mod pass;

--- a/platform/src/os/apple/apple_sys.rs
+++ b/platform/src/os/apple/apple_sys.rs
@@ -1275,6 +1275,10 @@ unsafe extern "system" fn(
     inClientData: *mut ()
 ) -> OSStatus>;
 
+// AVAudioSessionPortOverride values
+pub const AVAudioSessionPortOverrideNone: u64 = 0;
+pub const AVAudioSessionPortOverrideSpeaker: u64 = 1936747378; // 'spkr'
+
 #[link(name = "CoreAudio", kind = "framework")]
 extern "C" {
     pub static AVAudioSessionCategoryPlayAndRecord: ObjcId;

--- a/platform/src/os/apple/apple_sys.rs
+++ b/platform/src/os/apple/apple_sys.rs
@@ -1169,6 +1169,7 @@ pub enum AudioObjectPropertySelector {
     DefaultInputDevice = four_char_as_u32("dIn "),
     DefaultOutputDevice = four_char_as_u32("dOut"),
     DeviceIsAlive = four_char_as_u32("livn"),
+    NominalSampleRate = four_char_as_u32("nsrt"),
 }
 
 #[repr(u32)]
@@ -1181,6 +1182,9 @@ pub enum AudioObjectPropertyScope {
 pub enum AVAudioSessionCategoryOption {
     AllowBluetooth = 0x4,
     DefaultToSpeaker = 0x8,
+    AllowBluetoothA2DP = 0x20,
+    AllowAirPlay = 0x40,
+    MixWithOthers = 0x1,
 }
 
 #[repr(u32)]

--- a/platform/src/os/apple/apple_sys.rs
+++ b/platform/src/os/apple/apple_sys.rs
@@ -192,6 +192,7 @@ extern "C" {
     pub static AVAudioChannelLayout: ObjcId;
     pub static AVAudioSession: ObjcId;
     pub static AVMediaTypeVideo: ObjcId;
+    pub static AVMediaTypeAudio: ObjcId;
     pub static AVCaptureSession: ObjcId;
     pub static AVCaptureDeviceInput: ObjcId;
     pub static AVCaptureVideoDataOutput: ObjcId;

--- a/platform/src/os/apple/audio_unit.rs
+++ b/platform/src/os/apple/audio_unit.rs
@@ -156,9 +156,17 @@ impl AudioUnitAccess {
             let _success: bool = msg_send![
                 session, 
                 setCategory:AVAudioSessionCategoryPlayAndRecord
-                withOptions:AVAudioSessionCategoryOption::DefaultToSpeaker as usize// | AVAudioSessionCategoryOption::AllowBluetooth as usize
+                withOptions:AVAudioSessionCategoryOption::DefaultToSpeaker as usize | AVAudioSessionCategoryOption::AllowBluetooth as usize
                 error:&mut error
             ];
+            // Use VideoChat mode for AEC/AGC/NS + loudspeaker routing (VoiceChat routes to earpiece)
+            let mode: ObjcId = str_to_nsstring("AVAudioSessionModeVideoChat");
+            let () = msg_send![session, setMode: mode error:&mut error];
+            // Prefer 48 kHz to avoid 48k↔44.1k drift on AirPods, however this might 
+            // be overriden by the system or some other configuration.
+            let () = msg_send![session, setPreferredSampleRate: 48000.0 error:&mut error];
+            let () = msg_send![session, setPreferredIOBufferDuration:0.005 error:&mut error];
+            let () = msg_send![session, setActive: true error: &mut error];
         }
     }
         
@@ -223,11 +231,13 @@ impl AudioUnitAccess {
                         
                         let running = audio_inputs.iter_mut().find( | v | v.device_id == device_id).unwrap();
                         let audio_input_cb = audio_input_cb.clone();
+                        let sample_rate = audio_unit.sample_rate;
                         audio_unit.set_input_handler(move | time, output | {
                             if let Some(audio_input_cb) = &mut *audio_input_cb.lock().unwrap() {
                                 return audio_input_cb(AudioInfo{
-                                    device_id, 
-                                    time: Some(time)
+                                    device_id,
+                                    time: Some(time),
+                                    sample_rate,
                                 }, output)
                             }
                         });
@@ -291,11 +301,13 @@ impl AudioUnitAccess {
                         
                         let running = audio_outputs.iter_mut().find( | v | v.device_id == device_id).unwrap();
                         let audio_output_cb = audio_output_cb.clone();
+                        let sample_rate = audio_unit.sample_rate;
                         audio_unit.set_output_provider(move | time, output | {
                             if let Some(audio_output_cb) = &mut *audio_output_cb.lock().unwrap() {
                                 audio_output_cb(AudioInfo{
-                                    device_id, 
-                                    time:Some(time)
+                                    device_id,
+                                    time:Some(time),
+                                    sample_rate,
                                 }, output)
                             }
                         });
@@ -318,7 +330,7 @@ impl AudioUnitAccess {
         unsafe {
             let mut err: ObjcId = nil;
             let audio_session: ObjcId = msg_send![class!(AVAudioSession), sharedInstance];
-            let () = msg_send![audio_session, setCategory: AVAudioSessionCategoryMultiRoute error: &mut err];
+            // Do not force MultiRoute; keep the app's configured category/mode active
             let () = msg_send![audio_session, setActive: true error: &mut err];
         }
         let block = objc_block!(move | _note: ObjcId | {
@@ -506,7 +518,7 @@ impl AudioUnitAccess {
         Ok(())
     }
     
-     #[cfg(any(target_os = "ios", target_os = "tvos"))]
+    #[cfg(any(target_os = "ios", target_os = "tvos"))]
     pub fn update_device_list(&mut self) -> Result<(), OSError> {
         self.device_descs.clear();
 
@@ -516,9 +528,9 @@ impl AudioUnitAccess {
                 has_failed:false,
                 device_id:AudioDeviceId(live_id!(default_input)),
                 device_type: AudioDeviceType::Input,
-                channel_count: 2,
+                channel_count: 1, // iOS/tvOS microphone is mono by default
                 is_default: true,
-                name: "Default Output".to_string(),
+                name: "Default Input".to_string(),
             }
         });
          
@@ -530,7 +542,7 @@ impl AudioUnitAccess {
                 device_type: AudioDeviceType::Output,
                 channel_count: 2,
                 is_default: true,
-                name: "Default Input".to_string(),
+                name: "Default Output".to_string(),
             }
         });
         Ok(())
@@ -566,10 +578,18 @@ impl AudioUnitAccess {
                     AudioUnitSubType::RemoteIO, 
                 )
             }
+            #[cfg(target_os = "macos")]
             AudioUnitQuery::Input => {
                 AudioComponentDescription::new_all_manufacturers(
                     AudioUnitType::IO,
                     AudioUnitSubType::HalOutput,
+                )
+            }
+            #[cfg(any(target_os = "ios", target_os = "tvos"))]
+            AudioUnitQuery::Input => {
+                AudioComponentDescription::new_all_manufacturers(
+                    AudioUnitType::IO,
+                    AudioUnitSubType::VoiceProcessingIO,
                 )
             }
             AudioUnitQuery::Effect => {
@@ -609,16 +629,18 @@ impl AudioUnitAccess {
         let instantiation_handler = objc_block!(move | av_audio_unit: ObjcId, error: ObjcId | {
             let () = unsafe {msg_send![av_audio_unit, retain]};
             unsafe fn inner(_change_signal: SignalToUI, core_device_id: AudioDeviceID, av_audio_unit: ObjcId, error: ObjcId, unit_query: AudioUnitQuery) -> Result<AudioUnit, OSError> {
+                #[cfg(not(target_os="macos"))]
+                let _ = core_device_id; // silence unused on iOS/tvOS
                 OSError::from_nserror(error) ?;
                 let au_audio_unit: ObjcId = msg_send![av_audio_unit, AUAudioUnit];
                 let () = msg_send![av_audio_unit, retain];
                 
-                let mut err: ObjcId = nil;
-                let () = msg_send![au_audio_unit, allocateRenderResourcesAndReturnError: &mut err];
-                OSError::from_nserror(err) ?;
+                // Configure stream format before allocating resources
                 let mut render_block = None;
                 
-                let stream_desc = CAudioStreamBasicDescription {
+                // Default stream desc; on iOS we'll pull the AVAudioSession sample rate
+                #[allow(unused_mut)] // mut needed on iOS/tvOS but not macOS
+                let mut stream_desc = CAudioStreamBasicDescription {
                     mSampleRate: 48000.0,
                     mFormatID: AudioFormatId::LinearPCM,
                     mFormatFlags: LinearPcmFlags::IS_FLOAT as u32
@@ -632,11 +654,46 @@ impl AudioUnitAccess {
                     mReserved: 0
                 };
                 
+                // If on iOS/tvOS, fetch AVAudioSession sample rate
+                #[cfg(any(target_os="ios", target_os="tvos"))]
+                {
+                    let session: ObjcId = msg_send![class!(AVAudioSession), sharedInstance];
+                    // After setting preferred sample rate, query actual rate
+                    let sr: f64 = msg_send![session, sampleRate];
+                    if sr > 0.0 { stream_desc.mSampleRate = sr; }
+                }
+
+                // If on macOS, query the device's nominal sample rate
+                #[cfg(target_os = "macos")]
+                {
+                    let prop_addr = AudioObjectPropertyAddress {
+                        mSelector: AudioObjectPropertySelector::NominalSampleRate,
+                        mScope: AudioObjectPropertyScope::Global,
+                        mElement: AudioObjectPropertyElement::Master,
+                    };
+                    let mut sample_rate: f64 = 48000.0;
+                    let data_size = std::mem::size_of::<f64>();
+                    let result = unsafe {AudioObjectGetPropertyData(
+                        core_device_id,
+                        &prop_addr,
+                        0,
+                        std::ptr::null(),
+                        &data_size as *const _ as *mut _,
+                        &mut sample_rate as *mut f64 as *mut _,
+                    )};
+                    if result == 0 && sample_rate > 0.0 {
+                        stream_desc.mSampleRate = sample_rate;
+                    }
+                }
+
                 let av_audio_format: ObjcId = msg_send![class!(AVAudioFormat), alloc];
                 let () = msg_send![av_audio_format, initWithStreamDescription: &stream_desc];
                 
                 match unit_query {
                     AudioUnitQuery::Output => {
+                        let mut err: ObjcId = nil;
+                        let () = msg_send![au_audio_unit, allocateRenderResourcesAndReturnError: &mut err];
+                        OSError::from_nserror(err) ?;
                         let busses: ObjcId = msg_send![au_audio_unit, inputBusses];
                         let count: usize = msg_send![busses, count];
                         if count > 0 {
@@ -644,10 +701,11 @@ impl AudioUnitAccess {
                             let mut err: ObjcId = nil;
                             let () = msg_send![bus, setFormat: av_audio_format error: &mut err];
                             OSError::from_nserror(err) ?;
+                            let () = msg_send![bus, setEnabled: true];
                         }
                         
-                        let () = msg_send![au_audio_unit, setOutputEnabled: true];
-                        let () = msg_send![au_audio_unit, setInputEnabled: false];
+                        let () = msg_send![au_audio_unit, setOutputEnabled: false];
+                        let () = msg_send![au_audio_unit, setInputEnabled: true];
                         
                         #[cfg(target_os = "macos")]
                         {
@@ -656,31 +714,66 @@ impl AudioUnitAccess {
                             OSError::from_nserror(err) ?;
                         }
                         
-                        let mut err: ObjcId = nil;
+                        let () = msg_send![au_audio_unit, setOutputEnabled: true];
+                        let () = msg_send![au_audio_unit, setInputEnabled: false];
+                        
+                        #[cfg(target_os="macos")]
+                        {
+                            let mut err: ObjcId = nil;
+                            let () = msg_send![au_audio_unit, setDeviceID: core_device_id error: &mut err];
+                            OSError::from_nserror(err) ?;
+                        }
+                        // Ensure final state for output units before allocation
+                        let () = msg_send![au_audio_unit, setOutputEnabled: true];
+                        let () = msg_send![au_audio_unit, setInputEnabled: false];
+                        
+                        #[cfg(target_os="macos")]
+                        {
+                            let mut err: ObjcId = nil;
+                            let () = msg_send![au_audio_unit, setDeviceID: core_device_id error: &mut err];
+                            OSError::from_nserror(err) ?;
+                        }
                         let () = msg_send![au_audio_unit, startHardwareAndReturnError: &mut err];
                         OSError::from_nserror(err) ?;
                     }
                     AudioUnitQuery::Input => {
-                        // lets hardcode the format to 44100 float
+                        // On iOS/tvOS, mic is commonly mono. Prefer 1 channel there.
+                        #[cfg(any(target_os="ios", target_os="tvos"))]
+                        {
+                            stream_desc.mChannelsPerFrame = 1;
+                        }
+                        // Recreate AVAudioFormat with possibly adjusted channel count
+                        let av_audio_format: ObjcId = msg_send![class!(AVAudioFormat), alloc];
+                        let () = msg_send![av_audio_format, initWithStreamDescription: &stream_desc];
+                        
                         let busses: ObjcId = msg_send![au_audio_unit, outputBusses];
                         let count: usize = msg_send![busses, count];
-                        if count > 1 {
-                            let bus: ObjcId = msg_send![busses, objectAtIndexedSubscript: 1];
-                            //let format: ObjcId = msg_send![bus, format];
-                            //let format: *const CAudioStreamBasicDescription = msg_send![format, streamDescription];
-                            let mut err: ObjcId = nil;
-                            let () = msg_send![bus, setFormat: av_audio_format error: &mut err];
-                            OSError::from_nserror(err) ?;
-                            let () = msg_send![bus, setEnabled: true];
+                        if count > 0 {
+                            // RemoteIO/VoiceProcessingIO uses bus 1 for input on iOS/tvOS
+                            #[cfg(any(target_os="ios", target_os="tvos", target_os="macos"))]
+                            let bus_index = 1;
+                            if count > bus_index{
+                                let bus: ObjcId = msg_send![busses, objectAtIndexedSubscript: bus_index];
+                                let mut err: ObjcId = nil;
+                                let () = msg_send![bus, setFormat: av_audio_format error: &mut err];
+                                OSError::from_nserror(err) ?;
+                                let () = msg_send![bus, setEnabled: true];
+                            }
                         }
                         let () = msg_send![au_audio_unit, setOutputEnabled: false];
                         let () = msg_send![au_audio_unit, setInputEnabled: true];
                         
-                        let mut err: ObjcId = nil;
-                        let () = msg_send![au_audio_unit, setDeviceID: core_device_id error: &mut err];
-                        OSError::from_nserror(err) ?;
+                        #[cfg(target_os="macos")]
+                        {
+                            let mut err: ObjcId = nil;
+                            let () = msg_send![au_audio_unit, setDeviceID: core_device_id error: &mut err];
+                            OSError::from_nserror(err) ?;
+                        }
                         
+                        // Allocate after configuration
                         let mut err: ObjcId = nil;
+                        let () = msg_send![au_audio_unit, allocateRenderResourcesAndReturnError: &mut err];
+                        OSError::from_nserror(err) ?;
                         let () = msg_send![au_audio_unit, startHardwareAndReturnError: &mut err];
                         OSError::from_nserror(err) ?;
                         
@@ -698,7 +791,8 @@ impl AudioUnitAccess {
                     render_block,
                     unit_query,
                     av_audio_unit,
-                    au_audio_unit
+                    au_audio_unit,
+                    sample_rate: stream_desc.mSampleRate,
                 })
             }
             let change_signal = change_signal.clone();
@@ -763,10 +857,11 @@ impl AudioUnitAccess {
                     render_block,
                     unit_query,
                     av_audio_unit,
-                    au_audio_unit
+                    au_audio_unit,
+                    sample_rate: 48000.0, // Default for plugins, not device-dependent
                 })
             }
-            
+
             match unsafe {inner(av_audio_unit, error, unit_query)} {
                 Err(err) => unit_callback(Err(AudioError::System(format!("{:?}", err)))),
                 Ok(device) => unit_callback(Ok(device))
@@ -809,9 +904,9 @@ pub struct AudioUnit {
     au_audio_unit: ObjcId,
     render_block: Option<ObjcId>,
     view_controller: Arc<Mutex<Option<ObjcId >> >,
-    unit_query: AudioUnitQuery
+    unit_query: AudioUnitQuery,
+    sample_rate: f64,
 }
-
 unsafe impl Send for AudioUnitClone {}
 unsafe impl Sync for AudioUnitClone {}
 pub struct AudioUnitClone {
@@ -1168,15 +1263,22 @@ impl AudioUnit {
                     time_stamp: *const AudioTimeStamp,
                     frame_count: u32,
                     _input_bus_number: u64 | {
+                        // iOS/tvOS input is mono when using VoiceProcessingIO
+                        #[cfg(any(target_os="ios", target_os="tvos"))]
+                        let mut buffer = AudioBuffer::new_with_size(frame_count as usize, 1);
+                        #[cfg(not(any(target_os="ios", target_os="tvos")))]
                         let mut buffer = AudioBuffer::new_with_size(frame_count as usize, 2);
                         let mut flags = 0u32;
                         let mut buffer_list = buffer.to_audio_buffer_list();
                         
+                        // For RemoteIO/VoiceProcessingIO input, use bus 1
+                        let bus_index = 1u64;
+
                         objc_block_invoke!(render_block, invoke(
                             (&mut flags as *mut u32): *mut u32,
                             (time_stamp): *const AudioTimeStamp,
                             (frame_count): u32,
-                            (1): u64,
+                            (bus_index): u64,
                             (&mut buffer_list as *mut AudioBufferList): *mut AudioBufferList,
                             (nil): ObjcId
                         ) -> i32);
@@ -1312,4 +1414,3 @@ impl AudioUnit {
     }*/
     
 }
-

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -4,8 +4,8 @@ use {
         rc::Rc,
         cell::{RefCell},
     },
-
     crate::{
+        makepad_objc_sys::objc_block,
         makepad_live_id::*,
         os::{
             cx_native::EventFlow,
@@ -253,6 +253,9 @@ impl Cx {
             IosEvent::Timer(e) => if e.timer_id != 0 {
                 self.call_event_handler(&Event::Timer(e))
             }
+            IosEvent::PermissionResult(result) => {
+                self.call_event_handler(&Event::PermissionResult(result))
+            }
         }
 
         if self.any_passes_dirty() || self.need_redrawing() || self.new_next_frames.len() != 0 || paint_dirty|| self.demo_time_repaint{
@@ -282,6 +285,12 @@ impl Cx {
                 CxOsOp::StopTimer(timer_id) => {
                     with_ios_app(|app| app.stop_timer(timer_id));
                 },
+                CxOsOp::CheckPermission {permission, request_id} => {
+                    self.handle_permission_check(permission, request_id);
+                },
+                CxOsOp::RequestPermission {permission, request_id} => {
+                    self.handle_permission_request(permission, request_id);
+                },
                 CxOsOp::HttpRequest {request_id, request} => {
                     self.os.http_requests.make_http_request(request_id, request, self.os.network_response.sender.clone());
                 },
@@ -310,6 +319,104 @@ impl Cx {
         file_name:file_name.to_string(),
         content
     }]);*/
+    
+    fn check_audio_permission_status(&self) -> crate::permission::PermissionStatus {
+        unsafe {
+            let av_audio_session: ObjcId = msg_send![class!(AVAudioSession), sharedInstance];
+            let permission_status: i32 = msg_send![av_audio_session, recordPermission];
+            
+            match permission_status {
+                2 => crate::permission::PermissionStatus::Granted, // AVAudioSessionRecordPermissionGranted
+                1 => crate::permission::PermissionStatus::DeniedPermanent,  // AVAudioSessionRecordPermissionDenied - iOS doesn't re-prompt
+                _ => crate::permission::PermissionStatus::NotDetermined, // AVAudioSessionRecordPermissionUndetermined (0) or unknown
+            }
+        }
+    }
+
+    fn handle_permission_check(&mut self, permission: crate::permission::Permission, request_id: i32) {
+        let status = match permission {
+            crate::permission::Permission::AudioInput => self.check_audio_permission_status(),
+            _ => {
+                crate::log!("iOS permission check not implemented for: {:?}", permission);
+                crate::permission::PermissionStatus::DeniedPermanent
+            }
+        };
+        
+        self.call_event_handler(&crate::event::Event::PermissionResult(crate::permission::PermissionResult {
+            permission,
+            request_id,
+            status,
+        }));
+    }
+
+    fn handle_permission_request(&mut self, permission: crate::permission::Permission, request_id: i32) {
+        match permission {
+            crate::permission::Permission::AudioInput => {
+                let status = self.check_audio_permission_status();
+                match status {
+                    crate::permission::PermissionStatus::Granted => {
+                        // Already granted, don't re-ask
+                        self.call_event_handler(&crate::event::Event::PermissionResult(crate::permission::PermissionResult {
+                            permission,
+                            request_id,
+                            status,
+                        }));
+                    },
+                    crate::permission::PermissionStatus::DeniedPermanent => {
+                        // Previously denied, send denied event
+                        self.call_event_handler(&crate::event::Event::PermissionResult(crate::permission::PermissionResult {
+                            permission,
+                            request_id,
+                            status,
+                        }));
+                    },
+                    crate::permission::PermissionStatus::NotDetermined => {
+                        // Need to request permission
+                        self.ios_request_audio_permission(permission, request_id);
+                    }
+                    _ => {
+                        // For other statuses, send the result directly
+                        self.call_event_handler(&crate::event::Event::PermissionResult(crate::permission::PermissionResult {
+                            permission,
+                            request_id,
+                            status,
+                        }));
+                    }
+                }
+            },
+            _ => {
+                // For other permissions, auto-deny with warning
+                crate::log!("iOS permission not implemented for: {:?}", permission);
+                self.call_event_handler(&crate::event::Event::PermissionResult(crate::permission::PermissionResult {
+                    permission,
+                    request_id,
+                    status: crate::permission::PermissionStatus::DeniedPermanent,
+                }));
+            }
+        }
+    }
+    
+    fn ios_request_audio_permission(&mut self, permission: crate::permission::Permission, request_id: i32) {
+        unsafe {
+            let av_audio_session: ObjcId = msg_send![class!(AVAudioSession), sharedInstance];
+            
+            let completion_handler = objc_block!(move |granted: BOOL| {
+                let permission_result = crate::permission::PermissionResult {
+                    permission,
+                    request_id,
+                    status: if granted == YES {
+                        crate::permission::PermissionStatus::Granted
+                    } else {
+                        crate::permission::PermissionStatus::DeniedPermanent // iOS doesn't re-prompt
+                    },
+                };
+                
+                IosApp::do_callback(IosEvent::PermissionResult(permission_result));
+            });
+            
+            let () = msg_send![av_audio_session, requestRecordPermission: &completion_handler];
+        }
+    }
 
 }
 

--- a/platform/src/os/apple/ios/ios_event.rs
+++ b/platform/src/os/apple/ios/ios_event.rs
@@ -14,6 +14,7 @@ use {
             TouchUpdateEvent,
             VirtualKeyboardEvent,
         },
+        permission::PermissionResult,
     }
 };
 
@@ -39,4 +40,5 @@ pub enum IosEvent {
     TextCopy(TextClipboardEvent),
     TextCut(TextClipboardEvent),
     Timer(TimerEvent),
+    PermissionResult(PermissionResult),
 }

--- a/platform/src/os/apple/macos/macos_event.rs
+++ b/platform/src/os/apple/macos/macos_event.rs
@@ -1,23 +1,7 @@
 use crate::{
-    makepad_live_id::*,
-    window::WindowId,
-    //menu::MenuCommand,
     event::{
-        MouseDownEvent,
-        MouseUpEvent,
-        MouseMoveEvent,
-        ScrollEvent,
-        WindowGeomChangeEvent,
-        WindowDragQueryEvent,
-        WindowCloseRequestedEvent,
-        WindowClosedEvent,
-        TextInputEvent,
-        KeyEvent,
-        DragEvent,
-        DropEvent,
-        TextClipboardEvent,
-        TimerEvent,
-    },
+        DragEvent, DropEvent, KeyEvent, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ScrollEvent, TextClipboardEvent, TextInputEvent, TimerEvent, WindowCloseRequestedEvent, WindowClosedEvent, WindowDragQueryEvent, WindowGeomChangeEvent
+    }, makepad_live_id::*, permission::PermissionResult, window::WindowId
 };
 
 #[derive(Debug, Clone)]
@@ -47,4 +31,5 @@ pub enum MacosEvent {
     TextCut(TextClipboardEvent),
     Timer(TimerEvent),
     MacosMenuCommand(LiveId),
+    PermissionResult(PermissionResult),
 }

--- a/platform/src/os/linux/alsa_audio.rs
+++ b/platform/src/os/linux/alsa_audio.rs
@@ -216,6 +216,7 @@ impl AlsaAudioAccess {
                                 AudioInfo {
                                     device_id,
                                     time: None,
+                                    sample_rate: 48000.0,
                                 },
                                 &audio_buffer
                             );
@@ -275,6 +276,7 @@ impl AlsaAudioAccess {
                                 AudioInfo {
                                     device_id,
                                     time: None,
+                                    sample_rate: 48000.0,
                                 },
                                 &mut audio_buffer
                             );

--- a/platform/src/os/linux/android/android_audio.rs
+++ b/platform/src/os/linux/android/android_audio.rs
@@ -209,7 +209,8 @@ impl AndroidAudioOutput {
             data.audio_buffer.resize(frame_count as usize, data.channel_count);
             output_fn(AudioInfo {
                 device_id: data.device_id,
-                time: None
+                time: None,
+                sample_rate: 48000.0,
             }, &mut data.audio_buffer);
             let output = std::slice::from_raw_parts_mut(audio_data as *mut f32, frame_count as usize * data.actual_channel_count);
             if data.channel_count != data.actual_channel_count {
@@ -280,7 +281,8 @@ impl AndroidAudioInput {
             data.audio_buffer.copy_from_interleaved(data.channel_count, &input_data);
             input_fn(AudioInfo {
                 device_id: data.device_id,
-                time: None
+                time: None,
+                sample_rate: 48000.0,
             }, &data.audio_buffer);
         }
         AAUDIO_CALLBACK_RESULT_CONTINUE

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -92,6 +92,11 @@ pub enum FromJavaMessage {
         name: String,
         midi_device: jni_sys::jobject
     },
+    PermissionResult{
+        permission: String,
+        request_id: i32,
+        status: i32, // 0=NotDetermined, 1=Granted, 2=DeniedCanRetry, 3=DeniedPermanent
+    },
     VideoPlaybackPrepared {
         video_id: u64,
         video_width: u32,
@@ -688,6 +693,31 @@ pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onMidiDeviceOpen
     });
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onPermissionResult(
+    env: *mut jni_sys::JNIEnv,
+    _: jni_sys::jclass,
+    permission: jni_sys::jstring,
+    request_id: jni_sys::jint,
+    status: jni_sys::jint,
+) {
+    send_from_java_message(FromJavaMessage::PermissionResult {
+        permission: jstring_to_string(env, permission),
+        request_id: request_id as i32,
+        status,
+    });
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onPermissionDenied(
+    env: *mut jni_sys::JNIEnv,
+    class: jni_sys::jclass,
+    permission: jni_sys::jstring,
+    request_id: jni_sys::jint,
+) {
+    Java_dev_makepad_android_MakepadNative_onPermissionResult(env, class, permission, request_id, 3); // 3 = DeniedPermanent (assume worst case)
+}
+
 unsafe fn jstring_to_string(env: *mut jni_sys::JNIEnv, java_string: jni_sys::jstring) -> String {
     let chars = (**env).GetStringUTFChars.unwrap()(env, java_string, std::ptr::null_mut());
     let rust_string = std::ffi::CStr::from_ptr(chars).to_str().unwrap().to_string();
@@ -996,4 +1026,38 @@ pub unsafe fn to_java_cleanup_video_playback_resources(env: *mut jni_sys::JNIEnv
 
 pub unsafe fn to_java_cleanup_video_decoder_ref(env: *mut jni_sys::JNIEnv, video_decoder_ref: jni_sys::jobject) {
     (**env).DeleteGlobalRef.unwrap()(env, video_decoder_ref);
+}
+
+pub unsafe fn to_java_check_permission(permission: &str) -> i32 {
+    let env = attach_jni_env();
+    let permission_str = CString::new(permission).unwrap();
+    let permission_jstr = ((**env).NewStringUTF.unwrap())(env, permission_str.as_ptr());
+    
+    let result = ndk_utils::call_int_method!(
+        env,
+        get_activity(),
+        "checkPermission",
+        "(Ljava/lang/String;)I",
+        permission_jstr
+    );
+    
+    (**env).DeleteLocalRef.unwrap()(env, permission_jstr);
+    result
+}
+
+pub unsafe fn to_java_request_permission(permission: &str, request_id: i32) {
+    let env = attach_jni_env();
+    let permission_str = CString::new(permission).unwrap();
+    let permission_jstr = ((**env).NewStringUTF.unwrap())(env, permission_str.as_ptr());
+    
+    ndk_utils::call_void_method!(
+        env,
+        get_activity(),
+        "requestPermission",
+        "(Ljava/lang/String;I)V",
+        permission_jstr,
+        request_id as jni_sys::jint
+    );
+    
+    (**env).DeleteLocalRef.unwrap()(env, permission_jstr);
 }

--- a/platform/src/os/linux/pulse_audio.rs
+++ b/platform/src/os/linux/pulse_audio.rs
@@ -138,7 +138,8 @@ impl PulseInputStream {
             input.audio_buffer.copy_from_interleaved(2, interleaved);
             input_fn(AudioInfo {
                 device_id: input.device_id,
-                time: None
+                time: None,
+                sample_rate: 48000.0,
             }, &input.audio_buffer);
         }        
         pa_stream_drop(stream);
@@ -285,7 +286,8 @@ impl PulseOutputStream {
             if let Some(output_fn) = &mut *output_fn {
                 output_fn(AudioInfo {
                     device_id: output.device_id,
-                    time: None
+                    time: None,
+                    sample_rate: 48000.0,
                 }, &mut output.audio_buffer);
                 // lets copy it to interleaved format
                 let interleaved = std::slice::from_raw_parts_mut(write_ptr as *mut f32, output.write_byte_count / 4);

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -20,7 +20,7 @@ use {
         makepad_live_id::*,
         thread::SignalToUI,
         event::*,
-        permission::{PermissionCheckEvent, PermissionResult, PermissionStatus},
+        permission::{PermissionResult, PermissionStatus},
         pass::CxPassParent,
         cx::{Cx, OsType,LinuxWindowParams}, 
         os::cx_stdin::PollTimers,
@@ -349,7 +349,7 @@ impl Cx {
                 CxOsOp::CheckPermission {permission, request_id} => {
                     // Linux desktop apps have all permissions granted by default (handled at system level)
                     // TODO: Handle sandbox cases like flatpak
-                    self.call_event_handler(&Event::PermissionCheck(crate::permission::PermissionCheckEvent {
+                    self.call_event_handler(&Event::PermissionResult(crate::permission::PermissionResult {
                         permission,
                         request_id,
                         status: crate::permission::PermissionStatus::Granted,
@@ -358,9 +358,10 @@ impl Cx {
                 CxOsOp::RequestPermission {permission, request_id} => {
                     // Linux desktop apps have all permissions granted by default (handled at system level)
                     // TODO: Handle sandbox cases like flatpak
-                    self.call_event_handler(&Event::PermissionGranted(crate::permission::PermissionResult {
+                    self.call_event_handler(&Event::PermissionResult(crate::permission::PermissionResult {
                         permission,
                         request_id,
+                        status: crate::permission::PermissionStatus::Granted,
                     }));
                 },
                 e=>{

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -20,6 +20,7 @@ use {
         makepad_live_id::*,
         thread::SignalToUI,
         event::*,
+        permission::{PermissionCheckEvent, PermissionResult, PermissionStatus},
         pass::CxPassParent,
         cx::{Cx, OsType,LinuxWindowParams}, 
         os::cx_stdin::PollTimers,
@@ -344,6 +345,23 @@ impl Cx {
                     opengl_windows.iter_mut().for_each(|w| {
                         w.xlib_window.set_ime_spot(dvec2(0.0,0.0));
                     });
+                },
+                CxOsOp::CheckPermission {permission, request_id} => {
+                    // Linux desktop apps have all permissions granted by default (handled at system level)
+                    // TODO: Handle sandbox cases like flatpak
+                    self.call_event_handler(&Event::PermissionCheck(crate::permission::PermissionCheckEvent {
+                        permission,
+                        request_id,
+                        status: crate::permission::PermissionStatus::Granted,
+                    }));
+                },
+                CxOsOp::RequestPermission {permission, request_id} => {
+                    // Linux desktop apps have all permissions granted by default (handled at system level)
+                    // TODO: Handle sandbox cases like flatpak
+                    self.call_event_handler(&Event::PermissionGranted(crate::permission::PermissionResult {
+                        permission,
+                        request_id,
+                    }));
                 },
                 e=>{
                     crate::error!("Not implemented on this platform: CxOsOp::{:?}", e);

--- a/platform/src/os/web/from_wasm.rs
+++ b/platform/src/os/web/from_wasm.rs
@@ -178,6 +178,18 @@ pub struct FromWasmCancelHTTPRequest {
     pub request_id_hi: u32,
 }
 
+#[derive(FromWasm)]
+pub struct FromWasmCheckPermission {
+    pub permission: String,
+    pub request_id: u32,
+}
+
+#[derive(FromWasm)]
+pub struct FromWasmRequestPermission {
+    pub permission: String,
+    pub request_id: u32,
+}
+
 // WebGL API
 
 #[derive(FromWasm)]

--- a/platform/src/os/web/to_wasm.rs
+++ b/platform/src/os/web/to_wasm.rs
@@ -549,6 +549,13 @@ pub struct ToWasmHttpUploadProgress {
     pub loaded: u32,
     pub total: u32
 }
+
+#[derive(ToWasm)]
+pub struct ToWasmPermissionResult {
+    pub permission: String,
+    pub request_id: u32,
+    pub status: u32, // 0=NotDetermined, 1=Granted, 2=DeniedCanRetry, 3=DeniedPermanent
+}
 /*
 #[derive(ToWasm)]
 pub struct ToWasmWebSocketClose {

--- a/platform/src/os/web/web_audio.rs
+++ b/platform/src/os/web/web_audio.rs
@@ -137,7 +137,7 @@ pub unsafe extern "C" fn wasm_audio_output_entrypoint(context_ptr: u32, frames: 
     let mut output_fn = output_fn.lock().unwrap();
     
     if let Some(output_fn) = &mut *output_fn {
-        output_fn(AudioInfo {device_id, time: None}, &mut output_buffer);
+        output_fn(AudioInfo {device_id, time: None, sample_rate: 48000.0}, &mut output_buffer);
     }
     let ptr = output_buffer.data.as_ptr();
     

--- a/platform/src/os/windows/wasapi.rs
+++ b/platform/src/os/windows/wasapi.rs
@@ -151,7 +151,8 @@ impl WasapiAccess {
                             fbox(
                                 AudioInfo {
                                     device_id,
-                                    time: None
+                                    time: None,
+                                    sample_rate: 48000.0,
                                 },
                                 &buffer
                             );
@@ -210,6 +211,7 @@ impl WasapiAccess {
                                 AudioInfo {
                                     device_id,
                                     time: None,
+                                    sample_rate: 48000.0,
                                 },
                                 &mut buffer.audio_buffer
                             );

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -8,6 +8,7 @@ use {
         makepad_live_id::*,
         cx::*,
         event::*,
+        permission::{PermissionCheckEvent, PermissionResult, PermissionStatus},
         thread::SignalToUI,
         os::{
             windows::{
@@ -403,6 +404,21 @@ impl Cx {
                 CxOsOp::HideTextIME=>{
                                         
                 }
+                CxOsOp::CheckPermission {permission, request_id} => {
+                    // Windows desktop apps have all permissions granted by default
+                    self.call_event_handler(&Event::PermissionCheck(crate::permission::PermissionCheckEvent {
+                        permission,
+                        request_id,
+                        status: crate::permission::PermissionStatus::Granted,
+                    }));
+                },
+                CxOsOp::RequestPermission {permission, request_id} => {
+                    // Windows desktop apps have all permissions granted by default
+                    self.call_event_handler(&Event::PermissionGranted(crate::permission::PermissionResult {
+                        permission,
+                        request_id,
+                    }));
+                },
                 e=>{
                     crate::error!("Not implemented on this platform: CxOsOp::{:?}", e);
                 }

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -8,7 +8,7 @@ use {
         makepad_live_id::*,
         cx::*,
         event::*,
-        permission::{PermissionCheckEvent, PermissionResult, PermissionStatus},
+        permission::{PermissionResult, PermissionStatus},
         thread::SignalToUI,
         os::{
             windows::{
@@ -406,7 +406,7 @@ impl Cx {
                 }
                 CxOsOp::CheckPermission {permission, request_id} => {
                     // Windows desktop apps have all permissions granted by default
-                    self.call_event_handler(&Event::PermissionCheck(crate::permission::PermissionCheckEvent {
+                    self.call_event_handler(&Event::PermissionResult(crate::permission::PermissionResult {
                         permission,
                         request_id,
                         status: crate::permission::PermissionStatus::Granted,
@@ -414,9 +414,10 @@ impl Cx {
                 },
                 CxOsOp::RequestPermission {permission, request_id} => {
                     // Windows desktop apps have all permissions granted by default
-                    self.call_event_handler(&Event::PermissionGranted(crate::permission::PermissionResult {
+                    self.call_event_handler(&Event::PermissionResult(crate::permission::PermissionResult {
                         permission,
                         request_id,
+                        status: crate::permission::PermissionStatus::Granted,
                     }));
                 },
                 e=>{

--- a/platform/src/permission.rs
+++ b/platform/src/permission.rs
@@ -1,6 +1,9 @@
-
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Permission {
+    /// Permission to access the microphone for audio input.
+    /// 
+    /// Required on: iOS, Android, macOS, Web
+    /// Auto-granted on: Windows, Linux
     AudioInput,
     // Future permissions to be added here (Camera, Location, etc.)
 }
@@ -24,9 +27,9 @@ pub enum PermissionStatus {
     ///   e.g. "We need microphone access so you can record voice notes. Please allow access."
     /// - Modern Android (11+) automatically sets "don't ask again" after 2 denials
     /// 
-    /// **iOS/macOS behavior:**
+    /// **iOS/macOS and Web behavior:**
     /// - This status is not used on Apple platforms
-    /// - Apple platforms go directly from NotDetermined to DeniedPermanent
+    /// - These platforms go directly from NotDetermined to DeniedPermanent
     DeniedCanRetry,
     
     /// Permission was permanently denied and cannot be requested again.
@@ -40,6 +43,13 @@ pub enum PermissionStatus {
     /// **iOS/macOS behavior:**
     /// - User denied the permission once (Apple platforms don't re-prompt)
     /// - App should guide user to Settings > Privacy & Security > [Permission Type]
+    /// 
+    /// **Web behavior:**
+    /// - User denied the permission (browsers typically don't re-prompt)
+    /// - User must grant permission through browser settings (usually in URL bar)
+    /// 
+    /// **Desktop (Windows/Linux) behavior:**
+    /// - Not applicable - desktop apps typically have all permissions granted by default
     DeniedPermanent,
 }
 

--- a/platform/src/permission.rs
+++ b/platform/src/permission.rs
@@ -1,0 +1,51 @@
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Permission {
+    AudioInput,
+    // Future permissions to be added here (Camera, Location, etc.)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PermissionStatus {
+    /// Permission has been granted by the user.
+    /// The app can freely use the requested functionality.
+    Granted,
+    
+    /// Permission status has not been determined yet (first time asking).
+    /// This typically occurs before the user has been prompted for the permission.
+    /// The app should request the permission to show the system dialog.
+    NotDetermined,
+    
+    /// Permission was denied but can be requested again.
+    /// 
+    /// **Android behavior:**
+    /// - User denied the permission once but didn't trigger the "implicit don't ask again"
+    /// - The app can show a rationale explanation and request again, 
+    ///   e.g. "We need microphone access so you can record voice notes. Please allow access."
+    /// - Modern Android (11+) automatically sets "don't ask again" after 2 denials
+    /// 
+    /// **iOS/macOS behavior:**
+    /// - This status is not used on Apple platforms
+    /// - Apple platforms go directly from NotDetermined to DeniedPermanent
+    DeniedCanRetry,
+    
+    /// Permission was permanently denied and cannot be requested again.
+    /// The user must manually grant the permission in system settings.
+    /// 
+    /// **Android behavior:**
+    /// - User selected "Don't ask again" (older Android) or triggered implicit denial (Android 11+)
+    /// - After 2 denials on modern Android, the system stops showing permission dialogs
+    /// - App should guide user to Settings > Apps > [App Name] > Permissions
+    /// 
+    /// **iOS/macOS behavior:**
+    /// - User denied the permission once (Apple platforms don't re-prompt)
+    /// - App should guide user to Settings > Privacy & Security > [Permission Type]
+    DeniedPermanent,
+}
+
+#[derive(Debug, Clone)]
+pub struct PermissionResult {
+    pub permission: Permission,
+    pub request_id: i32,
+    pub status: PermissionStatus,
+}

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
@@ -40,6 +40,9 @@ public class MakepadNative {
 
     // midi
     public native static void onMidiDeviceOpened(String name, Object midi_device);
+    
+    // permissions
+    public native static void onPermissionResult(String permission, int requestId, int status);
 
     // video playback
     public static native void onVideoPlaybackPrepared(long videoId, int videoWidth, int videoHeight, long duration, VideoPlayer surfaceTexture);

--- a/tools/cargo_makepad/src/android/mod.rs
+++ b/tools/cargo_makepad/src/android/mod.rs
@@ -66,6 +66,8 @@ impl AndroidVariant {
                 <uses-permission android:name="android.permission.BLUETOOTH"/>
                 <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
                 <uses-permission android:name="android.permission.CAMERA"/>
+                <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+                <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
                 <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
                 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
                 <uses-permission android:name="android.permission.USE_BIOMETRIC" />
@@ -98,6 +100,8 @@ impl AndroidVariant {
                 <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
                 <uses-permission android:name="android.permission.INTERNET" />
                 <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+                <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+                <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
                 <uses-permission android:name="org.khronos.openxr.permission.OPENXR" />
                 <uses-permission android:name="org.khronos.openxr.permission.OPENXR_SYSTEM" />
                 <uses-permission android:name="com.oculus.permission.USE_ANCHOR_API" />

--- a/tools/cargo_makepad/src/apple/compile.rs
+++ b/tools/cargo_makepad/src/apple/compile.rs
@@ -279,6 +279,8 @@ impl PlistValues{
                 <false/>
                 <key>NSFaceIDUsageDescription</key>
                 <string>For biometric authentication</string>
+                <key>NSMicrophoneUsageDescription</key>
+                <string>This app needs access to the microphone for audio recording functionality.</string>
             </dict>
             </plist>"#,
             identifier = self.identifier,


### PR DESCRIPTION
Introduces cross-platform audio input permission handling and demonstrates its usage with a new audio example.

###  Changes
  - Permission system: Added `CheckPermission` and `RequestPermission` operations to CxOsOp, currently supports `Audio Input` permission (to be expaneded later with Camera, etc.).
  - Audio example project: New examples/audio demonstrating permission workflow with UI for device selection, microphone capture, and playback controls

#### Permissions

**Platform specifics:**
    - iOS/macOS: Uses AVAudioSession permission APIs
    - Android: Implements permission checks via JNI with updated manifest permissions
    - Linux/Windows: Added stub implementations. Linux and Windows don't have the same runtime per-app permission mechisms, and therefore default to granted permissons. This can later be expaneded to detect if the app is sandboxed through something like flatpak.

**Permissions API**

Permissions can now be requested through `cx` as follows:
```rust
cx.request_permission(Permission::AudioInput);
```
And the result of the request can be observed through `Event::PermissionResult`
```rust
  if let Event::PermissionResult(pr) = event {
      if pr.permission == Permission::AudioInput { // additionally you can check on the request id
          match pr.status {
              PermissionStatus::Granted => { /* initialize audio */ }
              PermissionStatus::DeniedPermanent => { 
                // warn the user that they need to provide permission in their system settings. App shouldn't request again.
              }
              PermissionStatus::DeniedCanRetry => {
                  // in Android, the app is able to re-request permission after the first deny, usually by showing the rationale
                  // macOS and iOS will always return DeniedPermanent, and modern Android will return DeniedPermanent
                  //  after the second deny. 
                  // We do this based on the permission status returned by the platform, preventing the app developer from
                 // thinking that they can re-request permissions, when the OS will likely not prompt the user at all.
              }
              _ => {}
          }
      }
  }
```
When requesting a permission, Makepad first checks the status to prevent re-requesting if the permission is already granted (and returns a granted result)

Both `CheckPermission` and `RequestPermission` result in the same event: `Event::PermissionResult`.

The complete documentation for the different permission statuses, and the platform-specific behavior can be found in: `platform/src/permission.rs`.
  
I tried to keep this implementation flexible but also simple for a first iteration, in the future we can add support for reporting the type of permission granted, e.g. there are permissions that are always on or allow things to happen in the background (instead of "only while in the app"), I didn't include this now since this is usually not available for audio input.
  
An example of this working in Moly in macOS:

https://github.com/user-attachments/assets/15c51137-53a3-4ffe-8e92-51c0ccddcbc8
  
#### Audio Example

The new audio example can be used as a reference of Makepad audio APIs, and permission handling. I've been using this mostly to test different speaker/mic devices.

https://github.com/user-attachments/assets/2f82b5e0-8449-4749-9e17-e4f07bcb3a62
