### PR TITLE
Enable drag scrolling by default in Scroll*Views

### DIFF
--- a/widgets/src/view_ui.rs
+++ b/widgets/src/view_ui.rs
@@ -837,18 +837,46 @@ live_design! {
     }
     
     pub CachedScrollXY = <CachedView> {
-        scroll_bars: <ScrollBars> {show_scroll_x: true, show_scroll_y: true}
+        scroll_bars: <ScrollBars> {
+            show_scroll_x: true, show_scroll_y: true
+            scroll_bar_x: {drag_scrolling: true}
+            scroll_bar_y: {drag_scrolling: true}
+        }
     }
         
     pub CachedScrollX = <CachedView> {
-        scroll_bars: <ScrollBars> {show_scroll_x: true, show_scroll_y: false}
+        scroll_bars: <ScrollBars> {
+            show_scroll_x: true, show_scroll_y: false
+            scroll_bar_x: {drag_scrolling: true}
+        }
     }
         
     pub CachedScrollY = <CachedView> {
-        scroll_bars: <ScrollBars> {show_scroll_x: false, show_scroll_y: true}
+        scroll_bars: <ScrollBars> {
+            show_scroll_x: false, show_scroll_y: true
+            scroll_bar_y: {drag_scrolling: true}
+        }
     }
         
-    pub ScrollXYView = <ViewBase> {scroll_bars: <ScrollBars> {show_scroll_x: true, show_scroll_y: true}}
-    pub ScrollXView = <ViewBase> {scroll_bars: <ScrollBars> {show_scroll_x: true, show_scroll_y: false}}
-    pub ScrollYView = <ViewBase> {scroll_bars: <ScrollBars> {show_scroll_x: false, show_scroll_y: true}}
+    pub ScrollXYView = <ViewBase> {
+        scroll_bars: <ScrollBars> {
+            show_scroll_x: true, show_scroll_y: true
+            scroll_bar_x: {drag_scrolling: true}
+            scroll_bar_y: {drag_scrolling: true}
+        }
+    }
+
+    pub ScrollXView = <ViewBase> {
+        scroll_bars: <ScrollBars> {
+            show_scroll_x: true, show_scroll_y: false
+            scroll_bar_x: {drag_scrolling: true}
+        }   
+    }
+
+    pub ScrollYView = <ViewBase> {
+        scroll_bars: <ScrollBars> {
+            show_scroll_x: false, show_scroll_y: true,
+            scroll_bar_y: {drag_scrolling: true}
+        }
+    }
 }


### PR DESCRIPTION
Enables drag (touch) scrolling by default for Scroll*Views, while still disabling by default at the `ScrollBar` level.

This is necessary because some of the Studio widgets have conflicting event handling (or at least different than `View` that causes touch scrolling detection to cause missing clicks on child widgets. I think this happens due to event order:

**View (used by ScrollXView)** works:
```rust
fn handle_event() {
    // 1: Handle scrollbar widget itself (dragging the handle)
    scroll_bars.handle_main_event(cx, event, scope, &mut actions);

    // 2: LET CHILDREN PROCESS EVENTS FIRST
    for child in children {
        child.handle_event(cx, event, scope);
    }

    // 3: Handle scroll events and touch drag
    scroll_bars.handle_scroll_event(cx, event, scope, &mut Vec::new());
    //                 ↑ This calls handle_touch_based_drag()
}
```

**FileTree/TabBar** break:
```rust
fn handle_event() {
    // ALL SCROLLBAR EVENTS PROCESSED FIRST (including touch drag)
    self.scroll_bars.handle_event(cx, event, scope);
    //   ↑ This calls BOTH handle_main_event() AND handle_scroll_event()
    //     which means handle_touch_based_drag() runs NOW

    // Children get events AFTER scrollbar already captured them
    for node in tree_nodes {
        node.handle_event(cx, event, node_id, scope, &mut node_actions);
    }
}
```

**Why This Breaks**

When `drag_scrolling: true` and `FileTree` calls scroll_bars.handle_event():
1. FingerDown hits the scroll area
2. handle_touch_based_drag() enters Drag state immediately
3. FingerMove gets processed by scrollbar, starts scrolling
4. File nodes/tabs never see the FingerDown/FingerMove events they need to detect clicks or start their own drag operations

The `is_area_captured()` guard (scroll_bar.rs) doesn't help because it checks if children already captured the area, but children haven't run yet.

By enabling drag_scrolling: true only in ScrollXView/ScrollYView definitions apps using ScrollXView get touch scrolling automatically, and FileTree/TabBar with their conflicting event order stay safe with `drag_scrolling: false`

--- 

For a more proper fix I'm not sure if we should refactor the event handling in the Studio widgets, or the scrollbar implementation itself to prevent the capturing.