### PR TITLE
Add focus loss detection to TextInput, for keyboard dismissal

### DIFF
--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -14,6 +14,7 @@ use {
                     SelectionRect,
                 },
             },
+            event::finger::TouchState,
             *
         },
         widget::*,
@@ -1041,6 +1042,14 @@ impl TextInput {
         self.history.force_new_edit_group();
     }
 
+    fn handle_focus_lost(&mut self, cx: &mut Cx, scope_path: &HeapLiveIdPath, uid: WidgetUid) {
+        self.animator_play(cx, id!(focus.off));
+        self.animator_play(cx, id!(blink.on));
+        cx.stop_timer(self.blink_timer);
+        cx.hide_text_ime();
+        cx.widget_action(uid, scope_path, TextInputAction::KeyFocusLost);
+    }
+
     fn ceil_word_boundary(&self, index: usize) -> usize {
         let mut prev_word_boundary_index = 0;
         for (word_boundary_index, _) in self.text.split_word_bound_indices() {
@@ -1202,6 +1211,33 @@ impl Widget for TextInput {
         }
 
         let uid = self.widget_uid();
+
+        // Self-detect focus loss from taps outside our area
+        if cx.has_key_focus(self.draw_bg.area()) {
+            let rect = self.draw_bg.area().rect(cx);
+            let should_lose_focus = match event {
+                // Handle desktop mouse clicks
+                Event::MouseUp(mu) => {
+                    !rect.contains(mu.abs)
+                }
+                // Handle mobile touch events
+                Event::TouchUpdate(tu) => {
+                    // Check if any touch ended outside our area
+                    tu.touches.iter().any(|touch| {
+                        matches!(touch.state, TouchState::Stop) && !rect.contains(touch.abs)
+                    })
+                }
+                _ => false
+            };
+
+            if should_lose_focus {
+                // Update focus state in cx
+                cx.set_key_focus(Area::Empty);
+                // Handle focus loss locally
+                self.handle_focus_lost(cx, &scope.path, uid);
+            }
+        }
+
         match event.hits(cx, self.draw_bg.area()) {
             Hit::FingerHoverIn(_) => {
                 self.animator_play(cx, id!(hover.on));
@@ -1215,11 +1251,7 @@ impl Widget for TextInput {
                 cx.widget_action(uid, &scope.path, TextInputAction::KeyFocus);
             },
             Hit::KeyFocusLost(_) => {
-                self.animator_play(cx, id!(focus.off));
-                self.animator_play(cx, id!(blink.on));
-                cx.stop_timer(self.blink_timer);
-                cx.hide_text_ime();
-                cx.widget_action(uid, &scope.path, TextInputAction::KeyFocusLost);
+                self.handle_focus_lost(cx, &scope.path, uid);
             }
             Hit::KeyDown(kev @ KeyEvent {
                 key_code: KeyCode::ArrowLeft,


### PR DESCRIPTION
## Problem
On mobile, tapping outside a focused TextInput wouldn't dismiss the keyboard unless the tapped widget explicitly grabbed key focus.

## Solution
`TextInput` now **proactively detects** when it should lose focus by listening for tap events outside its area, rather than passively waiting for other widgets to grab focus.

### Changes
- **Self-detection**: Check events for taps outside TextInput bounds
- **Non-consuming**: Events continue propagating to underlying widgets after keyboard dismissal
- **Helper method**: Extract `handle_focus_lost()` to avoid duplicating focus-lost logic
- **Backward compatible**: Maintains existing `KeyFocusLost` handling for programmatic focus changes
 