### PR TITLE
Fix window-level focus issues

### DIFF
--- a/draw/src/match_event.rs
+++ b/draw/src/match_event.rs
@@ -8,8 +8,8 @@ pub trait MatchEvent{
     fn handle_background(&mut self, _cx: &mut Cx){}
     fn handle_pause(&mut self, _cx: &mut Cx){}
     fn handle_resume(&mut self, _cx: &mut Cx){}
-    fn handle_app_got_focus(&mut self, _cx: &mut Cx){}
-    fn handle_app_lost_focus(&mut self, _cx: &mut Cx){}
+    fn handle_app_got_focus(&mut self, _cx: &mut Cx, _window_id: &WindowId){}
+    fn handle_app_lost_focus(&mut self, _cx: &mut Cx, _window_id: &WindowId){}
     fn handle_next_frame(&mut self, _cx: &mut Cx, _e:&NextFrameEvent){}
     fn handle_action(&mut self, _cx: &mut Cx, _e:&Action){}
     fn handle_actions(&mut self, cx: &mut Cx, actions:&Actions){
@@ -73,9 +73,9 @@ pub trait MatchEvent{
             Event::Pause=>self.handle_pause(cx),
             Event::Resume=>self.handle_resume(cx),
             Event::Signal=>self.handle_signal(cx),
-            Event::AppGotFocus=>self.handle_app_got_focus(cx),
+            Event::AppGotFocus(window_id)=>self.handle_app_got_focus(cx, window_id),
             Event::Timer(te)=>self.handle_timer(cx, te),
-            Event::AppLostFocus=>self.handle_app_lost_focus(cx),
+            Event::AppLostFocus(window_id)=>self.handle_app_lost_focus(cx, window_id),
             Event::NextFrame(e)=>self.handle_next_frame(cx, e),
             Event::Actions(e)=>self.handle_actions(cx,e),
             Event::Draw(e)=>self.handle_draw(cx, e),

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -610,6 +610,10 @@ impl Cx {
         self.keyboard.set_key_focus(focus_area);
     }
 
+    pub fn key_focus(&self) -> Area {
+        self.keyboard.key_focus()
+    }
+
     pub fn revert_key_focus(&mut self) {
         self.keyboard.revert_key_focus();
     }

--- a/platform/src/event/event.rs
+++ b/platform/src/event/event.rs
@@ -9,6 +9,7 @@ use {
         makepad_live_id::LiveId,
         cx::Cx,
         area::Area,
+        window::WindowId,
         //midi::{Midi1InputData, MidiInputInfo},
         event::{
             finger::*,
@@ -128,9 +129,9 @@ pub enum Event {
     Draw(DrawEvent),
     LiveEdit,
     /// The application has gained focus and is now the active window receiving user input.
-    AppGotFocus,
+    AppGotFocus(WindowId),
     /// The application has lost focus and is no longer the active window receiving user input.
-    AppLostFocus,
+    AppLostFocus(WindowId),
     NextFrame(NextFrameEvent),
     XrUpdate(XrUpdateEvent),
     XrLocal(XrLocalEvent),
@@ -321,8 +322,8 @@ impl Event{
 
             Self::Draw(_)=>7,
             Self::LiveEdit=>8,
-            Self::AppGotFocus=>9,
-            Self::AppLostFocus=>10,
+            Self::AppGotFocus(_)=>9,
+            Self::AppLostFocus(_)=>10,
             Self::NextFrame(_)=>11,
             Self::XrUpdate(_)=>12,
 

--- a/platform/src/event/keyboard.rs
+++ b/platform/src/event/keyboard.rs
@@ -40,6 +40,10 @@ impl CxKeyboard {
         self.next_key_focus = focus_area;
     }
 
+    pub fn key_focus(&self) -> Area {
+        self.key_focus
+    }
+
     pub fn revert_key_focus(&mut self) {
         self.next_key_focus = self.prev_key_focus;
     }

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -184,12 +184,12 @@ impl Cx {
                 self.call_event_handler(&Event::Startup);
                 self.redraw_all();
             }
-            IosEvent::AppGotFocus => { // repaint all window passes. Metal sometimes doesnt flip buffers when hidden/no focus
+            IosEvent::AppGotFocus(window_id) => { // repaint all window passes. Metal sometimes doesnt flip buffers when hidden/no focus
                 paint_dirty = true;
-                self.call_event_handler(&Event::AppGotFocus);
+                self.call_event_handler(&Event::AppGotFocus(window_id));
             }
-            IosEvent::AppLostFocus => {
-                self.call_event_handler(&Event::AppLostFocus);
+            IosEvent::AppLostFocus(window_id) => {
+                self.call_event_handler(&Event::AppLostFocus(window_id));
             }
             IosEvent::WindowGeomChange(re) => { // do this here because mac
                 let window_id = CxWindowPool::id_zero();

--- a/platform/src/os/apple/ios/ios_event.rs
+++ b/platform/src/os/apple/ios/ios_event.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        window::WindowId,
         event::{
             MouseDownEvent,
             MouseUpEvent,
@@ -21,8 +22,8 @@ use {
 #[derive(Debug, Clone)]
 pub enum IosEvent {
     Init,
-    AppGotFocus,
-    AppLostFocus,
+    AppGotFocus(WindowId),
+    AppLostFocus(WindowId),
     WindowGeomChange(WindowGeomChangeEvent),
     Paint,
     VirtualKeyboard(VirtualKeyboardEvent),

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -283,16 +283,16 @@ impl Cx {
         }
         //self.process_desktop_pre_event(&mut event);
         match event {
-            MacosEvent::AppGotFocus => { // repaint all window passes. Metal sometimes doesnt flip buffers when hidden/no focus
+            MacosEvent::AppGotFocus(window_id) => { // repaint all window passes. Metal sometimes doesnt flip buffers when hidden/no focus
                 for window in metal_windows.iter_mut() {
                     if let Some(main_pass_id) = self.windows[window.window_id].main_pass_id {
                         self.repaint_pass(main_pass_id);
                     }
                 }
-                self.call_event_handler(&Event::AppGotFocus);
+                self.call_event_handler(&Event::AppGotFocus(window_id));
             }
-            MacosEvent::AppLostFocus => {
-                self.call_event_handler(&Event::AppLostFocus);
+            MacosEvent::AppLostFocus(window_id) => {
+                self.call_event_handler(&Event::AppLostFocus(window_id));
             }
             MacosEvent::WindowResizeLoopStart(window_id) => {
                 if let Some(window) = metal_windows.iter_mut().find( | w | w.window_id == window_id) {
@@ -542,7 +542,6 @@ impl Cx {
                     with_macos_app(|app| app.set_mouse_cursor(cursor));
                 },
                 CxOsOp::StartTimer {timer_id, interval, repeats} => {
-                    println!("START TIMER {} {}", timer_id, repeats);
                     with_macos_app(|app| app.start_timer(timer_id, interval, repeats));
                 },
                 CxOsOp::StopTimer(timer_id) => {

--- a/platform/src/os/apple/macos/macos_event.rs
+++ b/platform/src/os/apple/macos/macos_event.rs
@@ -6,8 +6,8 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub enum MacosEvent {
-    AppGotFocus,
-    AppLostFocus,
+    AppGotFocus(WindowId),
+    AppLostFocus(WindowId),
     WindowResizeLoopStart(WindowId),
     WindowResizeLoopStop(WindowId),
     WindowGeomChange(WindowGeomChangeEvent),

--- a/platform/src/os/apple/macos/macos_window.rs
+++ b/platform/src/os/apple/macos/macos_window.rs
@@ -323,11 +323,11 @@ impl MacosWindow {
     }
     
     pub fn send_got_focus_event(&mut self) {
-        self.do_callback(MacosEvent::AppGotFocus);
+        self.do_callback(MacosEvent::AppGotFocus(self.window_id));
     }
     
     pub fn send_lost_focus_event(&mut self) {
-        self.do_callback(MacosEvent::AppLostFocus);
+        self.do_callback(MacosEvent::AppLostFocus(self.window_id));
     }
     
     pub fn mouse_down_can_drag_window(&mut self) -> bool {

--- a/platform/src/os/apple/tvos/tvos.rs
+++ b/platform/src/os/apple/tvos/tvos.rs
@@ -146,12 +146,12 @@ impl Cx {
                 self.call_event_handler(&Event::Startup);
                 self.redraw_all();
             }
-            TvosEvent::AppGotFocus => { // repaint all window passes. Metal sometimes doesnt flip buffers when hidden/no focus
+            TvosEvent::AppGotFocus(window_id) => { // repaint all window passes. Metal sometimes doesnt flip buffers when hidden/no focus
                 paint_dirty = true;
-                self.call_event_handler(&Event::AppGotFocus);
+                self.call_event_handler(&Event::AppGotFocus(window_id));
             }
-            TvosEvent::AppLostFocus => {
-                self.call_event_handler(&Event::AppLostFocus);
+            TvosEvent::AppLostFocus(window_id) => {
+                self.call_event_handler(&Event::AppLostFocus(window_id));
             } 
             TvosEvent::WindowGeomChange(re) => { // do this here because mac
                 let window_id = CxWindowPool::id_zero();

--- a/platform/src/os/apple/tvos/tvos_event.rs
+++ b/platform/src/os/apple/tvos/tvos_event.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        window::WindowId,
         event::{
             WindowGeomChangeEvent,
             TimerEvent,
@@ -10,8 +11,8 @@ use {
 #[derive(Debug, Clone)]
 pub enum TvosEvent {
     Init,
-    AppGotFocus,
-    AppLostFocus,
+    AppGotFocus(WindowId),
+    AppLostFocus(WindowId),
     WindowGeomChange(WindowGeomChangeEvent),
     Paint,
     Timer(TimerEvent),

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -494,10 +494,11 @@ impl Cx {
                 self.os.ignore_destroy = false;
             }
             FromJavaMessage::WindowFocusChanged { has_focus } => {
+                let window_id = CxWindowPool::id_zero();
                 if has_focus {
-                    self.call_event_handler(&Event::AppGotFocus);
+                    self.call_event_handler(&Event::AppGotFocus(window_id));
                 } else {
-                    self.call_event_handler(&Event::AppLostFocus);
+                    self.call_event_handler(&Event::AppLostFocus(window_id));
                 }
             }
             FromJavaMessage::Init(_) => {

--- a/platform/src/os/linux/wayland/linux_wayland.rs
+++ b/platform/src/os/linux/wayland/linux_wayland.rs
@@ -89,7 +89,7 @@ impl WaylandCx {
             }
         }
         match event {
-            XlibEvent::AppGotFocus => { // repaint all window passes. Metal sometimes doesnt flip buffers when hidden/no focus
+            XlibEvent::AppGotFocus(window_id) => { // repaint all window passes. Metal sometimes doesnt flip buffers when hidden/no focus
                 let mut cx = self.cx.borrow_mut();
                 for window in state.windows.iter_mut() {
                     if let Some(main_pass_id) = cx.windows[window.window_id].main_pass_id {
@@ -97,11 +97,11 @@ impl WaylandCx {
                     }
                 }
                 //paint_dirty = true;
-                cx.call_event_handler(&Event::AppGotFocus);
+                cx.call_event_handler(&Event::AppGotFocus(window_id));
             }
-            XlibEvent::AppLostFocus => {
+            XlibEvent::AppLostFocus(window_id) => {
                 let mut cx = self.cx.borrow_mut();
-                cx.call_event_handler(&Event::AppLostFocus);
+                cx.call_event_handler(&Event::AppLostFocus(window_id));
             }
             XlibEvent::WindowGeomChange(mut re) => { // do this here because mac
                 let mut cx = self.cx.borrow_mut();

--- a/platform/src/os/linux/wayland/wayland_state.rs
+++ b/platform/src/os/linux/wayland/wayland_state.rs
@@ -378,11 +378,15 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandState {
                         state.current_window = window_id;
                     }
                 });
-                state.do_callback(XlibEvent::AppGotFocus);
+                if let Some(window_id) = window_id {
+                    state.do_callback(XlibEvent::AppGotFocus(window_id));
+                }
             },
             wl_pointer::Event::Leave { serial, surface: _ } => {
                 state.pointer_serial = Some(serial);
-                state.do_callback(XlibEvent::AppLostFocus);
+                if let Some(window_id) = state.current_window {
+                    state.do_callback(XlibEvent::AppLostFocus(window_id));
+                }
             },
             wl_pointer::Event::Motion { time, surface_x, surface_y } => {
                 if let Some(window_id) = state.current_window {

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -94,7 +94,7 @@ impl X11Cx {
 
         //self.process_desktop_pre_event(&mut event);
        match event {
-            XlibEvent::AppGotFocus => { // repaint all window passes. Metal sometimes doesnt flip buffers when hidden/no focus
+            XlibEvent::AppGotFocus(window_id) => { // repaint all window passes. Metal sometimes doesnt flip buffers when hidden/no focus
                 let mut cx = self.cx.borrow_mut();
                 for window in opengl_windows.iter_mut() {
                     if let Some(main_pass_id) = cx.windows[window.window_id].main_pass_id {
@@ -102,11 +102,11 @@ impl X11Cx {
                     }
                 }
                 //paint_dirty = true;
-                cx.call_event_handler(&Event::AppGotFocus);
+                cx.call_event_handler(&Event::AppGotFocus(window_id));
             }
-            XlibEvent::AppLostFocus => {
+            XlibEvent::AppLostFocus(window_id) => {
                 let mut cx = self.cx.borrow_mut();
-                cx.call_event_handler(&Event::AppLostFocus);
+                cx.call_event_handler(&Event::AppLostFocus(window_id));
             }
             XlibEvent::WindowGeomChange(mut re) => { // do this here because mac
                 let mut cx = self.cx.borrow_mut();

--- a/platform/src/os/linux/x11/xlib_event.rs
+++ b/platform/src/os/linux/x11/xlib_event.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        window::WindowId,
         event::{
             MouseDownEvent,
             MouseUpEvent,
@@ -21,8 +22,8 @@ use {
 
 #[derive(Debug)]
 pub enum XlibEvent {
-    AppGotFocus,
-    AppLostFocus,
+    AppGotFocus(WindowId),
+    AppLostFocus(WindowId),
     WindowGeomChange(WindowGeomChangeEvent),
     WindowClosed(WindowClosedEvent),
     Paint,

--- a/platform/src/os/linux/x11/xlib_window.rs
+++ b/platform/src/os/linux/x11/xlib_window.rs
@@ -472,11 +472,11 @@ impl XlibWindow {
     }
     
     pub fn send_focus_event(&mut self) {
-        self.do_callback(XlibEvent::AppGotFocus);
+        self.do_callback(XlibEvent::AppGotFocus(self.window_id));
     }
     
     pub fn send_focus_lost_event(&mut self) {
-        self.do_callback(XlibEvent::AppLostFocus);
+        self.do_callback(XlibEvent::AppLostFocus(self.window_id));
     }
     
     pub fn send_mouse_down(&mut self, button: MouseButton, modifiers: KeyModifiers) {

--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -204,11 +204,13 @@ impl Cx {
                 }
                 
                 live_id!(ToWasmAppGotFocus) => {
-                    self.call_event_handler(&Event::AppGotFocus);
+                    let window_id = CxWindowPool::id_zero();
+                    self.call_event_handler(&Event::AppGotFocus(window_id));
                 }
                 
                 live_id!(ToWasmAppLostFocus) => {
-                    self.call_event_handler(&Event::AppLostFocus);
+                    let window_id = CxWindowPool::id_zero();
+                    self.call_event_handler(&Event::AppLostFocus(window_id));
                 }
                 
                 live_id!(ToWasmRedrawAll) => {

--- a/platform/src/os/windows/win32_event.rs
+++ b/platform/src/os/windows/win32_event.rs
@@ -23,8 +23,8 @@ use {
 
 #[derive(Debug)]
 pub enum Win32Event {
-    AppGotFocus,
-    AppLostFocus,
+    AppGotFocus(WindowId),
+    AppLostFocus(WindowId),
     WindowResizeLoopStart(WindowId),
     WindowResizeLoopStop(WindowId),
     WindowGeomChange(WindowGeomChangeEvent),

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -395,10 +395,10 @@ impl Win32Window {
         match msg {
             WM_ACTIVATE => {
                 if wparam.0 & 0xffff == WA_ACTIVE as usize {
-                    window.do_callback(Win32Event::AppGotFocus);
+                    window.do_callback(Win32Event::AppGotFocus(window.window_id));
                 }
                 else {
-                    window.do_callback(Win32Event::AppLostFocus);
+                    window.do_callback(Win32Event::AppLostFocus(window.window_id));
                 }
             },
             WM_NCCALCSIZE => {
@@ -1012,11 +1012,11 @@ impl Win32Window {
     }
     
     pub fn send_focus_event(&mut self) {
-        self.do_callback(Win32Event::AppGotFocus);
+        self.do_callback(Win32Event::AppGotFocus(self.window_id));
     }
     
     pub fn send_focus_lost_event(&mut self) {
-        self.do_callback(Win32Event::AppLostFocus);
+        self.do_callback(Win32Event::AppLostFocus(self.window_id));
     }
     
     pub fn send_mouse_down(&mut self, button: MouseButton, modifiers: KeyModifiers) {

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -88,17 +88,17 @@ impl Cx {
 
         //self.process_desktop_pre_event(&mut event);
         match event {
-            Win32Event::AppGotFocus => { // repaint all window passes. Metal sometimes doesnt flip buffers when hidden/no focus
+            Win32Event::AppGotFocus(window_id) => { // repaint all window passes. Metal sometimes doesnt flip buffers when hidden/no focus
                 for window in d3d11_windows.iter_mut() {
                     if let Some(main_pass_id) = self.windows[window.window_id].main_pass_id {
                         self.repaint_pass(main_pass_id);
                     }
                 }
                 //paint_dirty = true;
-                self.call_event_handler(&Event::AppGotFocus);
+                self.call_event_handler(&Event::AppGotFocus(window_id));
             }
-            Win32Event::AppLostFocus => {
-                self.call_event_handler(&Event::AppLostFocus);
+            Win32Event::AppLostFocus(window_id) => {
+                self.call_event_handler(&Event::AppLostFocus(window_id));
             }
             Win32Event::WindowResizeLoopStart(window_id) => {
                 if let Some(window) = d3d11_windows.iter_mut().find( | w | w.window_id == window_id) {

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -115,6 +115,7 @@ pub struct Window {
     #[live] nav_control: NavControl,
     #[live] window: WindowHandle,
     #[live] stdin_size: DrawColor,
+    #[rust] last_known_area: Area,
     #[rust(Overlay::new(cx))] overlay: Overlay,
     #[rust(DrawList2d::new(cx))] main_draw_list: DrawList2d,
     #[live] pass: Pass,
@@ -426,6 +427,21 @@ impl Widget for Window {
             Event::MouseMove(ev) => ev.window_id != self.window.window_id(),
             Event::MouseUp(ev) => ev.window_id != self.window.window_id(),
             Event::Scroll(ev) => ev.window_id != self.window.window_id(),
+            Event::AppGotFocus(window_id) => {
+                if *window_id == self.window.window_id() {
+                    cx.set_key_focus(self.last_known_area);
+                }
+
+                *window_id != self.window.window_id()
+            }
+            Event::AppLostFocus(window_id) => {
+                if *window_id == self.window.window_id() {
+                    self.last_known_area = cx.key_focus();
+                    cx.set_key_focus(Area::Empty);
+                }
+
+                *window_id != self.window.window_id()
+            }
             _ => false
         };
         


### PR DESCRIPTION
## Before

- On any Makepad desktop app, when the app's window is not focused, widgets still hold focus. This is not how other apps behave and logic depending on the current focus status may misbehave.
    - Also, related to this, if you left a text input focused and you leave the window, it will still consume CPU/GPU every time the cursor blinks. The text input already stops the timer when unfocused, but since the window focus lost is not reflected in the keyboard area focus, this happens. And it may happen in other widgets with similar behavior.
- On a multi window, Mac OS, Makepad app, since the content of a window is not clicked immediately when click you the other window, keyboard focus is still retained by the previous window. This means you can have the second window focused, but keyboard events will be sent to the previous window.


https://github.com/user-attachments/assets/040631d6-7185-46e1-a055-f7218384c050



## After

Issues mentioned before are solved. Windows keep track of their own focus, suspending it and restoring it when appropriate.


https://github.com/user-attachments/assets/d9b1fdc2-fc07-496e-a2e8-a6a0a84a851c



## Changes

- Forwarded `WindowId` from specific platform APIs down to `handle_event` through the `AppGotFocus` and `AppLostFocus`.
    - Note: On platforms that don't support multiple windows, `CxWindowPool::id_zero()` is reported following the pattern seen in other parts of the codebase.
- Expose the current area through a `cx.key_focus()` method.
- At the `Window` widget, the new exposed information (area and window id) are handled to make proper backups of the area to suspend and resume the focus when necessary.

## Manual tests

- Mac OS 🟢 Run natively
- WASM 🟢 Run natively
- Android 🟡 Run on simulator (1)
- iOS 🟡 Run on simulator (1)
- Windows 🟠 Cross-compiled but not run.
- tvOS 🔴 Not tested
- Linux 🔴 Not tested

> (1) On the mobile simulators, I could not focus text inputs but it's not related to this PR. I experience this on`dev` Makepad as well and it may be related to the virtual keyboard pop up. 