### PR TITLE
Fix macOS build on Apple Silicon by specifying clang architecture

### DIFF
--- a/platform/build.rs
+++ b/platform/build.rs
@@ -31,7 +31,17 @@ fn main() {
         "macos"=>{
             use std::process::Command;
             let out_dir = env::var("OUT_DIR").unwrap();
-            if !Command::new("clang").args(&["src/os/apple/metal_xpc.m", "-c", "-o"])
+            // Extract architecture from target triple (e.g., "aarch64-apple-darwin" -> "arm64")
+            let arch = if target.starts_with("aarch64") {
+                "arm64"
+            } else if target.starts_with("x86_64") {
+                "x86_64"
+            } else {
+                panic!("Unsupported architecture: {}", target);
+            };
+
+            if !Command::new("clang")
+                .args(&["-arch", arch, "src/os/apple/metal_xpc.m", "-c", "-o"])
                 .arg(&format!("{}/metal_xpc.o", out_dir))
                 .status().unwrap().success() {
                 panic!("CLANG FAILED");


### PR DESCRIPTION
## Summary

Fixes a build failure on macOS with Apple Silicon (arm64) where the build script was invoking clang without specifying the target architecture.

## Problem

The current build script in `platform/build.rs` compiles `metal_xpc.m` using clang without the `-arch` flag. On systems where clang defaults to x86_64 (even on arm64 systems), this causes the object file to be compiled for the wrong architecture, resulting in linking errors:

```
ld: warning: ignoring file 'metal_xpc.o': found architecture 'x86_64', required architecture 'arm64'
Undefined symbols for architecture arm64:
  "_define_xpc_service_protocol"
  "_hackily_heapify_block0"
  "_hackily_heapify_block2_obj_u64"
```

## Solution

This PR extracts the architecture from the `TARGET` environment variable (e.g., "aarch64-apple-darwin" → "arm64") and passes the appropriate `-arch` flag to clang, ensuring `metal_xpc.m` is compiled for the correct architecture.

## Testing

- [x] Successfully builds on Apple Silicon (arm64) in release mode
- [x] Maintains compatibility with x86_64 builds

## Changes

- Modified `platform/build.rs` to detect target architecture and pass `-arch` flag to clang