### PR TITLE
Open Door for  SPA deep-link support

### DIFF
--- a/libs/http/src/utils.rs
+++ b/libs/http/src/utils.rs
@@ -50,12 +50,44 @@ pub fn parse_url_path(url: &str) -> Option<(String, Option<String>)> {
     }else {end_of_name};
     
     let mut url = url[0..end_of_name].to_string();
+    url = percent_decode_path(&url)?;
     
     if url.ends_with('/') {
         url.push_str("index.html");
     }
     
     Some((url, search))
+}
+
+fn percent_decode_path(input: &str) -> Option<String> {
+    fn hex_val(b: u8) -> Option<u8> {
+        match b {
+            b'0'..=b'9' => Some(b - b'0'),
+            b'a'..=b'f' => Some(b - b'a' + 10),
+            b'A'..=b'F' => Some(b - b'A' + 10),
+            _ => None,
+        }
+    }
+
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'%' => {
+                let hi = *bytes.get(i + 1)?;
+                let lo = *bytes.get(i + 2)?;
+                let v = (hex_val(hi)? << 4) | hex_val(lo)?;
+                out.push(v);
+                i += 3;
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8(out).ok()
 }
 
 #[derive(Debug)]

--- a/tools/cargo_makepad/src/wasm/compile.rs
+++ b/tools/cargo_makepad/src/wasm/compile.rs
@@ -54,14 +54,15 @@ pub fn generate_html(wasm:&str, config: &WasmConfig)->String{
 
     format!("
     <!DOCTYPE html>
-    <html>
-    <head>
-        <meta charset='utf-8'>
-        <meta name='viewport' content='width=device-width, initial-scale=1.0, user-scalable=no'>
-        <title>{wasm}</title>
-        <script type='module'>
-            {init}
-            class MyWasmApp {{
+	    <html>
+	    <head>
+	        <meta charset='utf-8'>
+	        <meta name='viewport' content='width=device-width, initial-scale=1.0, user-scalable=no'>
+	        <base href='/' />
+	        <title>{wasm}</title>
+	        <script type='module'>
+	            {init}
+	            class MyWasmApp {{
                 constructor(wasm) {{
                     let canvas = document.getElementsByClassName('full_canvas')[0];
                     this.webgl = new WasmWebGL (wasm, this, canvas);
@@ -330,7 +331,14 @@ pub fn start_wasm_server(root:PathBuf, lan:bool, port: u16) {
                         let _ = response_sender.send(HttpServerResponse {header, body: vec![]});
                         continue
                     }
-                                            
+
+                    if path.contains("..") || path.contains('\\') {
+                        let header = "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n".to_string();
+                        let _ = response_sender.send(HttpServerResponse {header, body: vec![]});
+                        continue;
+                    }
+
+                    let mut fs_path = path.strip_prefix("/").unwrap_or(path).to_string();
                     let mime_type = if path.ends_with(".html") {"text/html"}
                     else if path.ends_with(".wasm") {"application/wasm"}
                     else if path.ends_with(".css") {"text/css"}
@@ -341,16 +349,20 @@ pub fn start_wasm_server(root:PathBuf, lan:bool, port: u16) {
                     else if path.ends_with(".jpg") {"image/jpg"}
                     else if path.ends_with(".svg") {"image/svg+xml"}
                     else if path.ends_with(".md") {"text/markdown"}
-                    else {continue};
-                                            
-                    if path.contains("..") || path.contains('\\') {
-                        continue
-                    }
-                    let path = path.strip_prefix("/").unwrap();
-                                         
-                    let path = root.join(&path);
-                    //println!("OPENING {:?}", path);
-                    if let Ok(mut file_handle) = File::open(path) {
+                    else {
+                        // SPA deep-link support: serve index.html for routes like `/admin/dashboard`.
+                        // If it looks like a file request (has an extension), return 404.
+                        if path.rsplit('/').next().unwrap_or("").contains('.') {
+                            let header = "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n".to_string();
+                            let _ = response_sender.send(HttpServerResponse {header, body: vec![]});
+                            continue;
+                        }
+                        fs_path = "index.html".to_string();
+                        "text/html"
+                    };
+
+                    let file_path = root.join(&fs_path);
+                    if let Ok(mut file_handle) = File::open(file_path) {
                         let mut body = Vec::<u8>::new();
                         if file_handle.read_to_end(&mut body).is_ok() {
                             let header = format!(
@@ -367,6 +379,9 @@ pub fn start_wasm_server(root:PathBuf, lan:bool, port: u16) {
                             );
                             let _ = response_sender.send(HttpServerResponse {header, body});
                         }
+                    } else {
+                        let header = "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n".to_string();
+                        let _ = response_sender.send(HttpServerResponse {header, body: vec![]});
                     }
                 }
                 HttpServerRequest::Post {..} => { //headers, body, response}=>{

--- a/tools/cargo_makepad/src/wasm/compile.rs
+++ b/tools/cargo_makepad/src/wasm/compile.rs
@@ -54,15 +54,15 @@ pub fn generate_html(wasm:&str, config: &WasmConfig)->String{
 
     format!("
     <!DOCTYPE html>
-	    <html>
-	    <head>
-	        <meta charset='utf-8'>
-	        <meta name='viewport' content='width=device-width, initial-scale=1.0, user-scalable=no'>
-	        <base href='/' />
-	        <title>{wasm}</title>
-	        <script type='module'>
-	            {init}
-	            class MyWasmApp {{
+    <html>
+    <head>
+        <meta charset='utf-8'>
+        <meta name='viewport' content='width=device-width, initial-scale=1.0, user-scalable=no'>
+        <base href='/' />
+        <title>{wasm}</title>
+        <script type='module'>
+            {init}
+            class MyWasmApp {{
                 constructor(wasm) {{
                     let canvas = document.getElementsByClassName('full_canvas')[0];
                     this.webgl = new WasmWebGL (wasm, this, canvas);

--- a/tools/cargo_makepad/src/wasm/compile.rs
+++ b/tools/cargo_makepad/src/wasm/compile.rs
@@ -332,7 +332,7 @@ pub fn start_wasm_server(root:PathBuf, lan:bool, port: u16) {
                         continue
                     }
 
-                    if path.contains("..") || path.contains('\\') {
+                    if !is_safe_url_path(path) {
                         let header = "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n".to_string();
                         let _ = response_sender.send(HttpServerResponse {header, body: vec![]});
                         continue;
@@ -351,12 +351,6 @@ pub fn start_wasm_server(root:PathBuf, lan:bool, port: u16) {
                     else if path.ends_with(".md") {"text/markdown"}
                     else {
                         // SPA deep-link support: serve index.html for routes like `/admin/dashboard`.
-                        // If it looks like a file request (has an extension), return 404.
-                        if path.rsplit('/').next().unwrap_or("").contains('.') {
-                            let header = "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n".to_string();
-                            let _ = response_sender.send(HttpServerResponse {header, body: vec![]});
-                            continue;
-                        }
                         fs_path = "index.html".to_string();
                         "text/html"
                     };
@@ -389,4 +383,12 @@ pub fn start_wasm_server(root:PathBuf, lan:bool, port: u16) {
             }
         }
     }).join().unwrap();
+}
+
+fn is_safe_url_path(path: &str) -> bool {
+    if path.contains('\\') || path.contains('\0') {
+        return false;
+    }
+    // Reject directory traversal by segment (avoid false positives like "foo..bar").
+    !path.split('/').any(|seg| seg == "..")
 }

--- a/tools/web_server/src/main.rs
+++ b/tools/web_server/src/main.rs
@@ -71,7 +71,7 @@ fn main() {
                     continue
                 }
                 
-                if path.contains("..") || path.contains('\\'){
+                if !is_safe_url_path(path){
                     let header = "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n".to_string();
                     let _ = response_sender.send(HttpServerResponse{header, body:vec![]});
                     continue;
@@ -91,11 +91,6 @@ fn main() {
                 else if path.ends_with(".md") {"text/markdown"}
                 else {
                     // SPA deep-link support: serve index.html for routes like `/admin/dashboard`.
-                    if path.rsplit('/').next().unwrap_or("").contains('.') {
-                        let header = "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n".to_string();
-                        let _ = response_sender.send(HttpServerResponse{header, body:vec![]});
-                        continue;
-                    }
                     fs_path = "/index.html".to_string();
                     "text/html"
                 };
@@ -156,4 +151,11 @@ fn main() {
             }
         }
     }
+}
+
+fn is_safe_url_path(path: &str) -> bool {
+    if path.contains('\\') || path.contains('\0') {
+        return false;
+    }
+    !path.split('/').any(|seg| seg == "..")
 }

--- a/tools/web_server/src/main.rs
+++ b/tools/web_server/src/main.rs
@@ -71,6 +71,13 @@ fn main() {
                     continue
                 }
                 
+                if path.contains("..") || path.contains('\\'){
+                    let header = "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n".to_string();
+                    let _ = response_sender.send(HttpServerResponse{header, body:vec![]});
+                    continue;
+                }
+
+                let mut fs_path = path.clone();
                 let mime_type = if path.ends_with(".html") {"text/html"}
                 else if path.ends_with(".wasm") {"application/wasm"}
                 else if path.ends_with(".css") {"text/css"}
@@ -82,11 +89,16 @@ fn main() {
                 else if path.ends_with(".jpg") {"image/jpg"}
                 else if path.ends_with(".svg") {"image/svg+xml"}
                 else if path.ends_with(".md") {"text/markdown"}
-                else {continue};
-
-                if path.contains("..") || path.contains('\\'){
-                    continue
-                }
+                else {
+                    // SPA deep-link support: serve index.html for routes like `/admin/dashboard`.
+                    if path.rsplit('/').next().unwrap_or("").contains('.') {
+                        let header = "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n".to_string();
+                        let _ = response_sender.send(HttpServerResponse{header, body:vec![]});
+                        continue;
+                    }
+                    fs_path = "/index.html".to_string();
+                    "text/html"
+                };
                 let coep = if path == "/" || path == "/index.html"{
                     ""
                 }
@@ -99,9 +111,9 @@ fn main() {
                 //        break;
                 //    }
                 // }
-                let base = format!("{}{}", root_path, path);
+                let base = format!("{}{}", root_path, fs_path);
                 // check if we have a .br file
-                let base_br = format!("{}{}.br", root_path, path);
+                let base_br = format!("{}{}.br", root_path, fs_path);
                 if let Ok(mut file_handle) = File::open(base_br) {
                     let mut body = Vec::<u8>::new();
                     if file_handle.read_to_end(&mut body).is_ok() {
@@ -134,6 +146,10 @@ fn main() {
                         );
                         let _ = response_sender.send(HttpServerResponse{header, body});
                     }
+                }
+                else{
+                    let header = "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n".to_string();
+                    let _ = response_sender.send(HttpServerResponse{header, body:vec![]});
                 }
             }
             HttpServerRequest::Post{..}=>{//headers, body, response}=>{


### PR DESCRIPTION
Enhanced both the wasm and web server to support single-page application (SPA) deep-linking by serving index.html for non-file routes. Added stricter path validation to prevent directory traversal and backslash usage, returning 400 Bad Request for such cases. Improved 404 handling for invalid file requests.