### PR TITLE
Expose whether a native LongPress has occurred before a FingerMove

### DIFF
--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -689,7 +689,10 @@ pub struct FingerMoveEvent {
     pub abs: Vec2d,
     pub digit_id: DigitId,
     pub device: DigitDevice,
-    
+    /// Whether a platform-native long press has occurred between
+    /// the original finger-down event and this finger-move event.
+    pub has_long_press_occurred: bool,
+
     pub tap_count: u32,
     pub modifiers: KeyModifiers,
     pub time: f64,
@@ -1084,6 +1087,7 @@ impl Event {
                                                     abs: t.abs,
                                                     digit_id,
                                                     device,
+                                                    has_long_press_occurred: capture.has_long_press_occurred,
                                                     tap_count,
                                                     modifiers: e.modifiers,
                                                     time: e.time,
@@ -1135,6 +1139,7 @@ impl Event {
                                     abs: t.abs,
                                     digit_id,
                                     device,
+                                    has_long_press_occurred: capture.has_long_press_occurred,
                                     tap_count,
                                     modifiers: e.modifiers,
                                     time: e.time,
@@ -1176,6 +1181,7 @@ impl Event {
                                             abs: e.abs,
                                             digit_id,
                                             device,
+                                            has_long_press_occurred: capture.has_long_press_occurred,
                                             tap_count,
                                             modifiers: e.modifiers,
                                             time: e.time,
@@ -1229,6 +1235,7 @@ impl Event {
                             abs: e.abs,
                             digit_id,
                             device,
+                            has_long_press_occurred: capture.has_long_press_occurred,
                             tap_count,
                             modifiers: e.modifiers,
                             time: e.time,

--- a/platform2/src/event/finger.rs
+++ b/platform2/src/event/finger.rs
@@ -661,6 +661,9 @@ pub struct FingerMoveEvent {
     pub abs: Vec2d,
     pub digit_id: DigitId,
     pub device: DigitDevice,
+    /// Whether a platform-native long press has occurred between
+    /// the original finger-down event and this finger-move event.
+    pub has_long_press_occurred: bool,
     
     pub tap_count: u32,
     pub modifiers: KeyModifiers,
@@ -1051,6 +1054,7 @@ impl Event {
                                                     abs: t.abs,
                                                     digit_id,
                                                     device,
+                                                    has_long_press_occurred: capture.has_long_press_occurred,
                                                     tap_count,
                                                     modifiers: e.modifiers,
                                                     time: e.time,
@@ -1102,6 +1106,7 @@ impl Event {
                                     abs: t.abs,
                                     digit_id,
                                     device,
+                                    has_long_press_occurred: capture.has_long_press_occurred,
                                     tap_count,
                                     modifiers: e.modifiers,
                                     time: e.time,
@@ -1143,6 +1148,7 @@ impl Event {
                                             abs: e.abs,
                                             digit_id,
                                             device,
+                                            has_long_press_occurred: capture.has_long_press_occurred,
                                             tap_count,
                                             modifiers: e.modifiers,
                                             time: e.time,
@@ -1196,6 +1202,7 @@ impl Event {
                             abs: e.abs,
                             digit_id,
                             device,
+                            has_long_press_occurred: capture.has_long_press_occurred,
                             tap_count,
                             modifiers: e.modifiers,
                             time: e.time,


### PR DESCRIPTION
This bit of info was already tracked, but it wasn't exposed by the `FingerMoveEvent` struct.

Doing so will allow widgets to differentiate between a gesture like long-press then drag (for drag-n-drop) vs. just a regular drag (for something like finger-based scrolling).
This is useful in TextInput, Dock, and any view that may respond differently to a drag vs a "select then drag".