### PR TITLE
fix: correct identifier comparison in expect_specific_ident function

### DIFF
--- a/platform/shader_compiler/src/shader_parser.rs
+++ b/platform/shader_compiler/src/shader_parser.rs
@@ -182,7 +182,7 @@ impl<'a> ShaderParser<'a> {
     #[inline]
     fn expect_specific_ident(&mut self, specific_id: LiveId) -> Result<(), LiveError> {
         match self.peek_token() {
-            LiveToken::Ident(id) if id == id => {
+            LiveToken::Ident(id) if id == specific_id => {
                 self.skip_token();
                 Ok(())
             }


### PR DESCRIPTION
Fix identifier comparsion on shader_compiler