### PR TITLE
Fix Markdown and HTML ordered list numbering and alignment

### DIFF
--- a/widgets/src/markdown.rs
+++ b/widgets/src/markdown.rs
@@ -424,7 +424,7 @@ impl Markdown {
                     } else {
                         "•".to_string()
                     };
-                    tf.begin_list_item(cx, &marker, 1.5);
+                    tf.begin_list_item(cx, &marker, 2.5);
                 }
                 MdEvent::End(TagEnd::Item) => {
                     tf.end_list_item(cx);

--- a/widgets/src/markdown.rs
+++ b/widgets/src/markdown.rs
@@ -299,6 +299,14 @@ live_design!{
     
 } 
 
+/// The state of a list at a given nesting level.
+struct ListState {
+    // Current item number for ordered lists.
+    current_number: u64,         
+    // Start number for ordered lists, None for unordered.
+    start_number: Option<u64>,  
+}
+
 #[derive(Live, LiveHook, Widget)]
 pub struct Markdown{
     #[deref] text_flow: TextFlow,
@@ -341,7 +349,7 @@ impl Markdown {
     fn process_markdown_doc(&mut self, cx: &mut Cx2d) {
         let tf = &mut self.text_flow;
         // Track state for nested formatting
-        let mut list_stack = Vec::new();
+        let mut list_stack: Vec<ListState> = Vec::new();
         let mut is_first_block = true;
 
         let parser = Parser::new_ext(self.body.as_ref(), Options::ENABLE_TABLES);        
@@ -390,7 +398,10 @@ impl Markdown {
                     tf.end_quote(cx);
                 }
                 MdEvent::Start(Tag::List(first_number)) => {
-                    list_stack.push(first_number);
+                    list_stack.push(ListState {
+                        start_number: first_number,
+                        current_number: first_number.unwrap_or(1),
+                    });
                 }
                 MdEvent::End(TagEnd::List(_is_ordered)) => {
                     list_stack.pop();
@@ -400,8 +411,16 @@ impl Markdown {
                          cx.turtle_new_line();
                      }
                      is_first_block = false;
-                    let marker = if let Some(Some(n)) = list_stack.last() {
-                        format!("{}.", n)
+                    let marker = if let Some(state) = list_stack.last_mut() {
+                        if state.start_number.is_some() {
+                            // Ordered list - use and increment the counter
+                            let num = state.current_number;
+                            state.current_number += 1;
+                            format!("{}.", num)
+                        } else {
+                            // Unordered list - use bullet
+                            "•".to_string()
+                        }
                     } else {
                         "•".to_string()
                     };

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -504,32 +504,26 @@ impl TextFlow{
         self.draw_normal.text_style.font_size = *fs as _;
         let fc = self.font_colors.last().unwrap_or(&self.font_color);
         self.draw_normal.color = *fc;
-        let pad = self.draw_normal.text_style.font_size as f64 * pad;
-        // we should add the line spacing of the turlte
-        
+
+        // Use the provided padding to reserve space for the marker
+        let font_based_padding = self.draw_normal.text_style.font_size as f64 * pad;
+
         cx.begin_turtle(self.list_item_walk, Layout{
             padding:Padding{
-                left: self.list_item_layout.padding.left + pad,
+                left: self.list_item_layout.padding.left + font_based_padding,
                 ..self.list_item_layout.padding
             },
             ..self.list_item_layout
         });
-        // lets draw the 'marker' at -x 
-        // lets get the turtle position and abs draw 
-        
-        let marker_len = dot.chars().count();
-        let pos = match marker_len {
-            1 => {
-                cx.turtle().pos() - dvec2(pad, 0.0)
-            },
-            _ => {
-                // This calculation takes into account when numbers have more than one digit
-                // making sure they are properly aligned.
-                let pad = pad + self.draw_normal.text_style.font_size as f64 * (marker_len - 2) as f64;
-                cx.turtle().pos() - dvec2(pad, 0.0)
-            }
-        };
-        self.draw_normal.draw_abs(cx, pos, dot);
+
+        // Move turtle back to draw the marker
+        cx.turtle_mut().move_right_down(dvec2(-font_based_padding, 0.0));
+
+        // Draw the marker and space using the turtle system
+        self.draw_text(cx, dot);
+        self.draw_text(cx, " ");
+
+        // The turtle is now positioned after the marker+space, content will flow naturally
         
         self.area_stack.push(self.draw_block.draw_vars.area);
     }


### PR DESCRIPTION
### Context
This PR fixes two issues with ordered lists in the Markdown widget:

1. Repeating numbers: Ordered lists were displaying the same starting number for all items instead of incrementing, showing:
```
1.
1.
1.
```
instead of:
```
1.
2.
3.
```
2. Number alignment: once I fixed the repeating numbers I noticed that list numbers were aligned to the right
```
 7.
 8.
 9.
10.
```
rather than to the left:
```
7.
8.
9.
10.
```
they now properly left-align, ensuring the decimal points line up vertically across all items.

3. Number clipping and overlap: Multi-digit numbers were either getting cut off on the left side (HTML) or overlapping with content text (Markdown).

 ### Changes

#### Markdown Widget (markdown.rs)

- Added proper state tracking: Introduced ListState struct to maintain both starting number and current counter for ordered lists
- Fixed increment logic: Each ordered list item now correctly increments its number while preserving bullet points for unordered lists
  
#### TextFlow (textflow.rs)

**Fixed alignment calculation:**
The original implementation had broken alignment logic that caused visual issues:

1. Backwards math: The positioning calculation was inverted - longer numbers were pushed further left instead of being properly aligned
2. Inconsistent spacing: Different marker lengths resulted in different spacing between markers and content
3. Clipping issues: Multi-digit numbers could get cut off at container boundaries

The original logic:
```rust
  let pos = match marker_len {
      1 => cx.turtle().pos() - dvec2(pad, 0.0),
      _ => {
          // This pushed longer numbers MORE left (backwards)
          let pad = pad + font_size * (marker_len - 2);
          cx.turtle().pos() - dvec2(pad, 0.0)
      }
  };
  ```

**New approach:**

Replaced the manual positioning with natural turtle flow:
1. Reserve space: Set left padding for content position
2. Move turtle back: Use move_right_down() with negative offset to position at marker location
3. Draw naturally: Use draw_text() for both the marker and space, letting the turtle handle positioning
4. Content flows: Turtle is now positioned where content should start, ensuring consistent spacing

```rust
  cx.turtle_mut().move_right_down(dvec2(-font_based_padding, 0.0));
  self.draw_text(cx, dot);
  self.draw_text(cx, " ");
```