### PR TITLE
Enhance touch handling by using touch radius across platforms

### DIFF
--- a/platform/src/os/apple/ios/ios_app.rs
+++ b/platform/src/os/apple/ios/ios_app.rs
@@ -262,9 +262,15 @@ impl IosApp {
     }
     
     pub fn update_touch(&mut self, uid: u64, abs: DVec2, state: TouchState) {
+        self.update_touch_with_details(uid, abs, state, dvec2(0.0, 0.0), 0.0);
+    }
+
+    pub fn update_touch_with_details(&mut self, uid: u64, abs: DVec2, state: TouchState, radius: DVec2, force: f64) {
         if let Some(touch) = self.touches.iter_mut().find( | v | v.uid == uid) {
             touch.state = state;
             touch.abs = abs;
+            touch.radius = radius;
+            touch.force = force;
         }
         else {
             self.touches.push(TouchPoint {
@@ -273,8 +279,8 @@ impl IosApp {
                 uid,
                 time: self.time_now(),
                 rotation_angle: 0.0,
-                force: 0.0,
-                radius: dvec2(0.0, 0.0),
+                force,
+                radius,
                 handled: Cell::new(Area::Empty),
                 sweep_lock: Cell::new(Area::Empty)
             })

--- a/platform/src/os/apple/ios/ios_delegates.rs
+++ b/platform/src/os/apple/ios/ios_delegates.rs
@@ -60,7 +60,19 @@ pub fn define_mtk_view() -> *const Class {
                     touch_id as u64
                 };
                 let p: NSPoint = msg_send![ios_touch, locationInView: this];
-                with_ios_app(|app| app.update_touch(uid, dvec2(p.x, p.y), state));
+
+                // Get touch radius and force from UITouch
+                // majorRadius is in points, representing the radius of the touch area
+                let major_radius: f64 = msg_send![ios_touch, majorRadius];
+                let force: f64 = msg_send![ios_touch, force];
+
+                with_ios_app(|app| app.update_touch_with_details(
+                    uid,
+                    dvec2(p.x, p.y),
+                    state,
+                    dvec2(major_radius, major_radius),
+                    force
+                ));
             }
         }
     }

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -437,6 +437,12 @@ pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_surfaceOnTouch(
         let rotation_angle = unsafe {ndk_utils::call_float_method!(env, event, "getOrientation", "(I)F", touch_index)} as f64;
         let force = unsafe {ndk_utils::call_float_method!(env, event, "getPressure", "(I)F", touch_index)} as f64;
 
+        // Get actual touch size from Android (returns diameter in pixels)
+        let touch_major = unsafe {ndk_utils::call_float_method!(env, event, "getTouchMajor", "(I)F", touch_index)} as f64;
+        let touch_minor = unsafe {ndk_utils::call_float_method!(env, event, "getTouchMinor", "(I)F", touch_index)} as f64;
+        // Convert diameter to radius
+        let radius = dvec2(touch_major / 2.0, touch_minor / 2.0);
+
         touches.push(TouchPoint {
             state: {
                 if action_index == touch_index {
@@ -454,7 +460,7 @@ pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_surfaceOnTouch(
             uid: id as u64,
             rotation_angle,
             force,
-            radius: dvec2(1.0, 1.0),
+            radius,
             handled: Cell::new(Area::Empty),
             sweep_lock: Cell::new(Area::Empty),
             abs: dvec2(x as f64, y as f64),


### PR DESCRIPTION
Improves touch accuracy by accounting for the physical size of finger contact on touchscreens. Previously, touch input was treated as an infinitely small point (hardcoded to 0.0 in iOS and 1.0 on Android); now the actual contact area (radius) is used for hit testing.

### Changes

- iOS: Retrieves majorRadius and force from UITouch API
- Android: Extracts touchMajor/touchMinor (diameter) and converts to radius
- Hit Testing: Expands hit area margins by touch radius, making small UI elements easier to tap
- Finger Up Events: Checks if touch is still over elements accounting for finger size

### Technical Details

Touch Radius: The physical size of the finger's contact area on screen. Modern touch APIs report this as a radius in X/Y directions (typically 8-12mm for fingers).

Touch Force: Pressure measurement from 3D Touch/Haptic Touch (iOS) and pressure sensors (Android).

Impact
- Small buttons/targets: Edges of buttons are now easier to hit
- Large fingers: Proper hit detection for users with larger finger contact areas
- Precision interactions: Finger-up "is_over" detection is now radius-aware

I notice this makes a big difference in my iPhone 13 mini. I thought it was a problem with DPI scaling at first but using the proper radius made touching much more reliable.

### Testing

Tested on iOS and Android, both example-simple and Moly.

#### Testing on my iPhone 13 mini 
This is not the most objective of tests but it now works more reliably without me having to aim more precisely at buttons. I can also tap on buttons in Moly much more closely to how I use other apps.

**Before using proper radius**

https://github.com/user-attachments/assets/4c12cd82-42c1-4460-b21b-1c263fc454db

**After using proper radius**

https://github.com/user-attachments/assets/a84681cf-8f5f-4617-8a76-ea6ff6bd02d3
