### PR TITLE
fix: rename Math widget to MathView to avoid shader namespace collision

### DIFF
--- a/libs/math_widget/src/math.rs
+++ b/libs/math_widget/src/math.rs
@@ -2,7 +2,7 @@
 ///
 /// DSL Usage:
 /// ```
-/// <Math> {
+/// <MathView> {
 ///     width: Fit,
 ///     height: Fit,
 ///     color: #fff,
@@ -44,7 +44,7 @@ live_design!{
         }
     }
     
-    pub Math = {{Math}} {
+    pub MathView = {{Math}} {
         color: #fff,
         font_size: 11.0,
         baseline_offset: -2.0,


### PR DESCRIPTION
The `pub Math` DSL registration in math_widget shadows the shader built-in `Math` namespace (defined in draw/src/shader/std.rs), which provides `Math::random_2d` and `Math::rotate_2d`. This causes runtime shader compilation errors in every widget that uses `Math::random_2d` for color dithering (Slider, Button, Label, CheckBox, Icon, TextInput, Tab, LinkLabel, PopupMenu, DropDown, RadioButton, View).

Rename the widget DSL name from `Math` to `MathView`, consistent with Makepad naming conventions (CodeView, CircleView, RoundedView, etc.). The Rust struct remains `Math` — only the DSL registration name changes.

Downstream users need to update:
  `inline_math = <Math> {}` → `inline_math = <MathView> {}`
  `display_math = <Math> {}` → `display_math = <MathView> {}`