### PR TITLE
cargo_makepad: return actual error code instead of silent failure

### DIFF
--- a/tools/cargo_makepad/src/main.rs
+++ b/tools/cargo_makepad/src/main.rs
@@ -5,6 +5,8 @@ mod open_harmony;
 mod utils;
 mod wasm;
 
+use std::borrow::Cow;
+
 use android::*;
 use apple::*;
 use check::*;
@@ -14,10 +16,7 @@ pub use makepad_wasm_strip;
 use open_harmony::*;
 use wasm::*;
 
-fn show_help(err: &str) {
-    if !err.is_empty() {
-        println!("{}", err);
-    }
+fn show_help() {
     println!("Makepad's cargo extension");
     println!("    This tool is used to configure and build makepad applications for more complex platforms");
     println!();
@@ -33,35 +32,30 @@ fn show_help(err: &str) {
     println!();
     println!("       --port=8010                               The port to run the wasm webserver");
     println!("       --lan                                     Bind the webserver to your lan ip");
-    println!(
-        "       --strip                                   Strip the wasm file of debug symbols"
-    );
-    println!(
-        "       --brotli                                  Use brotli to compress the wasm file"
-    );
+    println!("       --strip                                   Strip the wasm file of debug symbols");
+    println!("       --brotli                                  Use brotli to compress the wasm file");
     println!("       --bindgen                                 Enable wasm-bindgen compatibility");
     println!();
     println!("Apple iOS/TVOs Commands:");
     println!();
-    println!(
-        "    apple <ios|tvos> install-toolchain           Install the toolchain needed with rustup"
-    );
-    println!("    apple <ios|tvos> --org=x --app=x run-sim <cargo args>    runs the project on the aarch64 simulator");
-    println!("    apple <ios|tvos> --org=x --app=x run-device <cargo args>   runs the project on a real device");
-    println!(
-        "    apple list                                   Lists all certificates/profiles/devices"
-    );
-    println!(" in order for makepad to be able to install an ios application on a real device a provisioning");
-    println!(" profile is needed. To create one make an empty application in xcode and give it an organisation");
-    println!(" name and product name you copy exactly and without spaces/odd characters into --org=x and --app=x");
-    println!("                         --stable use stable compiler");
-    println!(" Also run it on the device it at least once, so the profile is created");
-    println!("                         --org=organisation_name");
-    println!("                         --app=product_name");
-    println!(" If you have multiple signing identities or devices or provision profiles you might have to set it explicitly");
-    println!("                         --profile=");
-    println!("                         --cert=");
-    println!("                         --device=");
+    println!("    apple <ios|tvos> install-toolchain           Install the toolchain needed with rustup");
+    println!("    apple list                                   Lists all certificates/profiles/devices");
+    println!("    apple <ios|tvos> [options] run-sim <cargo args>      Runs the project on the aarch64 simulator");
+    println!("    apple <ios|tvos> [options] run-device <cargo args>   Runs the project on a real device");
+    println!(" * Note: in order for Makepad to be able to install an ios application on a real device, a provisioning");
+    println!("   profile is needed. To create one, make an empty application in xcode and give it an organisation");
+    println!("   name and a product name. Then, copy those exactly (without spaces/odd characters) into the below '--org' and '--app' options");
+    println!(" * Also, you must run it on the device it at least once, so the profile is created");
+    println!(" * If you have multiple signing identities or devices or provision profiles you might have to set it explicitly");
+    println!();
+    println!("    [options]:");
+    println!();
+    println!("       --stable                                  Use the stable compiler (not nightly)");
+    println!("       --org=<ORGANISATION_NAME>                 The organisation name to use for signing/provisioning");
+    println!("       --app=<PRODUCT_NAME>                      The product name to use for signing/provisioning");
+    println!("       --profile=<PROFILE_NAME>                  The profile name to use for signing/provisioning");
+    println!("       --cert=<CERT_NAME>                        The certificate name to use for signing/provisioning");
+    println!("       --device=<DEVICE_NAME>                    The device name to use for signing/provisioning");
     println!();
     println!("Android commands:");
     println!();
@@ -73,11 +67,9 @@ fn show_help(err: &str) {
     println!();
     println!("       --abi=all,x86_64,aarch64,armv7,i686       Select the target ABIs (default is aarch64). On an intel chip simulator use x86_64");
     println!("                                                 Be sure to add this also to install-toolchain");
-    println!("       --package-name=\"package\"                The package name");
-    println!("       --app-label=\"applabel\"                  The app label");
-    println!(
-        "       --sdk-path=./android_33_sdk               The path to read/write the android SDK"
-    );
+    println!("       --package-name='PACKAGE_NAME'             The package name");
+    println!("       --app-label='APP_LABEL'                   The app name/label");
+    println!("       --sdk-path=./android_33_sdk               The path to read/write the android SDK");
     println!("       --full-ndk                                Install the full NDK prebuilts for the selected Host OS (default is a minimal subset).");
     println!("                                                 This is required for building apps that compile native code as part of the Rust build process.");
     println!("       --keep-sdk-sources                        Keep downloaded SDK source files (default is to remove them).");
@@ -91,20 +83,18 @@ fn show_help(err: &str) {
     println!();
     println!("Open Harmony commands:");
     println!();
-    println!(
-        "    ohos [options] install-toolchain             Install the toolchain needed with rustup"
-    );
+    println!("    ohos [options] install-toolchain             Install the toolchain needed with rustup");
     println!("    ohos [options] deveco <cargo args>           Create a DevEco project for Open Harmony OS");
     println!("    ohos [options] build <cargo args>            Build  DevEco project and output the Hap package for the Open Harmony OS");
     println!("    ohos [options] run <cargo args>              Run the Hap package on a open harmony device via hdc");
     println!("    ohos [options] hilog <cargo args>            Get hilog from open harmony device via hdc");
     println!("    ohos [options] cdylib <cargo args>           Build makepad shared library only");
-    println!("");
+    println!();
     println!("    [options]:");
-    println!("");
-    println!("       --arch=\"aarch64\"                        The target architecture for the OHOS target device (defaults to the current architecture).");
-    println!("       --deveco-home=\"deveco_path\"             The path of DevEco program, this parameter can also be specified by environment variable \"DEVECO_HOME\"");
-    println!("       --remote=\"<hdcip:port>\"                 Remote hdc service, this parameter can also be specified by environment variable \"HDC_REMOTE\"");
+    println!();
+    println!("       --arch='aarch64'                          The target architecture for the OHOS target device (defaults to the current architecture).");
+    println!("       --deveco-home='deveco_path'               The path of DevEco program, this parameter can also be specified by environment variable \"DEVECO_HOME\"");
+    println!("       --remote='<hdcip:port>'                   Remote hdc service, this parameter can also be specified by environment variable \"HDC_REMOTE\"");
     println!();
     println!("Linux commands:");
     println!();
@@ -113,7 +103,7 @@ fn show_help(err: &str) {
     println!();
 }
 
-fn main() {
+fn main() -> Result<(), Cow<'static, str>> {
     let args: Vec<String> = std::env::args().collect();
 
     // Skip the first argument if it's the binary path or 'cargo'
@@ -133,34 +123,19 @@ fn main() {
     };
 
     if args.len() <= 1 {
-        return show_help("not enough arguments");
+        show_help();
+        return Err("not enough arguments; expected 2 or more.".into());
     }
-    match args[0].as_ref() {
-        "android" => {
-            if let Err(e) = handle_android(&args[1..]) {
-                println!("Got error: {}", e);
-            }
+    let result = match args[0].as_ref() {
+        "android"   => handle_android(&args[1..]),
+        "wasm"      => handle_wasm(&args[1..]),
+        "apple"     => handle_apple(&args[1..]),
+        "ohos"      => handle_open_harmony(&args[1..]),
+        "check"     => handle_check(&args[1..]),
+        unsupported => {
+            show_help();
+            Err(format!("unsupported command: '{unsupported}'").into())
         }
-        "wasm" => {
-            if let Err(e) = handle_wasm(&args[1..]) {
-                println!("Got error: {}", e);
-            }
-        }
-        "apple" => {
-            if let Err(e) = handle_apple(&args[1..]) {
-                println!("Got error: {}", e);
-            }
-        }
-        "ohos" => {
-            if let Err(e) = handle_open_harmony(&args[1..]) {
-                println!("Got error: {}", e);
-            }
-        }
-        "check" => {
-            if let Err(e) = handle_check(&args[1..]) {
-                println!("Got error: {}", e);
-            }
-        }
-        _ => show_help("not implemented yet"),
-    }
+    };
+    result.map_err(Into::into)
 }


### PR DESCRIPTION
This ensures that if an error occurs in a `cargo makepad` invocation, the `cargo makepad` binary will actually return an error (and importantly, an error exit code) instead of returning a success exit code of `0` in all cases.
This allows CI passes and automated testing to work as normal.

Extra: cleaned up "show help" output