### PR TITLE
Fix modal; enable widgets to block scrolling except within a certain area

### DIFF
--- a/libs/math/src/math_f64.rs
+++ b/libs/math/src/math_f64.rs
@@ -52,15 +52,11 @@ impl Rect {
         }
     }
     
-    pub fn inside(&self, r:Rect) -> bool    {
-        if self.pos.x >= r.pos.x && 
-            self.pos.y >= r.pos.y && 
-            self.pos.x + self.size.x <= r.pos.x + r.size.x && 
-            self.pos.y + self.size.y <= r.pos.y + r.size.y
-        {
-            return true;
-        }
-        return false;
+    pub fn is_inside_of(&self, r:Rect) -> bool {
+        self.pos.x >= r.pos.x
+            && self.pos.y >= r.pos.y
+            && self.pos.x + self.size.x <= r.pos.x + r.size.x
+            && self.pos.y + self.size.y <= r.pos.y + r.size.y
     }
     
     pub fn intersects(&self, r: Rect) -> bool {

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -362,6 +362,29 @@ impl Cx {
         self.fingers.sweep_unlock(value);
     }
 
+    /// Returns whether scrolling is currently allowed within the given `area`.
+    pub fn is_scrolling_allowed_within(&mut self, area: &Area) -> bool {
+        let Some(scrollable_area) = self.fingers.blocked_scrolling_exception_area() else { return true };
+        area.rect(self).is_inside_of(scrollable_area.rect(self))
+    }
+
+    /// Blocks scrolling events/hits in the app *EXCEPT* for within the given `scrollable_area`.
+    ///
+    /// ***NOTE***: this must be re-invoked every time the area changes, which is upon every draw pass.
+    ///
+    /// If you want to block scrolling everywhere, pass in `Area::Empty`.
+    pub fn block_scrolling_except_within(&mut self, scrollable_area: Area) {
+        self.fingers.block_scrolling_within_area(Some(scrollable_area));
+    }
+
+    /// Fully unblocks scrolling, allowing scrolling to occur anywhere across the entire app.
+    ///
+    /// This effectively restores the default behavior, e.g., after a previous call to
+    /// [`Cx::block_scrolling_except_within()`].
+    pub fn unblock_scrolling(&mut self) {
+        self.fingers.block_scrolling_within_area(None);
+    }
+
     pub fn start_timeout(&mut self, delay: f64) -> Timer {
         self.timer_id += 1;
         self.platform_ops.push(CxOsOp::StartTimer {

--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -365,6 +365,9 @@ pub struct CxFingers {
     tap: CxDigitTap,
     hovers: Vec<CxDigitHover>,
     sweep_lock: Option<Area>,
+    /// * If `Some`, scrolling is currently blocked *except* within the contained area.
+    /// * If `None`, scrolling is not blocked anywhere.
+    block_scrolling_except_within: Option<Area>,
 }
 
 impl CxFingers {
@@ -585,6 +588,17 @@ impl CxFingers {
         if self.sweep_lock == Some(area) {
             self.sweep_lock = None;
         }
+    }
+
+    /// Returns the excepted area in which scrolling is currently allowed.
+    /// * If `Some`, scrolling is currently blocked *except* within the contained area.
+    /// * If `None`, scrolling is not blocked anywhere.
+    pub fn blocked_scrolling_exception_area(&self) -> Option<Area> {
+        self.block_scrolling_except_within
+    }
+
+    pub fn block_scrolling_within_area(&mut self, area: Option<Area>) {
+        self.block_scrolling_except_within = area;
     }
     
 }
@@ -917,8 +931,10 @@ impl Event {
             },
             Event::Scroll(e) => {
                 if cx.fingers.test_sweep_lock(options.sweep_area) {
-                    // log!("Skipping Scroll sweep_area: {:?}", options.sweep_area);
                     return Hit::Nothing
+                }
+                if !cx.is_scrolling_allowed_within(&area) {
+                    return Hit::Nothing;
                 }
                 let digit_id = live_id!(mouse).into();
                 
@@ -941,7 +957,6 @@ impl Event {
             },
             Event::TouchUpdate(e) => {
                 if cx.fingers.test_sweep_lock(options.sweep_area) {
-                    // log!("Skipping TouchUpdate, sweep_area: {:?}", options.sweep_area);
                     return Hit::Nothing
                 }
                 for t in &e.touches {
@@ -1122,7 +1137,6 @@ impl Event {
             }
             Event::MouseMove(e) => { // ok so we dont get hovers
                 if cx.fingers.test_sweep_lock(options.sweep_area) {
-                    // log!("Skipping MouseMove, sweep_area: {:?}", options.sweep_area);
                     return Hit::Nothing
                 }
                 
@@ -1275,7 +1289,6 @@ impl Event {
                 }
                 
                 if cx.fingers.test_sweep_lock(options.sweep_area) {
-                    // log!("Skipping MouseDown, sweep_area: {:?}", options.sweep_area);
                     return Hit::Nothing
                 }
                 
@@ -1314,7 +1327,6 @@ impl Event {
             },
             Event::MouseUp(e) => {
                 if cx.fingers.test_sweep_lock(options.sweep_area) {
-                    // log!("Skipping MouseUp, sweep_area: {:?}", options.sweep_area);
                     return Hit::Nothing
                 }
                 
@@ -1355,7 +1367,6 @@ impl Event {
             },
             Event::MouseLeave(e) => {
                 if cx.fingers.test_sweep_lock(options.sweep_area) {
-                    // log!("Skipping MouseLeave, sweep_area: {:?}", options.sweep_area);
                     return Hit::Nothing;
                 }
                 let device = DigitDevice::Mouse { button: MouseButton::empty() };
@@ -1379,7 +1390,6 @@ impl Event {
             },
             Event::LongPress(e) => {
                 if cx.fingers.test_sweep_lock(options.sweep_area) {
-                    log!("Skipping LongPress Hit, sweep_area: {:?}", options.sweep_area);
                     return Hit::Nothing
                 }
 

--- a/widgets/src/modal.rs
+++ b/widgets/src/modal.rs
@@ -40,6 +40,7 @@ live_design!{
         content: <View> {
             width: Fit
             height: Fit
+            flow: Down
         }
     }
 }
@@ -62,6 +63,10 @@ pub struct Modal {
     #[walk] walk: Walk,
 
     #[rust] is_open: bool,
+    /// Whether the modal can be dismissed via an external interaction, including:
+    /// clicking outside the content view, pressing Escape, or performing
+    /// the back navigational gesture (e.g., on Android).
+    #[live(true)] can_dismiss: bool,
 }
 
 impl LiveHook for Modal {
@@ -78,49 +83,59 @@ impl Widget for Modal {
 
         // Forward the event to the inner `content` view.
         self.content.handle_event(cx, event, scope);
-        
+
         // Proactively consume any hit that occurred in the bg area, which prevents the hit
         // from being handled by any views underneath this modal.
         let bg_area = self.draw_bg.area();
         let bg_area_hit = event.hits(cx, bg_area);
-        let content_area_hit = event.hits(cx, self.content.area()); // we already let `content` handle this event above
 
-        // Close the modal if any of the following conditions occur:
-        // * If the back navigational action/gesture was triggered (e.g., on Android),
-        // * If the Escape key was pressed while either the `bg_view` or `content` has key focus,
-        // * If there was a click/press in the background area, outside of the inner `content` view.
-        let should_close = event.back_pressed()
-            || match bg_area_hit {
-                Hit::KeyDown(KeyEvent { key_code: KeyCode::Escape, .. }) => true,
-                Hit::FingerUp(fe) => !self.content.area().rect(cx).contains(fe.abs),
-                _ => false,
+        if self.can_dismiss {
+            // This is fine, because we already let `content` handle this event above.
+            let content_area_hit = event.hits(cx, self.content.area());
+
+            // Close the modal if any of the following conditions occur:
+            // * If the back navigational action/gesture was triggered (e.g., on Android),
+            // * If the Escape key was pressed while either the `bg_view` or `content` has key focus,
+            // * If there was a click/press in the background area, outside of the inner `content` view.
+            let should_close = 
+                event.back_pressed()
+                || match bg_area_hit {
+                    Hit::KeyDown(KeyEvent { key_code: KeyCode::Escape, .. }) => true,
+                    Hit::FingerUp(fe) => !self.content.area().rect(cx).contains(fe.abs),
+                    _ => false,
+                }
+                || match content_area_hit {
+                    Hit::KeyDown(KeyEvent { key_code: KeyCode::Escape, .. }) => true,
+                    _ => false,
+                };
+            if should_close {
+                cx.widget_action(self.content.widget_uid(), &scope.path, ModalAction::Dismissed);
+                self.close(cx);
             }
-            || match content_area_hit {
-                Hit::KeyDown(KeyEvent { key_code: KeyCode::Escape, .. }) => true,
-                _ => false,
-            };
-        if should_close {
-            cx.widget_action(self.content.widget_uid(), &scope.path, ModalAction::Dismissed);
-            self.close(cx);
         }
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         self.draw_list.begin_overlay_reuse(cx);
-
-        cx.begin_turtle(walk, self.layout);
+        cx.begin_root_turtle_for_pass(self.layout);
         self.draw_bg.begin(cx, self.walk, self.layout);
 
         if self.is_open {
             let _ = self
                 .bg_view
-                .draw_walk(cx, scope, walk);
+                .draw_walk(cx, scope, walk.with_abs_pos(DVec2 { x: 0., y: 0. }));
             let _ = self.content.draw_all(cx, scope);
         }
 
         self.draw_bg.end(cx);
-        cx.end_turtle();
+        cx.end_pass_sized_turtle();
         self.draw_list.end(cx);
+
+        // After drawing the modal content, its area may have changed,
+        // so we need to update that area as a scrolling-allowed area bound.
+        if self.is_open {
+            cx.block_scrolling_except_within(self.content.area());
+        }
         DrawStep::done()
     }
 }
@@ -129,6 +144,7 @@ impl Modal {
     pub fn open(&mut self, cx: &mut Cx) {
         self.is_open = true;
         self.draw_bg.redraw(cx);
+        cx.set_key_focus(self.content.area());
     }
 
     pub fn close(&mut self, cx: &mut Cx) {
@@ -140,6 +156,8 @@ impl Modal {
         );
         self.is_open = false;
         self.draw_bg.redraw(cx);
+        cx.revert_key_focus();
+        cx.unblock_scrolling();
     }
 
     pub fn dismissed(&self, actions: &Actions) -> bool {

--- a/widgets/src/modal.rs
+++ b/widgets/src/modal.rs
@@ -30,14 +30,14 @@ live_design!{
             height: Fill
             show_bg: true
             draw_bg: {
+                color: #000000B3
                 fn pixel(self) -> vec4 {
-                    return vec4(0., 0., 0., 0.7)
+                    return self.color
                 }
             }
         }
         
         content: <View> {
-            flow: Overlay
             width: Fit
             height: Fit
         }
@@ -46,31 +46,22 @@ live_design!{
 
 #[derive(Clone, Debug, DefaultNone)]
 pub enum ModalAction {
-    None,
     Dismissed,
+    None,
 }
 
 #[derive(Live, Widget)]
 pub struct Modal {
-    #[live]
-    #[find]
-    content: View,
-    #[live] #[area]
-    bg_view: View,
+    #[live] #[find] content: View,
+    #[live] #[area] bg_view: View,
 
-    #[redraw]
-    #[rust(DrawList2d::new(cx))]
-    draw_list: DrawList2d,
+    #[redraw] #[rust(DrawList2d::new(cx))] draw_list: DrawList2d,
 
-    #[live]
-    draw_bg: DrawQuad,
-    #[layout]
-    layout: Layout,
-    #[walk]
-    walk: Walk,
+    #[live] draw_bg: DrawQuad,
+    #[layout] layout: Layout,
+    #[walk] walk: Walk,
 
-    #[rust]
-    opened: bool,
+    #[rust] is_open: bool,
 }
 
 impl LiveHook for Modal {
@@ -81,36 +72,35 @@ impl LiveHook for Modal {
 
 impl Widget for Modal {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        if !self.opened {
+        if !self.is_open {
             return;
         }
 
-        let area = self.draw_bg.area();
-
-        // When passing down events to the inner `content` view,
-        // we must temporarily suspend the sweep lock to allow the overlaid `content` View
-        // to correctly respond to events/hits.
-        cx.sweep_unlock(area);
+        // Forward the event to the inner `content` view.
         self.content.handle_event(cx, event, scope);
-        cx.sweep_lock(area);
-
-        // Consume any hit that occurred in the bg area, which prevents the hit
+        
+        // Proactively consume any hit that occurred in the bg area, which prevents the hit
         // from being handled by any views underneath this modal.
-        let consumed_hit = event.hits_with_sweep_area(cx, area, area);
+        let bg_area = self.draw_bg.area();
+        let bg_area_hit = event.hits(cx, bg_area);
+        let content_area_hit = event.hits(cx, self.content.area()); // we already let `content` handle this event above
 
         // Close the modal if any of the following conditions occur:
-        // * If the back navigational action/gesture was triggered (e.g., on Android)
-        // * If the Escape key was pressed
-        // * If there was a click/press in the background area, outside of the inner `content` view
+        // * If the back navigational action/gesture was triggered (e.g., on Android),
+        // * If the Escape key was pressed while either the `bg_view` or `content` has key focus,
+        // * If there was a click/press in the background area, outside of the inner `content` view.
         let should_close = event.back_pressed()
-            || matches!(event, Event::KeyUp(KeyEvent { key_code: KeyCode::Escape, .. }))
-            || match consumed_hit {
+            || match bg_area_hit {
+                Hit::KeyDown(KeyEvent { key_code: KeyCode::Escape, .. }) => true,
                 Hit::FingerUp(fe) => !self.content.area().rect(cx).contains(fe.abs),
+                _ => false,
+            }
+            || match content_area_hit {
+                Hit::KeyDown(KeyEvent { key_code: KeyCode::Escape, .. }) => true,
                 _ => false,
             };
         if should_close {
-            let widget_uid = self.content.widget_uid();
-            cx.widget_action(widget_uid, &scope.path, ModalAction::Dismissed);
+            cx.widget_action(self.content.widget_uid(), &scope.path, ModalAction::Dismissed);
             self.close(cx);
         }
     }
@@ -121,7 +111,7 @@ impl Widget for Modal {
         cx.begin_turtle(walk, self.layout);
         self.draw_bg.begin(cx, self.walk, self.layout);
 
-        if self.opened {
+        if self.is_open {
             let _ = self
                 .bg_view
                 .draw_walk(cx, scope, walk);
@@ -137,9 +127,8 @@ impl Widget for Modal {
 
 impl Modal {
     pub fn open(&mut self, cx: &mut Cx) {
-        self.opened = true;
+        self.is_open = true;
         self.draw_bg.redraw(cx);
-        cx.sweep_lock(self.draw_bg.area());
     }
 
     pub fn close(&mut self, cx: &mut Cx) {
@@ -149,9 +138,8 @@ impl Modal {
             &Event::Actions(vec![Box::new(ModalAction::Dismissed)]),
             &mut Scope::empty(),
         );
-        self.opened = false;
+        self.is_open = false;
         self.draw_bg.redraw(cx);
-        cx.sweep_unlock(self.draw_bg.area());
     }
 
     pub fn dismissed(&self, actions: &Actions) -> bool {
@@ -163,26 +151,32 @@ impl Modal {
 }
 
 impl ModalRef {
+    /// Returns whether the modal is currently open (displayed).
     pub fn is_open(&self) -> bool {
         if let Some(inner) = self.borrow() {
-            inner.opened
+            inner.is_open
         } else {
             false
         }
     }
 
+    /// Opens (displays) the model.
+    #[doc(alias = "show")]
     pub fn open(&self, cx: &mut Cx) {
         if let Some(mut inner) = self.borrow_mut() {
             inner.open(cx);
         }
     }
 
+    /// Closes (hides) the modal.
+    #[doc(alias = "hide")]
     pub fn close(&self, cx: &mut Cx) {
         if let Some(mut inner) = self.borrow_mut() {
             inner.close(cx);
         }
     }
 
+    /// Returns `true` if this modal was dismissed by the given `actions`.
     pub fn dismissed(&self, actions: &Actions) -> bool {
         if let Some(inner) = self.borrow() {
             inner.dismissed(actions)

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -918,7 +918,6 @@ impl Widget for PortalList {
         if !self.scroll_bar.is_area_captured(cx) || is_scroll{ 
             match event.hits_with_capture_overload(cx, self.area, self.capture_overload) {
                 Hit::FingerScroll(e) => {
-                    log!("PORTALLIST GOT FINGERSCROLL EVENT");
                     self.tail_range = false;
                     self.detect_tail_in_draw = true;
                     self.was_scrolling = false;

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -918,6 +918,7 @@ impl Widget for PortalList {
         if !self.scroll_bar.is_area_captured(cx) || is_scroll{ 
             match event.hits_with_capture_overload(cx, self.area, self.capture_overload) {
                 Hit::FingerScroll(e) => {
+                    log!("PORTALLIST GOT FINGERSCROLL EVENT");
                     self.tail_range = false;
                     self.detect_tail_in_draw = true;
                     self.was_scrolling = false;

--- a/widgets/src/scroll_bar.rs
+++ b/widgets/src/scroll_bar.rs
@@ -426,7 +426,7 @@ impl ScrollBar {
     
     pub fn handle_scroll_event(&mut self, cx: &mut Cx, event: &Event, scroll_area: Area, dispatch_action: &mut dyn FnMut(&mut Cx, ScrollBarAction)) {
         if let Event::Scroll(e) = event {
-            if scroll_area.rect(cx).contains(e.abs) {
+            if cx.is_scrolling_allowed_within(&scroll_area) && scroll_area.rect(cx).contains(e.abs) {
                 if !match self.axis {
                     ScrollAxis::Horizontal => e.handled_x.get(),
                     ScrollAxis::Vertical => e.handled_y.get()


### PR DESCRIPTION
* This is important for Modals to prevent scrolling of background widgets whilst still allowing the inner `content` view to be scrolled.
* Modals are now forcibly full-screen (or rather, full-window)  in order to properly ensure that scrolling-allowed areas always stay relevant, as the Modal can no longer be contained within a non-full-window parent widget/view.
* Modals can now optionally allow dismissal upon user interactions beyond whatever buttons are inside of the modal's inner content:
    1. If the back navigational action/gesture was triggered (e.g., on Android),
    2. If the <kbd>Esc</kbd> key was pressed while either the `bg_view` or `content` has key focus,
    3. If there was a click/tap in the background area, outside of the inner `content` view.