### PR TITLE
Improve horizontal scroll handling in scroll bar

### DIFF
--- a/widgets/src/scroll_bar.rs
+++ b/widgets/src/scroll_bar.rs
@@ -432,7 +432,17 @@ impl ScrollBar {
                     ScrollAxis::Vertical => e.handled_y.get()
                 } {
                     let scroll = match self.axis {
-                        ScrollAxis::Horizontal => if self.use_vertical_finger_scroll {e.scroll.y}else {e.scroll.x},
+                        ScrollAxis::Horizontal => {
+                            // Prioritize horizontal scroll (trackpad horizontal swipe) when available
+                            if e.scroll.x != 0.0 {
+                                e.scroll.x
+                            } else if self.use_vertical_finger_scroll {
+                                // Fall back to vertical scroll for horizontal scrolling if enabled
+                                e.scroll.y
+                            } else {
+                                e.scroll.x
+                            }
+                        },
                         ScrollAxis::Vertical => e.scroll.y
                     };
                     if !self.smoothing.is_none() && e.is_mouse {


### PR DESCRIPTION

I tried to run UI_ZOO example and on the header scrollbar i tried to swipe from my trackpad. It didnt worked. So just a quick fix.

- Horizontal scroll now prioritizes trackpad horizontal swipe (e.scroll.x) and falls back to vertical scroll (e.scroll.y) only if use_vertical_finger_scroll is enabled. This provides more intuitive scrolling behavior for users.