### PR TITLE
Add view_opacity uniform to draw list shaders

### DIFF
--- a/platform/shader_compiler/src/generate_glsl.rs
+++ b/platform/shader_compiler/src/generate_glsl.rs
@@ -329,10 +329,18 @@ impl<'a> DrawShaderGenerator<'a> {
         let pixel_decl = self.shader_registry.draw_shader_method_decl_from_ident(self.draw_shader_def, Ident(live_id!(fragment))).unwrap();
         write!(self.string, "\n").unwrap();
         if self.options.use_inout{
-            writeln!(self.string, "    fragColor = {}();", DisplayFnName(pixel_decl.fn_ptr, pixel_decl.ident)).unwrap();
+            if self.options.use_uniform_buffers {
+                writeln!(self.string, "    fragColor = {}() * draw_list.ds_view_opacity;", DisplayFnName(pixel_decl.fn_ptr, pixel_decl.ident)).unwrap();
+            } else {
+                writeln!(self.string, "    fragColor = {}() * ds_view_opacity;", DisplayFnName(pixel_decl.fn_ptr, pixel_decl.ident)).unwrap();
+            }
         }
         else{
-            writeln!(self.string, "    gl_FragColor = {}();", DisplayFnName(pixel_decl.fn_ptr, pixel_decl.ident)).unwrap();
+            if self.options.use_uniform_buffers {
+                writeln!(self.string, "    gl_FragColor = {}() * draw_list.ds_view_opacity;", DisplayFnName(pixel_decl.fn_ptr, pixel_decl.ident)).unwrap();
+            } else {
+                writeln!(self.string, "    gl_FragColor = {}() * ds_view_opacity;", DisplayFnName(pixel_decl.fn_ptr, pixel_decl.ident)).unwrap();
+            }
         }
         writeln!(self.string, "}}").unwrap();
     }

--- a/platform/shader_compiler/src/generate_hlsl.rs
+++ b/platform/shader_compiler/src/generate_hlsl.rs
@@ -451,12 +451,12 @@ impl<'a> DrawShaderGenerator<'a> {
         write!(self.string, "Varyings varyings").unwrap();
         writeln!(self.string, ") : SV_TARGET{{").unwrap();
         
-        write!(self.string, "    return ").unwrap();
+        write!(self.string, "    return (").unwrap();
         let pixel_def = self.shader_registry.draw_shader_method_decl_from_ident(self.draw_shader_def, Ident(live_id!(fragment))).unwrap();
         write!(self.string, "    {}", DisplayFnName(pixel_def.fn_ptr, pixel_def.ident)).unwrap();
         write!(self.string, "(").unwrap();
         self.backend_writer.write_call_expr_hidden_args(self.string, pixel_def.hidden_args.borrow().as_ref().unwrap(), "");
-        writeln!(self.string, ");").unwrap();
+        writeln!(self.string, ")) * uniforms_draw_list.ds_view_opacity;").unwrap();
         
         writeln!(self.string, "}}").unwrap();
     }

--- a/platform/shader_compiler/src/generate_metal.rs
+++ b/platform/shader_compiler/src/generate_metal.rs
@@ -409,7 +409,7 @@ impl<'a> DrawShaderGenerator<'a> {
         
         writeln!(self.string, ") {{").unwrap();
         
-        write!(self.string, "    return ").unwrap();
+        write!(self.string, "    return (").unwrap();
         
         let pixel_def = self.shader_registry.draw_shader_method_decl_from_ident(self.draw_shader_def, Ident(live_id!(fragment))).unwrap();
         write!(self.string, "    {}", DisplayFnName(pixel_def.fn_ptr, pixel_def.ident)).unwrap();
@@ -417,7 +417,7 @@ impl<'a> DrawShaderGenerator<'a> {
         write!(self.string, "(").unwrap();
         self.backend_writer.write_call_expr_hidden_args(self.string, pixel_def.hidden_args.borrow().as_ref().unwrap(), "");
         
-        writeln!(self.string, ");").unwrap();
+        writeln!(self.string, ")) * uniforms_draw_list.ds_view_opacity;").unwrap();
         
         writeln!(self.string, "}}").unwrap();
     }

--- a/platform/shader_compiler/src/shader_registry.rs
+++ b/platform/shader_compiler/src/shader_registry.rs
@@ -510,6 +510,7 @@ impl ShaderRegistry {
         draw_shader_def.add_uniform(id_lut!(view_transform), id_lut!(draw_list), Ty::Mat4f, TokenSpan::default());
         draw_shader_def.add_uniform(id_lut!(view_clip), id_lut!(draw_list), Ty::Vec4f, TokenSpan::default());
         draw_shader_def.add_uniform(id_lut!(view_shift), id_lut!(draw_list), Ty::Vec2f, TokenSpan::default());
+        draw_shader_def.add_uniform(id_lut!(view_opacity), id_lut!(draw_list), Ty::Float, TokenSpan::default());
         draw_shader_def.add_uniform(id_lut!(draw_zbias), id_lut!(draw_call), Ty::Float, TokenSpan::default());
         
         

--- a/platform/src/draw_list.rs
+++ b/platform/src/draw_list.rs
@@ -216,8 +216,10 @@ pub struct CxDrawListUniforms {
     pub view_transform: Mat4f,
     pub view_clip: Vec4f,
     pub view_shift: Vec2f,
+    /// Global opacity multiplier for everything rendered in this draw list.
+    pub view_opacity: f32,
     pub pad1: f32,
-    pub pad2: f32       
+    pub pad2: f32
 }
 
 impl Default for CxDrawListUniforms{
@@ -226,6 +228,7 @@ impl Default for CxDrawListUniforms{
             view_transform: Mat4f::identity(),
             view_clip: vec4(-100000.0, -100000.0, 100000.0, 100000.0),
             view_shift: vec2(0.0,0.0),
+            view_opacity: 1.0,
             pad1: 0.0,
             pad2: 0.0,
         }


### PR DESCRIPTION
Introduces a new view_opacity uniform to CxDrawListUniforms and integrates it into GLSL, HLSL, and Metal shader code generation. This allows for a global opacity multiplier to be applied to everything rendered in a draw list. The default value is set to 1.0, and padding fields are adjusted accordingly.

Usecase
This will help for custom route animations