### PR TITLE
iOS: Add UITextInput protocol implementation for IME support

### DIFF
--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -74,6 +74,9 @@ pub enum CxOsOp {
 
     ShowTextIME(Area, Vec2d),
     HideTextIME,
+    /// Sets the text and cursor position to the IME for autocorrect context
+    /// (text, cursor_position)
+    SetIMEText(String, usize),
     SetCursor(MouseCursor),
     StartTimer {
         timer_id: u64,
@@ -158,6 +161,7 @@ impl std::fmt::Debug for CxOsOp {
 
             Self::ShowTextIME(..)=>write!(f, "ShowTextIME"),
             Self::HideTextIME=>write!(f, "HideTextIME"),
+            Self::SetIMEText(..)=>write!(f, "SetIMEText"),
             Self::SetCursor(..)=>write!(f, "SetCursor"),
             Self::StartTimer{..}=>write!(f, "StartTimer"),
             Self::StopTimer(..)=>write!(f, "StopTimer"),
@@ -316,6 +320,11 @@ impl Cx {
     pub fn hide_text_ime(&mut self) {
         self.keyboard.reset_text_ime_dismissed();
         self.platform_ops.push(CxOsOp::HideTextIME);
+    }
+
+    /// Syncs text content to IME for autocorrect context
+    pub fn set_ime_text(&mut self, text: &str, cursor_pos: usize) {
+        self.platform_ops.push(CxOsOp::SetIMEText(text.to_string(), cursor_pos));
     }
 
     pub fn text_ime_was_dismissed(&mut self) {

--- a/platform/src/event/event.rs
+++ b/platform/src/event/event.rs
@@ -190,6 +190,7 @@ pub enum Event {
     KeyDown(KeyEvent),
     KeyUp(KeyEvent),
     TextInput(TextInputEvent),
+    TextRangeReplace(TextRangeReplaceEvent),
     TextCopy(TextClipboardEvent),
     TextCut(TextClipboardEvent),
 
@@ -277,6 +278,7 @@ impl Event{
             31=>"KeyDown",
             32=>"KeyUp",
             33=>"TextInput",
+            58=>"TextRangeReplace",
             34=>"TextCopy",
             35=>"TextCut",
 
@@ -351,6 +353,7 @@ impl Event{
             Self::KeyDown(_)=>31,
             Self::KeyUp(_)=>32,
             Self::TextInput(_)=>33,
+            Self::TextRangeReplace(_)=>58,
             Self::TextCopy(_)=>34,
             Self::TextCut(_)=>35,
 
@@ -406,6 +409,7 @@ pub enum Hit{
     KeyUp(KeyEvent),
     Trigger(TriggerHitEvent),
     TextInput(TextInputEvent),
+    TextRangeReplace(TextRangeReplaceEvent),
     TextCopy(TextClipboardEvent),
     TextCut(TextClipboardEvent),
 

--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -919,6 +919,11 @@ impl Event {
                     return Hit::TextInput(ti.clone())
                 }
             },
+            Event::TextRangeReplace(tr) => {
+                if cx.keyboard.has_key_focus(area) {
+                    return Hit::TextRangeReplace(tr.clone())
+                }
+            },
             Event::TextCopy(tc) => {
                 if cx.keyboard.has_key_focus(area) {
                     return Hit::TextCopy(tc.clone());

--- a/platform/src/event/keyboard.rs
+++ b/platform/src/event/keyboard.rs
@@ -137,6 +137,17 @@ pub struct TextClipboardEvent {
     pub response: Rc<RefCell<Option<String>>>
 }
 
+/// Event for replacing a specific range of text
+#[derive(Clone, Debug)]
+pub struct TextRangeReplaceEvent {
+    /// Start index (in characters, not bytes) of range to replace
+    pub start: usize,
+    /// End index (in characters, not bytes) of range to replace
+    pub end: usize,
+    /// Text to insert at the range
+    pub text: String,
+}
+
 impl Default for KeyCode {
     fn default() -> Self {KeyCode::Unknown}
 }

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -29,7 +29,10 @@ use {
         window::CxWindowPool,
         event::{
             Event,
-            NetworkResponseChannel
+            NetworkResponseChannel,
+            TextInputEvent,
+            TextRangeReplaceEvent,
+            KeyEvent,
         },
         cx_api::{CxOsApi, CxOsOp, OpenUrlInPlace},
         cx::{Cx, OsType, IosParams},
@@ -148,6 +151,41 @@ impl Cx {
                     let vk = with_ios_app(|app| app.virtual_keyboard_event.take());
                     if let Some(vk) = vk{
                         self.call_event_handler(&Event::VirtualKeyboard(vk));
+                    }
+                    // Process queued text input from UITextInput callbacks
+                    let queued_text = with_ios_app(|app| app.queued_text_input.take());
+                    if let Some((input, replace_last)) = queued_text {
+                        self.call_event_handler(&Event::TextInput(TextInputEvent {
+                            input,
+                            was_paste: false,
+                            replace_last,
+                        }));
+                    }
+                    // Process queued text range replacement (iOS autocorrect)
+                    let queued_range_replace = with_ios_app(|app| app.queued_text_range_replace.take());
+                    if let Some((start, end, text)) = queued_range_replace {
+                        self.call_event_handler(&Event::TextRangeReplace(TextRangeReplaceEvent {
+                            start,
+                            end,
+                            text,
+                        }));
+                    }
+                    // Process queued key events from UITextInput callbacks
+                    let queued_key = with_ios_app(|app| app.queued_key_event.take());
+                    if let Some(key_code) = queued_key {
+                        let time = with_ios_app(|app| app.time_now());
+                        self.call_event_handler(&Event::KeyDown(KeyEvent {
+                            key_code,
+                            is_repeat: false,
+                            modifiers: Default::default(),
+                            time,
+                        }));
+                        self.call_event_handler(&Event::KeyUp(KeyEvent {
+                            key_code,
+                            is_repeat: false,
+                            modifiers: Default::default(),
+                            time,
+                        }));
                     }
                     // check signals
                     if SignalToUI::check_and_clear_ui_signal(){
@@ -282,11 +320,15 @@ impl Cx {
                     window.window_geom = with_ios_app(|app| app.last_window_geom.clone());
                     window.is_created = true;
                 },
-                CxOsOp::ShowTextIME(_area, _pos) => {
+                CxOsOp::ShowTextIME(_area, pos) => {
+                    IosApp::set_ime_position(pos);
                     IosApp::show_keyboard();
                 },
                 CxOsOp::HideTextIME => {
                     IosApp::hide_keyboard();
+                },
+                CxOsOp::SetIMEText(text, cursor_pos) => {
+                    IosApp::set_ime_text(text, cursor_pos);
                 },
                 CxOsOp::StartTimer {timer_id, interval, repeats} => {
                     with_ios_app(|app| app.start_timer(timer_id, interval, repeats));
@@ -307,10 +349,10 @@ impl Cx {
                     self.os.http_requests.cancel_http_request(request_id);
                 },
                 CxOsOp::ShowClipboardActions { has_selection, rect, keyboard_shift } => {
-                    with_ios_app(|app| app.show_clipboard_actions(has_selection, rect, keyboard_shift));
+                    IosApp::show_clipboard_actions(has_selection, rect, keyboard_shift);
                 }
                 CxOsOp::HideClipboardActions => {
-                    with_ios_app(|app| app.hide_clipboard_actions());
+                    IosApp::hide_clipboard_actions();
                 }
                 CxOsOp::CopyToClipboard(content) => {
                     with_ios_app(|app| app.copy_to_clipboard(&content));

--- a/platform/src/os/apple/ios/ios_app.rs
+++ b/platform/src/os/apple/ios/ios_app.rs
@@ -69,6 +69,10 @@ pub struct IosClasses {
     pub textfield_delegate: *const Class,
     pub timer_delegate: *const Class,
     pub edit_menu_delegate: *const Class,
+    // UITextInput protocol classes for IME support
+    pub text_position: *const Class,
+    pub text_range: *const Class,
+    pub text_input_view: *const Class,
 }
 impl IosClasses {
     pub fn new() -> Self {
@@ -80,6 +84,10 @@ impl IosClasses {
             textfield_delegate: define_textfield_delegate(),
             timer_delegate: define_ios_timer_delegate(),
             edit_menu_delegate: define_edit_menu_interaction_delegate(),
+            // All UITextInput classes enabled
+            text_position: define_makepad_text_position(),
+            text_range: define_makepad_text_range(),
+            text_input_view: define_text_input_view(),
         }
     }
 }
@@ -87,6 +95,14 @@ impl IosClasses {
 pub struct IosApp {
     pub time_start: Instant,
     pub virtual_keyboard_event:  Option<VirtualKeyboardEvent>,
+    /// Queued text input from UITextInput
+    /// (input, replace_last)
+    pub queued_text_input: Option<(String, bool)>,
+    /// Queued text range replace from UITextInput
+    /// (start, end, text)
+    pub queued_text_range_replace: Option<(usize, usize, String)>,
+    /// Queued key event from UITextInput
+    pub queued_key_event: Option<KeyCode>,
     pub timer_delegate_instance: ObjcId,
     timers: Vec<IosTimer>,
     touches: Vec<TouchPoint>,
@@ -94,7 +110,10 @@ pub struct IosApp {
     metal_device: ObjcId,
     first_draw: bool,
     pub mtk_view: Option<ObjcId>,
-    pub textfield: Option<ObjcId>,
+    /// UITextInput view for IME support
+    pub text_input_view: Option<ObjcId>,
+    /// IME candidate window position
+    pub ime_position: Option<DVec2>,
     event_callback: Option<Box<dyn FnMut(IosEvent) -> EventFlow >>,
     event_flow: EventFlow,
     pasteboard: ObjcId,
@@ -118,12 +137,16 @@ impl IosApp {
             let edit_menu_delegate_instance: ObjcId = msg_send![get_ios_class_global().edit_menu_delegate, new];
             IosApp {
                 virtual_keyboard_event: None,
+                queued_text_input: None,
+                queued_text_range_replace: None,
+                queued_key_event: None,
                 touches: Vec::new(),
                 last_window_geom: WindowGeom::default(),
                 metal_device,
                 first_draw: true,
                 mtk_view: None,
-                textfield: None,
+                text_input_view: None,
+                ime_position: None,
                 time_start: Instant::now(),
                 timer_delegate_instance: msg_send![get_ios_class_global().timer_delegate, new],
                 timers: Vec::new(),
@@ -178,19 +201,31 @@ impl IosApp {
             let () = msg_send![mtk_view_obj, setAutoResizeDrawable: YES];
             let () = msg_send![mtk_view_obj, setMultipleTouchEnabled: YES];
             
+            // Create UITextInput view for proper IME support
+            let text_input_view: ObjcId = msg_send![get_ios_class_global().text_input_view, alloc];
+            let text_input_view: ObjcId = msg_send![text_input_view, initWithFrame: NSRect {
+                origin: NSPoint { x: 0.0, y: 0.0 },
+                size: NSSize { width: 1.0, height: 1.0 }
+            }];
+
+            // Initialize ivars
+            let marked_text: ObjcId = msg_send![class!(NSMutableAttributedString), alloc];
+            let marked_text: ObjcId = msg_send![marked_text, init];
+            (*text_input_view).set_ivar::<ObjcId>("markedText", marked_text);
+            (*text_input_view).set_ivar::<i64>("cursorPosition", 0);
+            (*text_input_view).set_ivar::<i64>("selectionStart", 0);
+            (*text_input_view).set_ivar::<i64>("selectionEnd", 0);
+            (*text_input_view).set_ivar::<ObjcId>("_inputDelegate", nil);
+            (*text_input_view).set_ivar::<ObjcId>("_tokenizer", nil);
+            (*text_input_view).set_ivar::<f64>("ime_pos_x", 0.0);
+            (*text_input_view).set_ivar::<f64>("ime_pos_y", 0.0);
+
+            let () = msg_send![text_input_view, setUserInteractionEnabled: YES];
+            let () = msg_send![mtk_view_obj, addSubview: text_input_view];
+
+            // Set up textfield delegate for keyboard notifications only
             let textfield_dlg: ObjcId = msg_send![get_ios_class_global().textfield_delegate, alloc];
             let textfield_dlg: ObjcId = msg_send![textfield_dlg, init];
-             
-            let textfield: ObjcId = msg_send![class!(UITextField), alloc];
-            let textfield: ObjcId =  msg_send![textfield, initWithFrame: NSRect {origin: NSPoint {x: 10.0, y: 10.0}, size: NSSize {width: 100.0, height: 50.0}}];
-            let () = msg_send![textfield, setAutocapitalizationType: 0]; // UITextAutocapitalizationTypeNone
-            let () = msg_send![textfield, setAutocorrectionType: 1]; // UITextAutocorrectionTypeNo
-            let () = msg_send![textfield, setSpellCheckingType: 1]; // UITextSpellCheckingTypeNo
-            let () = msg_send![textfield, setHidden: YES];
-            let () = msg_send![textfield, setDelegate: textfield_dlg];
-            // to make backspace work - with empty text there is no event on text removal
-            let () = msg_send![textfield, setText: str_to_nsstring("x")];
-            let () = msg_send![mtk_view_obj, addSubview: textfield];
             
             let notification_center: ObjcId = msg_send![class!(NSNotificationCenter), defaultCenter];
             let () = msg_send![notification_center, addObserver: textfield_dlg selector: sel!(keyboardDidChangeFrame:) name: UIKeyboardDidChangeFrameNotification object: nil];
@@ -220,7 +255,7 @@ impl IosApp {
             // Add the interaction to the MTKView
             let () = msg_send![mtk_view_obj, addInteraction: edit_menu_interaction];
 
-            self.textfield = Some(textfield);
+            self.text_input_view = Some(text_input_view);
             self.mtk_view = Some(mtk_view_obj);
             self.edit_menu_interaction = Some(edit_menu_interaction);
         }
@@ -359,15 +394,93 @@ impl IosApp {
     }
     
     pub fn show_keyboard() {
-        let textfield = with_ios_app(|app| app.textfield.unwrap());
-        let () = unsafe {msg_send![textfield, becomeFirstResponder]};
+        // Use text_input_view for keyboard (UITextInput protocol)
+        let _ = IOS_APP.try_with(|app| {
+            if let Ok(app_ref) = app.try_borrow_mut() {
+                if let Some(ref app) = *app_ref {
+                    if let Some(text_input_view) = app.text_input_view {
+                        let () = unsafe { msg_send![text_input_view, becomeFirstResponder] };
+                    }
+                }
+            }
+        });
     }
 
-    pub fn hide_keyboard(){
-        let textfield = with_ios_app(|app| app.textfield.unwrap());
-        let () = unsafe {msg_send![textfield, resignFirstResponder]};
+    pub fn hide_keyboard() {
+        // Use text_input_view for keyboard
+        let _ = IOS_APP.try_with(|app| {
+            if let Ok(app_ref) = app.try_borrow_mut() {
+                if let Some(ref app) = *app_ref {
+                    if let Some(text_input_view) = app.text_input_view {
+                        let () = unsafe { msg_send![text_input_view, resignFirstResponder] };
+                    }
+                }
+            }
+        });
     }
-    
+
+    pub fn set_ime_position(pos: DVec2) {
+        // Avoid re-entrant calls by checking if we're already in a with_ios_app call
+        let _ = IOS_APP.try_with(|app| {
+            if let Ok(mut app_ref) = app.try_borrow_mut() {
+                if let Some(ref mut app) = *app_ref {
+                    app.ime_position = Some(pos);
+                    // Also set ivars directly on the text_input_view to avoid re-entrant borrow issues
+                    // when UITextInput callbacks access the position
+                    if let Some(text_input_view) = app.text_input_view {
+                        unsafe {
+                            (*text_input_view).set_ivar::<f64>("ime_pos_x", pos.x);
+                            (*text_input_view).set_ivar::<f64>("ime_pos_y", pos.y);
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    pub fn set_ime_text(text: String, cursor_byte_pos: usize) {
+        // Convert byte position to UTF-16 code unit position for iOS
+        // cursor_byte_pos is a UTF-8 byte index, iOS NSString uses UTF-16 internally
+        let cursor_char_pos = text[..cursor_byte_pos.min(text.len())]
+            .encode_utf16()
+            .count();
+
+        let _ = IOS_APP.try_with(|app| {
+            if let Ok(mut app_ref) = app.try_borrow_mut() {
+                if let Some(ref mut app) = *app_ref {
+                    if let Some(text_input_view) = app.text_input_view {
+                        unsafe {
+                            // Get or create text buffer
+                            let buffer: ObjcId = *(*text_input_view).get_ivar("textBuffer");
+                            let buffer = if buffer != nil {
+                                buffer
+                            } else {
+                                let new_buffer: ObjcId = msg_send![class!(NSMutableString), alloc];
+                                let new_buffer: ObjcId = msg_send![new_buffer, init];
+                                (*text_input_view).set_ivar("textBuffer", new_buffer);
+                                new_buffer
+                            };
+
+                            // Clear existing content
+                            let len: u64 = msg_send![buffer, length];
+                            if len > 0 {
+                                let range = NSRange { location: 0, length: len };
+                                let () = msg_send![buffer, deleteCharactersInRange: range];
+                            }
+
+                            // Set new content
+                            let ns_text = str_to_nsstring(&text);
+                            let () = msg_send![buffer, appendString: ns_text];
+
+                            // Set cursor position (in characters, not bytes)
+                            (*text_input_view).set_ivar("cursorPosition", cursor_char_pos as i64);
+                        }
+                    }
+                }
+            }
+        });
+    }
+
     pub fn do_callback(event: IosEvent) {
         let cb = with_ios_app(|app| app.event_callback.take());
         if let Some(mut callback) = cb {
@@ -410,11 +523,7 @@ impl IosApp {
             let () = msg_send![pool, release];
         }
     }
-    
-    pub fn send_virtual_keyboard_event(event:VirtualKeyboardEvent){
-        IosApp::do_callback(IosEvent::VirtualKeyboard(event));
-    }
-    
+
     pub fn queue_virtual_keyboard_event(&mut self, event:VirtualKeyboardEvent){
         self.virtual_keyboard_event = Some(event);
     }
@@ -432,27 +541,50 @@ impl IosApp {
     }
     
     pub fn send_text_input(input: String, replace_last: bool) {
-        IosApp::do_callback(IosEvent::TextInput(TextInputEvent {
-            input: input,
-            was_paste: false,
-            replace_last: replace_last
-        }))
+        // Always queue - will be processed on next timer tick
+        // This avoids re-entrancy issues from UITextField delegate callbacks
+        let _ = IOS_APP.try_with(|app| {
+            if let Ok(mut app_ref) = app.try_borrow_mut() {
+                if let Some(ref mut app) = *app_ref {
+                    app.queued_text_input = Some((input, replace_last));
+                }
+            }
+        });
     }
-    
+
+    pub fn send_text_range_replace(start: usize, end: usize, text: String) {
+        // Queue range replacement for iOS autocorrect
+        // This avoids re-entrancy issues from UITextInput delegate callbacks
+        let _ = IOS_APP.try_with(|app| {
+            if let Ok(mut app_ref) = app.try_borrow_mut() {
+                if let Some(ref mut app) = *app_ref {
+                    app.queued_text_range_replace = Some((start, end, text));
+                }
+            }
+        });
+    }
+
     pub fn send_backspace() {
-        let time = with_ios_app(|app| app.time_now());
-        IosApp::do_callback(IosEvent::KeyDown(KeyEvent {
-            key_code: KeyCode::Backspace,
-            is_repeat: false,
-            modifiers: Default::default(),
-            time,
-        }));
-        IosApp::do_callback(IosEvent::KeyUp(KeyEvent {
-            key_code: KeyCode::Backspace,
-            is_repeat: false,
-            modifiers: Default::default(),
-            time,
-        }));
+        // Always queue - will be processed on next timer tick
+        // This avoids re-entrancy issues from UITextField delegate callbacks
+        let _ = IOS_APP.try_with(|app| {
+            if let Ok(mut app_ref) = app.try_borrow_mut() {
+                if let Some(ref mut app) = *app_ref {
+                    app.queued_key_event = Some(KeyCode::Backspace);
+                }
+            }
+        });
+    }
+
+    pub fn send_return_key() {
+        // Queue Return key event
+        let _ = IOS_APP.try_with(|app| {
+            if let Ok(mut app_ref) = app.try_borrow_mut() {
+                if let Some(ref mut app) = *app_ref {
+                    app.queued_key_event = Some(KeyCode::ReturnKey);
+                }
+            }
+        });
     }
     
     pub fn send_timer_received(nstimer: ObjcId) {
@@ -494,18 +626,23 @@ impl IosApp {
         }
     }
 
-    pub fn show_clipboard_actions(&self, has_selection: bool, rect: Rect, _keyboard_shift: f64) {
+    pub fn show_clipboard_actions(has_selection: bool, rect: Rect, _keyboard_shift: f64) {
+        // Extract what we need from IosApp first, then do ObjC calls AFTER the borrow ends
+        // This avoids re-entrant borrow panics when UIKit triggers keyboard notifications
+        let views = IOS_APP.try_with(|app| {
+            if let Ok(app_ref) = app.try_borrow_mut() {
+                if let Some(ref app) = *app_ref {
+                    if let (Some(mtk_view), Some(edit_menu_interaction)) = (app.mtk_view, app.edit_menu_interaction) {
+                        return Some((mtk_view, edit_menu_interaction));
+                    }
+                }
+            }
+            None
+        }).ok().flatten();
+
+        let Some((mtk_view, edit_menu_interaction)) = views else { return };
+
         unsafe {
-            let mtk_view = match self.mtk_view {
-                Some(view) => view,
-                None => return,
-            };
-
-            let edit_menu_interaction = match self.edit_menu_interaction {
-                Some(interaction) => interaction,
-                None => return,
-            };
-
             // Store selection state in the view for canPerformAction filtering
             let has_sel: BOOL = if has_selection { YES } else { NO };
             (*mtk_view).set_ivar::<BOOL>("has_selection", has_sel);
@@ -515,11 +652,6 @@ impl IosApp {
             (*mtk_view).set_ivar::<f64>("menu_rect_y", rect.pos.y);
             (*mtk_view).set_ivar::<f64>("menu_rect_width", rect.size.x.max(1.0));
             (*mtk_view).set_ivar::<f64>("menu_rect_height", rect.size.y.max(1.0));
-
-            // Note: We do NOT call becomeFirstResponder here because:
-            // 1. UIEditMenuInteraction doesn't require the view to be first responder
-            // 2. Calling becomeFirstResponder triggers keyboard notifications which causes
-            //    re-entrant with_ios_app calls and crashes
 
             // Create configuration with source point at center of the rect
             let source_point = NSPoint {
@@ -532,14 +664,25 @@ impl IosApp {
                 sourcePoint: source_point
             ];
 
-            // Present the edit menu
+            // Present the edit menu - this may trigger keyboard notifications,
+            // but now we're not holding any borrow so it's safe
             let () = msg_send![edit_menu_interaction, presentEditMenuWithConfiguration: config];
         }
     }
 
-    pub fn hide_clipboard_actions(&self) {
-        unsafe {
-            if let Some(edit_menu_interaction) = self.edit_menu_interaction {
+    pub fn hide_clipboard_actions() {
+        // Extract what we need first, then do ObjC calls after borrow ends
+        let interaction = IOS_APP.try_with(|app| {
+            if let Ok(app_ref) = app.try_borrow_mut() {
+                if let Some(ref app) = *app_ref {
+                    return app.edit_menu_interaction;
+                }
+            }
+            None
+        }).ok().flatten();
+
+        if let Some(edit_menu_interaction) = interaction {
+            unsafe {
                 let () = msg_send![edit_menu_interaction, dismissMenu];
             }
         }

--- a/platform/src/os/apple/ios/ios_delegates.rs
+++ b/platform/src/os/apple/ios/ios_delegates.rs
@@ -5,12 +5,53 @@ use {
         animator::Ease,
         os::{
             apple::ios_app::IosApp,
-            apple::apple_util::nsstring_to_string,
+            apple::apple_util::{nsstring_to_string, str_to_nsstring},
             apple::apple_sys::*,
-            apple::ios_app::with_ios_app,
+            apple::ios_app::{with_ios_app, get_ios_class_global, IOS_APP},
         },
-    }
+    },
+    makepad_objc_sys::runtime::Protocol,
 };
+
+/// Count UTF-16 code units in a Rust string.
+/// This is needed because iOS NSString uses UTF-16 internally, and UITextInput
+/// positions are measured in UTF-16 code units, not characters or bytes.
+/// For ASCII: 1 char = 1 UTF-16 code unit
+/// For most Unicode (including CJK): 1 char = 1 UTF-16 code unit
+/// For emoji and other astral plane characters: 1 char = 2 UTF-16 code units (surrogate pair)
+fn utf16_len(s: &str) -> i64 {
+    s.encode_utf16().count() as i64
+}
+
+/// Convert a UTF-16 code unit index to a character index.
+/// This is needed because iOS sends UTF-16 indices but Makepad uses character indices.
+fn utf16_index_to_char_index(s: &str, utf16_index: usize) -> usize {
+    let mut char_index = 0;
+    let mut utf16_pos = 0;
+    for c in s.chars() {
+        let c_len = c.len_utf16();
+        if utf16_pos + c_len > utf16_index {
+            break;
+        }
+        utf16_pos += c_len;
+        char_index += 1;
+    }
+    char_index
+}
+
+// Helper to safely access IosApp without causing re-entrant borrow panics.
+// Returns None if we're already inside a with_ios_app call.
+// This is critical for callbacks from UIKit that can occur during borrows.
+fn try_with_ios_app<R>(f: impl FnOnce(&mut crate::os::apple::ios::ios_app::IosApp) -> R) -> Option<R> {
+    IOS_APP.try_with(|app| {
+        if let Ok(mut app_ref) = app.try_borrow_mut() {
+            if let Some(app) = app_ref.as_mut() {
+                return Some(f(app));
+            }
+        }
+        None
+    }).ok().flatten()
+}
 
 
 pub fn define_ios_app_delegate() -> *const Class {
@@ -304,7 +345,7 @@ pub fn define_ios_timer_delegate() -> *const Class {
 }
 
 pub fn define_textfield_delegate() -> *const Class {
-    let mut decl = ClassDecl::new("NSTexfieldDlg", class!(NSObject)).unwrap();
+    let mut decl = ClassDecl::new("NSTextFieldDlg", class!(NSObject)).unwrap();
     
     // those 3 callbacks are for resizing the canvas when keyboard is opened
     // which is not currenlty supported by miniquad
@@ -341,48 +382,59 @@ pub fn define_textfield_delegate() -> *const Class {
         }
     }
     
-    extern "C" fn keyboard_did_change_frame(_: &Object, _: Sel, _notif: ObjcId) {
-    }
-    
-    extern "C" fn keyboard_will_change_frame(_: &Object, _: Sel, _notif: ObjcId) {
-    }
-    
+    // Stubs for keyboard frame change notifications - could be used for finer-grained
+    // keyboard tracking in the future (e.g., during interactive keyboard dismissal)
+    extern "C" fn keyboard_did_change_frame(_: &Object, _: Sel, _notif: ObjcId) {}
+    extern "C" fn keyboard_will_change_frame(_: &Object, _: Sel, _notif: ObjcId) {}
+
     extern "C" fn keyboard_will_hide(_: &Object, _: Sel, notif: ObjcId) {
+        // Get notification data OUTSIDE the borrow
         let height = get_height_delta(notif);
         let (duration, ease) = get_curve_duration(notif);
-        let time = with_ios_app(|app| app.time_now());
-        with_ios_app(|app| app.queue_virtual_keyboard_event(VirtualKeyboardEvent::WillHide {
-            time,
-            ease,
-            height: -height,
-            duration
-        }));
+        // Now borrow to get time and queue event
+        if let Some(time) = try_with_ios_app(|app| app.time_now()) {
+            try_with_ios_app(|app| app.queue_virtual_keyboard_event(VirtualKeyboardEvent::WillHide {
+                time,
+                ease,
+                height: -height,
+                duration
+            }));
+        }
     }
-    
+
     extern "C" fn keyboard_did_hide(_: &Object, _: Sel, _notif: ObjcId) {
-        let time = with_ios_app(|app| app.time_now());
-        IosApp::send_virtual_keyboard_event(VirtualKeyboardEvent::DidHide {
-            time,
-        });
+        if let Some(time) = try_with_ios_app(|app| app.time_now()) {
+            try_with_ios_app(|app| app.queue_virtual_keyboard_event(VirtualKeyboardEvent::DidHide {
+                time,
+            }));
+        }
     }
+
     extern "C" fn keyboard_will_show(_: &Object, _: Sel, notif: ObjcId) {
+        // Get notification data OUTSIDE the borrow
         let height = get_height_delta(notif);
         let (duration, ease) = get_curve_duration(notif);
-        let time = with_ios_app(|app| app.time_now());
-        IosApp::send_virtual_keyboard_event(VirtualKeyboardEvent::WillShow {
-            time,
-            height,
-            ease,
-            duration
-        });
+        // Now borrow to get time and queue event
+        if let Some(time) = try_with_ios_app(|app| app.time_now()) {
+            try_with_ios_app(|app| app.queue_virtual_keyboard_event(VirtualKeyboardEvent::WillShow {
+                time,
+                height,
+                ease,
+                duration
+            }));
+        }
     }
+
     extern "C" fn keyboard_did_show(_: &Object, _: Sel, notif: ObjcId) {
+        // Get notification data OUTSIDE the borrow
         let height = get_height_delta(notif);
-        let time = with_ios_app(|app| app.time_now());
-        IosApp::send_virtual_keyboard_event(VirtualKeyboardEvent::DidShow {
-            time,
-            height: height
-        });
+        // Now borrow to get time and queue event
+        if let Some(time) = try_with_ios_app(|app| app.time_now()) {
+            try_with_ios_app(|app| app.queue_virtual_keyboard_event(VirtualKeyboardEvent::DidShow {
+                time,
+                height,
+            }));
+        }
     }
     extern "C" fn should_change_characters_in_range(
         _this: &Object,
@@ -404,10 +456,6 @@ pub fn define_textfield_delegate() -> *const Class {
     }
     
     unsafe {
-        /*decl.add_method(
-            sel!(drawInMTKView:),
-            draw_in_rect as extern "C" fn(&Object, Sel, ObjcId),
-        );*/
         decl.add_method(sel!(keyboardDidChangeFrame:), keyboard_did_change_frame as extern "C" fn(&Object, Sel, ObjcId),);
         decl.add_method(sel!(keyboardWillChangeFrame:), keyboard_will_change_frame as extern "C" fn(&Object, Sel, ObjcId),);
         decl.add_method(sel!(keyboardWillShow:), keyboard_will_show as extern "C" fn(&Object, Sel, ObjcId),);
@@ -466,6 +514,1027 @@ pub fn define_edit_menu_interaction_delegate() -> *const Class {
             sel!(editMenuInteraction:targetRectForConfiguration:),
             target_rect_for_configuration as extern "C" fn(&Object, Sel, ObjcId, ObjcId) -> NSRect,
         );
+    }
+
+    return decl.register();
+}
+
+// =============================================================================
+// UITextInput Protocol Implementation for IME Support
+// =============================================================================
+
+/// Defines a custom UITextPosition subclass.
+/// UITextInput protocol requires custom position/range classes (token-based, not integer-based).
+pub fn define_makepad_text_position() -> *const Class {
+    let mut decl = ClassDecl::new("MakepadTextPosition", class!(UITextPosition)).unwrap();
+
+    decl.add_ivar::<i64>("_offset");
+
+    extern "C" fn get_offset(this: &Object, _: Sel) -> i64 {
+        unsafe { *this.get_ivar::<i64>("_offset") }
+    }
+
+    extern "C" fn set_offset(this: &mut Object, _: Sel, offset: i64) {
+        unsafe { this.set_ivar::<i64>("_offset", offset); }
+    }
+
+    extern "C" fn position_with_offset(cls: &Class, _: Sel, offset: i64) -> ObjcId {
+        unsafe {
+            let obj: ObjcId = msg_send![cls, alloc];
+            let obj: ObjcId = msg_send![obj, init];
+            (*obj).set_ivar::<i64>("_offset", offset);
+            let obj: ObjcId = msg_send![obj, autorelease];
+            obj
+        }
+    }
+
+    unsafe {
+        decl.add_method(sel!(offset), get_offset as extern "C" fn(&Object, Sel) -> i64);
+        decl.add_method(sel!(setOffset:), set_offset as extern "C" fn(&mut Object, Sel, i64));
+        decl.add_class_method(
+            sel!(positionWithOffset:),
+            position_with_offset as extern "C" fn(&Class, Sel, i64) -> ObjcId,
+        );
+    }
+
+    return decl.register();
+}
+
+/// Defines a custom UITextRange subclass.
+/// Stores start and end offsets directly, creates positions on demand.
+pub fn define_makepad_text_range() -> *const Class {
+    let mut decl = ClassDecl::new("MakepadTextRange", class!(UITextRange)).unwrap();
+
+    // Store offsets directly instead of position objects to avoid memory management issues
+    decl.add_ivar::<i64>("_startOffset");
+    decl.add_ivar::<i64>("_endOffset");
+
+    extern "C" fn get_start(this: &Object, _: Sel) -> ObjcId {
+        unsafe {
+            let offset: i64 = *this.get_ivar::<i64>("_startOffset");
+            let pos_class = get_ios_class_global().text_position;
+            msg_send![pos_class, positionWithOffset: offset]
+        }
+    }
+
+    extern "C" fn get_end(this: &Object, _: Sel) -> ObjcId {
+        unsafe {
+            let offset: i64 = *this.get_ivar::<i64>("_endOffset");
+            let pos_class = get_ios_class_global().text_position;
+            msg_send![pos_class, positionWithOffset: offset]
+        }
+    }
+
+    extern "C" fn is_empty(this: &Object, _: Sel) -> BOOL {
+        unsafe {
+            let start: i64 = *this.get_ivar::<i64>("_startOffset");
+            let end: i64 = *this.get_ivar::<i64>("_endOffset");
+            if start == end { YES } else { NO }
+        }
+    }
+
+    // Simplified class method using the class parameter directly
+    extern "C" fn range_with_start_end(cls: &Class, _: Sel, start: i64, end: i64) -> ObjcId {
+        unsafe {
+            let obj: ObjcId = msg_send![cls, alloc];
+            let obj: ObjcId = msg_send![obj, init];
+            (*obj).set_ivar::<i64>("_startOffset", start);
+            (*obj).set_ivar::<i64>("_endOffset", end);
+            let obj: ObjcId = msg_send![obj, autorelease];
+            obj
+        }
+    }
+
+    extern "C" fn range_with_positions(cls: &Class, _: Sel, start: ObjcId, end: ObjcId) -> ObjcId {
+        unsafe {
+            let obj: ObjcId = msg_send![cls, alloc];
+            let obj: ObjcId = msg_send![obj, init];
+            let start_offset: i64 = if start != nil { msg_send![start, offset] } else { 0 };
+            let end_offset: i64 = if end != nil { msg_send![end, offset] } else { 0 };
+            (*obj).set_ivar::<i64>("_startOffset", start_offset);
+            (*obj).set_ivar::<i64>("_endOffset", end_offset);
+            let obj: ObjcId = msg_send![obj, autorelease];
+            obj
+        }
+    }
+
+    unsafe {
+        decl.add_method(sel!(start), get_start as extern "C" fn(&Object, Sel) -> ObjcId);
+        decl.add_method(sel!(end), get_end as extern "C" fn(&Object, Sel) -> ObjcId);
+        decl.add_method(sel!(isEmpty), is_empty as extern "C" fn(&Object, Sel) -> BOOL);
+        decl.add_class_method(
+            sel!(rangeWithStart:end:),
+            range_with_start_end as extern "C" fn(&Class, Sel, i64, i64) -> ObjcId,
+        );
+        decl.add_class_method(
+            sel!(rangeWithStartPosition:endPosition:),
+            range_with_positions as extern "C" fn(&Class, Sel, ObjcId, ObjcId) -> ObjcId,
+        );
+    }
+
+    return decl.register();
+}
+
+/// Defines the main text input view conforming to UITextInput protocol.
+/// This replaces the hidden UITextField and provides full IME support.
+pub fn define_text_input_view() -> *const Class {
+    let mut decl = ClassDecl::new("MakepadTextInputView", class!(UIView)).unwrap();
+
+    // Instance variables for text input state
+    decl.add_ivar::<ObjcId>("markedText");           // NSMutableAttributedString
+    decl.add_ivar::<ObjcId>("textBuffer");           // NSMutableString - tracks text for iOS context
+    decl.add_ivar::<i64>("cursorPosition");          // Current cursor position
+    decl.add_ivar::<i64>("selectionStart");          // Selection start
+    decl.add_ivar::<i64>("selectionEnd");            // Selection end
+    decl.add_ivar::<ObjcId>("_inputDelegate");       // id<UITextInputDelegate>
+    decl.add_ivar::<ObjcId>("_tokenizer");           // UITextInputStringTokenizer
+    // IME position stored in ivars to avoid re-entrant borrow issues
+    decl.add_ivar::<f64>("ime_pos_x");
+    decl.add_ivar::<f64>("ime_pos_y");
+
+    // ==========================================================================
+    // UIResponder methods
+    // ==========================================================================
+
+    extern "C" fn can_become_first_responder(_: &Object, _: Sel) -> BOOL {
+        YES
+    }
+
+    // ==========================================================================
+    // UIKeyInput protocol methods
+    // ==========================================================================
+
+    extern "C" fn has_text(_this: &Object, _: Sel) -> BOOL {
+        // Always return YES so iOS keeps sending deleteBackward events
+        // even when our buffer is empty (user might be deleting initial text
+        // that we don't track)
+        YES
+    }
+
+    // Helper to get or create the text buffer
+    unsafe fn get_text_buffer(this: &Object) -> ObjcId {
+        let buffer: ObjcId = *this.get_ivar("textBuffer");
+        if buffer != nil {
+            return buffer;
+        }
+        // Create new buffer
+        let new_buffer: ObjcId = msg_send![class!(NSMutableString), alloc];
+        let new_buffer: ObjcId = msg_send![new_buffer, init];
+        (*(this as *const _ as *mut Object)).set_ivar("textBuffer", new_buffer);
+        new_buffer
+    }
+
+    extern "C" fn insert_text(this: &Object, _: Sel, text: ObjcId) {
+        unsafe {
+            let string = nsstring_to_string(text);
+
+            // Handle Enter/Return key specially
+            if string == "\n" {
+                let buffer = get_text_buffer(this);
+                let () = msg_send![buffer, appendString: text];
+                IosApp::send_return_key();
+                return;
+            }
+
+            // Get inputDelegate for notifications
+            let input_delegate: ObjcId = *this.get_ivar("_inputDelegate");
+
+            // Notify that text and selection will change
+            if input_delegate != nil {
+                let () = msg_send![input_delegate, textWillChange: this as *const _ as ObjcId];
+                let () = msg_send![input_delegate, selectionWillChange: this as *const _ as ObjcId];
+            }
+
+            // Clear marked text BEFORE sending to Makepad
+            let marked_text: ObjcId = *this.get_ivar("markedText");
+            if marked_text != nil {
+                let len: u64 = msg_send![marked_text, length];
+                if len > 0 {
+                    let mutable_string: ObjcId = msg_send![marked_text, mutableString];
+                    let empty = str_to_nsstring("");
+                    let () = msg_send![mutable_string, setString: empty];
+                }
+            }
+
+            // Send the text input event to Makepad
+            IosApp::send_text_input(string.clone(), false);
+
+            // Update text buffer - insert at cursor position, not append
+            let buffer = get_text_buffer(this);
+            let cursor: i64 = *this.get_ivar("cursorPosition");
+            let buffer_len: u64 = msg_send![buffer, length];
+            let insert_pos = (cursor.max(0) as u64).min(buffer_len);
+            let () = msg_send![buffer, insertString: text atIndex: insert_pos];
+
+            // Update cursor position using UTF-16 code units (matches iOS NSString.length)
+            let new_cursor = cursor + utf16_len(&string);
+            (*(this as *const _ as *mut Object)).set_ivar("cursorPosition", new_cursor);
+
+            // Notify that text and selection did change
+            if input_delegate != nil {
+                let () = msg_send![input_delegate, selectionDidChange: this as *const _ as ObjcId];
+                let () = msg_send![input_delegate, textDidChange: this as *const _ as ObjcId];
+            }
+        }
+    }
+
+    extern "C" fn delete_backward(this: &Object, _: Sel) {
+        unsafe {
+            // Update text buffer - remove character BEFORE cursor position
+            let buffer = get_text_buffer(this);
+            let cursor: i64 = *this.get_ivar("cursorPosition");
+
+            if cursor > 0 {
+                let delete_pos = (cursor - 1) as u64;
+                let buffer_len: u64 = msg_send![buffer, length];
+                if delete_pos < buffer_len {
+                    let range = NSRange { location: delete_pos, length: 1 };
+                    let () = msg_send![buffer, deleteCharactersInRange: range];
+                }
+                // Update cursor position
+                (*(this as *const _ as *mut Object)).set_ivar("cursorPosition", cursor - 1);
+            }
+        }
+        // Always send backspace - Makepad handles actual text deletion and bounds
+        IosApp::send_backspace();
+    }
+
+    // ==========================================================================
+    // UITextInput protocol - Marked text (composition) methods
+    // ==========================================================================
+
+    extern "C" fn has_marked_text(this: &Object, _: Sel) -> BOOL {
+        unsafe {
+            let marked_text: ObjcId = *this.get_ivar("markedText");
+            if marked_text == nil {
+                return NO;
+            }
+            let len: u64 = msg_send![marked_text, length];
+            if len > 0 { YES } else { NO }
+        }
+    }
+
+    extern "C" fn marked_text_range(this: &Object, _: Sel) -> ObjcId {
+        unsafe {
+            let marked_text: ObjcId = *this.get_ivar("markedText");
+            if marked_text == nil {
+                return nil;
+            }
+            let len: u64 = msg_send![marked_text, length];
+            if len > 0 {
+                let cursor: i64 = *this.get_ivar("cursorPosition");
+                let range_class = get_ios_class_global().text_range;
+                msg_send![range_class, rangeWithStart: cursor end: cursor + (len as i64)]
+            } else {
+                nil
+            }
+        }
+    }
+
+    extern "C" fn set_marked_text(this: &mut Object, _: Sel, marked_text_input: ObjcId, _selected_range: NSRange) {
+        unsafe {
+            // Notify inputDelegate that text will change
+            let input_delegate: ObjcId = *this.get_ivar("_inputDelegate");
+            if input_delegate != nil {
+                let () = msg_send![input_delegate, textWillChange: this as *const _ as ObjcId];
+            }
+
+            let marked_text_ref: &mut ObjcId = this.get_mut_ivar("markedText");
+
+            if *marked_text_ref != nil {
+                let () = msg_send![*marked_text_ref, release];
+            }
+
+            // Create new marked text storage
+            let new_marked: ObjcId = msg_send![class!(NSMutableAttributedString), alloc];
+
+            if marked_text_input != nil {
+                let has_attr: BOOL = msg_send![marked_text_input, isKindOfClass: class!(NSAttributedString)];
+                if has_attr == YES {
+                    let () = msg_send![new_marked, initWithAttributedString: marked_text_input];
+                } else {
+                    let () = msg_send![new_marked, initWithString: marked_text_input];
+                }
+            } else {
+                let () = msg_send![new_marked, init];
+            }
+
+            *marked_text_ref = new_marked;
+
+            // Send marked text to Makepad for inline display
+            let text_string: ObjcId = msg_send![new_marked, string];
+            let marked_string = nsstring_to_string(text_string);
+
+            // Always send with replace_last=true - empty string clears composition preview
+            IosApp::send_text_input(marked_string, true);
+
+            // Notify inputDelegate that text did change
+            if input_delegate != nil {
+                let () = msg_send![input_delegate, textDidChange: this as *const _ as ObjcId];
+            }
+        }
+    }
+
+    extern "C" fn unmark_text(this: &Object, _: Sel) {
+        unsafe {
+            let marked_text: ObjcId = *this.get_ivar("markedText");
+            if marked_text == nil {
+                return;
+            }
+
+            let len: u64 = msg_send![marked_text, length];
+            if len == 0 {
+                return;
+            }
+
+            // Get the marked text string
+            let text_string: ObjcId = msg_send![marked_text, string];
+            let string = nsstring_to_string(text_string);
+
+            // Get inputDelegate for notifications
+            let input_delegate: ObjcId = *this.get_ivar("_inputDelegate");
+
+            // Notify that text will change
+            if input_delegate != nil {
+                let () = msg_send![input_delegate, textWillChange: this as *const _ as ObjcId];
+                let () = msg_send![input_delegate, selectionWillChange: this as *const _ as ObjcId];
+            }
+
+            // Commit the marked text to Makepad
+            IosApp::send_text_input(string.clone(), false);
+
+            // Update text buffer - insert at cursor position, not append
+            let buffer = get_text_buffer(this);
+            let cursor: i64 = *this.get_ivar("cursorPosition");
+            let buffer_len: u64 = msg_send![buffer, length];
+            let insert_pos = (cursor.max(0) as u64).min(buffer_len);
+            let () = msg_send![buffer, insertString: text_string atIndex: insert_pos];
+
+            // Update cursor position using UTF-16 code units (matches iOS NSString.length)
+            let new_cursor = cursor + utf16_len(&string);
+            (*(this as *const _ as *mut Object)).set_ivar("cursorPosition", new_cursor);
+
+            // Clear the marked text
+            let mutable_string: ObjcId = msg_send![marked_text, mutableString];
+            let empty = str_to_nsstring("");
+            let () = msg_send![mutable_string, setString: empty];
+
+            // Notify that text did change
+            if input_delegate != nil {
+                let () = msg_send![input_delegate, selectionDidChange: this as *const _ as ObjcId];
+                let () = msg_send![input_delegate, textDidChange: this as *const _ as ObjcId];
+            }
+        }
+    }
+
+    extern "C" fn marked_text_style(_: &Object, _: Sel) -> ObjcId {
+        nil
+    }
+
+    extern "C" fn set_marked_text_style(_: &mut Object, _: Sel, _style: ObjcId) {
+        // Not implemented - we don't use custom styling
+    }
+
+    // ==========================================================================
+    // UITextInput protocol - Selection methods
+    // ==========================================================================
+
+    extern "C" fn selected_text_range(this: &Object, _: Sel) -> ObjcId {
+        unsafe {
+            let cursor: i64 = *this.get_ivar("cursorPosition");
+            let range_class = get_ios_class_global().text_range;
+            msg_send![range_class, rangeWithStart: cursor end: cursor]
+        }
+    }
+
+    extern "C" fn set_selected_text_range(this: &mut Object, _: Sel, range: ObjcId) {
+        if range == nil {
+            return;
+        }
+        unsafe {
+            let start: ObjcId = msg_send![range, start];
+            let end: ObjcId = msg_send![range, end];
+            if start != nil && end != nil {
+                let start_offset: i64 = msg_send![start, offset];
+                let end_offset: i64 = msg_send![end, offset];
+                this.set_ivar("selectionStart", start_offset);
+                this.set_ivar("selectionEnd", end_offset);
+                this.set_ivar("cursorPosition", end_offset);
+            }
+        }
+    }
+
+    // ==========================================================================
+    // UITextInput protocol - Text storage methods
+    // ==========================================================================
+
+    extern "C" fn text_in_range(this: &Object, _: Sel, range: ObjcId) -> ObjcId {
+        if range == nil {
+            return str_to_nsstring("");
+        }
+        unsafe {
+            let start: ObjcId = msg_send![range, start];
+            let end: ObjcId = msg_send![range, end];
+
+            if start == nil || end == nil {
+                return str_to_nsstring("");
+            }
+
+            let start_offset: i64 = msg_send![start, offset];
+            let end_offset: i64 = msg_send![end, offset];
+
+            if start_offset >= end_offset {
+                return str_to_nsstring("");
+            }
+
+            let buffer = get_text_buffer(this);
+            let buffer_len: u64 = msg_send![buffer, length];
+            let cursor: i64 = *this.get_ivar("cursorPosition");
+
+            // Check if this is querying the marked text range
+            let marked_text: ObjcId = *this.get_ivar("markedText");
+            if marked_text != nil {
+                let marked_len: u64 = msg_send![marked_text, length];
+                if marked_len > 0 {
+                    // Marked text is at cursor position
+                    let marked_start = cursor;
+                    let marked_end = cursor + marked_len as i64;
+
+                    // If query overlaps with marked text range, return marked text
+                    if start_offset >= marked_start && end_offset <= marked_end {
+                        let text_string: ObjcId = msg_send![marked_text, string];
+                        return text_string;
+                    }
+                }
+            }
+
+            // Otherwise return from buffer
+            let start_idx = (start_offset.max(0) as u64).min(buffer_len);
+            let end_idx = (end_offset.max(0) as u64).min(buffer_len);
+
+            if start_idx >= end_idx {
+                return str_to_nsstring("");
+            }
+
+            let range = NSRange { location: start_idx, length: end_idx - start_idx };
+            msg_send![buffer, substringWithRange: range]
+        }
+    }
+
+    extern "C" fn replace_range_with_text(this: &Object, _: Sel, range: ObjcId, text: ObjcId) {
+        unsafe {
+            let new_string = nsstring_to_string(text);
+
+            // Get inputDelegate for notifications
+            let input_delegate: ObjcId = *this.get_ivar("_inputDelegate");
+
+            // Notify that text will change
+            if input_delegate != nil {
+                let () = msg_send![input_delegate, textWillChange: this as *const _ as ObjcId];
+                let () = msg_send![input_delegate, selectionWillChange: this as *const _ as ObjcId];
+            }
+
+            // Clear marked text first
+            let marked_text: ObjcId = *this.get_ivar("markedText");
+            if marked_text != nil {
+                let len: u64 = msg_send![marked_text, length];
+                if len > 0 {
+                    let mutable_string: ObjcId = msg_send![marked_text, mutableString];
+                    let empty = str_to_nsstring("");
+                    let () = msg_send![mutable_string, setString: empty];
+                }
+            }
+
+            // Get range bounds by extracting offsets from our custom position objects
+            let (range_start, range_end) = if range != nil {
+                let start_pos: ObjcId = msg_send![range, start];
+                let end_pos: ObjcId = msg_send![range, end];
+
+                let start: i64 = if start_pos != nil {
+                    let responds: BOOL = msg_send![start_pos, respondsToSelector: sel!(offset)];
+                    if responds == YES { msg_send![start_pos, offset] } else { 0 }
+                } else { 0 };
+
+                let end: i64 = if end_pos != nil {
+                    let responds: BOOL = msg_send![end_pos, respondsToSelector: sel!(offset)];
+                    if responds == YES { msg_send![end_pos, offset] } else { start }
+                } else { start };
+
+                (start.max(0) as usize, end.max(0) as usize)
+            } else {
+                let cursor: i64 = *this.get_ivar("cursorPosition");
+                let pos = cursor.max(0) as usize;
+                (pos, pos)
+            };
+
+            // Update iOS text buffer directly
+            let buffer = get_text_buffer(this);
+            let buffer_len: u64 = msg_send![buffer, length];
+            let buf_start = (range_start as u64).min(buffer_len);
+            let buf_end = (range_end as u64).min(buffer_len);
+
+            // Get buffer contents BEFORE modification for UTF-16 to char index conversion
+            let buffer_string = nsstring_to_string(buffer);
+
+            // Delete the range from buffer
+            if buf_start < buf_end {
+                let delete_range = NSRange { location: buf_start, length: buf_end - buf_start };
+                let () = msg_send![buffer, deleteCharactersInRange: delete_range];
+            }
+
+            // Insert new text at buf_start
+            if !new_string.is_empty() {
+                let new_buf_len: u64 = msg_send![buffer, length];
+                let insert_pos = buf_start.min(new_buf_len);
+                let () = msg_send![buffer, insertString: text atIndex: insert_pos];
+            }
+
+            // Convert UTF-16 indices to character indices for Makepad
+            // iOS uses UTF-16 code units, but Makepad expects character indices
+            let char_start = utf16_index_to_char_index(&buffer_string, range_start);
+            let char_end = utf16_index_to_char_index(&buffer_string, range_end);
+
+            // Send the range replacement event to Makepad
+            IosApp::send_text_range_replace(char_start, char_end, new_string.clone());
+
+            // Update cursor position to end of inserted text (using UTF-16 code units)
+            let new_cursor = range_start as i64 + utf16_len(&new_string);
+            (*(this as *const _ as *mut Object)).set_ivar("cursorPosition", new_cursor);
+
+            // Notify that text did change
+            if input_delegate != nil {
+                let () = msg_send![input_delegate, selectionDidChange: this as *const _ as ObjcId];
+                let () = msg_send![input_delegate, textDidChange: this as *const _ as ObjcId];
+            }
+        }
+    }
+
+    // ==========================================================================
+    // UITextInput protocol - Position/Range methods
+    // ==========================================================================
+
+    extern "C" fn beginning_of_document(_: &Object, _: Sel) -> ObjcId {
+        unsafe {
+            let pos_class = get_ios_class_global().text_position;
+            msg_send![pos_class, positionWithOffset: 0i64]
+        }
+    }
+
+    extern "C" fn end_of_document(this: &Object, _: Sel) -> ObjcId {
+        unsafe {
+            // Return the actual buffer length. The iOS text buffer is kept in sync
+            // with text input operations, so this should match reality.
+            let buffer = get_text_buffer(this);
+            let buffer_len: i64 = msg_send![buffer, length];
+            let pos_class = get_ios_class_global().text_position;
+            msg_send![pos_class, positionWithOffset: buffer_len]
+        }
+    }
+
+    extern "C" fn position_from_position_offset(_: &Object, _: Sel, position: ObjcId, offset: i64) -> ObjcId {
+        if position == nil {
+            return nil;
+        }
+        unsafe {
+            let pos: i64 = msg_send![position, offset];
+            let new_pos = pos + offset;
+            if new_pos < 0 {
+                return nil;
+            }
+            let pos_class = get_ios_class_global().text_position;
+            msg_send![pos_class, positionWithOffset: new_pos]
+        }
+    }
+
+    extern "C" fn position_from_position_in_direction_offset(
+        _: &Object,
+        _: Sel,
+        position: ObjcId,
+        direction: i64,
+        offset: i64,
+    ) -> ObjcId {
+        if position == nil {
+            return nil;
+        }
+        unsafe {
+            let pos: i64 = msg_send![position, offset];
+            // UITextLayoutDirection: 0=right, 1=left, 2=up, 3=down
+            let actual_offset = if direction == 1 { -offset } else { offset };
+            let new_pos = pos + actual_offset;
+            if new_pos < 0 {
+                return nil;
+            }
+            let pos_class = get_ios_class_global().text_position;
+            msg_send![pos_class, positionWithOffset: new_pos]
+        }
+    }
+
+    extern "C" fn text_range_from_position_to_position(
+        _: &Object,
+        _: Sel,
+        from_position: ObjcId,
+        to_position: ObjcId,
+    ) -> ObjcId {
+        if from_position == nil || to_position == nil {
+            return nil;
+        }
+        unsafe {
+            let range_class = get_ios_class_global().text_range;
+            msg_send![range_class, rangeWithStartPosition: from_position endPosition: to_position]
+        }
+    }
+
+    extern "C" fn compare_position_to_position(
+        _: &Object,
+        _: Sel,
+        position: ObjcId,
+        other: ObjcId,
+    ) -> i64 {
+        if position == nil || other == nil {
+            return 0; // NSOrderedSame
+        }
+        unsafe {
+            let pos1: i64 = msg_send![position, offset];
+            let pos2: i64 = msg_send![other, offset];
+            if pos1 < pos2 {
+                -1 // NSOrderedAscending
+            } else if pos1 > pos2 {
+                1 // NSOrderedDescending
+            } else {
+                0 // NSOrderedSame
+            }
+        }
+    }
+
+    extern "C" fn offset_from_position_to_position(
+        _: &Object,
+        _: Sel,
+        from: ObjcId,
+        to: ObjcId,
+    ) -> i64 {
+        if from == nil || to == nil {
+            return 0;
+        }
+        unsafe {
+            let from_pos: i64 = msg_send![from, offset];
+            let to_pos: i64 = msg_send![to, offset];
+            to_pos - from_pos
+        }
+    }
+
+    extern "C" fn position_within_range_farthest_in_direction(
+        _: &Object,
+        _: Sel,
+        range: ObjcId,
+        direction: i64,
+    ) -> ObjcId {
+        if range == nil {
+            return nil;
+        }
+        unsafe {
+            // UITextLayoutDirection: 0=right, 1=left, 2=up, 3=down
+            // For left/up, return start; for right/down, return end
+            if direction == 1 || direction == 2 {
+                msg_send![range, start]
+            } else {
+                msg_send![range, end]
+            }
+        }
+    }
+
+    extern "C" fn character_range_by_extending_position_in_direction(
+        _: &Object,
+        _: Sel,
+        position: ObjcId,
+        _direction: i64,
+    ) -> ObjcId {
+        if position == nil {
+            return nil;
+        }
+        // Return a zero-width range at the position
+        unsafe {
+            let range_class = get_ios_class_global().text_range;
+            msg_send![range_class, rangeWithStartPosition: position endPosition: position]
+        }
+    }
+
+    // ==========================================================================
+    // UITextInput protocol - Geometry methods
+    // ==========================================================================
+
+    extern "C" fn first_rect_for_range(this: &Object, _: Sel, _range: ObjcId) -> NSRect {
+        // Return a rect at the IME position for candidate window placement
+        // Read directly from ivars to avoid any re-entrant borrow issues
+        unsafe {
+            let x: f64 = *this.get_ivar("ime_pos_x");
+            let y: f64 = *this.get_ivar("ime_pos_y");
+
+            let view = this as *const _ as ObjcId;
+            let view_frame: NSRect = msg_send![view, frame];
+
+            NSRect {
+                origin: NSPoint { x, y: view_frame.size.height - y },
+                size: NSSize { width: 1.0, height: 20.0 },
+            }
+        }
+    }
+
+    extern "C" fn caret_rect_for_position(this: &Object, sel: Sel, _position: ObjcId) -> NSRect {
+        first_rect_for_range(this, sel, nil)
+    }
+
+    extern "C" fn selection_rects_for_range(_: &Object, _: Sel, _range: ObjcId) -> ObjcId {
+        // Return empty array
+        unsafe { msg_send![class!(NSArray), array] }
+    }
+
+    extern "C" fn closest_position_to_point(_: &Object, _: Sel, _point: NSPoint) -> ObjcId {
+        // Return position 0 - we don't do hit testing
+        unsafe {
+            let pos_class = get_ios_class_global().text_position;
+            msg_send![pos_class, positionWithOffset: 0i64]
+        }
+    }
+
+    extern "C" fn closest_position_to_point_within_range(
+        _: &Object,
+        _: Sel,
+        _point: NSPoint,
+        range: ObjcId,
+    ) -> ObjcId {
+        if range == nil {
+            return nil;
+        }
+        // Return start of range
+        unsafe { msg_send![range, start] }
+    }
+
+    extern "C" fn character_range_at_point(_: &Object, _: Sel, _point: NSPoint) -> ObjcId {
+        nil
+    }
+
+    // ==========================================================================
+    // UITextInput protocol - Writing direction (required methods)
+    // ==========================================================================
+
+    extern "C" fn base_writing_direction_for_position(
+        _: &Object,
+        _: Sel,
+        _position: ObjcId,
+        _direction: i64,
+    ) -> i64 {
+        0 // NSWritingDirectionNatural
+    }
+
+    extern "C" fn set_base_writing_direction(
+        _: &Object,
+        _: Sel,
+        _direction: i64,
+        _range: ObjcId,
+    ) {
+        // No-op - we don't support changing writing direction
+    }
+
+    // ==========================================================================
+    // UITextInput protocol - Input delegate and tokenizer
+    // ==========================================================================
+
+    extern "C" fn input_delegate(this: &Object, _: Sel) -> ObjcId {
+        unsafe { *this.get_ivar("_inputDelegate") }
+    }
+
+    extern "C" fn set_input_delegate(this: &mut Object, _: Sel, delegate: ObjcId) {
+        unsafe { this.set_ivar("_inputDelegate", delegate); }
+    }
+
+    extern "C" fn tokenizer(this: &Object, _: Sel) -> ObjcId {
+        unsafe {
+            let tok: ObjcId = *this.get_ivar("_tokenizer");
+            if tok != nil {
+                return tok;
+            }
+            // Create tokenizer on first access
+            let view = this as *const _ as ObjcId;
+            let new_tok: ObjcId = msg_send![class!(UITextInputStringTokenizer), alloc];
+            let new_tok: ObjcId = msg_send![new_tok, initWithTextInput: view];
+            (*(this as *const _ as *mut Object)).set_ivar("_tokenizer", new_tok);
+            new_tok
+        }
+    }
+
+    // ==========================================================================
+    // UITextInputTraits protocol
+    // ==========================================================================
+
+    extern "C" fn keyboard_type(_: &Object, _: Sel) -> i64 {
+        0 // UIKeyboardTypeDefault
+    }
+
+    extern "C" fn autocorrection_type(_this: &Object, _: Sel) -> i64 {
+        unsafe {
+            // Try to get current input mode to check keyboard language
+            let input_mode: ObjcId = msg_send![class!(UITextInputMode), currentInputMode];
+            if input_mode != nil {
+                let primary_lang: ObjcId = msg_send![input_mode, primaryLanguage];
+                if primary_lang != nil {
+                    let lang = nsstring_to_string(primary_lang);
+                    // Disable autocorrect for CJK languages (composition-based IME)
+                    if lang.starts_with("zh")      // Chinese
+                        || lang.starts_with("ja")  // Japanese
+                        || lang.starts_with("ko")  // Korean
+                    {
+                        return 1; // UITextAutocorrectionTypeNo
+                    }
+                }
+            }
+            0 // UITextAutocorrectionTypeDefault
+        }
+    }
+
+    extern "C" fn autocapitalization_type(_: &Object, _: Sel) -> i64 {
+        2 // UITextAutocapitalizationTypeSentences
+    }
+
+    extern "C" fn spell_checking_type(_: &Object, _: Sel) -> i64 {
+        0 // UITextSpellCheckingTypeDefault
+    }
+
+    extern "C" fn smart_quotes_type(_: &Object, _: Sel) -> i64 {
+        1 // UITextSmartQuotesTypeNo - disable for code/text editing
+    }
+
+    extern "C" fn smart_dashes_type(_: &Object, _: Sel) -> i64 {
+        1 // UITextSmartDashesTypeNo
+    }
+
+    extern "C" fn smart_insert_delete_type(_: &Object, _: Sel) -> i64 {
+        1 // UITextSmartInsertDeleteTypeNo
+    }
+
+    extern "C" fn keyboard_appearance(_: &Object, _: Sel) -> i64 {
+        0 // UIKeyboardAppearanceDefault
+    }
+
+    extern "C" fn return_key_type(_: &Object, _: Sel) -> i64 {
+        0 // UIReturnKeyDefault
+    }
+
+    extern "C" fn enables_return_key_automatically(_: &Object, _: Sel) -> BOOL {
+        NO
+    }
+
+    extern "C" fn is_secure_text_entry(_: &Object, _: Sel) -> BOOL {
+        NO
+    }
+
+    extern "C" fn text_content_type(_: &Object, _: Sel) -> ObjcId {
+        nil // No specific content type
+    }
+
+    // ==========================================================================
+    // Register all methods
+    // ==========================================================================
+
+    unsafe {
+        // UIResponder
+        decl.add_method(
+            sel!(canBecomeFirstResponder),
+            can_become_first_responder as extern "C" fn(&Object, Sel) -> BOOL,
+        );
+
+        // UIKeyInput
+        decl.add_method(sel!(hasText), has_text as extern "C" fn(&Object, Sel) -> BOOL);
+        decl.add_method(sel!(insertText:), insert_text as extern "C" fn(&Object, Sel, ObjcId));
+        decl.add_method(sel!(deleteBackward), delete_backward as extern "C" fn(&Object, Sel));
+
+        // UITextInput - Marked text
+        decl.add_method(sel!(hasMarkedText), has_marked_text as extern "C" fn(&Object, Sel) -> BOOL);
+        decl.add_method(sel!(markedTextRange), marked_text_range as extern "C" fn(&Object, Sel) -> ObjcId);
+        decl.add_method(
+            sel!(setMarkedText:selectedRange:),
+            set_marked_text as extern "C" fn(&mut Object, Sel, ObjcId, NSRange),
+        );
+        decl.add_method(sel!(unmarkText), unmark_text as extern "C" fn(&Object, Sel));
+        decl.add_method(sel!(markedTextStyle), marked_text_style as extern "C" fn(&Object, Sel) -> ObjcId);
+        decl.add_method(
+            sel!(setMarkedTextStyle:),
+            set_marked_text_style as extern "C" fn(&mut Object, Sel, ObjcId),
+        );
+
+        // UITextInput - Selection
+        decl.add_method(sel!(selectedTextRange), selected_text_range as extern "C" fn(&Object, Sel) -> ObjcId);
+        decl.add_method(
+            sel!(setSelectedTextRange:),
+            set_selected_text_range as extern "C" fn(&mut Object, Sel, ObjcId),
+        );
+
+        // UITextInput - Text storage
+        decl.add_method(sel!(textInRange:), text_in_range as extern "C" fn(&Object, Sel, ObjcId) -> ObjcId);
+        decl.add_method(
+            sel!(replaceRange:withText:),
+            replace_range_with_text as extern "C" fn(&Object, Sel, ObjcId, ObjcId),
+        );
+
+        // UITextInput - Position/Range
+        decl.add_method(sel!(beginningOfDocument), beginning_of_document as extern "C" fn(&Object, Sel) -> ObjcId);
+        decl.add_method(sel!(endOfDocument), end_of_document as extern "C" fn(&Object, Sel) -> ObjcId);
+        decl.add_method(
+            sel!(positionFromPosition:offset:),
+            position_from_position_offset as extern "C" fn(&Object, Sel, ObjcId, i64) -> ObjcId,
+        );
+        decl.add_method(
+            sel!(positionFromPosition:inDirection:offset:),
+            position_from_position_in_direction_offset as extern "C" fn(&Object, Sel, ObjcId, i64, i64) -> ObjcId,
+        );
+        decl.add_method(
+            sel!(textRangeFromPosition:toPosition:),
+            text_range_from_position_to_position as extern "C" fn(&Object, Sel, ObjcId, ObjcId) -> ObjcId,
+        );
+        decl.add_method(
+            sel!(comparePosition:toPosition:),
+            compare_position_to_position as extern "C" fn(&Object, Sel, ObjcId, ObjcId) -> i64,
+        );
+        decl.add_method(
+            sel!(offsetFromPosition:toPosition:),
+            offset_from_position_to_position as extern "C" fn(&Object, Sel, ObjcId, ObjcId) -> i64,
+        );
+        decl.add_method(
+            sel!(positionWithinRange:farthestInDirection:),
+            position_within_range_farthest_in_direction as extern "C" fn(&Object, Sel, ObjcId, i64) -> ObjcId,
+        );
+        decl.add_method(
+            sel!(characterRangeByExtendingPosition:inDirection:),
+            character_range_by_extending_position_in_direction as extern "C" fn(&Object, Sel, ObjcId, i64) -> ObjcId,
+        );
+
+        // UITextInput - Geometry
+        decl.add_method(
+            sel!(firstRectForRange:),
+            first_rect_for_range as extern "C" fn(&Object, Sel, ObjcId) -> NSRect,
+        );
+        decl.add_method(
+            sel!(caretRectForPosition:),
+            caret_rect_for_position as extern "C" fn(&Object, Sel, ObjcId) -> NSRect,
+        );
+        decl.add_method(
+            sel!(selectionRectsForRange:),
+            selection_rects_for_range as extern "C" fn(&Object, Sel, ObjcId) -> ObjcId,
+        );
+        decl.add_method(
+            sel!(closestPositionToPoint:),
+            closest_position_to_point as extern "C" fn(&Object, Sel, NSPoint) -> ObjcId,
+        );
+        decl.add_method(
+            sel!(closestPositionToPoint:withinRange:),
+            closest_position_to_point_within_range as extern "C" fn(&Object, Sel, NSPoint, ObjcId) -> ObjcId,
+        );
+        decl.add_method(
+            sel!(characterRangeAtPoint:),
+            character_range_at_point as extern "C" fn(&Object, Sel, NSPoint) -> ObjcId,
+        );
+
+        // UITextInput - Writing direction
+        decl.add_method(
+            sel!(baseWritingDirectionForPosition:inDirection:),
+            base_writing_direction_for_position as extern "C" fn(&Object, Sel, ObjcId, i64) -> i64,
+        );
+        decl.add_method(
+            sel!(setBaseWritingDirection:forRange:),
+            set_base_writing_direction as extern "C" fn(&Object, Sel, i64, ObjcId),
+        );
+
+        // UITextInput - Delegate and tokenizer
+        decl.add_method(sel!(inputDelegate), input_delegate as extern "C" fn(&Object, Sel) -> ObjcId);
+        decl.add_method(
+            sel!(setInputDelegate:),
+            set_input_delegate as extern "C" fn(&mut Object, Sel, ObjcId),
+        );
+        decl.add_method(sel!(tokenizer), tokenizer as extern "C" fn(&Object, Sel) -> ObjcId);
+
+        // UITextInputTraits
+        decl.add_method(sel!(keyboardType), keyboard_type as extern "C" fn(&Object, Sel) -> i64);
+        decl.add_method(sel!(autocorrectionType), autocorrection_type as extern "C" fn(&Object, Sel) -> i64);
+        decl.add_method(sel!(autocapitalizationType), autocapitalization_type as extern "C" fn(&Object, Sel) -> i64);
+        decl.add_method(sel!(spellCheckingType), spell_checking_type as extern "C" fn(&Object, Sel) -> i64);
+        decl.add_method(sel!(smartQuotesType), smart_quotes_type as extern "C" fn(&Object, Sel) -> i64);
+        decl.add_method(sel!(smartDashesType), smart_dashes_type as extern "C" fn(&Object, Sel) -> i64);
+        decl.add_method(sel!(smartInsertDeleteType), smart_insert_delete_type as extern "C" fn(&Object, Sel) -> i64);
+        decl.add_method(sel!(keyboardAppearance), keyboard_appearance as extern "C" fn(&Object, Sel) -> i64);
+        decl.add_method(sel!(returnKeyType), return_key_type as extern "C" fn(&Object, Sel) -> i64);
+        decl.add_method(
+            sel!(enablesReturnKeyAutomatically),
+            enables_return_key_automatically as extern "C" fn(&Object, Sel) -> BOOL,
+        );
+        decl.add_method(sel!(isSecureTextEntry), is_secure_text_entry as extern "C" fn(&Object, Sel) -> BOOL);
+        decl.add_method(sel!(textContentType), text_content_type as extern "C" fn(&Object, Sel) -> ObjcId);
+    }
+
+    // Protocol conformance
+    if let Some(protocol) = Protocol::get("UIKeyInput") {
+        decl.add_protocol(protocol);
+    }
+    if let Some(protocol) = Protocol::get("UITextInput") {
+        decl.add_protocol(protocol);
     }
 
     return decl.register();

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -613,7 +613,11 @@ pub struct TextInput {
     #[rust] blink_timer: Timer,
     #[rust] preserved_selection_cursor: Option<Cursor>,
     /// Skip finger move after long press to prevent selection changes
-    #[rust] ignore_next_move: bool, 
+    #[rust] ignore_next_move: bool,
+    /// IME composition tracking - byte index where composition starts
+    #[rust] composition_start: usize,
+    /// IME composition tracking - byte length of current composition
+    #[rust] composition_length: usize,
 }
 
  impl LiveHook for TextInput{
@@ -1348,6 +1352,8 @@ impl Widget for TextInput {
             Hit::KeyFocus(_) => {
                 self.animator_play(cx, ids!(focus.on));
                 self.reset_blink_timer(cx);
+                // Sync text to iOS for autocorrect context
+                cx.set_ime_text(&self.text, self.selection.cursor.index);
                 cx.widget_action(uid, &scope.path, TextInputAction::KeyFocus);
             },
             Hit::KeyFocusLost(_) => {
@@ -1698,23 +1704,116 @@ impl Widget for TextInput {
             }) if !self.is_read_only => {
                 let input = self.filter_input(&input, false);
                 if input.is_empty() {
+                    // Empty input with replace_last means composition was cancelled
+                    if replace_last && self.composition_length > 0 {
+                        // Remove the composition text
+                        self.create_or_extend_edit_group(EditKind::Other);
+                        self.apply_edit(
+                            cx,
+                            Edit {
+                                start: self.composition_start,
+                                end: self.composition_start + self.composition_length,
+                                replace_with: String::new()
+                            }
+                        );
+                        self.composition_length = 0;
+                        self.draw_bg.redraw(cx);
+                        cx.widget_action(uid, &scope.path, TextInputAction::Changed(self.text.clone()));
+                    }
                     return;
                 }
-                self.create_or_extend_edit_group(
-                    if replace_last || was_paste {
-                        EditKind::Other
+
+                if replace_last {
+                    // IME composition update
+                    if self.composition_length > 0 {
+                        // Replace previous composition text
+                        self.create_or_extend_edit_group(EditKind::Other);
+                        self.apply_edit(
+                            cx,
+                            Edit {
+                                start: self.composition_start,
+                                end: self.composition_start + self.composition_length,
+                                replace_with: input.clone()
+                            }
+                        );
+                        self.composition_length = input.len();
                     } else {
-                        EditKind::Insert
+                        // First composition character - record start position
+                        self.composition_start = self.selection.start().index;
+                        self.composition_length = input.len();
+                        self.create_or_extend_edit_group(EditKind::Other);
+                        self.apply_edit(
+                            cx,
+                            Edit {
+                                start: self.selection.start().index,
+                                end: self.selection.end().index,
+                                replace_with: input
+                            }
+                        );
                     }
-                );
+                } else {
+                    // Final commit or regular text input
+                    if self.composition_length > 0 {
+                        // Replace composition with final committed text
+                        self.create_or_extend_edit_group(EditKind::Other);
+                        self.apply_edit(
+                            cx,
+                            Edit {
+                                start: self.composition_start,
+                                end: self.composition_start + self.composition_length,
+                                replace_with: input
+                            }
+                        );
+                        self.composition_length = 0;
+                    } else {
+                        // Normal text input (no active composition)
+                        self.create_or_extend_edit_group(
+                            if was_paste {
+                                EditKind::Other
+                            } else {
+                                EditKind::Insert
+                            }
+                        );
+                        self.apply_edit(
+                            cx,
+                            Edit {
+                                start: self.selection.start().index,
+                                end: self.selection.end().index,
+                                replace_with: input
+                            }
+                        );
+                    }
+                }
+                self.animator_play(cx, ids!(empty.off));
+                self.draw_bg.redraw(cx);
+                cx.widget_action(uid, &scope.path, TextInputAction::Changed(self.text.clone()));
+            }
+            Hit::TextRangeReplace(event) if !self.is_read_only => {
+                // iOS autocorrect sends range replacement events
+                // Convert character indices to byte indices
+                let byte_start = self.text.char_indices()
+                    .nth(event.start)
+                    .map(|(i, _)| i)
+                    .unwrap_or(self.text.len());
+                let byte_end = self.text.char_indices()
+                    .nth(event.end)
+                    .map(|(i, _)| i)
+                    .unwrap_or(self.text.len());
+
+                // Clear any active composition
+                self.composition_length = 0;
+
+                // Perform the replacement
+                self.create_or_extend_edit_group(EditKind::Other);
                 self.apply_edit(
                     cx,
                     Edit {
-                        start: self.selection.start().index,
-                        end: self.selection.end().index,
-                        replace_with: input
+                        start: byte_start,
+                        end: byte_end,
+                        replace_with: event.text.clone()
                     }
                 );
+
                 self.animator_play(cx, ids!(empty.off));
                 self.draw_bg.redraw(cx);
                 cx.widget_action(uid, &scope.path, TextInputAction::Changed(self.text.clone()));


### PR DESCRIPTION
## Changes

### UITextInput Protocol Implementation
- New `MakepadTextInputView` class conforming to UITextInput protocol
- Custom `MakepadTextPosition` and `MakepadTextRange` classes for text positions
- Full marked text (composition) support for CJK input methods

### New Events
- `TextRangeReplaceEvent` for iOS autocorrect/autocomplete suggestions
- Event routing through `Hit::TextRangeReplace` to focused widgets

### Widget Integration
- `TextInput` widget handles `TextRangeReplace` for autocorrect
- `set_ime_text()` API for syncing text state to iOS