### PR TITLE
Add optional serde derives for Serialization/Deserialization on select public types

### DIFF
--- a/draw/Cargo.toml
+++ b/draw/Cargo.toml
@@ -13,6 +13,7 @@ metadata.makepad-auto-version = "4ghwd5Pq8xlLJrln_NpXXshbpeE="
 makepad-platform = { path = "../platform", version = "1.0.0" }
 makepad-vector = { path = "./vector", version = "1.0.0" }
 makepad-html ={ path = "../libs/html", version = "1.0.0" }
+makepad-live-id = { path = "../libs/live_id", version = "1.0.0" }
 
 # HACK(eddyb) only a git dep until https://github.com/RazrFalcon/rustybuzz/pull/71
 # ends up being published in a release (only affects build times, not behavior).
@@ -25,3 +26,9 @@ unicode-linebreak = "0.1.5"
 unicode-segmentation = "1.11.0"
 png = "0.17.13"
 ttf-parser = "0.25.1"
+serde = { version = "1.0", optional = true, features = ["derive"] }
+
+[features]
+default = []
+## Enables certain public-facing types to derive serde serialization traits.
+serde = ["dep:serde", "makepad-live-id/serde"]

--- a/draw/src/text/selection.rs
+++ b/draw/src/text/selection.rs
@@ -1,4 +1,5 @@
 #[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Selection {
     pub cursor: Cursor,
     pub anchor: Cursor,
@@ -22,12 +23,14 @@ impl Selection {
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cursor {
     pub index: usize,
     pub prefer_next_row: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CursorPosition {
     pub row_index: usize,
     pub x_in_lpxs: f32,

--- a/libs/live_id/Cargo.toml
+++ b/libs/live_id/Cargo.toml
@@ -12,3 +12,10 @@ metadata.makepad-auto-version = "Fjf_rJTOgvZXwyU7Yb-CZMF6Hmo="
 [dependencies]
 makepad-live-id-macros = { path = "id_macros", version = "1.0.0" }
 #makepad-error-log = { path = "../error_log", version = "0.4.0" }
+
+serde = { version = "1.0", optional = true, features = ["derive"] }
+
+[features]
+default = []
+## Enables certain public-facing types to derive serde serialization traits.
+serde = ["dep:serde"]

--- a/libs/live_id/src/live_id.rs
+++ b/libs/live_id/src/live_id.rs
@@ -135,6 +135,7 @@ impl LiveIdInterner {
 }
 
 #[derive(Clone, Default, Eq, Hash, Copy, Ord, PartialOrd, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LiveId(pub u64);
 
 impl LiveId {

--- a/widgets/Cargo.toml
+++ b/widgets/Cargo.toml
@@ -26,3 +26,9 @@ makepad-fonts-chinese-regular-2 = {path = "./fonts/chinese_regular_2", version =
 makepad-fonts-chinese-bold = {path = "./fonts/chinese_bold", version = "1.0.1"}
 makepad-fonts-chinese-bold-2 = {path = "./fonts/chinese_bold_2", version = "1.0.1"}
 
+serde = { version = "1.0", optional = true, features = ["derive"] }
+
+[features]
+default = []
+## Enables certain public-facing types to derive serde serialization traits.
+serde = ["dep:serde", "makepad-draw/serde", "makepad-derive-widget/serde"]

--- a/widgets/derive_widget/Cargo.toml
+++ b/widgets/derive_widget/Cargo.toml
@@ -19,3 +19,5 @@ makepad-live-id = { path = "../../libs/live_id", version = "1.0.0" }
 [features]
 default = ["nightly"]
 nightly = []
+## Enables deriving serde (de)serialization traits for the LiveId type.
+serde = ["makepad-live-id/serde"]

--- a/widgets/src/dock.rs
+++ b/widgets/src/dock.rs
@@ -311,6 +311,7 @@ pub enum DropPart {
 }
 
 #[derive(Clone, Debug, Live, LiveHook, SerRon, DeRon)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[live_ignore]
 pub enum DockItem {
     #[live {axis: SplitterAxis::Vertical, align: SplitterAlign::Weighted(0.5), a: LiveId(0), b: LiveId(0)}]

--- a/widgets/src/splitter.rs
+++ b/widgets/src/splitter.rs
@@ -116,6 +116,7 @@ pub struct DrawSplitter {
 }
 
 #[derive(Copy, Clone, Debug, Live, LiveHook, SerRon, DeRon)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[live_ignore]
 pub enum SplitterAxis {
     #[pick] Horizontal,
@@ -130,6 +131,7 @@ impl Default for SplitterAxis {
 
 
 #[derive(Clone, Copy, Debug, Live, LiveHook, SerRon, DeRon)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[live_ignore]
 pub enum SplitterAlign {
     #[live(50.0)] FromA(f64),

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -1785,6 +1785,7 @@ impl TextInputRef {
 
 /// The saved (checkpointed) state of a text input widget.
 #[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TextInputState {
     text: String,
     password_text: String,
@@ -1804,6 +1805,7 @@ pub enum TextInputAction {
 }
 
 #[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct History {
     current_edit_kind: Option<EditKind>,
     undo_stack: EditStack,
@@ -1875,6 +1877,7 @@ impl History {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 enum EditKind {
     Insert,
     Backspace,
@@ -1893,6 +1896,7 @@ impl EditKind {
 }
 
 #[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct EditStack {
     edit_groups: Vec<EditGroup>,
     edits: Vec<Edit>,
@@ -1927,12 +1931,14 @@ impl EditStack {
 }
 
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct EditGroup {
     selection: Selection,
     edit_start: usize
 }
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct Edit {
     start: usize,
     end: usize,


### PR DESCRIPTION
Can be activated by setting the "serde" feature on `makepad-widgets` (or other internal crates).