### PR TITLE
FoldHeader hides the body when opened < 0.1

### DIFF
--- a/widgets/src/fold_header.rs
+++ b/widgets/src/fold_header.rs
@@ -71,7 +71,9 @@ impl Widget for FoldHeader {
         };
         
         self.header.handle_event(cx,  event, scope);
-        
+        if self.body.visible() {
+            self.body.handle_event(cx, event, scope);
+        }
         if let Event::Actions(actions) = event{
             match actions.find_widget_action(self.header.widget(ids!(fold_button)).widget_uid()).cast() {
                 FoldButtonAction::Opening => {

--- a/widgets/src/fold_header.rs
+++ b/widgets/src/fold_header.rs
@@ -100,6 +100,11 @@ impl Widget for FoldHeader {
             );
             self.draw_state.set(DrawState::DrawBody);
         }
+        if self.opened == 0.0 {
+            self.body.set_visible(cx, false);
+        } else {
+            self.body.set_visible(cx, true);
+        }
         if let Some(DrawState::DrawBody) = self.draw_state.get() {
             let walk = self.body.walk(cx);
             self.body.draw_walk(cx, scope, walk) ?;

--- a/widgets/src/fold_header.rs
+++ b/widgets/src/fold_header.rs
@@ -100,7 +100,7 @@ impl Widget for FoldHeader {
             );
             self.draw_state.set(DrawState::DrawBody);
         }
-        if self.opened == 0.0 {
+        if self.opened < 0.1 {
             self.body.set_visible(cx, false);
         } else {
             self.body.set_visible(cx, true);


### PR DESCRIPTION
FolderHeader current does not hide the body when it is closed. Causing a big gap with the next item after it is closed.
https://github.com/user-attachments/assets/9a839294-669b-45c3-8b78-a88a77da74bf

