### PR TITLE
Hide the `Tooltip` widget upon any click/tap, drag, or scroll event

### DIFF
--- a/platform/src/event/event.rs
+++ b/platform/src/event/event.rs
@@ -174,7 +174,7 @@ pub enum Event {
     /// `hit` functions ([`Event::hits()`]) and handle the returned [`Hit::FingerLongPress`].
     LongPress(LongPressEvent),
     /// The raw event that occurs when the user scrolls, e.g.,
-    /// by using the mouse wheel or a touch flick.
+    /// by using the mouse wheel or a touchpad/trackpad gesture.
     ///
     /// Do not match upon or handle this event directly; instead use the family of
     /// `hit` functions ([`Event::hits()`]) and handle the returned [`Hit::FingerScroll`].

--- a/widgets/src/tooltip.rs
+++ b/widgets/src/tooltip.rs
@@ -1,3 +1,5 @@
+use makepad_draw::event::TouchUpdateEvent;
+
 use crate::{
     makepad_derive_widget::*,
     makepad_draw::*,
@@ -87,12 +89,22 @@ impl Widget for Tooltip {
 
         self.content.handle_event(cx, event, scope);
 
-        // Hide the tooltip if the user taps/clicks, drags, or scrolls anywhere.
-        match event.hits_with_capture_overload(cx, self.draw_bg.area(), true) {
-            Hit::FingerUp(_)
-            | Hit::FingerMove(_)
-            | Hit::FingerScroll(_) => {
+        // Hide the tooltip if any kind of user interaction occurs (taps/clicks, drags, scrolls, etc).
+        //
+        // Typically you don't handle raw events, but we do so here because:
+        // 1. We don't want to impact the way that hit handling occurs for other views.
+        // 2. We don't care about the details of the hit, only the fact that it happened.
+        match event {
+            Event::BackPressed { .. }
+            | Event::MouseDown(_)
+            | Event::MouseUp(_)
+            | Event::Scroll(_) => {
                 self.hide(cx);
+            }
+            Event::TouchUpdate(TouchUpdateEvent { touches, .. }) => {
+                if touches.iter().any(|tp| matches!(tp.state, event::TouchState::Start)) {
+                    self.hide(cx);
+                }
             }
             _ => { }
         }

--- a/widgets/src/tooltip.rs
+++ b/widgets/src/tooltip.rs
@@ -87,8 +87,11 @@ impl Widget for Tooltip {
 
         self.content.handle_event(cx, event, scope);
 
-        match event.hits_with_capture_overload(cx, self.content.area(), true) {
-            Hit::FingerUp(fue) if fue.is_over => {
+        // Hide the tooltip if the user taps/clicks, drags, or scrolls anywhere.
+        match event.hits_with_capture_overload(cx, self.draw_bg.area(), true) {
+            Hit::FingerUp(_)
+            | Hit::FingerMove(_)
+            | Hit::FingerScroll(_) => {
                 self.hide(cx);
             }
             _ => { }


### PR DESCRIPTION
This makes the Tooltip's behavior consistent with that of OS-native tooltips.