### PR TITLE
Fix various issues in `cargo makepad wasm`

### DIFF
--- a/tools/cargo_makepad/src/open_harmony/compile.rs
+++ b/tools/cargo_makepad/src/open_harmony/compile.rs
@@ -32,7 +32,7 @@ fn get_deveco_sdk_home(deveco_home: &Path, _host_os: &HostOs) -> Result<PathBuf,
 
 fn get_node_home(deveco_home: &Path, host_os: &HostOs) -> Result<PathBuf, String> {
     match host_os {
-        HostOs::LinuxX64 => {
+        HostOs::Linux => {
             let node = deveco_home.join("tool/node");
             if node.is_dir() {
                 return Ok(node);
@@ -52,7 +52,7 @@ fn get_node_home(deveco_home: &Path, host_os: &HostOs) -> Result<PathBuf, String
 
 fn get_node_path(deveco_home: &Path, host_os: &HostOs) -> Result<PathBuf, String> {
     match host_os {
-        HostOs::LinuxX64 => {
+        HostOs::Linux => {
             let node = deveco_home.join("tool/node/bin/node");
             if node.is_file() {
                 return Ok(node);
@@ -79,7 +79,7 @@ fn get_node_path(deveco_home: &Path, host_os: &HostOs) -> Result<PathBuf, String
 
 fn get_hvigor_path(deveco_home: &Path, host_os: &HostOs) -> Result<PathBuf, String> {
     match host_os {
-        HostOs::LinuxX64 => {
+        HostOs::Linux => {
             let hvigor = deveco_home.join("hvigor/bin/hvigorw.js");
             if hvigor.is_file() {
                 return Ok(hvigor);
@@ -106,7 +106,7 @@ fn get_hvigor_path(deveco_home: &Path, host_os: &HostOs) -> Result<PathBuf, Stri
 
 fn get_hdc_path(deveco_home: &Path, host_os: &HostOs) -> Result<PathBuf, String> {
     match host_os {
-        HostOs::LinuxX64 | HostOs::MacOS => {
+        HostOs::Linux | HostOs::MacOS => {
             let hdc_path = deveco_home.join(format!("sdk/default/openharmony/toolchains/hdc"));
             if hdc_path.is_file() {
                     return Ok(hdc_path);
@@ -218,7 +218,7 @@ pub fn rust_build(deveco_home: &Option<String>, host_os: &HostOs, args: &[String
     let sdk_path = get_sdk_home(deveco_home, &host_os)?;
 
     let bin_path = |file_name: &str, extension:& str| match host_os {
-        HostOs::LinuxX64 => String::from(file_name),
+        HostOs::Linux => String::from(file_name),
         HostOs::WindowsX64 => format!("{file_name}.{extension}"),
         HostOs::MacOS => String::from(file_name),
         _ => panic!()

--- a/tools/cargo_makepad/src/open_harmony/mod.rs
+++ b/tools/cargo_makepad/src/open_harmony/mod.rs
@@ -8,7 +8,7 @@ mod sdk;
 pub enum HostOs {
     WindowsX64,
     MacOS,
-    LinuxX64,
+    Linux,
     Unsupported
 }
 
@@ -52,7 +52,12 @@ impl OpenHarmonyTarget {
 pub fn handle_open_harmony(mut args: &[String]) -> Result<(), String> {
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))] let host_os = HostOs::WindowsX64;
     #[cfg(all(target_os = "macos"))] let host_os = HostOs::MacOS;
-    #[cfg(all(target_os = "linux", target_arch = "x86_64"))] let host_os = HostOs::LinuxX64;
+    #[cfg(all(target_os = "linux"))] let host_os = HostOs::Linux;
+    #[cfg(not(any(
+        all(target_os = "windows", target_arch = "x86_64"),
+        all(target_os = "macos"),
+        all(target_os = "linux")
+    )))] let host_os = HostOs::Unsupported;
     let mut targets = Vec::new();
     let mut deveco_home = None;
     let mut hdc_remote = None;

--- a/tools/cargo_makepad/src/open_harmony/mod.rs
+++ b/tools/cargo_makepad/src/open_harmony/mod.rs
@@ -53,11 +53,6 @@ pub fn handle_open_harmony(mut args: &[String]) -> Result<(), String> {
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))] let host_os = HostOs::WindowsX64;
     #[cfg(all(target_os = "macos"))] let host_os = HostOs::MacOS;
     #[cfg(all(target_os = "linux"))] let host_os = HostOs::Linux;
-    #[cfg(not(any(
-        all(target_os = "windows", target_arch = "x86_64"),
-        all(target_os = "macos"),
-        all(target_os = "linux")
-    )))] let host_os = HostOs::Unsupported;
     let mut targets = Vec::new();
     let mut deveco_home = None;
     let mut hdc_remote = None;

--- a/tools/cargo_makepad/src/utils.rs
+++ b/tools/cargo_makepad/src/utils.rs
@@ -51,7 +51,7 @@ pub fn get_crate_dep_dirs(build_crate: &str, build_dir:&Path, target:&str) -> Ha
     let mut dependencies = HashMap::new();
     let cwd = std::env::current_dir().unwrap();
     let target = format!("--target={target}");
-    if let Ok(cargo_tree_output) = shell_env_cap(&[], &cwd, "cargo", &["tree", "-p", build_crate, &target]) {
+    if let Ok(cargo_tree_output) = shell_env_cap(&[], &cwd, "cargo", &["tree", "--color", "never", "-p", build_crate, &target]) {
         println!("@@@ cargo tree output:\n{}", cargo_tree_output);
         for line in cargo_tree_output.lines().skip(1) {
             if let Some((name, path)) = extract_dependency_paths(line) {

--- a/tools/cargo_makepad/src/utils.rs
+++ b/tools/cargo_makepad/src/utils.rs
@@ -52,6 +52,7 @@ pub fn get_crate_dep_dirs(build_crate: &str, build_dir:&Path, target:&str) -> Ha
     let cwd = std::env::current_dir().unwrap();
     let target = format!("--target={target}");
     if let Ok(cargo_tree_output) = shell_env_cap(&[], &cwd, "cargo", &["tree", "-p", build_crate, &target]) {
+        println!("@@@ cargo tree output:\n{}", cargo_tree_output);
         for line in cargo_tree_output.lines().skip(1) {
             if let Some((name, path)) = extract_dependency_paths(line) {
                 if let Some(path) = path{

--- a/tools/cargo_makepad/src/utils.rs
+++ b/tools/cargo_makepad/src/utils.rs
@@ -52,7 +52,6 @@ pub fn get_crate_dep_dirs(build_crate: &str, build_dir:&Path, target:&str) -> Ha
     let cwd = std::env::current_dir().unwrap();
     let target = format!("--target={target}");
     if let Ok(cargo_tree_output) = shell_env_cap(&[], &cwd, "cargo", &["tree", "--color", "never", "-p", build_crate, &target]) {
-        println!("@@@ cargo tree output:\n{}", cargo_tree_output);
         for line in cargo_tree_output.lines().skip(1) {
             if let Some((name, path)) = extract_dependency_paths(line) {
                 if let Some(path) = path{

--- a/tools/cargo_makepad/src/wasm/compile.rs
+++ b/tools/cargo_makepad/src/wasm/compile.rs
@@ -38,7 +38,7 @@ pub fn generate_html(wasm:&str, config: &WasmConfig)->String{
             let wasm = await init({{module_or_path: module}}, env);
             set_wasm(wasm);
 
-            wasm._has_thread_support = true;
+            wasm._has_thread_support = wasm.exports.memory.buffer instanceof SharedArrayBuffer;
             wasm._memory = wasm.exports.memory;
             wasm._module = module;
             import {{WasmWebGL}} from './makepad_platform/web_gl.js'

--- a/tools/cargo_makepad/src/wasm/compile.rs
+++ b/tools/cargo_makepad/src/wasm/compile.rs
@@ -160,7 +160,6 @@ pub fn build(config:WasmConfig, args: &[String]) -> Result<WasmBuildResult, Stri
         
     }
     let resources = get_crate_dep_dirs(build_crate, &build_dir, "wasm32-unknown-unknown");
-    println!("@@@ resources: {:?}", resources);
     for (name, dep_dir) in resources.iter() {
         // alright we need special handling for makepad-wasm-bridge
         // and makepad-platform
@@ -202,7 +201,6 @@ pub fn build(config:WasmConfig, args: &[String]) -> Result<WasmBuildResult, Stri
             rename.insert("NotoColorEmoji.ttf".into(), "IBMPlexSans-Text.ttf".into());
         }
         
-        println!("@@@ Checking resource path: {:?}", resources_path);
         if resources_path.is_dir(){
             // alright so.. the easiest thing is to rename a bunch of resources
             

--- a/tools/cargo_makepad/src/wasm/compile.rs
+++ b/tools/cargo_makepad/src/wasm/compile.rs
@@ -160,6 +160,7 @@ pub fn build(config:WasmConfig, args: &[String]) -> Result<WasmBuildResult, Stri
         
     }
     let resources = get_crate_dep_dirs(build_crate, &build_dir, "wasm32-unknown-unknown");
+    println!("@@@ resources: {:?}", resources);
     for (name, dep_dir) in resources.iter() {
         // alright we need special handling for makepad-wasm-bridge
         // and makepad-platform
@@ -201,6 +202,7 @@ pub fn build(config:WasmConfig, args: &[String]) -> Result<WasmBuildResult, Stri
             rename.insert("NotoColorEmoji.ttf".into(), "IBMPlexSans-Text.ttf".into());
         }
         
+        println!("@@@ Checking resource path: {:?}", resources_path);
         if resources_path.is_dir(){
             // alright so.. the easiest thing is to rename a bunch of resources
             

--- a/tools/cargo_makepad/src/wasm/compile.rs
+++ b/tools/cargo_makepad/src/wasm/compile.rs
@@ -232,6 +232,7 @@ pub fn build(config:WasmConfig, args: &[String]) -> Result<WasmBuildResult, Stri
             .replace("imports['env'] = __wbg_star0;", "")
             .replace("return wasm;\n}", "return instance;\n}")
             .replace("__wbg_init(module_or_path, memory) {", "__wbg_init(module_or_path, env) {let memory;")
+            .replace("__wbg_init(module_or_path) {", "__wbg_init(module_or_path, env) {let memory;")
             .replace("imports = __wbg_get_imports();", "imports = __wbg_get_imports(); imports.env = env;");
         std::fs::OpenOptions::new().write(true).truncate(true).open(&jsfile).unwrap().write(patched.as_bytes()).unwrap();
         cp_brotli(&jsfile, &app_dir.join("bindgen.js"), false, config.brotli)?;

--- a/tools/cargo_makepad/src/wasm/compile.rs
+++ b/tools/cargo_makepad/src/wasm/compile.rs
@@ -132,7 +132,7 @@ pub fn build(config:WasmConfig, args: &[String]) -> Result<WasmBuildResult, Stri
     }
     
     shell_env(&[
-        ("RUSTFLAGS", "-C codegen-units=1 -C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--export=__stack_pointer -C opt-level=z"),
+        ("RUSTFLAGS", "-C codegen-units=1 -C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--export=__stack_pointer -C link-arg=--shared-memory -C link-arg=--max-memory=2147483648 -C link-arg=--import-memory -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base -C opt-level=z"),
         ("MAKEPAD", "lines"),
     ], &cwd, "rustup", &args_out) ?;
     


### PR DESCRIPTION
## Changes
- Use `--color never` in the `cargo tree` execution that is used internally for copying resources, so setting `CARGO_TERM_COLOR` doesn't break resource copying silently.
- Handle `__wbg_init` without `memory` arg for the `--bindgen` patch.
- Set `_has_thread_support` based on the kind of memory buffer, instead of setting it to `true` unconditionally.
- Add a lot of linker flags to ensure the final WASM build has and exposes the required functionalities. 
- Fix `cargo-makepad` not compiling in Linux ARM (like Docker in Apple Silicon), due to `target_arch = "x86_64"` conditional compilation in (unrelated) OpenHarmony code.