### PR TITLE
Add video texture support to new script/shader compiler

### DIFF
--- a/platform/script/src/mod_shader.rs
+++ b/platform/script/src/mod_shader.rs
@@ -19,6 +19,7 @@ pub const SHADER_IO_VERTEX_BUFFER: ShaderIoType = ShaderIoType(4);
 pub const SHADER_IO_VARYING: ShaderIoType = ShaderIoType(5);
 pub const SHADER_IO_VERTEX_POSITION: ShaderIoType = ShaderIoType(6);
 pub const SHADER_IO_TEXTURE_1D: ShaderIoType = ShaderIoType(7);
+pub const SHADER_IO_TEXTURE_VIDEO: ShaderIoType = ShaderIoType(8);
 pub const SHADER_IO_TEXTURE_1D_ARRAY: ShaderIoType = ShaderIoType(9);
 pub const SHADER_IO_TEXTURE_2D: ShaderIoType = ShaderIoType(10);
 pub const SHADER_IO_TEXTURE_2D_ARRAY: ShaderIoType = ShaderIoType(11);
@@ -246,6 +247,19 @@ pub fn define_shader_module(heap: &mut ScriptHeap, native: &mut ScriptNative) {
             let value = script_value!(vm, args.value);
             let obj = vm.bx.heap.new_with_proto(value);
             vm.bx.heap.set_shader_io(obj, SHADER_IO_TEXTURE_DEPTH_ARRAY);
+            obj.into()
+        },
+    );
+
+    native.add_method(
+        heap,
+        shader,
+        id_lut!(texture_video),
+        script_args!(value = NIL),
+        |vm, args| {
+            let value = script_value!(vm, args.value);
+            let obj = vm.bx.heap.new_with_proto(value);
+            vm.bx.heap.set_shader_io(obj, SHADER_IO_TEXTURE_VIDEO);
             obj.into()
         },
     );

--- a/platform/script/src/shader.rs
+++ b/platform/script/src/shader.rs
@@ -584,6 +584,7 @@ impl ShaderFnCompiler {
                                 SHADER_IO_TEXTURE_DEPTH_ARRAY => {
                                     Some(TextureType::TextureDepthArray)
                                 }
+                                SHADER_IO_TEXTURE_VIDEO => Some(TextureType::TextureVideo),
                                 _ => None,
                             };
                             if let Some(tex_type) = tex_type {

--- a/platform/script/src/shader_backend.rs
+++ b/platform/script/src/shader_backend.rs
@@ -106,6 +106,10 @@ impl ShaderBackend {
                             ShaderIoKind::Texture(TextureType::TextureDepthArray),
                             ShaderIoPrefix::Prefix("_io."),
                         ),
+                        SHADER_IO_TEXTURE_VIDEO => (
+                            ShaderIoKind::Texture(TextureType::TextureVideo),
+                            ShaderIoPrefix::Prefix("_io."),
+                        ),
                         SHADER_IO_SAMPLER => (
                             ShaderIoKind::Sampler(ShaderSamplerOptions::default()),
                             ShaderIoPrefix::Prefix("_io."),
@@ -189,6 +193,10 @@ impl ShaderBackend {
                             ),
                             SHADER_IO_TEXTURE_DEPTH_ARRAY => (
                                 ShaderIoKind::Texture(TextureType::TextureDepthArray),
+                                ShaderIoPrefix::Prefix("_io."),
+                            ),
+                            SHADER_IO_TEXTURE_VIDEO => (
+                                ShaderIoKind::Texture(TextureType::TextureVideo),
                                 ShaderIoPrefix::Prefix("_io."),
                             ),
                             SHADER_IO_SAMPLER => (
@@ -284,6 +292,10 @@ impl ShaderBackend {
                                 ShaderIoKind::Texture(TextureType::TextureDepthArray),
                                 ShaderIoPrefix::Prefix(""),
                             ),
+                            SHADER_IO_TEXTURE_VIDEO => (
+                                ShaderIoKind::Texture(TextureType::TextureVideo),
+                                ShaderIoPrefix::Prefix(""),
+                            ),
                             SHADER_IO_SAMPLER => (
                                 ShaderIoKind::Sampler(ShaderSamplerOptions::default()),
                                 ShaderIoPrefix::Prefix(""),
@@ -365,6 +377,10 @@ impl ShaderBackend {
                             ),
                             SHADER_IO_TEXTURE_DEPTH_ARRAY => (
                                 ShaderIoKind::Texture(TextureType::TextureDepthArray),
+                                ShaderIoPrefix::Prefix(""),
+                            ),
+                            SHADER_IO_TEXTURE_VIDEO => (
+                                ShaderIoKind::Texture(TextureType::TextureVideo),
                                 ShaderIoPrefix::Prefix(""),
                             ),
                             SHADER_IO_SAMPLER => (
@@ -458,6 +474,10 @@ impl ShaderBackend {
                         ShaderIoKind::Texture(TextureType::TextureDepthArray),
                         ShaderIoPrefix::Prefix("rcx.tex_"),
                     ),
+                    SHADER_IO_TEXTURE_VIDEO => (
+                        ShaderIoKind::Texture(TextureType::TextureVideo),
+                        ShaderIoPrefix::Prefix("rcx.tex_"),
+                    ),
                     SHADER_IO_SAMPLER => (
                         ShaderIoKind::Sampler(ShaderSamplerOptions::default()),
                         ShaderIoPrefix::Prefix("rcx.sampler_"),
@@ -542,6 +562,10 @@ impl ShaderBackend {
                     ),
                     SHADER_IO_TEXTURE_DEPTH_ARRAY => (
                         ShaderIoKind::Texture(TextureType::TextureDepthArray),
+                        ShaderIoPrefix::Prefix("tex_"),
+                    ),
+                    SHADER_IO_TEXTURE_VIDEO => (
+                        ShaderIoKind::Texture(TextureType::TextureVideo),
                         ShaderIoPrefix::Prefix("tex_"),
                     ),
                     SHADER_IO_SAMPLER => (

--- a/platform/script/src/shader_calls.rs
+++ b/platform/script/src/shader_calls.rs
@@ -1414,6 +1414,50 @@ impl ShaderFnCompiler {
                     );
                 }
             }
+            id!(sample_video) => {
+                // sample_video(coord) samples a video texture (platform external texture).
+                // In GLSL this calls sample2dOES() which is provided by the runtime preamble.
+                // On other backends, falls back to regular sample.
+                if args.len() != 1 {
+                    script_err_invalid_args!(self.trap, "texture.sample_video requires 1 arg");
+                    let empty = self.stack.new_string();
+                    self.stack.push(
+                        self.trap.pass(),
+                        ShaderType::Pod(vm.bx.code.builtins.pod.pod_vec4f),
+                        empty,
+                    );
+                } else {
+                    let coord = &args[0];
+                    let mut s = self.stack.new_string();
+
+                    let sampler = ShaderSampler::default();
+                    let sampler_idx = output.get_or_create_sampler(sampler);
+
+                    match output.backend {
+                        ShaderBackend::Glsl => {
+                            output.bind_texture_sampler(&texture_expr, sampler_idx);
+                            write!(s, "sample2dOES({}, {})", texture_expr, coord).ok();
+                        }
+                        ShaderBackend::Metal => {
+                            write!(s, "{}.sample(_s{}, {})", texture_expr, sampler_idx, coord).ok();
+                        }
+                        ShaderBackend::Wgsl => {
+                            write!(s, "textureSample({}, _s{}, {})", texture_expr, sampler_idx, coord).ok();
+                        }
+                        ShaderBackend::Hlsl => {
+                            write!(s, "{}.SampleLevel(_s{}, {}, 0.0)", texture_expr, sampler_idx, coord).ok();
+                        }
+                        ShaderBackend::Rust => {
+                            write!(s, "{}.sample({})", texture_expr, coord).ok();
+                        }
+                    }
+                    self.stack.push(
+                        self.trap.pass(),
+                        ShaderType::Pod(vm.bx.code.builtins.pod.pod_vec4f),
+                        s,
+                    );
+                }
+            }
             _ => {
                 script_err_not_found!(
                     self.trap,
@@ -1421,7 +1465,7 @@ impl ShaderFnCompiler {
                     method_id,
                     suggest_from_live_ids(
                         method_id,
-                        &[id!(sample), id!(sample_as_bgra), id!(size)]
+                        &[id!(sample), id!(sample_as_bgra), id!(sample_video), id!(size)]
                     )
                 );
             }
@@ -1775,6 +1819,7 @@ impl ShaderFnCompiler {
             SHADER_IO_TEXTURE_CUBE_ARRAY => TextureType::TextureCubeArray,
             SHADER_IO_TEXTURE_DEPTH => TextureType::TextureDepth,
             SHADER_IO_TEXTURE_DEPTH_ARRAY => TextureType::TextureDepthArray,
+            SHADER_IO_TEXTURE_VIDEO => TextureType::TextureVideo,
             _ => return false,
         };
 

--- a/platform/script/src/shader_glsl.rs
+++ b/platform/script/src/shader_glsl.rs
@@ -701,6 +701,7 @@ impl ShaderOutput {
             TextureType::TextureCubeArray => "samplerCubeArray",
             TextureType::TextureDepth => "sampler2D",
             TextureType::TextureDepthArray => "sampler2DArray",
+            TextureType::TextureVideo => "samplerExternalOES",
         }
     }
 

--- a/platform/script/src/shader_hlsl.rs
+++ b/platform/script/src/shader_hlsl.rs
@@ -472,6 +472,7 @@ impl ShaderOutput {
                         TextureType::TextureCubeArray => "TextureCubeArray",
                         TextureType::TextureDepth => "Texture2D",
                         TextureType::TextureDepthArray => "Texture2DArray",
+                        TextureType::TextureVideo => "Texture2D", // Video textures are standard Texture2D on HLSL
                     };
                     let io_name = self.backend.map_io_name(io.name);
                     writeln!(out, "{} {} : register(t{});", hlsl_type, io_name, tex_idx).ok();

--- a/platform/script/src/shader_metal.rs
+++ b/platform/script/src/shader_metal.rs
@@ -33,6 +33,7 @@ impl ShaderOutput {
                         TextureType::TextureCubeArray => "texturecube_array<float>",
                         TextureType::TextureDepth => "depth2d<float>",
                         TextureType::TextureDepthArray => "depth2d_array<float>",
+                        TextureType::TextureVideo => "texture2d<float>", // Video textures are standard texture2d on Metal
                     };
                     writeln!(out, "    {} {};", metal_type, io.name).ok();
                 }
@@ -289,6 +290,7 @@ impl ShaderOutput {
                         TextureType::TextureCubeArray => "texturecube_array<float>",
                         TextureType::TextureDepth => "depth2d<float>",
                         TextureType::TextureDepthArray => "depth2d_array<float>",
+                        TextureType::TextureVideo => "texture2d<float>", // Video textures are standard texture2d on Metal
                     };
                     writeln!(
                         out,
@@ -417,6 +419,7 @@ impl ShaderOutput {
                         TextureType::TextureCubeArray => "texturecube_array<float>",
                         TextureType::TextureDepth => "depth2d<float>",
                         TextureType::TextureDepthArray => "depth2d_array<float>",
+                        TextureType::TextureVideo => "texture2d<float>", // Video textures are standard texture2d on Metal
                     };
                     writeln!(out, ",").ok();
                     write!(

--- a/platform/script/src/shader_output.rs
+++ b/platform/script/src/shader_output.rs
@@ -79,6 +79,7 @@ pub enum TextureType {
     TextureCubeArray,
     TextureDepth,
     TextureDepthArray,
+    TextureVideo,
 }
 
 #[derive(Debug, Clone)]
@@ -373,7 +374,8 @@ impl ShaderOutput {
                             SHADER_IO_TEXTURE_CUBE_ARRAY => self.io.push(ShaderIo { kind: ShaderIoKind::Texture(TextureType::TextureCubeArray), name: field_id, ty: ScriptPodType::VOID, buffer_index: None }),
                             SHADER_IO_TEXTURE_DEPTH => self.io.push(ShaderIo { kind: ShaderIoKind::Texture(TextureType::TextureDepth), name: field_id, ty: ScriptPodType::VOID, buffer_index: None }),
                             SHADER_IO_TEXTURE_DEPTH_ARRAY => self.io.push(ShaderIo { kind: ShaderIoKind::Texture(TextureType::TextureDepthArray), name: field_id, ty: ScriptPodType::VOID, buffer_index: None }),
-                            
+                            SHADER_IO_TEXTURE_VIDEO => self.io.push(ShaderIo { kind: ShaderIoKind::Texture(TextureType::TextureVideo), name: field_id, ty: ScriptPodType::VOID, buffer_index: None }),
+
                             // Other IO types are handled during compilation or elsewhere
                             _ => {}
                         }

--- a/platform/script/src/shader_wgsl.rs
+++ b/platform/script/src/shader_wgsl.rs
@@ -52,6 +52,7 @@ fn wgsl_texture_type(tex_type: TextureType) -> &'static str {
         TextureType::TextureCubeArray => "texture_cube_array<f32>",
         TextureType::TextureDepth => "texture_depth_2d",
         TextureType::TextureDepthArray => "texture_depth_2d_array",
+        TextureType::TextureVideo => "texture_external",
     }
 }
 

--- a/platform/src/draw_shader.rs
+++ b/platform/src/draw_shader.rs
@@ -232,12 +232,18 @@ impl DrawShaderInputs {
                 self.total_slots += slots;
             }
             DrawShaderInputPacking::UniformsGLSL140 => {
-                if slots > 4 {
-                    if (self.total_slots & 3) != 0 {
-                        self.total_slots += 4 - (self.total_slots & 3);
-                    }
-                } else if (self.total_slots & 3) + slots > 4 {
-                    self.total_slots += 4 - (self.total_slots & 3);
+                // std140 alignment rules:
+                // scalar (1 slot): no alignment requirement
+                // vec2 (2 slots): 2-slot aligned
+                // vec3/vec4 (3-4 slots): 4-slot aligned
+                // larger (matrices, arrays): 4-slot aligned
+                let alignment = match slots {
+                    1 => 1,
+                    2 => 2,
+                    _ => 4,
+                };
+                if self.total_slots % alignment != 0 {
+                    self.total_slots += alignment - (self.total_slots % alignment);
                 }
                 self.inputs.push(DrawShaderInput {
                     id,

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -784,6 +784,27 @@ pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onClipboardPaste
     });
 }
 
+// IME stubs - Java side references these but full IME support is on a separate branch
+#[no_mangle]
+pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onImeTextStateChanged(
+    _env: *mut jni_sys::JNIEnv,
+    _: jni_sys::jclass,
+    _full_text: jni_sys::jstring,
+    _selection_start: jni_sys::jint,
+    _selection_end: jni_sys::jint,
+    _composing_start: jni_sys::jint,
+    _composing_end: jni_sys::jint,
+) {
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onImeEditorAction(
+    _: *mut jni_sys::JNIEnv,
+    _: jni_sys::jclass,
+    _action_code: jni_sys::jint,
+) {
+}
+
 unsafe fn jstring_to_string(env: *mut jni_sys::JNIEnv, java_string: jni_sys::jstring) -> String {
     let chars = (**env).GetStringUTFChars.unwrap()(env, java_string, std::ptr::null_mut());
     let rust_string = std::ffi::CStr::from_ptr(chars)

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -592,11 +592,21 @@ impl Cx {
                             (gl.glUniform1i)(loc, i as i32);
                         }
                         if let Some(gl_bind_sampler) = gl.glBindSampler {
-                            let sampler = shgl
-                                .samplers
-                                .get(i)
-                                .and_then(|sampler| sampler.sampler)
-                                .unwrap_or(0);
+                            // Do not bind sampler objects for OES external textures;
+                            // per GL ES spec, using sampler objects with external textures
+                            // is undefined behavior.
+                            let is_oes = matches!(
+                                sh.mapping.textures[i].tex_type,
+                                TextureType::TextureVideo
+                            );
+                            let sampler = if is_oes {
+                                0
+                            } else {
+                                shgl.samplers
+                                    .get(i)
+                                    .and_then(|sampler| sampler.sampler)
+                                    .unwrap_or(0)
+                            };
                             gl_bind_sampler(i as u32, sampler);
                         }
                     }
@@ -1517,8 +1527,8 @@ impl CxOsDrawShader {
             && !is_emulator
         {
             (
-            "#extension GL_OES_EGL_image_external : require\n",
-            "vec4 sample2dOES(samplerExternalOES sampler, vec2 pos){ return texture2D(sampler, vec2(pos.x, pos.y));}"
+            "#extension GL_OES_EGL_image_external_essl3 : require\n",
+            "vec4 sample2dOES(samplerExternalOES sampler, vec2 pos){ return texture(sampler, vec2(pos.x, pos.y));}"
         )
         } else {
             ("", "")
@@ -2123,8 +2133,7 @@ impl CxTexture {
                     self.os.gl_texture = Some(gl_texture.assume_init());
                 }
             }
-        }
-        if self.take_initial() {
+
             unsafe {
                 let gpu_renderer = get_gl_string(gl, gl_sys::RENDERER);
                 if gpu_renderer.contains("Adreno") {

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -7,6 +7,7 @@ use crate::{
 script_mod! {
     use mod.prelude.widgets_internal.*
 
+    mod.widgets.VideoDataSource = #(VideoDataSource::script_api(vm))
     mod.widgets.VideoBase = #(Video::register_widget(vm))
 
     mod.widgets.Video = set_type_default() do mod.widgets.VideoBase{
@@ -14,11 +15,9 @@ script_mod! {
         height: 100
 
         draw_bg +: {
-            shape: Solid
-            fill: Image
-            texture video_texture: textureOES
-            texture thumbnail_texture: texture2d
-            uniform show_thumbnail: 0.0
+            video_texture: texture_video()
+            thumbnail_texture: texture_2d(float)
+            show_thumbnail: uniform(0.0)
 
             opacity: instance(1.0)
             image_scale: instance(vec2(1.0, 1.0))
@@ -34,7 +33,7 @@ script_mod! {
                     if self.show_thumbnail > 0.0 {
                         return self.thumbnail_texture.sample_as_bgra(self.pos).xyzw
                     } else {
-                        return self.video_texture.sampleOES(self.pos)
+                        return self.video_texture.sample_video(self.pos)
                     }
                 }
 
@@ -67,7 +66,7 @@ script_mod! {
                 if self.show_thumbnail > 0.5 {
                     return self.thumbnail_texture.sample_as_bgra(adjusted_pos).xyzw
                 } else {
-                    return self.video_texture.sampleOES(adjusted_pos)
+                    return self.video_texture.sample_video(adjusted_pos)
                 }
             }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                
                                   
- Add texture_video() / sample_video() to the script shader compiler, enabling the Video widget on Android with the new script_mod! system. Note that I've renamed this from textureOES and sampleOES from the previous implementation, since we'll use this in a less platform-specific fashion
- Fix std140 uniform buffer alignment for vec2 types (was causing rendering artifacts when shaders read vec2 uniforms after a float)
- Skip glBindSampler for external video textures (undefined behavior per GL ES spec)
- Add missing JNI stubs for IME methods (onImeTextStateChanged, onImeEditorAction)