### PR TITLE
Math rendering in Markdown

### DIFF
--- a/libs/math_widget/src/math.rs
+++ b/libs/math_widget/src/math.rs
@@ -26,13 +26,16 @@ live_design!{
     }
     
     pub Math = {{Math}} {
+        color: #fff,
+        font_size: 11.0,
+        baseline_offset: -2.0,
         draw_math: {
             texture tex: texture2d
         }
     }
 }
 
-#[derive(Live, LiveHook, Widget)]
+#[derive(Live, Widget)]
 pub struct Math {
     #[live]
     draw_math: DrawMath,
@@ -46,53 +49,100 @@ pub struct Math {
     #[live]
     text: String,
 
+    #[live]
+    color: Vec4,
+
+    #[live]
+    font_size: f64,
+
+    #[live]
+    baseline_offset: f64,
+
     #[rust]
     old_text: String,
+    #[rust]
+    old_color: Vec4,
+    #[rust]
+    old_font_size: f64,
+    #[rust]
+    old_dpi_factor: f64,
     #[rust]
     world: MathWorld,
     #[rust]
     texture: Option<Texture>,
 }
 
+impl LiveHook for Math {
+    fn after_apply(&mut self, cx: &mut Cx, _apply: &mut Apply, _index: usize, _nodes: &[LiveNode]) {
+        // Reset cached values to force re-render when properties change
+        self.old_text.clear();
+        self.old_color = Vec4::default();
+        self.old_font_size = 0.0;
+        self.old_dpi_factor = 0.0;
+        self.redraw(cx);
+    }
+}
+
 impl Widget for Math {
     fn handle_event(&mut self, _cx: &mut Cx, _event: &Event, _scope: &mut Scope) {}
 
     fn draw_walk(&mut self, cx: &mut Cx2d, _scope: &mut Scope, mut walk: Walk) -> DrawStep {
-        self.render_math(cx);    
+        self.render_math(cx);
         if let Some(texture) = &self.texture {
-            let (width, height) = texture.get_format(cx).vec_width_height().unwrap_or((0, 0));
-            walk.width = Size::Fixed(width as f64);
-            walk.height = Size::Fixed(height as f64);
+            walk.width = self.walk.width;
+            walk.height = self.walk.height;
+            walk.margin.top += self.baseline_offset;
             self.draw_math.draw_vars.set_texture(0, texture);
             self.draw_math.draw_walk(cx, walk);
         }
         DrawStep::done()
     }
+
+    fn set_text(&mut self, cx: &mut Cx, text: &str) {
+        self.text = text.to_string();
+        self.redraw(cx);
+    }
 }
 
 impl Math {
-    fn render_math(&mut self, cx: &mut Cx) {
-        if self.text == self.old_text {
+    fn render_math(&mut self, cx: &mut Cx2d) {
+        let dpi_factor = cx.current_dpi_factor();
+        if self.text == self.old_text
+            && self.color == self.old_color
+            && self.font_size == self.old_font_size
+            && dpi_factor == self.old_dpi_factor
+        {
             return;
         }
-        let header = r#"
+        // Convert color to typst rgb format
+        let r = (self.color.x * 255.0) as u8;
+        let g = (self.color.y * 255.0) as u8;
+        let b = (self.color.z * 255.0) as u8;
+        // Scale factor to match Makepad font sizes to typst font sizes
+        // roughly ~1.75 ratio
+        const FONT_SIZE_SCALE: f64 = 1.75;
+        let font_size_pt = self.font_size * FONT_SIZE_SCALE;
+        let header = format!(r#"
             #set page(width: auto, height: auto, margin: 0pt, fill: none)
-            #set text(fill: white)
+            #set text(fill: rgb({}, {}, {}), size: {}pt)
             #let mitexsqrt = math.sqrt
             #let frac(x, y) = $ (#x)/(#y) $
-        "#;
+        "#, r, g, b, font_size_pt);
         let typst_text = mitex::convert_math(&self.text, None).unwrap_or_else(|e| {
              log!("Mitex error: {:?}", e);
              format!("$ \"Error: {}\" $", e)
         });
-        let full_text = format!("{}{}", header, format!("$ {} $", typst_text));
+        let full_text = format!("{}$ {} $", header, typst_text);
         self.world.set_text(&full_text);
         self.old_text = self.text.clone();
+        self.old_color = self.color;
+        self.old_font_size = self.font_size;
+        self.old_dpi_factor = dpi_factor;
 
         match typst::compile::<PagedDocument>(&self.world).output {
             Ok(document) => {
                 if let Some(page) = document.pages.first() {
-                    let pixmap = typst_render::render(page, 2.0);
+                    let pixmap = typst_render::render(page, dpi_factor as f32);
                     let width = pixmap.width() as usize;
                     let height = pixmap.height() as usize;
                     let rgba_data = pixmap.data();
@@ -116,9 +166,9 @@ impl Math {
                     });
                     
                     self.texture = Some(texture);
-                    
-                    self.walk.width = Size::Fixed(width as f64 / 2.0);
-                    self.walk.height = Size::Fixed(height as f64 / 2.0);
+
+                    self.walk.width = Size::Fixed(width as f64 / dpi_factor);
+                    self.walk.height = Size::Fixed(height as f64 / dpi_factor);
                 }
             }
             Err(errors) => {

--- a/widgets/src/markdown.rs
+++ b/widgets/src/markdown.rs
@@ -316,6 +316,7 @@ pub struct Markdown{
     #[live(false)] use_code_block_widget:bool,
     #[rust] in_code_block: bool,
     #[rust] code_block_string: String,
+    #[live(false)] use_math_widget: bool,
     #[rust] auto_id: u64,
     #[live] heading_base_scale: f64,
 }
@@ -352,7 +353,7 @@ impl Markdown {
         let mut list_stack: Vec<ListState> = Vec::new();
         let mut is_first_block = true;
 
-        let parser = Parser::new_ext(self.body.as_ref(), Options::ENABLE_TABLES);        
+        let parser = Parser::new_ext(self.body.as_ref(), Options::ENABLE_TABLES | Options::ENABLE_MATH);        
         
         for event in parser.into_iter() {
             match event {
@@ -517,6 +518,48 @@ impl Markdown {
                     tf.font_sizes.pop();
                     tf.fixed.pop();
                     tf.inline_code.pop();
+                }
+                // Inline math ($...$)
+                MdEvent::InlineMath(text) => {
+                    if self.use_math_widget {
+                        let entry_id = tf.new_counted_id();
+                        tf.item_with(cx, entry_id, live_id!(inline_math), |cx, item, _tf| {
+                            item.set_text(cx, &text);
+                            item.draw_all_unscoped(cx);
+                        });
+                    } else {
+                        // Fallback: render as inline code style
+                        const FIXED_FONT_SIZE_SCALE: f64 = 0.85;
+                        tf.push_size_rel_scale(FIXED_FONT_SIZE_SCALE);
+                        tf.fixed.push();
+                        tf.inline_code.push();
+                        tf.draw_text(cx, &text);
+                        tf.font_sizes.pop();
+                        tf.fixed.pop();
+                        tf.inline_code.pop();
+                    }
+                }
+                // Display math ($$...$$)
+                MdEvent::DisplayMath(text) => {
+                    if !is_first_block {
+                        cx.turtle_new_line_with_spacing(self.paragraph_spacing);
+                    }
+                    is_first_block = false;
+
+                    if self.use_math_widget {
+                        let entry_id = tf.new_counted_id();
+                        tf.item_with(cx, entry_id, live_id!(display_math), |cx, item, _tf| {
+                            item.set_text(cx, &text);
+                            item.draw_all_unscoped(cx);
+                        });
+                    } else {
+                        // Fallback: render as code block style
+                        tf.begin_code(cx);
+                        tf.fixed.push();
+                        tf.draw_text(cx, &text);
+                        tf.fixed.pop();
+                        tf.end_code(cx);
+                    }
                 }
                 MdEvent::Text(text) => {
                     if self.in_code_block {


### PR DESCRIPTION
Adds support for rendering math in the Markdown widget

### Changes

Adds a new flag to the Markdown widget `use_math_widget` that shares the same mechanism as the existing `use_code_block_widget` which allows specifying a widget that will take care of rendering the math:

```rust
md_with_math = <Markdown> {
    font_size: 12.0,
    use_math_widget: true,
    inline_math = <Math> {} // <--- here we reference the Math widget
    display_math = <Math> { // <--- here we reference the Math widget
        font_size: 12.0,
    }
    body: "
# Math in Markdown

Here is some inline math: $E = mc^2$ and also $\\alpha + \\beta = \\gamma$.

And here is display math:

$$
\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}
$$

More inline: The quadratic formula is $x = \\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$.

$$
\\sum_{n=1}^{\\infty} \\frac{1}{n^2} = \\frac{\\pi^2}{6}
$$
"
}
```

This renders as:

<img width="1184" height="1304" alt="image" src="https://github.com/user-attachments/assets/99a82c5b-ec14-48cc-b8a0-64b232a74304" />

If a math widget is not provided then the math blocks will be displayed as code blocks for clarity.

For this I also added `font_size` and `color` to the Math widget. There is some very rudimentary logic to make the given font size match the font size used in Makepad, rather than the direct font size used in Typst. This allows the user to say both Markdown and Math have the same `font_size` value, and also be visually similar (it's approximate not exact).