### PR TITLE
Ensure that LongPress (LongClick) on Android properly tracks touch movement

### DIFF
--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -162,8 +162,6 @@ class MakepadSurface
 
         // If the touch has moved more than the touch slop, ignore this long click.
         if (isTouchBeyondSlopDistance(view)) {
-            // Log.d("Makepad", "onLongClick returning false due to slop movement");
-
             // Returning false here indicates that we have not handled the long click event,
             // which does *not* trigger the haptic feedback (vibration motor) to buzz.
             return false;

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -70,14 +70,14 @@ class MakepadSurface
 {
 
     // The X,Y coordinates and pointer ID of the most recent ACTION_DOWN touch.
-    private float latestDownTouchX;
-    private float latestDownTouchY;
-    private int latestDownTouchPointerId;
+    private float latestDownTouchX = Float.NaN;
+    private float latestDownTouchY = Float.NaN;
+    private int latestDownTouchPointerId = -1;
 
     // The X,Y coordinates and pointer ID of the most recent non-ACTION_DOWN touch event.
-    private float latestTouchX;
-    private float latestTouchY;
-    private int latestTouchPointerId;
+    private float latestTouchX = Float.NaN;
+    private float latestTouchY = Float.NaN;
+    private int latestTouchPointerId = -1;
 
 
     public MakepadSurface(Context context){
@@ -136,7 +136,10 @@ class MakepadSurface
             latestDownTouchX = event.getX(index);
             latestDownTouchY = event.getY(index);
             latestDownTouchPointerId = pointerId;
-            latestTouchPointerId = -1; // invalidate the previous latestTouchX/Y values.
+            // Re-set the latestTouchX/Y values on each down-touch.
+            latestTouchX = latestDownTouchX;
+            latestTouchY = latestDownTouchY;
+            latestTouchPointerId = -1;
         }
         else if (actionMasked == MotionEvent.ACTION_MOVE) {
             latestTouchX = event.getX(index);
@@ -159,6 +162,8 @@ class MakepadSurface
 
         // If the touch has moved more than the touch slop, ignore this long click.
         if (isTouchBeyondSlopDistance(view)) {
+            // Log.d("Makepad", "onLongClick returning false due to slop movement");
+
             // Returning false here indicates that we have not handled the long click event,
             // which does *not* trigger the haptic feedback (vibration motor) to buzz.
             return false;
@@ -238,10 +243,6 @@ class MakepadSurface
                 MakepadNative.surfaceOnCharacter(character);
             }
         }
-
-        // if ((keyCode == KeyEvent.KEYCODE_BACK)) {
-        //     Log.d("Makepad", "KEYCODE_BACK");
-        // }
 
         if ((keyCode == KeyEvent.KEYCODE_VOLUME_UP) || (keyCode == KeyEvent.KEYCODE_VOLUME_DOWN)) {
             return super.onKeyUp(keyCode, event);


### PR DESCRIPTION
Previously, we assumed that multiple touch action events would occur before a LongClick, but that is not necessarily true. It is possible to just have one down touch immediately followed by a LongClick, so we now account for that.

This also fixes the tracking of touch event locations such that stale values aren't accidentally used when calculating if a finger movement exceeded the allowable touch slop for considering a touch as a long press. (Rust would've caught that... thanks Java)