### PR TITLE
Android: Implement ShowClipboardActions with native ActionMode

### DIFF
--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -90,6 +90,7 @@ pub struct Cx {
     pub keyboard: CxKeyboard,
     pub fingers: CxFingers,
     pub (crate) ime_area: Area,
+    pub keyboard_shift: f64,
     pub (crate) drag_drop: CxDragDrop,
     
     pub (crate) platform_ops: Vec<CxOsOp>,
@@ -323,6 +324,7 @@ impl Cx {
             fingers: Default::default(),
             drag_drop: Default::default(),
             ime_area: Default::default(),
+            keyboard_shift: 0.0,
             platform_ops: Default::default(),
             studio_web_socket: None,
             studio_http: "".to_string(),

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -85,7 +85,8 @@ pub enum CxOsOp {
 
     StartDragging(Vec<DragItem>),
     UpdateMacosMenu(MacosMenu),
-    ShowClipboardActions(String),
+    ShowClipboardActions { has_selection: bool, rect: Rect, keyboard_shift: f64 },
+    HideClipboardActions,
     CopyToClipboard(String),
 
     CheckPermission {
@@ -164,7 +165,8 @@ impl std::fmt::Debug for CxOsOp {
 
             Self::StartDragging(..)=>write!(f, "StartDragging"),
             Self::UpdateMacosMenu(..)=>write!(f, "UpdateMacosMenu"),
-            Self::ShowClipboardActions(..)=>write!(f, "ShowClipboardActions"),
+            Self::ShowClipboardActions { .. }=>write!(f, "ShowClipboardActions"),
+            Self::HideClipboardActions=>write!(f, "HideClipboardActions"),
             Self::CopyToClipboard(..)=>write!(f, "CopyToClipboard"),
 
             Self::CheckPermission{..}=>write!(f, "CheckPermission"),
@@ -321,9 +323,36 @@ impl Cx {
         self.platform_ops.push(CxOsOp::HideTextIME);
     }
 
-    pub fn show_clipboard_actions(&mut self, selected: String) {
+    /// Shows the native clipboard actions menu (Copy/Paste/Cut/Select All).
+    ///
+    /// Displays a platform-specific floating menu with text editing actions. The menu items
+    /// are enabled/disabled based on the current selection state:
+    /// - Copy/Cut: Only shown when `has_selection` is true
+    /// - Paste: Only shown when clipboard has content
+    /// - Select All: Always shown
+    ///
+    /// # Parameters
+    /// * `has_selection` - Whether text is currently selected (enables Copy/Cut actions)
+    /// * `rect` - Selection bounding box in logical pixels (for menu positioning)
+    /// * `keyboard_shift` - Vertical offset caused by virtual keyboard (in logical pixels)
+    ///
+    /// # Platform Support
+    /// - Android: Uses ActionMode with floating toolbar
+    /// - iOS: TODO - Will use UIMenuController
+    /// - Other platforms: No-op
+    ///
+    /// # Note
+    /// The actual clipboard operations (copy/cut/paste) are performed by querying
+    /// the text selection from Rust directly. The `has_selection` parameter is only
+    /// used to determine which menu items to show, not for the operations themselves.
+    pub fn show_clipboard_actions(&mut self, has_selection: bool, rect: Rect, keyboard_shift: f64) {
         self.platform_ops
-            .push(CxOsOp::ShowClipboardActions(selected));
+            .push(CxOsOp::ShowClipboardActions { has_selection, rect, keyboard_shift });
+    }
+
+    /// Hides the clipboard actions menu
+    pub fn hide_clipboard_actions(&mut self) {
+        self.platform_ops.push(CxOsOp::HideClipboardActions);
     }
 
     /// Copies the given string to the clipboard.

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -309,8 +309,8 @@ impl Cx {
                 CxOsOp::CancelHttpRequest {request_id} => {
                     self.os.http_requests.cancel_http_request(request_id);
                 },
-                CxOsOp::ShowClipboardActions(_request) => {
-                    crate::log!("Show clipboard actions not supported yet");
+                CxOsOp::ShowClipboardActions { has_selection, .. } => {
+                    with_ios_app(|app| app.show_clipboard_actions(has_selection));
                 }
                 CxOsOp::CopyToClipboard(content) => {
                     with_ios_app(|app| app.copy_to_clipboard(&content));

--- a/platform/src/os/apple/ios/ios_app.rs
+++ b/platform/src/os/apple/ios/ios_app.rs
@@ -461,6 +461,39 @@ impl IosApp {
         }
     }
 
+    pub fn paste_from_clipboard(&self) -> String {
+        unsafe {
+            let pasteboard: ObjcId = self.pasteboard;
+            let nsstring: ObjcId = msg_send![pasteboard, string];
+            if nsstring != nil {
+                nsstring_to_string(nsstring)
+            } else {
+                String::new()
+            }
+        }
+    }
+
+    pub fn show_clipboard_actions(&self, _has_selection: bool) {
+        // Note: Full UIMenuController implementation requires:
+        // 1. A custom UIView that can become first responder
+        // 2. Implementation of canPerformAction:withSender:
+        // 3. Action methods (copy:, paste:, cut:, selectAll:)
+        // 4. Proper positioning of the menu
+        //
+        // This is a placeholder that logs the intent.
+        // The hidden textfield approach currently used for IME doesn't
+        // easily support UIMenuController as it's designed for keyboard input only.
+        //
+        // For full implementation, we need to either:
+        // A) Add a custom responder view to the view hierarchy, OR
+        // B) Make the MTKView conform to the required protocols
+
+        crate::log!("iOS: showClipboardActions called - UIMenuController not yet implemented");
+
+        // TODO: Implement UIMenuController properly
+        // Reference implementation needed similar to Android's ActionMode
+    }
+
     pub fn get_ios_directory_paths() -> String {
         unsafe {
             let file_manager: ObjcId = msg_send![class!(NSFileManager), defaultManager];

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -563,7 +563,7 @@ impl Cx {
                 CxOsOp::CancelHttpRequest {request_id} => {
                     self.os.http_requests.cancel_http_request(request_id);
                 },
-                CxOsOp::ShowClipboardActions(_request) => {
+                CxOsOp::ShowClipboardActions { .. } => {
                     crate::log!("Show clipboard actions not supported yet");
                 },
                 CxOsOp::CopyToClipboard(content) => {

--- a/platform/src/os/apple/tvos/tvos.rs
+++ b/platform/src/os/apple/tvos/tvos.rs
@@ -205,7 +205,7 @@ impl Cx {
                 CxOsOp::CancelHttpRequest {request_id} => {
                     self.os.http_requests.cancel_http_request(request_id);
                 },
-                CxOsOp::ShowClipboardActions(_request) => {
+                CxOsOp::ShowClipboardActions { .. } => {
                     crate::log!("Show clipboard actions not supported yet");
                 }
                 CxOsOp::CopyToClipboard(_request) => {

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -276,12 +276,16 @@ impl Cx {
                                 response: response.clone()
                             });
                             self.call_event_handler(&e);
-                            // let response = response.borrow();
-                            // if let Some(response) = response.as_ref(){
-                            //     to_java.copy_to_clipboard(response);
-                            // }
                         } else if makepad_keycode == KeyCode::KeyV {
-                            //to_java.paste_from_clipboard();
+                            let content = unsafe { android_jni::to_java_paste_from_clipboard() };
+                            if !content.is_empty() {
+                                e = Event::TextInput(TextInputEvent {
+                                    input: content,
+                                    replace_last: false,
+                                    was_paste: true,
+                                });
+                                self.call_event_handler(&e);
+                            }
                         }
                     } else {
                         if makepad_keycode == KeyCode::Back {
@@ -500,6 +504,53 @@ impl Cx {
                 } else {
                     self.call_event_handler(&Event::WindowLostFocus(window_id));
                 }
+            }
+            FromJavaMessage::ClipboardAction { action } => {
+                if action == "copy" {
+                    let response = Rc::new(RefCell::new(None));
+                    let e = Event::TextCopy(TextClipboardEvent {
+                        response: response.clone()
+                    });
+                    self.call_event_handler(&e);
+                    // Get the copied text from the widget's response
+                    if let Some(text) = response.borrow().as_ref() {
+                        // Copy to clipboard
+                        unsafe { to_java_copy_to_clipboard(text.clone()); }
+                    };
+                } else if action == "cut" {
+                    let response = Rc::new(RefCell::new(None));
+                    let e = Event::TextCut(TextClipboardEvent {
+                        response: response.clone()
+                    });
+                    self.call_event_handler(&e);
+                    // Get the cut text from the widget's response
+                    if let Some(text) = response.borrow().as_ref() {
+                        // Copy to clipboard
+                        unsafe { to_java_copy_to_clipboard(text.clone()); }
+                    };
+                } else if action == "select_all" {
+                    // Simulate Ctrl+A keypress to trigger select_all in widgets
+                    let e = Event::KeyDown(KeyEvent {
+                        key_code: KeyCode::KeyA,
+                        is_repeat: false,
+                        modifiers: KeyModifiers {
+                            shift: false,
+                            control: true,  // Ctrl modifier
+                            alt: false,
+                            logo: false,
+                        },
+                        time: self.seconds_since_app_start(),
+                    });
+                    self.call_event_handler(&e);
+                }
+            }
+            FromJavaMessage::ClipboardPaste { content } => {
+                let e = Event::TextInput(TextInputEvent {
+                    input: content,
+                    replace_last: false,
+                    was_paste: true,
+                });
+                self.call_event_handler(&e);
             }
             FromJavaMessage::Init(_) => {
             }
@@ -926,6 +977,12 @@ impl Cx {
                 },
                 CxOsOp::CopyToClipboard(content) => {
                     unsafe {android_jni::to_java_copy_to_clipboard(content);}
+                },
+                CxOsOp::ShowClipboardActions { has_selection, rect, keyboard_shift } => {
+                    unsafe {android_jni::to_java_show_clipboard_actions(has_selection, rect, keyboard_shift, self.os.dpi_factor);}
+                },
+                CxOsOp::HideClipboardActions => {
+                    unsafe {android_jni::to_java_dismiss_clipboard_actions();}
                 },
                 CxOsOp::CheckPermission {permission, request_id} => {
                     self.handle_permission_check(permission, request_id);

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -122,6 +122,12 @@ pub enum FromJavaMessage {
     WindowFocusChanged {
         has_focus: bool,
     },
+    ClipboardAction {
+        action: String, // "copy", "cut", "select_all"
+    },
+    ClipboardPaste {
+        content: String,
+    },
 }
 unsafe impl Send for FromJavaMessage {}
 
@@ -724,6 +730,28 @@ pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onPermissionDeni
     Java_dev_makepad_android_MakepadNative_onPermissionResult(env, class, permission, request_id, 3); // 3 = DeniedPermanent (assume worst case)
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onClipboardAction(
+    env: *mut jni_sys::JNIEnv,
+    _: jni_sys::jclass,
+    action: jni_sys::jstring,
+) {
+    send_from_java_message(FromJavaMessage::ClipboardAction {
+        action: jstring_to_string(env, action),
+    });
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onClipboardPaste(
+    env: *mut jni_sys::JNIEnv,
+    _: jni_sys::jclass,
+    content: jni_sys::jstring,
+) {
+    send_from_java_message(FromJavaMessage::ClipboardPaste {
+        content: jstring_to_string(env, content),
+    });
+}
+
 unsafe fn jstring_to_string(env: *mut jni_sys::JNIEnv, java_string: jni_sys::jstring) -> String {
     let chars = (**env).GetStringUTFChars.unwrap()(env, java_string, std::ptr::null_mut());
     let rust_string = std::ffi::CStr::from_ptr(chars).to_str().unwrap().to_string();
@@ -804,6 +832,31 @@ pub unsafe fn to_java_copy_to_clipboard(content: String) {
     let content = CString::new(content.clone()).unwrap();
     let content = ((**env).NewStringUTF.unwrap())(env, content.as_ptr());
     ndk_utils::call_void_method!(env, get_activity(), "copyToClipboard", "(Ljava/lang/String;)V", content);
+}
+
+pub unsafe fn to_java_paste_from_clipboard() -> String {
+    let env = attach_jni_env();
+    let result = ndk_utils::call_object_method!(env, get_activity(), "pasteFromClipboard", "()Ljava/lang/String;");
+    if result.is_null() {
+        return String::new();
+    }
+    jstring_to_string(env, result)
+}
+
+pub unsafe fn to_java_show_clipboard_actions(has_selection: bool, rect: crate::makepad_math::Rect, keyboard_shift: f64, dpi_factor: f64) {
+    let env = attach_jni_env();
+    // Apply DPI scaling
+    let left = (rect.pos.x * dpi_factor) as i32;
+    let top = (rect.pos.y * dpi_factor) as i32;
+    let right = ((rect.pos.x + rect.size.x) * dpi_factor) as i32;
+    let bottom = ((rect.pos.y + rect.size.y) * dpi_factor) as i32;
+    let shift = (keyboard_shift * dpi_factor) as i32;
+    ndk_utils::call_void_method!(env, get_activity(), "showClipboardActions", "(ZIIIII)V", has_selection as jni_sys::jboolean as std::ffi::c_uint, left, top, right, bottom, shift);
+}
+
+pub unsafe fn to_java_dismiss_clipboard_actions() {
+    let env = attach_jni_env();
+    ndk_utils::call_void_method!(env, get_activity(), "dismissClipboardActions", "()V");
 }
 
 pub unsafe fn to_java_http_request(request_id: LiveId, request: HttpRequest) {

--- a/platform/src/os/linux/wayland/linux_wayland.rs
+++ b/platform/src/os/linux/wayland/linux_wayland.rs
@@ -319,7 +319,7 @@ impl WaylandCx {
                 },
                 CxOsOp::RepositionWindow(window_id, size) => {
                 },
-                CxOsOp::ShowClipboardActions(_) =>{
+                CxOsOp::ShowClipboardActions { .. } =>{
                 },
                 CxOsOp::CopyToClipboard(content) => {
                 }

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -364,7 +364,7 @@ impl X11Cx {
                             window.xlib_window.set_position(size);
                         }
                     },
-                    CxOsOp::ShowClipboardActions(_) =>{
+                    CxOsOp::ShowClipboardActions { .. } =>{
                     },
                     CxOsOp::CopyToClipboard(content) => {
                         if let Some(window) = opengl_windows.get(0) {

--- a/tools/cargo_makepad/src/android/compile.rs
+++ b/tools/cargo_makepad/src/android/compile.rs
@@ -303,6 +303,11 @@ fn build_dex(sdk_dir: &Path, build_paths: &BuildPaths, urls:&AndroidSDKUrls) -> 
             (compiled_java_classes_dir.join("VideoPlayer$3.class").to_str().unwrap()),
             (compiled_java_classes_dir.join("MakepadActivity$1.class").to_str().unwrap()),
             (compiled_java_classes_dir.join("MakepadActivity$2.class").to_str().unwrap()),
+            (compiled_java_classes_dir.join("MakepadActivity$3.class").to_str().unwrap()),
+            (compiled_java_classes_dir.join("MakepadActivity$3$1.class").to_str().unwrap()),
+            (compiled_java_classes_dir.join("MakepadActivity$3$2.class").to_str().unwrap()),
+            (compiled_java_classes_dir.join("MakepadActivity$4.class").to_str().unwrap()),
+            (compiled_java_classes_dir.join("MakepadActivity$5.class").to_str().unwrap()),
             (build_paths.java_class.to_str().unwrap()),
             (build_paths.xr_class.to_str().unwrap()),
         ]

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -26,7 +26,10 @@ import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.SystemClock;
 import android.util.Log;
+import android.view.ActionMode;
 import android.view.Display;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.Surface;
@@ -160,10 +163,7 @@ class MakepadSurface
     public boolean onLongClick(View view) {
         long timeMillis = SystemClock.uptimeMillis();
 
-        // If the touch has moved more than the touch slop, ignore this long click.
         if (isTouchBeyondSlopDistance(view)) {
-            // Returning false here indicates that we have not handled the long click event,
-            // which does *not* trigger the haptic feedback (vibration motor) to buzz.
             return false;
         }
 
@@ -305,6 +305,12 @@ public class MakepadActivity
     static Handler mWebSocketsHandler;
     static HashMap<Long, MakepadWebSocket> mActiveWebsockets = new HashMap<>();
     static HashMap<Long, MakepadWebSocketReader> mActiveWebsocketsReaders = new HashMap<>();
+
+    // clipboard actions (ActionMode for copy/paste/cut)
+    private ActionMode mActionMode;
+    private boolean mHasSelection = false;
+    private int[] mSelectionBounds = new int[4]; // left, top, right, bottom
+    private int mKeyboardShift = 0; // keyboard shift amount from Rust
 
     static {
         System.loadLibrary("makepad");
@@ -539,10 +545,197 @@ public class MakepadActivity
         clipboard.setPrimaryClip(clip);
     }
 
+    public String pasteFromClipboard() {
+        ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+        if (clipboard.hasPrimaryClip()) {
+            ClipData clipData = clipboard.getPrimaryClip();
+            if (clipData != null && clipData.getItemCount() > 0) {
+                ClipData.Item item = clipData.getItemAt(0);
+                CharSequence text = item.getText();
+                if (text != null) {
+                    return text.toString();
+                }
+            }
+        }
+        return "";
+    }
+
     private String getApplicationName() {
         ApplicationInfo applicationInfo = getApplicationContext().getApplicationInfo();
         CharSequence appName = applicationInfo.loadLabel(getPackageManager());
         return appName.toString();
+    }
+
+    public void showClipboardActions(final boolean hasSelection, final int left, final int top, final int right, final int bottom, final int keyboardShift) {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                mHasSelection = hasSelection;
+                mSelectionBounds[0] = left;
+                mSelectionBounds[1] = top;
+                mSelectionBounds[2] = right;
+                mSelectionBounds[3] = bottom;
+                mKeyboardShift = keyboardShift;
+
+                // If ActionMode is already showing, finish it first
+                if (mActionMode != null) {
+                    mActionMode.finish();
+                }
+
+                // Start ActionMode with our callback
+                // Use TYPE_FLOATING (API 23+) to show near finger, falls back to primary for older versions
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    mActionMode = startActionMode(new ActionMode.Callback2() {
+                        @Override
+                        public boolean onCreateActionMode(ActionMode mode, Menu menu) {
+                            return onCreateActionModeInternal(mode, menu);
+                        }
+
+                        @Override
+                        public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+                            return onPrepareActionModeInternal(mode, menu);
+                        }
+
+                        @Override
+                        public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
+                            return onActionItemClickedInternal(mode, item);
+                        }
+
+                        @Override
+                        public void onDestroyActionMode(ActionMode mode) {
+                            onDestroyActionModeInternal(mode);
+                        }
+
+                        @Override
+                        public void onGetContentRect(ActionMode mode, View view, android.graphics.Rect outRect) {
+                            // The content rect tells Android what area to AVOID covering (not where to position)
+                            // Android's FloatingToolbar will automatically position itself above or below this rect
+                            // based on available screen space
+
+                            // Use asymmetric padding: more above (for better spacing when popup appears above),
+                            // less below (already looks good), and some on sides for visual balance
+                            int topPadding = 16;      // More padding above pushes popup higher
+                            int bottomPadding = 2;    // Minimal padding below (already good spacing)
+                            int sidePadding = 2;      // Horizontal padding for visual balance
+
+                            int left = mSelectionBounds[0] - sidePadding;
+                            int top = mSelectionBounds[1] - topPadding;
+                            int right = mSelectionBounds[2] + sidePadding;
+                            int bottom = mSelectionBounds[3] + bottomPadding;
+
+                            outRect.set(left, top, right, bottom);
+                        }
+                    }, ActionMode.TYPE_FLOATING);
+                } else {
+                    mActionMode = startActionMode(new ActionMode.Callback() {
+                        @Override
+                        public boolean onCreateActionMode(ActionMode mode, Menu menu) {
+                            return onCreateActionModeInternal(mode, menu);
+                        }
+
+                        @Override
+                        public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+                            return onPrepareActionModeInternal(mode, menu);
+                        }
+
+                        @Override
+                        public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
+                            return onActionItemClickedInternal(mode, item);
+                        }
+
+                        @Override
+                        public void onDestroyActionMode(ActionMode mode) {
+                            onDestroyActionModeInternal(mode);
+                        }
+                    });
+                }
+            }
+        });
+    }
+
+    public void dismissClipboardActions() {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                if (mActionMode != null) {
+                    mActionMode.finish();
+                    mActionMode = null;
+                }
+            }
+        });
+    }
+
+    // Helper methods for ActionMode callbacks (shared between Callback and Callback2)
+    private boolean onCreateActionModeInternal(ActionMode mode, Menu menu) {
+        // Add menu items: Copy, Cut, Paste, Select All
+        menu.add(0, android.R.id.copy, 0, android.R.string.copy);
+        menu.add(0, android.R.id.cut, 0, android.R.string.cut);
+        menu.add(0, android.R.id.paste, 0, android.R.string.paste);
+        menu.add(0, android.R.id.selectAll, 0, android.R.string.selectAll);
+        return true;
+    }
+
+    private boolean onPrepareActionModeInternal(ActionMode mode, Menu menu) {
+        // Enable/disable menu items based on state
+        boolean hasSelection = mHasSelection;
+        boolean hasClipboard = false;
+
+        ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+        if (clipboard.hasPrimaryClip()) {
+            hasClipboard = true;
+        }
+
+        MenuItem copyItem = menu.findItem(android.R.id.copy);
+        MenuItem cutItem = menu.findItem(android.R.id.cut);
+        MenuItem pasteItem = menu.findItem(android.R.id.paste);
+
+        if (copyItem != null) copyItem.setVisible(hasSelection);
+        if (cutItem != null) cutItem.setVisible(hasSelection);
+        if (pasteItem != null) pasteItem.setVisible(hasClipboard);
+
+        return true;
+    }
+
+    private boolean onActionItemClickedInternal(ActionMode mode, MenuItem item) {
+        int id = item.getItemId();
+
+        if (id == android.R.id.copy) {
+            MakepadNative.onClipboardAction("copy");
+            mode.finish();
+            return true;
+        } else if (id == android.R.id.cut) {
+            MakepadNative.onClipboardAction("cut");
+            mode.finish();
+            return true;
+        } else if (id == android.R.id.paste) {
+            String content = pasteFromClipboard();
+            MakepadNative.onClipboardPaste(content);
+            mode.finish();
+            return true;
+        } else if (id == android.R.id.selectAll) {
+            MakepadNative.onClipboardAction("select_all");
+
+            // After select all, re-show the menu with Copy/Cut options
+            // Post delayed to give Rust time to update selection
+            final ActionMode currentMode = mode;
+            new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    if (currentMode != null) {
+                        mHasSelection = true;
+                        currentMode.invalidate();
+                    }
+                }
+            }, 50); // 50ms delay
+
+            return true; // Don't finish mode - let it update
+        }
+        return false;
+    }
+
+    private void onDestroyActionModeInternal(ActionMode mode) {
+        mActionMode = null;
+        mHasSelection = false;
     }
 
     public void requestHttp(long id, long metadataId, String url, String method, String headers, byte[] body) {

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
@@ -37,6 +37,9 @@ public class MakepadNative {
     public native static void onWebSocketClosed(long callback);
     public native static void onWebSocketError(String error, long callback);
 
+    // clipboard
+    public native static void onClipboardAction(String action);
+    public native static void onClipboardPaste(String content);
 
     // midi
     public native static void onMidiDeviceOpened(String name, Object midi_device);

--- a/widgets/src/keyboard_view.rs
+++ b/widgets/src/keyboard_view.rs
@@ -64,10 +64,12 @@ impl Widget for KeyboardView {
                 AnimState::Opening{duration, start_time, ease, height}=>{
                     if e.time - start_time < *duration{
                         self.keyboard_shift = ease.map((e.time - start_time)/duration) * height;
+                        cx.keyboard_shift = self.keyboard_shift;
                         self.next_frame = cx.new_next_frame();
                     }
                     else{
                         self.keyboard_shift = *height;
+                        cx.keyboard_shift = self.keyboard_shift;
                         self.anim_state = AnimState::Open;
                     }
                     self.redraw(cx);
@@ -75,10 +77,12 @@ impl Widget for KeyboardView {
                 AnimState::Closing{duration, start_time, ease, height}=>{
                     if e.time - start_time < *duration{
                         self.keyboard_shift = (1.0-ease.map((e.time - start_time)/duration)) * height;
+                        cx.keyboard_shift = self.keyboard_shift;
                         self.next_frame = cx.new_next_frame();
                     }
-                    else{ 
+                    else{
                         self.keyboard_shift = 0.0;
+                        cx.keyboard_shift = self.keyboard_shift;
                         self.anim_state = AnimState::Closed;
                     }
                     self.redraw(cx);
@@ -112,6 +116,7 @@ impl Widget for KeyboardView {
                     VirtualKeyboardEvent::DidShow{time:_, height}=>{
                         if let AnimState::Closed = self.anim_state{
                             self.keyboard_shift = self.compute_max_height(*height, cx);
+                            cx.keyboard_shift = self.keyboard_shift;
                         }
                         self.anim_state = AnimState::Open;
                         self.redraw(cx);
@@ -119,6 +124,7 @@ impl Widget for KeyboardView {
                     VirtualKeyboardEvent::DidHide{time:_}=>{
                         self.anim_state = AnimState::Closed;
                         self.keyboard_shift = 0.0;
+                        cx.keyboard_shift = self.keyboard_shift;
                         self.redraw(cx);
                     }
                 }

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -611,6 +611,9 @@ pub struct TextInput {
     #[rust] selection: Selection,
     #[rust] history: History,
     #[rust] blink_timer: Timer,
+    #[rust] preserved_selection_cursor: Option<Cursor>,
+    /// Skip finger move after long press to prevent selection changes
+    #[rust] ignore_next_move: bool, 
 }
 
  impl LiveHook for TextInput{
@@ -893,7 +896,7 @@ impl TextInput {
             .laidout_text
             .as_ref()
             .expect("layout should not be `None` because we called `layout_text` in `draw_walk`");
-        
+
         self.draw_selection.begin_many_instances(cx);
         for SelectionRect { rect_in_lpxs, .. } in laidout_text.selection_rects(
             self.selection_to_password_selection(self.selection)
@@ -909,6 +912,57 @@ impl TextInput {
             );
         }
         self.draw_selection.end_many_instances(cx);
+    }
+
+    /// Calculate the bounding rectangle of the current text selection in screen coordinates
+    /// We use the draw_bg area which should give us the actual drawn position
+    fn get_selection_rect(&self, cx: &Cx) -> Rect {
+        let widget_rect = self.draw_bg.area().rect(cx);
+
+        // If no layout yet, return a small rect below the widget
+        let Some(laidout_text) = self.laidout_text.as_ref() else {
+            return rect(widget_rect.pos.x, widget_rect.pos.y + widget_rect.size.y, 10.0, 20.0);
+        };
+
+        // Get all selection rectangles
+        let selection_rects = laidout_text.selection_rects(
+            self.selection_to_password_selection(self.selection)
+        );
+
+        if selection_rects.is_empty() {
+            // No selection, return position below the widget
+            return rect(widget_rect.pos.x, widget_rect.pos.y + widget_rect.size.y, 10.0, 20.0);
+        }
+
+        // Calculate bounding box of all selection rects
+        let first = &selection_rects[0].rect_in_lpxs;
+        let mut min_x = first.origin.x;
+        let mut min_y = first.origin.y;
+        let mut max_x = first.origin.x + first.size.width;
+        let mut max_y = first.origin.y + first.size.height;
+
+        for SelectionRect { rect_in_lpxs, .. } in selection_rects.iter().skip(1) {
+            min_x = min_x.min(rect_in_lpxs.origin.x);
+            min_y = min_y.min(rect_in_lpxs.origin.y);
+            max_x = max_x.max(rect_in_lpxs.origin.x + rect_in_lpxs.size.width);
+            max_y = max_y.max(rect_in_lpxs.origin.y + rect_in_lpxs.size.height);
+        }
+
+        // Convert to screen coordinates using widget position as base
+        let text_offset_x = widget_rect.pos.x + self.layout.padding.left as f64;
+        let text_offset_y = widget_rect.pos.y + self.layout.padding.top as f64;
+
+        let sel_x = text_offset_x + (min_x * self.draw_text.font_scale) as f64;
+        let sel_y = text_offset_y + (min_y * self.draw_text.font_scale) as f64;
+        let sel_width = ((max_x - min_x) * self.draw_text.font_scale) as f64;
+        let sel_height = ((max_y - min_y) * self.draw_text.font_scale) as f64;
+
+        rect(
+            sel_x,
+            sel_y,
+            sel_width.max(10.0),
+            sel_height.max(20.0),
+        )
     }
 
     fn scroll_to_cursor(&mut self, cx: &mut Cx2d) {
@@ -1085,6 +1139,13 @@ impl TextInput {
         self.animator_play(cx, ids!(blink.on));
         cx.stop_timer(self.blink_timer);
         cx.hide_text_ime();
+        // Only hide clipboard actions on mobile platforms where they're supported
+        match cx.os_type() {
+            OsType::Android(_) | OsType::Ios(_) => {
+                cx.hide_clipboard_actions();
+            }
+            _ => {}
+        }
         cx.widget_action(uid, scope_path, TextInputAction::KeyFocusLost);
     }
 
@@ -1378,20 +1439,57 @@ impl Widget for TextInput {
                     warning!("can't move cursor because layout was invalidated by earlier event");
                     return;
                 };
-                self.set_cursor(
-                    cx,
-                    cursor,
+
+                let selection = self.selection();
+                let has_selection = selection.cursor != selection.anchor;
+                let touching_selection = if has_selection {
+                    let sel_start = selection.start().index;
+                    let sel_end = selection.end().index;
+                    cursor.index >= sel_start && cursor.index <= sel_end
+                } else {
                     false
-                );
+                };
+
+                if tap_count > 1 || !touching_selection {
+                    self.set_cursor(cx, cursor, false);
+                    self.preserved_selection_cursor = None;
+                } else {
+                    self.preserved_selection_cursor = Some(cursor);
+                }
+
                 match tap_count {
-                    2 => self.select_word(cx),
-                    3 => self.select_all(cx),
+                    2 => {
+                        self.select_word(cx);
+                        if device.is_touch() {
+                            let has_selection = !self.selected_text().is_empty();
+                            let selection_rect = self.get_selection_rect(cx);
+                            cx.show_clipboard_actions(has_selection, selection_rect, cx.keyboard_shift);
+                        }
+                    }
+                    3 => {
+                        self.select_all(cx);
+                        if device.is_touch() {
+                            let has_selection = !self.selected_text().is_empty();
+                            let selection_rect = self.get_selection_rect(cx);
+                            cx.show_clipboard_actions(has_selection, selection_rect, cx.keyboard_shift);
+                        }
+                    }
                     _ => {}
                 }
 
                 self.animator_play(cx, ids!(hover.down));
             }
             Hit::FingerUp(fe) => {
+                self.ignore_next_move = false;
+
+                if fe.was_tap() {
+                    if let Some(cursor) = self.preserved_selection_cursor.take() {
+                        self.set_cursor(cx, cursor, false);
+                    }
+                } else {
+                    self.preserved_selection_cursor = None;
+                }
+
                 if fe.is_over && fe.was_tap() {
                     if fe.has_hovers() {
                         self.animator_play(cx, ids!(hover.on));
@@ -1402,12 +1500,48 @@ impl Widget for TextInput {
                     self.animator_play(cx, ids!(hover.off));
                 }
             }
+            Hit::FingerLongPress(lp) => {
+                self.preserved_selection_cursor = None;
+
+                // Select word at long press position
+                let rel = lp.abs - self.text_area.rect(cx).pos;
+                if let Ok(cursor) = self.point_in_lpxs_to_cursor(
+                    Point::new(rel.x as f32, rel.y as f32)
+                ) {
+                    // Check if cursor is over actual text
+                    if cursor.index < self.text.len() {
+                        self.set_cursor(cx, cursor, false);
+                        self.select_word(cx);
+                    } else {
+                        // Long press on empty space just position the cursor
+                        self.set_cursor(cx, cursor, false);
+                    }
+                }
+
+                // Show clipboard actions menu with updated selection
+                if lp.device.is_touch() {
+                    let has_selection = !self.selected_text().is_empty();
+                    let selection_rect = self.get_selection_rect(cx);
+                    cx.show_clipboard_actions(has_selection, selection_rect, cx.keyboard_shift);
+                }
+
+                // Skip next move to prevent selection change when finger lifts
+                self.ignore_next_move = true;
+            }
             Hit::FingerMove(FingerMoveEvent {
                 abs,
                 tap_count,
                 device,
                 ..
             }) if device.is_primary_hit() => {
+                // Skip first move after long press to prevent selection changes
+                if self.ignore_next_move {
+                    self.ignore_next_move = false;
+                    return;
+                }
+
+                // Clear preserved cursor - user is dragging to select
+                self.preserved_selection_cursor = None;
                 self.reset_blink_timer(cx);
                 self.set_key_focus(cx);
                 let rel = abs - self.text_area.rect(cx).pos;


### PR DESCRIPTION
## Summary

Implements the `ShowClipboardActions` platform API with full Android ActionMode support, enabling native clipboard operations (Copy/Paste/Cut/Select All) in text inputs.

## What's New

### Cx API
- `show_clipboard_actions(&mut self, has_selection: bool, rect: Rect, keyboard_shift: f64) `: shows native clipboard menu with selection text, position rect, and keyboard shift (this method was already present but didn't do anything)
- `hide_clipboard_actions(&mut self)`: dismisses the clipboard menu

### TextInput Widget
- Long press and double tap: Selects word and shows clipboard menu

### Android Implementation
Native ActionMode: Floating toolbar with Copy/Paste/Cut/Select All actions
- Uses `onGetContentRect()` to define protected area
- Android's FloatingToolbar automatically positions above/below based on space

### iOS Foundation
- Stubbed `paste_from_clipboard()` method to be implemented in iOS UIMenuController implementation
(full implementation requires custom responder view)

## Demo
https://github.com/user-attachments/assets/33faa4e8-f4c1-406d-a8ca-a7f53b749fc6

## Next Steps
- iOS UIMenuController implementation with custom responder view to implement this for iOS