### PR TITLE
Fix: overflow panic during for serializing empty slices/maps

### DIFF
--- a/libs/micro_serde/src/serde_json.rs
+++ b/libs/micro_serde/src/serde_json.rs
@@ -897,7 +897,7 @@ where
 {
     fn ser_json(&self, d: usize, s: &mut SerJsonState) {
         s.out.push('[');
-        let last = self.len() - 1;
+        let last = self.len().saturating_sub(1);
         for (index, item) in self.iter().enumerate() {
             item.ser_json(d + 1, s);
             if index != last {
@@ -1058,7 +1058,7 @@ where
 {
     fn ser_json(&self, d: usize, s: &mut SerJsonState) {
         s.out.push('{');
-        let last = self.len() - 1;
+        let last = self.len().saturating_sub(1);
         for (index, (k, v)) in self.iter().enumerate() {
             s.indent(d + 1);
             k.ser_json(d + 1, s);
@@ -1108,5 +1108,17 @@ where
 {
     fn de_json(s: &mut DeJsonState, i: &mut Chars) -> Result<Box<T>, DeJsonErr> {
         Ok(Box::new(DeJson::de_json(s, i)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SerJson;
+    use std::collections::HashMap;
+
+    #[test]
+    fn serialize_empty_hashmap_json() {
+        let map: HashMap<String, String> = HashMap::new();
+        assert_eq!(map.serialize_json(), "{}");
     }
 }

--- a/libs/micro_serde/src/serde_ron.rs
+++ b/libs/micro_serde/src/serde_ron.rs
@@ -743,7 +743,7 @@ where
 {
     fn ser_ron(&self, d: usize, s: &mut SerRonState) {
         s.out.push('(');
-        let last = self.len() - 1;
+        let last = self.len().saturating_sub(1);
         for (index, item) in self.iter().enumerate() {
             item.ser_ron(d + 1, s);
             if index != last {


### PR DESCRIPTION
Replace occurrences of self.len() - 1 with self.len().saturating_sub(1) in serialization code to avoid underflow when serializing empty slices/maps. Adds a unit test in serde_json to confirm an empty HashMap serializes to "{}". Changes touch libs/micro_serde/src/serde_json.rs and libs/micro_serde/src/serde_ron.rs.