### PR TITLE
Fix ident comparison in expect_specific_ident

### DIFF
--- a/platform/shader_compiler/src/shader_parser.rs
+++ b/platform/shader_compiler/src/shader_parser.rs
@@ -182,7 +182,7 @@ impl<'a> ShaderParser<'a> {
     #[inline]
     fn expect_specific_ident(&mut self, specific_id: LiveId) -> Result<(), LiveError> {
         match self.peek_token() {
-            LiveToken::Ident(id) if id == id => {
+            LiveToken::Ident(id) if id == specific_id => {
                 self.skip_token();
                 Ok(())
             }


### PR DESCRIPTION
Corrects the comparison in expect_specific_ident to use the specific_id parameter instead of comparing id to itself, ensuring proper token matching.