### PR TITLE
Add touch-based drag scrolling to ScrollBar

### DIFF
--- a/widgets/src/scroll_bar.rs
+++ b/widgets/src/scroll_bar.rs
@@ -185,6 +185,21 @@ pub enum ScrollAxis {
     #[pick] Horizontal,
     Vertical
 }
+
+/// A sample of a scroll event
+#[derive(Clone, Copy)]
+struct ScrollSample {
+    abs: f64,
+    time: f64,
+}
+
+/// The scrolling state
+enum ScrollState {
+    Stopped,
+    Drag { samples: Vec<ScrollSample> },
+    Flick { delta: f64, next_frame: NextFrame },
+}
+
 #[derive(Live, LiveHook, LiveRegister)]
 pub struct ScrollBar {
     #[live] draw_bg: DrawScrollBar,
@@ -195,7 +210,18 @@ pub struct ScrollBar {
     
     #[live] use_vertical_finger_scroll: bool,
     #[live] smoothing: Option<f64>,
-    
+
+    /// The minimum amount of scroll to trigger a flick animation
+    #[live(0.2)] flick_scroll_minimum: f64,
+    /// The maximum amount of scroll to trigger a flick animation
+    #[live(80.0)] flick_scroll_maximum: f64,
+    /// The scaling factor for the flick animation
+    #[live(0.005)] flick_scroll_scaling: f64,
+    /// The decay factor for the flick animation
+    #[live(0.97)] flick_scroll_decay: f64,
+    /// Whether to enable drag scrolling
+    #[live(true)] drag_scrolling: bool,
+
     #[animator] animator: Animator,
     
     #[rust] next_frame: NextFrame,
@@ -208,6 +234,7 @@ pub struct ScrollBar {
     #[rust] scroll_target: f64,
     #[rust] scroll_delta: f64,
     #[rust] drag_point: Option<f64>, // the point in pixels where we are dragging
+    #[rust(ScrollState::Stopped)] scroll_state: ScrollState,
 }
 
 #[derive(Live, LiveHook, LiveRegister)]
@@ -432,12 +459,101 @@ impl ScrollBar {
                 }
             }
         }
+
+        self.handle_touch_based_drag(cx, event, scroll_area, dispatch_action);
     }
+
     pub fn is_area_captured(&self, cx:&Cx)->bool{
         cx.fingers.is_area_captured(self.draw_bg.area())
     }
+
+    /// Handles touch-based drag scrolling
+    fn handle_touch_based_drag(&mut self, cx: &mut Cx, event: &Event, scroll_area: Area, dispatch_action: &mut dyn FnMut(&mut Cx, ScrollBarAction)) {
+        if !self.drag_scrolling {
+            return;
+        }
+
+        // Check if scroll bar handle is not captured
+        if self.is_area_captured(cx) {
+            self.scroll_state = ScrollState::Stopped;
+            return;
+        }
+
+        match event.hits(cx, scroll_area) {
+            Hit::FingerDown(fe) if fe.is_primary_hit() => {
+                let abs = match self.axis {
+                    ScrollAxis::Horizontal => fe.abs.x,
+                    ScrollAxis::Vertical => fe.abs.y
+                };
+                self.scroll_state = ScrollState::Drag {
+                    samples: vec![ScrollSample { abs, time: fe.time }]
+                };
+            }
+            Hit::FingerMove(e) => {
+                match &mut self.scroll_state {
+                    ScrollState::Drag { samples } => {
+                        let new_abs = match self.axis {
+                            ScrollAxis::Horizontal => e.abs.x,
+                            ScrollAxis::Vertical => e.abs.y
+                        };
+                        let old_sample = *samples.last().unwrap();
+                        samples.push(ScrollSample { abs: new_abs, time: e.time });
+                        if samples.len() > 4 {
+                            samples.remove(0);
+                        }
+
+                        let delta = new_abs - old_sample.abs;
+                        let scroll_pos = self.get_scroll_pos();
+
+                        if self.set_scroll_pos(cx, scroll_pos - delta) {
+                            dispatch_action(cx, self.make_scroll_action());
+                        }
+                    }
+                    _ => ()
+                }
+            }
+            Hit::FingerUp(fe) if fe.is_primary_hit() => {
+                match &mut self.scroll_state {
+                    ScrollState::Drag { samples } => {
+                        let mut last = None;
+                        let mut scaled_delta = 0.0;
+                        let mut total_delta = 0.0;
+
+                        for sample in samples.iter().rev() {
+                            if last.is_none() {
+                                last = Some(sample);
+                            } else {
+                                let time_delta = last.unwrap().time - sample.time;
+                                if time_delta > 0.0 {
+                                    let abs_delta = last.unwrap().abs - sample.abs;
+                                    total_delta += abs_delta;
+                                    scaled_delta += abs_delta / time_delta;
+                                }
+                            }
+                        }
+
+                        scaled_delta *= self.flick_scroll_scaling;
+
+                        if total_delta.abs() > 10.0 && scaled_delta.abs() > self.flick_scroll_minimum {
+                            let delta = scaled_delta.min(self.flick_scroll_maximum).max(-self.flick_scroll_maximum);
+                            self.scroll_state = ScrollState::Flick {
+                                delta,
+                                next_frame: cx.new_next_frame()
+                            };
+                        } else {
+                            self.scroll_state = ScrollState::Stopped;
+                        }
+                    }
+                    _ => ()
+                }
+            }
+            _ => ()
+        }
+    }
     
     pub fn handle_event_with(&mut self, cx: &mut Cx, event: &Event, dispatch_action: &mut dyn FnMut(&mut Cx, ScrollBarAction)) {
+        self.handle_flick(cx, event, dispatch_action);
+
         if self.visible {
             self.animator_handle_event(cx, event);
             if self.next_frame.is_event(event).is_some() {
@@ -508,6 +624,36 @@ impl ScrollBar {
                  },
                 _ => ()
             };
+        }
+    }
+
+    fn handle_flick(&mut self, cx: &mut Cx, event: &Event, dispatch_action: &mut dyn FnMut(&mut Cx, ScrollBarAction)) {
+        let flick_delta = if let ScrollState::Flick { delta, next_frame } = &self.scroll_state {
+            if next_frame.is_event(event).is_some() {
+                Some(*delta)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        if let Some(mut delta) = flick_delta {
+            delta = delta * self.flick_scroll_decay;
+
+            if delta.abs() > self.flick_scroll_minimum {
+                let scroll_pos = self.get_scroll_pos();
+                if self.set_scroll_pos(cx, scroll_pos - delta) {
+                    dispatch_action(cx, self.make_scroll_action());
+                }
+
+                self.scroll_state = ScrollState::Flick {
+                    delta,
+                    next_frame: cx.new_next_frame()
+                };
+            } else {
+                self.scroll_state = ScrollState::Stopped;
+            }
         }
     }
     

--- a/widgets/src/scroll_bars.rs
+++ b/widgets/src/scroll_bars.rs
@@ -26,15 +26,41 @@ live_design!{
     }
 }
 
+/// A sample of a scroll event
+#[derive(Clone, Copy)]
+struct ScrollSample {
+    abs: DVec2,
+    time: f64,
+}
+
+enum ScrollState {
+    Stopped,
+    Drag { samples: Vec<ScrollSample> },
+    Flick { delta: DVec2, next_frame: NextFrame },
+}
+
 #[derive(Live, LiveHook, LiveRegister)]
 pub struct ScrollBars {
     #[live] show_scroll_x: bool,
     #[live] show_scroll_y: bool,
     #[live] scroll_bar_x: ScrollBar,
     #[live] scroll_bar_y: ScrollBar,
+
+    /// The minimum amount of scroll to trigger a flick animation
+    #[live(0.2)] flick_scroll_minimum: f64,
+    /// The maximum amount of scroll to trigger a flick animation
+    #[live(80.0)] flick_scroll_maximum: f64,
+    /// The scaling factor for the flick animation
+    #[live(0.005)] flick_scroll_scaling: f64,
+    /// The decay factor for the flick animation
+    #[live(0.97)] flick_scroll_decay: f64,
+    /// Whether to enable drag scrolling
+    #[live(true)] drag_scrolling: bool,
+
     #[rust] nav_scroll_index: Option<NavScrollIndex>,
     #[rust] scroll: DVec2,
     #[rust] area: Area,
+    #[rust(ScrollState::Stopped)] scroll_state: ScrollState,
 }
 
 pub enum ScrollBarsAction {
@@ -65,6 +91,8 @@ impl ScrollBars {
     }
     
     pub fn handle_main_event(&mut self, cx: &mut Cx, event: &Event, _scope:&mut Scope, actions: &mut Vec<ScrollBarsAction> ) {
+        self.handle_flick(cx, event, actions);
+
         if let Event::Trigger(te) = event{
             if let Some(triggers) = te.triggers.get(&self.area){
                 if let Some(trigger) = triggers.iter().find(|t| t.id == live_id!(scroll_focus_nav)){
@@ -134,6 +162,163 @@ impl ScrollBars {
                 }
             });
             if let Some(y) = ret_y {self.scroll.y = y; self.redraw(cx);}
+        }
+
+        self.handle_touch_based_drag(cx, event, actions);
+    }
+
+    fn handle_flick(&mut self, cx: &mut Cx, event: &Event, actions: &mut Vec<ScrollBarsAction> ) {
+        let flick_delta = if let ScrollState::Flick { delta, next_frame } = &self.scroll_state {
+            if next_frame.is_event(event).is_some() {
+                Some(*delta)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        if let Some(mut delta) = flick_delta {
+            delta = delta * self.flick_scroll_decay;
+
+            let mut should_continue = false;
+            if self.show_scroll_x && delta.x.abs() > self.flick_scroll_minimum {
+                should_continue = true;
+            }
+            if self.show_scroll_y && delta.y.abs() > self.flick_scroll_minimum {
+                should_continue = true;
+            }
+
+            if should_continue {
+                let mut pos = self.scroll;
+                if self.show_scroll_x {
+                    pos.x -= delta.x;
+                }
+                if self.show_scroll_y {
+                    pos.y -= delta.y;
+                }
+
+                if self.set_scroll_pos(cx, pos) {
+                    if self.show_scroll_x && delta.x.abs() > 0.0 {
+                        actions.push(ScrollBarsAction::ScrollX(pos.x));
+                    }
+                    if self.show_scroll_y && delta.y.abs() > 0.0 {
+                        actions.push(ScrollBarsAction::ScrollY(pos.y));
+                    }
+                }
+
+                self.scroll_state = ScrollState::Flick {
+                    delta,
+                    next_frame: cx.new_next_frame()
+                };
+            } else {
+                self.scroll_state = ScrollState::Stopped;
+            }
+        }
+    }
+    
+    /// Handles touch-based drag scrolling
+    fn handle_touch_based_drag(&mut self, cx: &mut Cx, event: &Event, actions: &mut Vec<ScrollBarsAction> ) {
+        if !self.drag_scrolling {
+            return;
+        }
+
+        // Check if scroll bar handles are not captured
+        let scroll_bar_captured = self.scroll_bar_x.is_area_captured(cx)
+            || self.scroll_bar_y.is_area_captured(cx);
+
+        if scroll_bar_captured {
+            self.scroll_state = ScrollState::Stopped;
+            return;
+        }
+
+        match event.hits(cx, self.area) {
+            Hit::FingerDown(fe) if fe.is_primary_hit() => {
+                self.scroll_state = ScrollState::Drag {
+                    samples: vec![ScrollSample { abs: fe.abs, time: fe.time }]
+                };
+            }
+            Hit::FingerMove(e) => {
+                match &mut self.scroll_state {
+                    ScrollState::Drag { samples } => {
+                        let new_abs = e.abs;
+                        let old_sample = *samples.last().unwrap();
+                        samples.push(ScrollSample { abs: new_abs, time: e.time });
+                        if samples.len() > 4 {
+                            samples.remove(0);
+                        }
+
+                        let delta = new_abs - old_sample.abs;
+                        let mut pos = self.scroll;
+
+                        if self.show_scroll_x {
+                            pos.x -= delta.x;
+                        }
+                        if self.show_scroll_y {
+                            pos.y -= delta.y;
+                        }
+
+                        if self.set_scroll_pos(cx, pos) {
+                            if self.show_scroll_x && delta.x.abs() > 0.0 {
+                                actions.push(ScrollBarsAction::ScrollX(pos.x));
+                            }
+                            if self.show_scroll_y && delta.y.abs() > 0.0 {
+                                actions.push(ScrollBarsAction::ScrollY(pos.y));
+                            }
+                        }
+                    }
+                    _ => ()
+                }
+            }
+            Hit::FingerUp(fe) if fe.is_primary_hit() => {
+                match &mut self.scroll_state {
+                    ScrollState::Drag { samples } => {
+                        let mut last = None;
+                        let mut scaled_delta = DVec2::default();
+                        let mut total_delta = DVec2::default();
+
+                        for sample in samples.iter().rev() {
+                            if last.is_none() {
+                                last = Some(sample);
+                            } else {
+                                let time_delta = last.unwrap().time - sample.time;
+                                if time_delta > 0.0 {
+                                    let abs_delta = last.unwrap().abs - sample.abs;
+                                    total_delta += abs_delta;
+                                    scaled_delta += abs_delta / time_delta;
+                                }
+                            }
+                        }
+
+                        scaled_delta *= self.flick_scroll_scaling;
+
+                        // Check if we should start flick animation
+                        let mut should_flick = false;
+                        if self.show_scroll_x && total_delta.x.abs() > 10.0 && scaled_delta.x.abs() > self.flick_scroll_minimum {
+                            should_flick = true;
+                        }
+                        if self.show_scroll_y && total_delta.y.abs() > 10.0 && scaled_delta.y.abs() > self.flick_scroll_minimum {
+                            should_flick = true;
+                        }
+
+                        if should_flick {
+                            // Clamp the delta to maximum values
+                            let delta = DVec2 {
+                                x: scaled_delta.x.min(self.flick_scroll_maximum).max(-self.flick_scroll_maximum),
+                                y: scaled_delta.y.min(self.flick_scroll_maximum).max(-self.flick_scroll_maximum),
+                            };
+                            self.scroll_state = ScrollState::Flick {
+                                delta,
+                                next_frame: cx.new_next_frame()
+                            };
+                        } else {
+                            self.scroll_state = ScrollState::Stopped;
+                        }
+                    }
+                    _ => ()
+                }
+            }
+            _ => ()
         }
     }
     


### PR DESCRIPTION
### Add touch-based drag scrolling to ScrollBar

Implements touch, drag and flick scrolling for `ScrollBar`, enabling mobile-friendly scrolling for all scrollable views (ScrollXView, ScrollYView, etc.).

**Implementation** (mostly copied from `PortalList`):
- Touch event handling in ScrollBar::handle_scroll_event() tracks finger position and velocity
- Momentum-based flick scrolling with configurable decay animation
- Same configuration fields `PortalList`: `flick_scroll_minimum`, `flick_scroll_maximum`, `flick_scroll_scaling`, `flick_scroll_decay`, `drag_scrolling`

**Notes:**
- Implemented in `ScrollBar` (individual axis) rather than `ScrollBars` (both axes wrapper)
  - Each axis handles touch independently, extracting X or Y from 2D touch input
  - Any widget using ScrollBar directly gets touch scrolling
- Does not interfere with existing functionality:
  - Scroll bar handle dragging still works
  - Mouse wheel scrolling unchanged
  - PortalList unaffected (uses different event handler)
  
Parameters defaults match `PortalList` to keep the feel consistent across widgets (since we don't override these in most use cases).