### PR TITLE
Allow set_texture to rotated image widget

### DIFF
--- a/widgets/src/rotated_image.rs
+++ b/widgets/src/rotated_image.rs
@@ -156,3 +156,14 @@ impl RotatedImage {
         DrawStep::done()
     }
 }
+
+impl RotatedImageRef {
+    pub fn set_texture(&self, cx:&mut Cx, texture: Option<Texture>) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.texture = texture;
+            if cx.in_draw_event(){
+                inner.redraw(cx);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added set_texture function to rotated image widget.
Currently the rotated image widget's image can only be set using source. 