### PR TITLE
Add clipboard actions support for iOS

### DIFF
--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -306,8 +306,11 @@ impl Cx {
                 CxOsOp::CancelHttpRequest {request_id} => {
                     self.os.http_requests.cancel_http_request(request_id);
                 },
-                CxOsOp::ShowClipboardActions { has_selection, .. } => {
-                    with_ios_app(|app| app.show_clipboard_actions(has_selection));
+                CxOsOp::ShowClipboardActions { has_selection, rect, keyboard_shift } => {
+                    with_ios_app(|app| app.show_clipboard_actions(has_selection, rect, keyboard_shift));
+                }
+                CxOsOp::HideClipboardActions => {
+                    with_ios_app(|app| app.hide_clipboard_actions());
                 }
                 CxOsOp::CopyToClipboard(content) => {
                     with_ios_app(|app| app.copy_to_clipboard(&content));

--- a/platform/src/os/apple/ios/ios_app.rs
+++ b/platform/src/os/apple/ios/ios_app.rs
@@ -1,6 +1,8 @@
 use {
     std::{
-        cell::{Cell,RefCell},
+        cell::{Cell, RefCell},
+        ffi::c_void,
+        rc::Rc,
         time::Instant,
     },
     crate::{
@@ -66,6 +68,7 @@ pub struct IosClasses {
     pub gesture_recognizer_handler: *const Class,
     pub textfield_delegate: *const Class,
     pub timer_delegate: *const Class,
+    pub edit_menu_delegate: *const Class,
 }
 impl IosClasses {
     pub fn new() -> Self {
@@ -75,7 +78,8 @@ impl IosClasses {
             mtk_view_delegate: define_mtk_view_delegate(),
             gesture_recognizer_handler: define_gesture_recognizer_handler(),
             textfield_delegate: define_textfield_delegate(),
-            timer_delegate: define_ios_timer_delegate()
+            timer_delegate: define_ios_timer_delegate(),
+            edit_menu_delegate: define_edit_menu_interaction_delegate(),
         }
     }
 }
@@ -93,13 +97,15 @@ pub struct IosApp {
     pub textfield: Option<ObjcId>,
     event_callback: Option<Box<dyn FnMut(IosEvent) -> EventFlow >>,
     event_flow: EventFlow,
-    pasteboard: ObjcId
+    pasteboard: ObjcId,
+    edit_menu_delegate_instance: ObjcId,
+    edit_menu_interaction: Option<ObjcId>,
 }
 
 impl IosApp {
     pub fn new(metal_device: ObjcId, event_callback: Box<dyn FnMut(IosEvent) -> EventFlow>) -> IosApp {
         unsafe {
-            
+
             // Construct the bits that are shared between windows
             //let ns_app: ObjcId = msg_send![class!(UIApplication), sharedApplication];
             //let app_delegate_instance: ObjcId = msg_send![get_ios_class_global().app_delegate, new];
@@ -107,8 +113,9 @@ impl IosApp {
             //   panic!();
             //}
             //let () = msg_send![ns_app, setDelegate: app_delegate_instance];
-            
+
             let pasteboard: ObjcId = msg_send![class!(UIPasteboard), generalPasteboard];
+            let edit_menu_delegate_instance: ObjcId = msg_send![get_ios_class_global().edit_menu_delegate, new];
             IosApp {
                 virtual_keyboard_event: None,
                 touches: Vec::new(),
@@ -123,6 +130,8 @@ impl IosApp {
                 event_flow: EventFlow::Poll,
                 event_callback: Some(event_callback),
                 pasteboard,
+                edit_menu_delegate_instance,
+                edit_menu_interaction: None,
             }
         }
     }
@@ -199,9 +208,21 @@ impl IosApp {
             //let () = msg_send![view_ctrl_obj, endAppearanceTransition];
             
             let () = msg_send![window_obj, makeKeyAndVisible];
-            
+
+            // Initialize UIEditMenuInteraction for clipboard actions
+            // Store MTKView reference in the delegate for accessing menu rect
+            (*self.edit_menu_delegate_instance).set_ivar("mtk_view", mtk_view_obj as *mut c_void);
+
+            // Create UIEditMenuInteraction with our delegate
+            let edit_menu_interaction: ObjcId = msg_send![class!(UIEditMenuInteraction), alloc];
+            let edit_menu_interaction: ObjcId = msg_send![edit_menu_interaction, initWithDelegate: self.edit_menu_delegate_instance];
+
+            // Add the interaction to the MTKView
+            let () = msg_send![mtk_view_obj, addInteraction: edit_menu_interaction];
+
             self.textfield = Some(textfield);
             self.mtk_view = Some(mtk_view_obj);
+            self.edit_menu_interaction = Some(edit_menu_interaction);
         }
     }
     
@@ -473,25 +494,113 @@ impl IosApp {
         }
     }
 
-    pub fn show_clipboard_actions(&self, _has_selection: bool) {
-        // Note: Full UIMenuController implementation requires:
-        // 1. A custom UIView that can become first responder
-        // 2. Implementation of canPerformAction:withSender:
-        // 3. Action methods (copy:, paste:, cut:, selectAll:)
-        // 4. Proper positioning of the menu
-        //
-        // This is a placeholder that logs the intent.
-        // The hidden textfield approach currently used for IME doesn't
-        // easily support UIMenuController as it's designed for keyboard input only.
-        //
-        // For full implementation, we need to either:
-        // A) Add a custom responder view to the view hierarchy, OR
-        // B) Make the MTKView conform to the required protocols
+    pub fn show_clipboard_actions(&self, has_selection: bool, rect: Rect, _keyboard_shift: f64) {
+        unsafe {
+            let mtk_view = match self.mtk_view {
+                Some(view) => view,
+                None => return,
+            };
 
-        crate::log!("iOS: showClipboardActions called - UIMenuController not yet implemented");
+            let edit_menu_interaction = match self.edit_menu_interaction {
+                Some(interaction) => interaction,
+                None => return,
+            };
 
-        // TODO: Implement UIMenuController properly
-        // Reference implementation needed similar to Android's ActionMode
+            // Store selection state in the view for canPerformAction filtering
+            let has_sel: BOOL = if has_selection { YES } else { NO };
+            (*mtk_view).set_ivar::<BOOL>("has_selection", has_sel);
+
+            // Store the menu rect in the view for the delegate's targetRectForConfiguration
+            (*mtk_view).set_ivar::<f64>("menu_rect_x", rect.pos.x);
+            (*mtk_view).set_ivar::<f64>("menu_rect_y", rect.pos.y);
+            (*mtk_view).set_ivar::<f64>("menu_rect_width", rect.size.x.max(1.0));
+            (*mtk_view).set_ivar::<f64>("menu_rect_height", rect.size.y.max(1.0));
+
+            // Note: We do NOT call becomeFirstResponder here because:
+            // 1. UIEditMenuInteraction doesn't require the view to be first responder
+            // 2. Calling becomeFirstResponder triggers keyboard notifications which causes
+            //    re-entrant with_ios_app calls and crashes
+
+            // Create configuration with source point at center of the rect
+            let source_point = NSPoint {
+                x: rect.pos.x + rect.size.x / 2.0,
+                y: rect.pos.y + rect.size.y / 2.0,
+            };
+            let config: ObjcId = msg_send![
+                class!(UIEditMenuConfiguration),
+                configurationWithIdentifier: nil
+                sourcePoint: source_point
+            ];
+
+            // Present the edit menu
+            let () = msg_send![edit_menu_interaction, presentEditMenuWithConfiguration: config];
+        }
+    }
+
+    pub fn hide_clipboard_actions(&self) {
+        unsafe {
+            if let Some(edit_menu_interaction) = self.edit_menu_interaction {
+                let () = msg_send![edit_menu_interaction, dismissMenu];
+            }
+        }
+    }
+
+    // Action dispatch methods called from MakepadView's action handlers
+    pub fn send_clipboard_action(action: &str) {
+        match action {
+            "copy" => {
+                let response = Rc::new(RefCell::new(None));
+                IosApp::do_callback(IosEvent::TextCopy(TextClipboardEvent {
+                    response: response.clone()
+                }));
+                // After the event handler fills in the response, copy to clipboard
+                let text_to_copy = response.borrow().clone();
+                if let Some(text) = text_to_copy {
+                    with_ios_app(|app| app.copy_to_clipboard(&text));
+                }
+            },
+            "cut" => {
+                let response = Rc::new(RefCell::new(None));
+                IosApp::do_callback(IosEvent::TextCut(TextClipboardEvent {
+                    response: response.clone()
+                }));
+                // After the event handler fills in the response, copy to clipboard
+                let text_to_copy = response.borrow().clone();
+                if let Some(text) = text_to_copy {
+                    with_ios_app(|app| app.copy_to_clipboard(&text));
+                }
+            },
+            "select_all" => {
+                // Send Cmd+A keypress to trigger select all in widgets
+                // On Apple platforms, is_primary() checks for logo (Command)
+                let time = with_ios_app(|app| app.time_now());
+                IosApp::do_callback(IosEvent::KeyDown(KeyEvent {
+                    key_code: KeyCode::KeyA,
+                    is_repeat: false,
+                    modifiers: KeyModifiers {
+                        shift: false,
+                        control: false,
+                        alt: false,
+                        logo: true,
+                    },
+                    time,
+                }));
+            },
+            _ => {
+                crate::log!("iOS: Unknown clipboard action: {}", action);
+            }
+        }
+    }
+
+    pub fn send_clipboard_paste() {
+        let content = with_ios_app(|app| app.paste_from_clipboard());
+        if !content.is_empty() {
+            IosApp::do_callback(IosEvent::TextInput(TextInputEvent {
+                input: content,
+                replace_last: false,
+                was_paste: true,
+            }));
+        }
     }
 
     pub fn get_ios_directory_paths() -> String {

--- a/platform/src/os/apple/ios/ios_delegates.rs
+++ b/platform/src/os/apple/ios/ios_delegates.rs
@@ -40,10 +40,73 @@ pub fn define_ios_app_delegate() -> *const Class {
 
 pub fn define_mtk_view() -> *const Class {
     let mut decl = ClassDecl::new("MakepadView", class!(MTKView)).unwrap();
+
+    // Add instance variables for clipboard menu state
+    decl.add_ivar::<BOOL>("has_selection");
+    decl.add_ivar::<f64>("menu_rect_x");
+    decl.add_ivar::<f64>("menu_rect_y");
+    decl.add_ivar::<f64>("menu_rect_width");
+    decl.add_ivar::<f64>("menu_rect_height");
+    decl.add_ivar::<*mut c_void>("edit_menu_interaction");
+
     extern "C" fn yes(_: &Object, _: Sel) -> BOOL {
         YES
     }
-    
+
+    // Required for UIEditMenuInteraction to work - view must be able to become first responder
+    extern "C" fn can_become_first_responder(_: &Object, _: Sel) -> BOOL {
+        YES
+    }
+
+    // Return nil to prevent keyboard from showing when MakepadView becomes first responder
+    // (The hidden UITextField handles keyboard input separately)
+    extern "C" fn input_view(_: &Object, _: Sel) -> ObjcId {
+        nil
+    }
+
+    // Filter which clipboard actions are available based on selection state
+    extern "C" fn can_perform_action(this: &Object, _: Sel, action: Sel, _sender: ObjcId) -> BOOL {
+        unsafe {
+            let has_selection: BOOL = *this.get_ivar("has_selection");
+
+            // Copy and Cut require a selection
+            if action == sel!(copy:) || action == sel!(cut:) {
+                return has_selection;
+            }
+
+            // Paste requires clipboard to have text content
+            if action == sel!(paste:) {
+                let pasteboard: ObjcId = msg_send![class!(UIPasteboard), generalPasteboard];
+                let has_strings: BOOL = msg_send![pasteboard, hasStrings];
+                return has_strings;
+            }
+
+            // Select All is always available
+            if action == sel!(selectAll:) {
+                return YES;
+            }
+
+            NO
+        }
+    }
+
+    // Action handlers for clipboard operations
+    extern "C" fn copy_action(_this: &Object, _: Sel, _sender: ObjcId) {
+        IosApp::send_clipboard_action("copy");
+    }
+
+    extern "C" fn cut_action(_this: &Object, _: Sel, _sender: ObjcId) {
+        IosApp::send_clipboard_action("cut");
+    }
+
+    extern "C" fn paste_action(_this: &Object, _: Sel, _sender: ObjcId) {
+        IosApp::send_clipboard_paste();
+    }
+
+    extern "C" fn select_all_action(_this: &Object, _: Sel, _sender: ObjcId) {
+        IosApp::send_clipboard_action("select_all");
+    }
+
     fn on_touch(this: &Object, event: ObjcId, state: TouchState) {
         unsafe {
             let enumerator: ObjcId = msg_send![event, allTouches];
@@ -115,8 +178,41 @@ pub fn define_mtk_view() -> *const Class {
             sel!(touchesCanceled: withEvent:),
             touches_canceled as extern "C" fn(&Object, Sel, ObjcId, ObjcId),
         );
+
+        // First responder support for clipboard menu
+        decl.add_method(
+            sel!(canBecomeFirstResponder),
+            can_become_first_responder as extern "C" fn(&Object, Sel) -> BOOL,
+        );
+        // Return nil to prevent keyboard from appearing when view becomes first responder
+        decl.add_method(
+            sel!(inputView),
+            input_view as extern "C" fn(&Object, Sel) -> ObjcId,
+        );
+        decl.add_method(
+            sel!(canPerformAction:withSender:),
+            can_perform_action as extern "C" fn(&Object, Sel, Sel, ObjcId) -> BOOL,
+        );
+
+        // Clipboard action handlers
+        decl.add_method(
+            sel!(copy:),
+            copy_action as extern "C" fn(&Object, Sel, ObjcId),
+        );
+        decl.add_method(
+            sel!(cut:),
+            cut_action as extern "C" fn(&Object, Sel, ObjcId),
+        );
+        decl.add_method(
+            sel!(paste:),
+            paste_action as extern "C" fn(&Object, Sel, ObjcId),
+        );
+        decl.add_method(
+            sel!(selectAll:),
+            select_all_action as extern "C" fn(&Object, Sel, ObjcId),
+        );
     }
-    
+
     return decl.register();
 }
 
@@ -325,5 +421,52 @@ pub fn define_textfield_delegate() -> *const Class {
         );
     }
     decl.add_ivar::<*mut c_void>("display_ptr");
+    return decl.register();
+}
+
+/// Defines a delegate class for UIEditMenuInteraction
+/// This delegate provides the target rect for menu positioning.
+pub fn define_edit_menu_interaction_delegate() -> *const Class {
+    let mut decl = ClassDecl::new("MakepadEditMenuDelegate", class!(NSObject)).unwrap();
+
+    // Store a reference to the MTKView for accessing menu rect
+    decl.add_ivar::<*mut c_void>("mtk_view");
+
+    // editMenuInteraction:targetRectForConfiguration:
+    // Returns the rect where the menu should point to (selection rect)
+    extern "C" fn target_rect_for_configuration(
+        this: &Object,
+        _: Sel,
+        _interaction: ObjcId,
+        _configuration: ObjcId,
+    ) -> NSRect {
+        unsafe {
+            let mtk_view: *mut c_void = *this.get_ivar("mtk_view");
+            if mtk_view.is_null() {
+                return NSRect {
+                    origin: NSPoint { x: 0.0, y: 0.0 },
+                    size: NSSize { width: 1.0, height: 1.0 },
+                };
+            }
+            let view = mtk_view as ObjcId;
+            let x: f64 = *(*view).get_ivar("menu_rect_x");
+            let y: f64 = *(*view).get_ivar("menu_rect_y");
+            let width: f64 = *(*view).get_ivar("menu_rect_width");
+            let height: f64 = *(*view).get_ivar("menu_rect_height");
+            NSRect {
+                origin: NSPoint { x, y },
+                size: NSSize { width, height },
+            }
+        }
+    }
+
+    unsafe {
+        // UIEditMenuInteractionDelegate method: editMenuInteraction:targetRectForConfiguration:
+        decl.add_method(
+            sel!(editMenuInteraction:targetRectForConfiguration:),
+            target_rect_for_configuration as extern "C" fn(&Object, Sel, ObjcId, ObjcId) -> NSRect,
+        );
+    }
+
     return decl.register();
 }

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -1423,7 +1423,17 @@ impl Widget for TextInput {
                 key_code: KeyCode::KeyA,
                 modifiers,
                 ..
-            }) if modifiers.is_primary() => self.select_all(cx),
+            }) if modifiers.is_primary() => {
+                self.select_all(cx);
+                // On touch platforms, show clipboard actions after select all
+                // This handles the case where select_all is triggered from the clipboard menu
+                #[cfg(any(target_os = "ios", target_os = "android"))]
+                {
+                    let has_selection = !self.selected_text().is_empty();
+                    let selection_rect = self.get_selection_rect(cx);
+                    cx.show_clipboard_actions(has_selection, selection_rect, cx.keyboard_shift);
+                }
+            }
             Hit::FingerDown(FingerDownEvent {
                 abs,
                 tap_count,


### PR DESCRIPTION
Implements native iOS clipboard actions (Copy/Paste/Cut/Select All) context menu using UIEditMenuInteraction (iOS 16+), matching the Android ActionMode implementation from PR #821.

### Summary of changes
- Add UIEditMenuInteractionDelegate for menu positioning
- Extend MakepadView with first responder support and standard action handlers (copy:, cut:, paste:, selectAll:)
- Implement `show_clipboard_actions()` and `hide_clipboard_actions()` in IosApp
- Handle ShowClipboardActions/HideClipboardActions platform ops


This also updates the TextInput widget to re-show clipboard menu after select_all on touch platforms, currently after select_all the context menu disappears and double tapping again or holding down to trigger show it causes the select_all selection replaced with a new one, making select_all useless.