### PR TITLE
Restore IME support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ workspace.members = [
     "examples/comfyui",
     "examples/aichat",
     "examples/pdf",
+    "examples/text_input",
 #    "examples/matrix",
     "libs/gltf",
     "libs/makepad_physics",

--- a/examples/text_input/Cargo.toml
+++ b/examples/text_input/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "makepad-example-text-input"
+version = "1.0.0"
+edition = "2021"
+
+[dependencies]
+makepad-widgets = { path = "../../widgets", version = "2.0.0" }

--- a/examples/text_input/src/app.rs
+++ b/examples/text_input/src/app.rs
@@ -1,0 +1,188 @@
+use makepad_widgets::*;
+
+app_main!(App);
+
+script_mod! {
+    use mod.prelude.widgets.*
+
+    let app = startup() do #(App::script_component(vm)){
+        ui: Root{
+            main_window := Window{
+                window.inner_size: vec2(700, 900)
+                body +: {
+                    ScrollYView{
+                        flow: Down
+                        padding: 20
+                        spacing: 20
+
+                        Label{
+                            draw_text.text_style.font_size: 16.0
+                            text: "TextInput IME Configuration Test"
+                        }
+
+                        // 1. Default multiline with autocorrect
+                        View{
+                            height: Fit flow: Down spacing: 5
+                            Label{ text: "1. Default (multiline, autocorrect, sentences capitalization)" }
+                            input_default := TextInput{
+                                empty_text: "Default text input..."
+                                width: Fill height: 150
+                                is_multiline: true
+                            }
+                        }
+
+                        // 2. Single-line (Enter submits instead of newline)
+                        View{
+                            height: Fit flow: Down spacing: 5
+                            Label{ text: "2. Single-line (Enter submits, Done button)" }
+                            input_singleline := TextInput{
+                                empty_text: "Single line, press Enter to submit..."
+                                width: Fill height: 50
+                                return_key_type: Done
+                            }
+                        }
+
+                        // 3. Email input
+                        View{
+                            height: Fit flow: Down spacing: 5
+                            Label{ text: "3. Email" }
+                            input_email := TextInput{
+                                empty_text: "email@example.com"
+                                width: Fill height: 50
+                                input_mode: Email
+                                autocorrect: Disabled
+                                autocapitalize: None
+                            }
+                        }
+
+                        // 4. URL input
+                        View{
+                            height: Fit flow: Down spacing: 5
+                            Label{ text: "4. URL (url keyboard, no autocorrect)" }
+                            input_url := TextInput{
+                                empty_text: "https://example.com"
+                                width: Fill height: 50
+                                input_mode: Url
+                                autocorrect: Disabled
+                                autocapitalize: None
+                                return_key_type: Go
+                            }
+                        }
+
+                        // 5. Number input
+                        View{
+                            height: Fit flow: Down spacing: 5
+                            Label{ text: "5. Number (decimal pad)" }
+                            input_number := TextInput{
+                                empty_text: "123.45"
+                                width: Fill height: 50
+                                input_mode: Decimal
+                            }
+                        }
+
+                        // 6. Search input
+                        View{
+                            height: Fit flow: Down spacing: 5
+                            Label{ text: "6. Search (search button, autocorrect on)" }
+                            input_search := TextInput{
+                                empty_text: "Search..."
+                                width: Fill height: 50
+                                input_mode: Search
+                                return_key_type: Search
+                            }
+                        }
+
+                        // 7. Password input
+                        View{
+                            height: Fit flow: Down spacing: 5
+                            Label{ text: "7. Password (secure, no autocorrect)" }
+                            input_password := TextInput{
+                                empty_text: "Password"
+                                width: Fill height: 50
+                                is_password: true
+                                autocorrect: Disabled
+                                autocapitalize: None
+                            }
+                        }
+
+                        // 8. All caps hint (mobile keyboard only)
+                        View{
+                            height: Fit flow: Down spacing: 5
+                            Label{ text: "8. Autocapitalize hint (mobile only)" }
+                            input_allcaps := TextInput{
+                                empty_text: "ALL CAPS INPUT"
+                                width: Fill height: 50
+                                autocapitalize: AllCharacters
+                            }
+                        }
+
+                        // 9. ASCII input (filtered on all platforms)
+                        View{
+                            height: Fit flow: Down spacing: 5
+                            Label{ text: "9. ASCII (filtered, ASCII keyboard on mobile)" }
+                            input_ascii := TextInput{
+                                empty_text: "ASCII input"
+                                width: Fill height: 50
+                                autocorrect: Enabled
+                                input_mode: Ascii
+                            }
+                        }
+
+                        // Status label
+                        Label{
+                            draw_text.text_style.font_size: 12.0
+                            text: "Status: Ready"
+                        }
+                        status_label := Label{
+                            draw_text.text_style.font_size: 11.0
+                            text: ""
+                        }
+                    }
+                }
+            }
+        }
+    }
+    app
+}
+
+impl App {
+    fn run(vm: &mut ScriptVm) -> Self {
+        crate::makepad_widgets::script_mod(vm);
+        App::from_script_mod(vm, self::script_mod)
+    }
+}
+
+#[derive(Script, ScriptHook)]
+pub struct App {
+    #[live]
+    ui: WidgetRef,
+}
+
+impl MatchEvent for App {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions) {
+        let inputs = [
+            ("singleline", ids!(input_singleline)),
+            ("email", ids!(input_email)),
+            ("url", ids!(input_url)),
+            ("number", ids!(input_number)),
+            ("search", ids!(input_search)),
+            ("password", ids!(input_password)),
+            ("allcaps", ids!(input_allcaps)),
+        ];
+
+        for (name, id) in inputs {
+            if let Some((text, _mods)) = self.ui.text_input(cx, id).returned(actions) {
+                let msg = format!("Returned from {}: \"{}\"", name, text);
+                log!("{}", msg);
+                self.ui.label(cx, ids!(status_label)).set_text(cx, &msg);
+            }
+        }
+    }
+}
+
+impl AppMain for App {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event) {
+        self.match_event(cx, event);
+        self.ui.handle_event(cx, event, &mut Scope::empty());
+    }
+}

--- a/examples/text_input/src/lib.rs
+++ b/examples/text_input/src/lib.rs
@@ -1,0 +1,2 @@
+pub use makepad_widgets;
+pub mod app;

--- a/examples/text_input/src/main.rs
+++ b/examples/text_input/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    makepad_example_text_input::app::app_main()
+}

--- a/libs/voice/build.rs
+++ b/libs/voice/build.rs
@@ -184,6 +184,24 @@ fn build_speech_bridge(target_os: &str) {
     println!("cargo:rustc-link-search=native={}", out_dir);
     println!("cargo:rustc-link-lib=static=speech_bridge");
 
+    // On iOS, ensure the linker uses the same deployment target as the Swift objects.
+    // Without this, Rust's default target triple (arm64-apple-ios10.0.0) causes a
+    // mismatch and missing symbols like ___chkstk_darwin from the Swift async runtime.
+    if target_os == "ios" {
+        let deployment_key = {
+            let abi = env::var("CARGO_CFG_TARGET_ABI").unwrap_or_default();
+            let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+            if abi == "sim" || arch == "x86_64" {
+                "IPHONESIMULATOR_DEPLOYMENT_TARGET"
+            } else {
+                "IPHONEOS_DEPLOYMENT_TARGET"
+            }
+        };
+        let deployment = env::var(deployment_key)
+            .unwrap_or_else(|_| IOS_DEPLOYMENT_TARGET_DEFAULT.to_string());
+        println!("cargo:rustc-link-arg=-miphoneos-version-min={}", deployment);
+    }
+
     // Link Apple frameworks
     println!("cargo:rustc-link-lib=framework=Speech");
     println!("cargo:rustc-link-lib=framework=Foundation");

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -8,9 +8,11 @@ use {
         draw_list::DrawListId,
         draw_pass::{CxDrawPassParent, CxDrawPassRect, DrawPassId},
         dvec2,
+        event::keyboard::CharOffset,
         event::xr::XrAnchor,
         event::{DragItem, HttpRequest, NextFrame, Timer, Trigger, VideoSource},
         gpu_info::GpuInfo,
+        ime::TextInputConfig,
         macos_menu::MacosMenu,
         makepad_futures::executor::Spawner,
         makepad_live_id::*,
@@ -21,6 +23,7 @@ use {
     },
     std::{
         any::{Any, TypeId},
+        ops::Range,
         rc::Rc,
     },
 };
@@ -81,8 +84,13 @@ pub enum CxOsOp {
     SetTopmost(WindowId, bool),
     ShowInDock(bool),
 
-    ShowTextIME(Area, Vec2d),
+    ShowTextIME(Area, Vec2d, TextInputConfig),
     HideTextIME,
+    SyncImeState {
+        text: String,
+        selection: Range<CharOffset>,
+        composition: Option<Range<CharOffset>>,
+    },
     SetCursor(MouseCursor),
     StartTimer {
         timer_id: u64,
@@ -170,6 +178,7 @@ impl std::fmt::Debug for CxOsOp {
 
             Self::ShowTextIME(..) => write!(f, "ShowTextIME"),
             Self::HideTextIME => write!(f, "HideTextIME"),
+            Self::SyncImeState { .. } => write!(f, "SyncImeState"),
             Self::SetCursor(..) => write!(f, "SetCursor"),
             Self::StartTimer { .. } => write!(f, "StartTimer"),
             Self::StopTimer(..) => write!(f, "StopTimer"),
@@ -387,10 +396,28 @@ impl Cx {
     }
 
     pub fn show_text_ime(&mut self, area: Area, pos: Vec2d) {
+        self.show_text_ime_with_config(area, pos, TextInputConfig::default());
+    }
+
+    pub fn show_text_ime_with_config(&mut self, area: Area, pos: Vec2d, config: TextInputConfig) {
         if !self.keyboard.text_ime_dismissed {
             self.ime_area = area;
-            self.platform_ops.push(CxOsOp::ShowTextIME(area, pos));
+            self.platform_ops
+                .push(CxOsOp::ShowTextIME(area, pos, config));
         }
+    }
+
+    pub fn sync_ime_state(
+        &mut self,
+        text: String,
+        selection: Range<CharOffset>,
+        composition: Option<Range<CharOffset>>,
+    ) {
+        self.platform_ops.push(CxOsOp::SyncImeState {
+            text,
+            selection,
+            composition,
+        });
     }
 
     pub fn hide_text_ime(&mut self) {

--- a/platform/src/event/event.rs
+++ b/platform/src/event/event.rs
@@ -190,6 +190,7 @@ pub enum Event {
     TextRangeReplace(TextRangeReplaceEvent),
     TextCopy(TextClipboardEvent),
     TextCut(TextClipboardEvent),
+    ImeAction(ImeActionEvent),
 
     Drag(DragEvent),
     Drop(DropEvent),
@@ -305,6 +306,7 @@ impl Event {
 
             56 => "DesignerPick",
             57 => "XrLocal",
+            58 => "ImeAction",
             _ => panic!(),
         }
     }
@@ -355,6 +357,7 @@ impl Event {
             Self::TextRangeReplace(_) => 35,
             Self::TextCopy(_) => 36,
             Self::TextCut(_) => 37,
+            Self::ImeAction(_) => 58,
 
             Self::Drag(_) => 38,
             Self::Drop(_) => 39,
@@ -410,6 +413,7 @@ pub enum Hit {
     TextRangeReplace(TextRangeReplaceEvent),
     TextCopy(TextClipboardEvent),
     TextCut(TextClipboardEvent),
+    ImeAction(ImeActionEvent),
 
     FingerScroll(FingerScrollEvent),
     FingerDown(FingerDownEvent),

--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -967,6 +967,11 @@ impl Event {
                     return Hit::TextCut(tc.clone());
                 }
             }
+            Event::ImeAction(ia) => {
+                if cx.keyboard.has_key_focus(area) {
+                    return Hit::ImeAction(ia.clone());
+                }
+            }
             Event::Scroll(e) => {
                 if cx.fingers.test_sweep_lock(options.sweep_area) {
                     return Hit::Nothing;

--- a/platform/src/event/keyboard.rs
+++ b/platform/src/event/keyboard.rs
@@ -7,6 +7,7 @@ use {
         makepad_script::*,
     },
     std::cell::RefCell,
+    std::ops::Range,
     std::rc::Rc,
 };
 
@@ -127,11 +128,88 @@ pub struct KeyFocusEvent {
     pub focus: Area,
 }
 
-#[derive(Clone, Debug, SerBin, DeBin, SerJson, DeJson, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TextInputEvent {
+    /// Text to insert or replace
     pub input: String,
+    /// If true, replaces the previous composition/input
     pub replace_last: bool,
+    /// True if this input came from paste operation
     pub was_paste: bool,
+    /// Composition range in character offsets (within input string)
+    pub composition: Option<Range<usize>>,
+    /// Full text state synchronization (Android only)
+    pub full_state_sync: Option<FullTextState>,
+    /// Range to replace in existing text (iOS autocorrect/paste)
+    pub replace_range: Option<(CharOffset, CharOffset)>,
+}
+
+impl Default for TextInputEvent {
+    fn default() -> Self {
+        Self {
+            input: String::new(),
+            replace_last: false,
+            was_paste: false,
+            composition: None,
+            full_state_sync: None,
+            replace_range: None,
+        }
+    }
+}
+
+// Manual serialization: only serialize the 3 wire-compatible fields.
+// The IME-specific fields are only used in-process, not over the stdin protocol.
+#[derive(SerBin, DeBin, SerJson, DeJson)]
+struct TextInputEventWire {
+    input: String,
+    replace_last: bool,
+    was_paste: bool,
+}
+
+impl SerBin for TextInputEvent {
+    fn ser_bin(&self, s: &mut Vec<u8>) {
+        let wire = TextInputEventWire {
+            input: self.input.clone(),
+            replace_last: self.replace_last,
+            was_paste: self.was_paste,
+        };
+        wire.ser_bin(s);
+    }
+}
+
+impl DeBin for TextInputEvent {
+    fn de_bin(o: &mut usize, d: &[u8]) -> Result<Self, DeBinErr> {
+        let wire = TextInputEventWire::de_bin(o, d)?;
+        Ok(Self {
+            input: wire.input,
+            replace_last: wire.replace_last,
+            was_paste: wire.was_paste,
+            ..Default::default()
+        })
+    }
+}
+
+impl SerJson for TextInputEvent {
+    fn ser_json(&self, d: usize, s: &mut SerJsonState) {
+        let wire = TextInputEventWire {
+            input: self.input.clone(),
+            replace_last: self.replace_last,
+            was_paste: self.was_paste,
+        };
+        wire.ser_json(d, s);
+    }
+}
+
+impl DeJson for TextInputEvent {
+    fn de_json(s: &mut DeJsonState, i: &mut std::str::Chars) -> Result<Self, DeJsonErr> {
+        let wire = TextInputEventWire::de_json(s, i)?;
+        Ok(Self {
+            input: wire.input,
+            replace_last: wire.replace_last,
+            was_paste: wire.was_paste,
+            ..Default::default()
+        })
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -148,6 +226,87 @@ pub struct TextRangeReplaceEvent {
     pub end: usize,
     /// Text to insert at the range
     pub text: String,
+}
+
+/// Character offset (Unicode scalar values)
+/// Platform-independent index type for text positions
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, SerBin, DeBin, SerJson, DeJson)]
+pub struct CharOffset(pub usize);
+
+impl CharOffset {
+    /// Convert to byte index in UTF-8 string
+    pub fn to_byte_index(self, text: &str) -> usize {
+        text.char_indices()
+            .nth(self.0)
+            .map(|(byte_idx, _)| byte_idx)
+            .unwrap_or(text.len())
+    }
+
+    /// Convert from UTF-16 index (Android/Java)
+    pub fn from_utf16_index(text: &str, utf16_idx: usize) -> Self {
+        let mut utf16_count = 0;
+        for (char_idx, c) in text.chars().enumerate() {
+            if utf16_count >= utf16_idx {
+                return CharOffset(char_idx);
+            }
+            utf16_count += c.len_utf16();
+        }
+        CharOffset(text.chars().count())
+    }
+
+    /// Convert to UTF-16 index (for Android/Java)
+    pub fn to_utf16_index(self, text: &str) -> usize {
+        text.chars().take(self.0).map(|c| c.len_utf16()).sum()
+    }
+
+    /// Convert Range<CharOffset> to Range<usize> (byte indices)
+    pub fn range_to_bytes(range: &Range<CharOffset>, text: &str) -> Range<usize> {
+        range.start.to_byte_index(text)..range.end.to_byte_index(text)
+    }
+}
+
+/// Full text state from platform IME (Android InputConnection)
+#[derive(Clone, Debug, PartialEq)]
+pub struct FullTextState {
+    pub text: String,
+    pub selection: Range<CharOffset>,
+    pub composition: Option<Range<CharOffset>>,
+}
+
+/// IME editor action type (from mobile soft keyboard action buttons)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ImeAction {
+    Unspecified,
+    None,
+    Go,
+    Search,
+    Send,
+    Next,
+    Done,
+    Previous,
+}
+
+impl ImeAction {
+    /// Convert from Android EditorInfo action codes
+    pub fn from_android_action_code(code: i32) -> Self {
+        match code {
+            0 => ImeAction::Unspecified,
+            1 => ImeAction::None,
+            2 => ImeAction::Go,
+            3 => ImeAction::Search,
+            4 => ImeAction::Send,
+            5 => ImeAction::Next,
+            6 => ImeAction::Done,
+            7 => ImeAction::Previous,
+            _ => ImeAction::Unspecified,
+        }
+    }
+}
+
+/// Event for IME editor action (Done, Go, Search, etc.)
+#[derive(Clone, Debug)]
+pub struct ImeActionEvent {
+    pub action: ImeAction,
 }
 
 impl Default for KeyCode {

--- a/platform/src/ime.rs
+++ b/platform/src/ime.rs
@@ -1,0 +1,108 @@
+use crate::makepad_script::*;
+
+script_mod! {
+    mod.ime = {
+        InputMode: mod.std.set_type_default() do #(InputMode::script_api(vm)),
+        ..me.InputMode,
+        AutoCapitalize: mod.std.set_type_default() do #(AutoCapitalize::script_api(vm)),
+        ..me.AutoCapitalize,
+        AutoCorrect: mod.std.set_type_default() do #(AutoCorrect::script_api(vm)),
+        ..me.AutoCorrect,
+        ReturnKeyType: mod.std.set_type_default() do #(ReturnKeyType::script_api(vm)),
+        ..me.ReturnKeyType,
+    }
+}
+
+/// Input mode hint for soft keyboards (matches web standard `inputmode` attribute).
+///
+/// Supported on iOS and Android. On desktop platforms, this has no effect.
+#[derive(Script, ScriptHook, Clone, Copy, Debug, PartialEq)]
+pub enum InputMode {
+    #[pick]
+    Text,
+    Ascii,
+    Url,
+    Numeric,
+    Tel,
+    Email,
+    Decimal,
+    Search,
+}
+
+/// Autocapitalization behavior for soft keyboards.
+///
+/// Supported on iOS and Android. On desktop platforms, this has no effect.
+#[derive(Script, ScriptHook, Clone, Copy, Debug, PartialEq)]
+pub enum AutoCapitalize {
+    None,
+    Words,
+    #[pick]
+    Sentences,
+    AllCharacters,
+}
+
+/// Autocorrection behavior for soft keyboards.
+///
+/// Supported on iOS and Android. On desktop platforms, this has no effect.
+#[derive(Script, ScriptHook, Clone, Copy, Debug, PartialEq)]
+pub enum AutoCorrect {
+    #[pick]
+    Default,
+    Enabled,
+    Disabled,
+}
+
+/// Return key type - controls the visual appearance and action of the return key.
+///
+/// Supported on iOS and Android. On desktop platforms, this has no effect.
+#[derive(Script, ScriptHook, Clone, Copy, Debug, PartialEq)]
+pub enum ReturnKeyType {
+    #[pick]
+    Default,
+    Go,
+    Search,
+    Send,
+    Done,
+}
+
+impl Default for InputMode {
+    fn default() -> Self {
+        InputMode::Text
+    }
+}
+
+impl Default for AutoCapitalize {
+    fn default() -> Self {
+        AutoCapitalize::Sentences
+    }
+}
+
+impl Default for AutoCorrect {
+    fn default() -> Self {
+        AutoCorrect::Default
+    }
+}
+
+impl Default for ReturnKeyType {
+    fn default() -> Self {
+        ReturnKeyType::Default
+    }
+}
+
+/// Soft keyboard configuration for mobile platforms (iOS/Android).
+/// These settings have no effect on desktop platforms.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct SoftKeyboardConfig {
+    pub input_mode: InputMode,
+    pub autocapitalize: AutoCapitalize,
+    pub autocorrect: AutoCorrect,
+    pub return_key_type: ReturnKeyType,
+}
+
+/// Text input configuration combining cross-platform and mobile-specific settings.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct TextInputConfig {
+    pub soft_keyboard: SoftKeyboardConfig,
+    pub is_multiline: bool,
+    pub is_secure: bool,
+}

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -26,6 +26,7 @@ mod draw_vars;
 
 mod area;
 pub mod component;
+pub mod ime;
 mod component_list;
 mod component_map;
 mod cursor;
@@ -90,6 +91,7 @@ pub use {
         },
         draw_vars::DrawVars,
         event::{
+            CharOffset,
             DesignerPickEvent,
             DigitDevice,
             DragEvent,
@@ -107,6 +109,7 @@ pub use {
             FingerMoveEvent,
             FingerScrollEvent,
             FingerUpEvent,
+            FullTextState,
             GameInputState,
             Hit,
             HitDesigner,
@@ -117,6 +120,8 @@ pub use {
             HttpProgress,
             HttpRequest,
             HttpResponse,
+            ImeAction,
+            ImeActionEvent,
             Inset,
             KeyCode,
             KeyEvent,
@@ -132,6 +137,7 @@ pub use {
             NextFrameEvent,
             TextClipboardEvent,
             TextInputEvent,
+            TextRangeReplaceEvent,
             //MidiInputListEvent,
             Timer,
             TimerEvent,
@@ -149,6 +155,10 @@ pub use {
             XrLocalEvent,
             XrState,
             XrUpdateEvent,
+        },
+        ime::{
+            AutoCapitalize, AutoCorrect, InputMode, ReturnKeyType, SoftKeyboardConfig,
+            TextInputConfig,
         },
         game_input::*,
         geometry::{Geometry, GeometryId},

--- a/platform/src/os/apple/apple_resources.rs
+++ b/platform/src/os/apple/apple_resources.rs
@@ -31,4 +31,26 @@ impl Cx {
             }
         }
     }
+
+    /// Load a single file from the app bundle by relative path.
+    ///
+    /// Used by the script resource system to load fonts and other assets
+    /// on iOS/tvOS devices where filesystem paths from the build machine
+    /// are not available.
+    #[allow(unused)]
+    pub(crate) fn apple_bundle_load_file(&self, path: &str) -> Result<Rc<Vec<u8>>, String> {
+        let bundle_path = unsafe {
+            let main: ObjcId = msg_send![class!(NSBundle), mainBundle];
+            let path: ObjcId = msg_send![main, resourcePath];
+            nsstring_to_string(path)
+        };
+
+        let full_path = format!("{}/{}", bundle_path, path);
+        let mut file = File::open(&full_path)
+            .map_err(|e| format!("Bundle file open failed: {} ({})", full_path, e))?;
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer)
+            .map_err(|e| format!("Bundle file read failed: {} ({})", full_path, e))?;
+        Ok(Rc::new(buffer))
+    }
 }

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -152,6 +152,7 @@ impl Cx {
                                     input,
                                     replace_last,
                                     was_paste: false,
+                                    ..Default::default()
                                 }));
                             }
                             ios_app::IosTextInputEvent::RangeReplace(start, end, text) => {
@@ -312,12 +313,20 @@ impl Cx {
                     window.window_geom = with_ios_app(|app| app.last_window_geom.clone());
                     window.is_created = true;
                 }
-                CxOsOp::ShowTextIME(_area, pos) => {
+                CxOsOp::ShowTextIME(_area, pos, config) => {
                     IosApp::set_ime_position(pos);
+                    IosApp::configure_keyboard(&config);
                     IosApp::show_keyboard();
                 }
                 CxOsOp::HideTextIME => {
                     IosApp::hide_keyboard();
+                }
+                CxOsOp::SyncImeState {
+                    text,
+                    selection,
+                    composition: _,
+                } => {
+                    IosApp::set_ime_text(text, selection.end.0);
                 }
                 CxOsOp::StartTimer {
                     timer_id,

--- a/platform/src/os/apple/ios/ios_app.rs
+++ b/platform/src/os/apple/ios/ios_app.rs
@@ -148,6 +148,8 @@ pub struct IosApp {
     edit_menu_interaction: Option<ObjcId>,
     /// Keyboard notification observer delegate - stored for cleanup
     keyboard_observer_delegate: Option<ObjcId>,
+    /// Cached keyboard config to avoid redundant reloadInputViews calls
+    last_keyboard_config: Option<crate::ime::TextInputConfig>,
 }
 
 impl IosApp {
@@ -178,6 +180,7 @@ impl IosApp {
                 edit_menu_delegate_instance,
                 edit_menu_interaction: None,
                 keyboard_observer_delegate: None,
+                last_keyboard_config: None,
             }
         }
     }
@@ -446,6 +449,71 @@ impl IosApp {
 
             UIApplicationMain(argc, &mut argv, nil, class_string);
         }
+    }
+
+    /// Configure keyboard settings (UITextInputTraits)
+    /// Uses caching to avoid calling reloadInputViews every frame
+    pub fn configure_keyboard(config: &crate::ime::TextInputConfig) {
+        use crate::ime::{AutoCapitalize, AutoCorrect, InputMode, ReturnKeyType};
+
+        let _ = IOS_APP.try_with(|app| {
+            if let Ok(mut app_ref) = app.try_borrow_mut() {
+                if let Some(ref mut app) = *app_ref {
+                    if app.last_keyboard_config.as_ref() == Some(config) {
+                        return;
+                    }
+
+                    if let Some(text_input_view) = app.text_input_view {
+                        unsafe {
+                            let kb_type: i64 = match config.soft_keyboard.input_mode {
+                                InputMode::Text => UI_KEYBOARD_TYPE_DEFAULT,
+                                InputMode::Ascii => UI_KEYBOARD_TYPE_ASCII_CAPABLE,
+                                InputMode::Url => UI_KEYBOARD_TYPE_URL,
+                                InputMode::Numeric => UI_KEYBOARD_TYPE_NUMBER_PAD,
+                                InputMode::Tel => UI_KEYBOARD_TYPE_PHONE_PAD,
+                                InputMode::Email => UI_KEYBOARD_TYPE_EMAIL_ADDRESS,
+                                InputMode::Decimal => UI_KEYBOARD_TYPE_DECIMAL_PAD,
+                                InputMode::Search => UI_KEYBOARD_TYPE_WEB_SEARCH,
+                            };
+
+                            let autocap_type: i64 = match config.soft_keyboard.autocapitalize {
+                                AutoCapitalize::None => UI_TEXT_AUTOCAPITALIZATION_NONE,
+                                AutoCapitalize::Words => UI_TEXT_AUTOCAPITALIZATION_WORDS,
+                                AutoCapitalize::Sentences => UI_TEXT_AUTOCAPITALIZATION_SENTENCES,
+                                AutoCapitalize::AllCharacters => UI_TEXT_AUTOCAPITALIZATION_ALL,
+                            };
+
+                            let autocorrect_type: i64 = match config.soft_keyboard.autocorrect {
+                                AutoCorrect::Default => -1,
+                                AutoCorrect::Disabled => UI_TEXT_AUTOCORRECTION_NO,
+                                AutoCorrect::Enabled => UI_TEXT_AUTOCORRECTION_YES,
+                            };
+
+                            let return_type: i64 = match config.soft_keyboard.return_key_type {
+                                ReturnKeyType::Default => UI_RETURN_KEY_DEFAULT,
+                                ReturnKeyType::Go => UI_RETURN_KEY_GO,
+                                ReturnKeyType::Search => UI_RETURN_KEY_SEARCH,
+                                ReturnKeyType::Send => UI_RETURN_KEY_SEND,
+                                ReturnKeyType::Done => UI_RETURN_KEY_DONE,
+                            };
+
+                            (*text_input_view).set_ivar::<i64>("_keyboard_type", kb_type);
+                            (*text_input_view)
+                                .set_ivar::<i64>("_autocapitalization_type", autocap_type);
+                            (*text_input_view)
+                                .set_ivar::<i64>("_autocorrection_type", autocorrect_type);
+                            (*text_input_view).set_ivar::<i64>("_return_key_type", return_type);
+                            (*text_input_view)
+                                .set_ivar::<bool>("_secure_text_entry", config.is_secure);
+
+                            let () = msg_send![text_input_view, reloadInputViews];
+                        }
+                    }
+
+                    app.last_keyboard_config = Some(*config);
+                }
+            }
+        });
     }
 
     pub fn show_keyboard() {
@@ -835,6 +903,7 @@ impl IosApp {
                 input: content,
                 replace_last: false,
                 was_paste: true,
+                ..Default::default()
             }));
         }
     }

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -609,7 +609,7 @@ impl Cx {
                         metal_window.cocoa_window.hide();
                     }
                 }
-                CxOsOp::ShowTextIME(area, pos) => {
+                CxOsOp::ShowTextIME(area, pos, _config) => {
                     let pos = area.clipped_rect(self).pos + pos;
                     metal_windows.iter_mut().for_each(|w| {
                         w.cocoa_window.set_ime_spot(pos);
@@ -654,9 +654,10 @@ impl Cx {
                 CxOsOp::CancelHttpRequest { request_id } => {
                     self.os.http_requests.cancel_http_request(request_id);
                 }
-                CxOsOp::ShowClipboardActions { .. } => {
-                    crate::log!("Show clipboard actions not supported yet");
-                }
+                // These ops are mobile-only (soft keyboard, clipboard UI); no-op on macOS
+                CxOsOp::SyncImeState { .. } => {}
+                CxOsOp::ShowClipboardActions { .. } => {}
+                CxOsOp::HideClipboardActions => {}
                 CxOsOp::CopyToClipboard(content) => {
                     with_macos_app(|app| app.copy_to_clipboard(&content));
                 }

--- a/platform/src/os/apple/macos/macos_app.rs
+++ b/platform/src/os/apple/macos/macos_app.rs
@@ -392,6 +392,7 @@ impl MacosApp {
                                         input: string,
                                         was_paste: true,
                                         replace_last: false,
+                                        ..Default::default()
                                     }));
                                 }
                             }

--- a/platform/src/os/apple/macos/macos_stdin.rs
+++ b/platform/src/os/apple/macos/macos_stdin.rs
@@ -437,7 +437,7 @@ impl Cx {
                          CxOsOp::SetTopmost(_window_id, _is_topmost) => {}
                          CxOsOp::XrStartPresenting(_) => {},
                          CxOsOp::XrStopPresenting(_) => {},
-                         CxOsOp::ShowTextIME(_area, _pos) => {},
+                         CxOsOp::ShowTextIME(_area, _pos, _config) => {},
                          CxOsOp::HideTextIME => {},
                          CxOsOp::SetCursor(_cursor) => {},
                          CxOsOp::StartTimer {timer_id, interval, repeats} => {},

--- a/platform/src/os/apple/macos/macos_window.rs
+++ b/platform/src/os/apple/macos/macos_window.rs
@@ -423,6 +423,7 @@ impl MacosWindow {
             input: input,
             was_paste: false,
             replace_last: replace_last,
+            ..Default::default()
         }))
     }
 

--- a/platform/src/os/apple/tvos/tvos.rs
+++ b/platform/src/os/apple/tvos/tvos.rs
@@ -241,9 +241,10 @@ impl Cx {
                 CxOsOp::CancelHttpRequest { request_id } => {
                     self.os.http_requests.cancel_http_request(request_id);
                 }
-                CxOsOp::ShowClipboardActions { .. } => {
-                    crate::log!("Show clipboard actions not supported yet");
-                }
+                // Mobile-only ops; no-op on tvOS
+                CxOsOp::SyncImeState { .. } => {}
+                CxOsOp::ShowClipboardActions { .. } => {}
+                CxOsOp::HideClipboardActions => {}
                 CxOsOp::CopyToClipboard(_request) => {
                     crate::error!("Clipboard actions not yet implemented for tvOS");
                 }

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -28,6 +28,7 @@ use {
         draw_pass::CxDrawPassParent,
         draw_pass::{DrawPassClearColor, DrawPassClearDepth, DrawPassId},
         event::{
+            keyboard::{CharOffset, FullTextState, ImeAction, ImeActionEvent},
             Event,
             HttpError,
             HttpResponse,
@@ -117,6 +118,9 @@ impl Cx {
                 }
                 Ok(message) => {
                     self.handle_message(message);
+                    // Dispatch platform ops immediately after non-RenderLoop messages.
+                    // This ensures SyncImeState reaches Java before the IME's next buffer query.
+                    self.handle_platform_ops();
                 }
                 Err(e) => {
                     crate::error!("Error receiving message: {:?}", e);
@@ -335,6 +339,7 @@ impl Cx {
                         input: character.to_string(),
                         replace_last: false,
                         was_paste: false,
+                        ..Default::default()
                     });
                     self.call_event_handler(&e);
                 }
@@ -374,6 +379,7 @@ impl Cx {
                                     input: content,
                                     replace_last: false,
                                     was_paste: true,
+                                    ..Default::default()
                                 });
                                 self.call_event_handler(&e);
                             }
@@ -682,7 +688,43 @@ impl Cx {
                     input: content,
                     replace_last: false,
                     was_paste: true,
+                    ..Default::default()
                 });
+                self.call_event_handler(&e);
+            }
+            FromJavaMessage::ImeTextStateChanged {
+                full_text,
+                selection_start,
+                selection_end,
+                composing_start,
+                composing_end,
+            } => {
+                let sel_start = CharOffset::from_utf16_index(&full_text, selection_start as usize);
+                let sel_end = CharOffset::from_utf16_index(&full_text, selection_end as usize);
+
+                let composition = if composing_start >= 0 && composing_end >= 0 {
+                    let comp_start =
+                        CharOffset::from_utf16_index(&full_text, composing_start as usize);
+                    let comp_end =
+                        CharOffset::from_utf16_index(&full_text, composing_end as usize);
+                    Some(comp_start..comp_end)
+                } else {
+                    None
+                };
+
+                let e = Event::TextInput(TextInputEvent {
+                    full_state_sync: Some(FullTextState {
+                        text: full_text,
+                        selection: sel_start..sel_end,
+                        composition,
+                    }),
+                    ..Default::default()
+                });
+                self.call_event_handler(&e);
+            }
+            FromJavaMessage::ImeEditorAction { action_code } => {
+                let action = ImeAction::from_android_action_code(action_code);
+                let e = Event::ImeAction(ImeActionEvent { action });
                 self.call_event_handler(&e);
             }
             FromJavaMessage::Init(_) => {}
@@ -1069,6 +1111,7 @@ impl Cx {
                      input: text,
                      replace_last: false,
                      was_paste: true,
+                     ..Default::default()
                  }
              );
              self.call_event_handler(&e);
@@ -1223,16 +1266,30 @@ impl Cx {
                 CxOsOp::StopTimer(timer_id) => {
                     self.os.timers.timers.remove(&timer_id);
                 }
-                CxOsOp::ShowTextIME(_area, _pos) => {
-                    //self.os.keyboard_trigger_position = area.get_clipped_rect(self).pos;
+                CxOsOp::ShowTextIME(_area, _pos, config) => {
                     unsafe {
+                        android_jni::to_java_configure_keyboard(&config);
                         android_jni::to_java_show_keyboard(true);
                     }
                 }
                 CxOsOp::HideTextIME => {
-                    //self.os.keyboard_visible = false;
                     unsafe {
                         android_jni::to_java_show_keyboard(false);
+                    }
+                }
+                CxOsOp::SyncImeState {
+                    text,
+                    selection,
+                    composition: _,
+                } => {
+                    let sel_start_utf16 = selection.start.to_utf16_index(&text) as i32;
+                    let sel_end_utf16 = selection.end.to_utf16_index(&text) as i32;
+                    unsafe {
+                        android_jni::to_java_update_ime_text_state(
+                            &text,
+                            sel_start_utf16,
+                            sel_end_utf16,
+                        );
                     }
                 }
                 CxOsOp::CopyToClipboard(content) => unsafe {

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -7,11 +7,13 @@ use {
         area::Area,
         cx::AndroidParams,
         event::{HttpRequest, TouchPoint, TouchState, VideoSource},
+        ime::{AutoCapitalize, AutoCorrect, InputMode, ReturnKeyType, TextInputConfig},
         makepad_live_id::*,
         makepad_math::*,
         WebSocketMessage,
     },
     makepad_android_state::{get_activity, get_java_vm},
+    std::ffi::c_uint,
     std::sync::Mutex,
     std::{
         cell::Cell,
@@ -127,6 +129,16 @@ pub enum FromJavaMessage {
     },
     ClipboardPaste {
         content: String,
+    },
+    ImeTextStateChanged {
+        full_text: String,
+        selection_start: i32,
+        selection_end: i32,
+        composing_start: i32,
+        composing_end: i32,
+    },
+    ImeEditorAction {
+        action_code: i32,
     },
 }
 unsafe impl Send for FromJavaMessage {}
@@ -784,25 +796,35 @@ pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onClipboardPaste
     });
 }
 
-// IME stubs - Java side references these but full IME support is on a separate branch
 #[no_mangle]
 pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onImeTextStateChanged(
-    _env: *mut jni_sys::JNIEnv,
+    env: *mut jni_sys::JNIEnv,
     _: jni_sys::jclass,
-    _full_text: jni_sys::jstring,
-    _selection_start: jni_sys::jint,
-    _selection_end: jni_sys::jint,
-    _composing_start: jni_sys::jint,
-    _composing_end: jni_sys::jint,
+    full_text: jni_sys::jstring,
+    selection_start: jni_sys::jint,
+    selection_end: jni_sys::jint,
+    composing_start: jni_sys::jint,
+    composing_end: jni_sys::jint,
 ) {
+    let text = jstring_to_string(env, full_text);
+    send_from_java_message(FromJavaMessage::ImeTextStateChanged {
+        full_text: text,
+        selection_start: selection_start as i32,
+        selection_end: selection_end as i32,
+        composing_start: composing_start as i32,
+        composing_end: composing_end as i32,
+    });
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_onImeEditorAction(
     _: *mut jni_sys::JNIEnv,
     _: jni_sys::jclass,
-    _action_code: jni_sys::jint,
+    action_code: jni_sys::jint,
 ) {
+    send_from_java_message(FromJavaMessage::ImeEditorAction {
+        action_code: action_code as i32,
+    });
 }
 
 unsafe fn jstring_to_string(env: *mut jni_sys::JNIEnv, java_string: jni_sys::jstring) -> String {
@@ -1206,4 +1228,77 @@ pub unsafe fn to_java_request_permission(permission: &str, request_id: i32) {
     );
 
     (**env).DeleteLocalRef.unwrap()(env, permission_jstr);
+}
+
+/// Configure keyboard/IME settings before showing the keyboard
+pub unsafe fn to_java_configure_keyboard(config: &TextInputConfig) {
+    let env = attach_jni_env();
+
+    let input_mode = match config.soft_keyboard.input_mode {
+        InputMode::Text => 0,
+        InputMode::Ascii => 1,
+        InputMode::Url => 2,
+        InputMode::Numeric => 3,
+        InputMode::Tel => 4,
+        InputMode::Email => 5,
+        InputMode::Decimal => 6,
+        InputMode::Search => 7,
+    };
+
+    let autocapitalize = match config.soft_keyboard.autocapitalize {
+        AutoCapitalize::None => 0,
+        AutoCapitalize::Words => 1,
+        AutoCapitalize::Sentences => 2,
+        AutoCapitalize::AllCharacters => 3,
+    };
+
+    let autocorrect = match config.soft_keyboard.autocorrect {
+        AutoCorrect::Default => 0,
+        AutoCorrect::Enabled => 1,
+        AutoCorrect::Disabled => 2,
+    };
+
+    let return_key_type = match config.soft_keyboard.return_key_type {
+        ReturnKeyType::Default => 0,
+        ReturnKeyType::Go => 1,
+        ReturnKeyType::Search => 2,
+        ReturnKeyType::Send => 3,
+        ReturnKeyType::Done => 5,
+    };
+
+    ndk_utils::call_void_method!(
+        env,
+        get_activity(),
+        "configureKeyboard",
+        "(IIIIZZ)V",
+        input_mode as jni_sys::jint,
+        autocapitalize as jni_sys::jint,
+        autocorrect as jni_sys::jint,
+        return_key_type as jni_sys::jint,
+        config.is_multiline as jni_sys::jboolean as c_uint,
+        config.is_secure as jni_sys::jboolean as c_uint
+    );
+}
+
+/// Update IME text state for programmatic changes (Rust→Java)
+pub unsafe fn to_java_update_ime_text_state(
+    full_text: &str,
+    selection_start: i32,
+    selection_end: i32,
+) {
+    let env = attach_jni_env();
+    let text_cstr = CString::new(full_text).unwrap();
+    let text_jstr = ((**env).NewStringUTF.unwrap())(env, text_cstr.as_ptr());
+
+    ndk_utils::call_void_method!(
+        env,
+        get_activity(),
+        "updateImeTextState",
+        "(Ljava/lang/String;II)V",
+        text_jstr,
+        selection_start as jni_sys::jint,
+        selection_end as jni_sys::jint
+    );
+
+    (**env).DeleteLocalRef.unwrap()(env, text_jstr);
 }

--- a/platform/src/os/linux/direct/raw_input.rs
+++ b/platform/src/os/linux/direct/raw_input.rs
@@ -958,6 +958,7 @@ impl RawInput {
                                     input: format!("{}", inp),
                                     was_paste: false,
                                     replace_last: false,
+                                    ..Default::default()
                                 }));
                             }
                         }

--- a/platform/src/os/linux/open_harmony/oh_callbacks.rs
+++ b/platform/src/os/linux/open_harmony/oh_callbacks.rs
@@ -40,6 +40,7 @@ pub fn handle_insert_text_event(text: String) -> napi_ohos::Result<()> {
         input: text,
         replace_last: false,
         was_paste: false,
+        ..Default::default()
     };
     send_from_ohos_message(FromOhosMessage::TextInput(e));
     Ok(())

--- a/platform/src/os/linux/open_harmony/open_harmony.rs
+++ b/platform/src/os/linux/open_harmony/open_harmony.rs
@@ -549,7 +549,7 @@ impl Cx {
                 CxOsOp::Quit => {
                     self.os.quit = true;
                 }
-                CxOsOp::ShowTextIME(_area, _pos) => {
+                CxOsOp::ShowTextIME(_area, _pos, _config) => {
                     let _ = self.os.arkts_obj.as_mut().unwrap().call_js_function(
                         "showKeyBoard",
                         0,

--- a/platform/src/os/linux/wayland/linux_wayland.rs
+++ b/platform/src/os/linux/wayland/linux_wayland.rs
@@ -101,6 +101,7 @@ impl WaylandCx {
                 input,
                 replace_last: false,
                 was_paste: true,
+                ..Default::default()
             }));
         }
         if let EventFlow::Exit = self.handle_platform_ops(state) {
@@ -426,7 +427,7 @@ impl WaylandCx {
                     use crate::os::linux::http::LinuxHttpSocket;
                     LinuxHttpSocket::cancel(request_id);
                 }
-                CxOsOp::ShowTextIME(area, pos) => {
+                CxOsOp::ShowTextIME(area, pos, _config) => {
                     if let Some(window) = state.current_window {
                         if let Some(text_input) = state.text_input.as_ref() {
                             text_input.enable();
@@ -448,6 +449,9 @@ impl WaylandCx {
                         text_input.commit();
                     }
                 }
+                // Mobile-only ops (soft keyboard, clipboard UI); no-op on desktop
+                CxOsOp::SyncImeState { .. } => {}
+                CxOsOp::HideClipboardActions => {}
                 e => {
                     crate::error!("Not implemented on this platform: CxOsOp::{:?}", e);
                 }

--- a/platform/src/os/linux/wayland/wayland_state.rs
+++ b/platform/src/os/linux/wayland/wayland_state.rs
@@ -553,6 +553,7 @@ impl Dispatch<zwp_text_input_v3::ZwpTextInputV3, ()> for WaylandState {
                         input: text_str,
                         replace_last: false,
                         was_paste: false,
+                        ..Default::default()
                     }));
                 }
             }
@@ -664,6 +665,7 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandState {
                                     input: text_str,
                                     replace_last: false,
                                     was_paste: false,
+                                    ..Default::default()
                                 }));
                             }
                         }
@@ -1045,6 +1047,7 @@ impl WaylandState {
                 input: self.clipboard_text.clone(),
                 replace_last: false,
                 was_paste: true,
+                ..Default::default()
             }));
         }
     }

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -464,7 +464,7 @@ impl X11Cx {
                     use crate::os::linux::http::LinuxHttpSocket;
                     LinuxHttpSocket::cancel(request_id);
                 }
-                CxOsOp::ShowTextIME(area, pos) => {
+                CxOsOp::ShowTextIME(area, pos, _config) => {
                     let pos = area.clipped_rect(&cx).pos + pos;
                     opengl_windows.iter_mut().for_each(|w| {
                         w.xlib_window.set_ime_spot(pos);
@@ -503,6 +503,9 @@ impl X11Cx {
                         },
                     ));
                 }
+                // Mobile-only ops (soft keyboard, clipboard UI); no-op on desktop
+                CxOsOp::SyncImeState { .. } => {}
+                CxOsOp::HideClipboardActions => {}
                 e => {
                     crate::error!("Not implemented on this platform: CxOsOp::{:?}", e);
                 }

--- a/platform/src/os/linux/x11/linux_x11_stdin.rs
+++ b/platform/src/os/linux/x11/linux_x11_stdin.rs
@@ -536,7 +536,7 @@ impl Cx {
                          CxOsOp::SetTopmost(_window_id, _is_topmost) => {}
                          CxOsOp::XrStartPresenting(_) => {},
                          CxOsOp::XrStopPresenting(_) => {},
-                         CxOsOp::ShowTextIME(_area, _pos) => {},
+                         CxOsOp::ShowTextIME(_area, _pos, _config) => {},
                          CxOsOp::HideTextIME => {},
                          CxOsOp::SetCursor(_cursor) => {},
                          CxOsOp::StartTimer {timer_id, interval, repeats} => {},

--- a/platform/src/os/linux/x11/xlib_app.rs
+++ b/platform/src/os/linux/x11/xlib_app.rs
@@ -147,6 +147,7 @@ impl XlibApp {
                                     input: utf8_string,
                                     was_paste: true,
                                     replace_last: false,
+                                    ..Default::default()
                                 }));
                             }
                             x11_sys::XFree(ret as *mut _ as *mut c_void);
@@ -533,6 +534,7 @@ impl XlibApp {
                                         input: utf8,
                                         was_paste: false,
                                         replace_last: false,
+                                        ..Default::default()
                                     }));
                                 }
                             }

--- a/platform/src/os/linux/x11/xlib_window.rs
+++ b/platform/src/os/linux/x11/xlib_window.rs
@@ -549,6 +549,7 @@ impl XlibWindow {
             input,
             was_paste: false,
             replace_last,
+            ..Default::default()
         }))
     }
 }

--- a/platform/src/os/web/to_wasm.rs
+++ b/platform/src/os/web/to_wasm.rs
@@ -474,6 +474,7 @@ impl Into<TextInputEvent> for ToWasmTextInput {
             was_paste: self.was_paste,
             replace_last: self.replace_last,
             input: self.input,
+            ..Default::default()
         }
     }
 }

--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -472,7 +472,7 @@ impl Cx {
                 CxOsOp::XrStopPresenting => {
                     self.os.from_wasm(FromWasmXrStopPresenting {});
                 }
-                CxOsOp::ShowTextIME(area, pos) => {
+                CxOsOp::ShowTextIME(area, pos, _config) => {
                     let pos = area.clipped_rect(self).pos + pos;
                     self.os
                         .from_wasm(FromWasmShowTextIME { x: pos.x, y: pos.y });

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -414,6 +414,7 @@ impl Win32Window {
                                             input: utf8,
                                             was_paste: true,
                                             replace_last: false,
+                                            ..Default::default()
                                         }));
                                     }
                                 } else {
@@ -471,6 +472,7 @@ impl Win32Window {
                             input: utf8,
                             was_paste: false,
                             replace_last: false,
+                            ..Default::default()
                         }));
                     }
                 }
@@ -1021,6 +1023,7 @@ impl Win32Window {
             input: input,
             was_paste: false,
             replace_last: replace_last,
+            ..Default::default()
         }))
     }
 

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -439,7 +439,7 @@ impl Cx {
 
                     //todo!("HttpRequest not implemented yet on windows, we'll get there");
                 }
-                CxOsOp::ShowTextIME(area, pos) => {
+                CxOsOp::ShowTextIME(area, pos, _config) => {
                     let pos = area.clipped_rect(self).pos + pos;
                     d3d11_windows.iter_mut().for_each(|w| {
                         w.win32_window.set_ime_spot(pos);
@@ -476,6 +476,10 @@ impl Cx {
                         },
                     ));
                 }
+                // Mobile-only ops (soft keyboard, clipboard UI); no-op on desktop
+                CxOsOp::SyncImeState { .. } => {}
+                CxOsOp::ShowClipboardActions { .. } => {}
+                CxOsOp::HideClipboardActions => {}
                 e => {
                     crate::error!("Not implemented on this platform: CxOsOp::{:?}", e);
                 }

--- a/platform/src/os/windows/windows_stdin.rs
+++ b/platform/src/os/windows/windows_stdin.rs
@@ -381,7 +381,7 @@ impl Cx {
                          CxOsOp::SetTopmost(_window_id, _is_topmost) => {}
                          CxOsOp::XrStartPresenting(_) => {},
                          CxOsOp::XrStopPresenting(_) => {},
-                         CxOsOp::ShowTextIME(_area, _pos) => {},
+                         CxOsOp::ShowTextIME(_area, _pos, _config) => {},
                          CxOsOp::HideTextIME => {},
                          CxOsOp::SetCursor(_cursor) => {},
                          CxOsOp::StartTimer {timer_id, interval, repeats} => {},

--- a/platform/src/script/res.rs
+++ b/platform/src/script/res.rs
@@ -162,26 +162,44 @@ impl Cx {
                     }
                 }
 
-                match File::open(&res.abs_path) {
-                    Ok(mut file) => {
-                        let mut data = Vec::new();
-                        match file.read_to_end(&mut data) {
-                            Ok(_) => {
-                                res.data = CxScriptResourceData::Loaded(Rc::new(data));
-                            }
-                            Err(e) => {
-                                res.data = CxScriptResourceData::Error(format!(
-                                    "Failed to read file: {}",
-                                    e
-                                ));
-                            }
+                // Try loading from the filesystem (works on desktop/simulator)
+                if let Ok(mut file) = File::open(&res.abs_path) {
+                    let mut data = Vec::new();
+                    match file.read_to_end(&mut data) {
+                        Ok(_) => {
+                            res.data = CxScriptResourceData::Loaded(Rc::new(data));
+                        }
+                        Err(e) => {
+                            res.data = CxScriptResourceData::Error(format!(
+                                "Failed to read file: {}",
+                                e
+                            ));
                         }
                     }
-                    Err(e) => {
-                        res.data =
-                            CxScriptResourceData::Error(format!("Failed to open file: {}", e));
+                    continue;
+                }
+
+                // On iOS/tvOS device, fall back to loading from the app bundle.
+                // The bundle has resources at {bundle}/makepad/{crate_name}/{file_path}.
+                #[cfg(any(target_os = "ios", target_os = "tvos"))]
+                {
+                    if let Some(dep_path) = res.dependency_path.as_deref() {
+                        let bundle_path = if let Some(root) = self.package_root.as_deref() {
+                            format!("{}/{}", root, dep_path)
+                        } else {
+                            dep_path.to_string()
+                        };
+                        if let Ok(data) = self.apple_bundle_load_file(&bundle_path) {
+                            res.data = CxScriptResourceData::Loaded(data);
+                            continue;
+                        }
                     }
                 }
+
+                res.data = CxScriptResourceData::Error(format!(
+                    "Failed to open resource: {}",
+                    res.abs_path
+                ));
             }
         }
 

--- a/studio/src/ai_chat/ai_chat_view.rs
+++ b/studio/src/ai_chat/ai_chat_view.rs
@@ -44,6 +44,7 @@ script_mod! {
                 width: Fill
                 height: Fit
                 empty_text: "Enter prompt"
+                is_multiline: true
             }
         }
     }

--- a/studio/src/integration.rs
+++ b/studio/src/integration.rs
@@ -57,6 +57,7 @@ script_mod! {
                 margin: Inset{left: 10.0 right: 10.0 bottom: 10.0}
                 empty_text: "Output Log"
                 is_read_only: true
+                is_multiline: true
             }
         }
     }

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -241,6 +241,7 @@ pub use crate::video::*;
 
 pub fn script_mod(vm: &mut ScriptVm) {
     makepad_draw::script_mod(vm);
+    makepad_platform::ime::script_mod(vm);
 
     vm.bx.heap.new_module(id!(prelude));
     vm.bx.heap.new_module(id!(themes));
@@ -262,6 +263,11 @@ pub fn script_mod(vm: &mut ScriptVm) {
                 ..mod.turtle,
                 ..mod.turtle.Size,
                 ..mod.turtle.Flow,
+                ..mod.ime,
+                ..mod.ime.InputMode,
+                ..mod.ime.AutoCapitalize,
+                ..mod.ime.AutoCorrect,
+                ..mod.ime.ReturnKeyType,
                 ..mod.std
                 theme:mod.theme,
                 draw:mod.draw,
@@ -376,6 +382,11 @@ pub fn script_mod(vm: &mut ScriptVm) {
                 ..mod.turtle,
                 ..mod.turtle.Size,
                 ..mod.turtle.Flow,
+                ..mod.ime,
+                ..mod.ime.InputMode,
+                ..mod.ime.AutoCapitalize,
+                ..mod.ime.AutoCorrect,
+                ..mod.ime.ReturnKeyType,
                 ..mod.draw.MouseCursor
             }
         }

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -4,6 +4,11 @@ use {
         makepad_derive_widget::*,
         makepad_draw::{
             event::finger::TouchState,
+            event::keyboard::CharOffset,
+            ime::{
+                AutoCapitalize, AutoCorrect, InputMode, ReturnKeyType, SoftKeyboardConfig,
+                TextInputConfig,
+            },
             text::{
                 geom::Point,
                 layouter::{LaidoutText, SelectionRect},
@@ -290,6 +295,14 @@ script_mod! {
             }
         }
 
+        draw_composition_underline +: {
+            color: uniform(#8)
+
+            pixel: fn() {
+                return self.color
+            }
+        }
+
         animator: Animator{
             empty: {
                 default: @off
@@ -479,6 +492,8 @@ pub struct TextInput {
     draw_selection: DrawQuad,
     #[live]
     draw_cursor: DrawQuad,
+    #[live]
+    draw_composition_underline: DrawQuad,
 
     #[layout]
     layout: Layout,
@@ -493,6 +508,16 @@ pub struct TextInput {
     is_read_only: bool,
     #[live]
     is_numeric_only: bool,
+    #[live]
+    input_mode: InputMode,
+    #[live]
+    autocapitalize: AutoCapitalize,
+    #[live]
+    autocorrect: AutoCorrect,
+    #[live]
+    return_key_type: ReturnKeyType,
+    #[live(false)]
+    is_multiline: bool,
     #[live]
     scroll_y: f64,
     #[live]
@@ -522,9 +547,21 @@ pub struct TextInput {
     /// IME composition tracking - byte index where composition starts
     #[rust]
     composition_start: usize,
-    /// IME composition tracking - byte length of current composition
+    /// IME composition tracking - byte index where composition ends
     #[rust]
-    composition_length: usize,
+    composition_end: usize,
+    /// Frame ID when IME input was last received (echo prevention)
+    #[rust]
+    ime_update_frame: u64,
+    /// Cached text last sent to platform IME (echo prevention)
+    #[rust]
+    last_sent_ime_text: String,
+    /// Cached selection start (byte index) last sent to platform IME
+    #[rust]
+    last_sent_ime_sel_start: usize,
+    /// Cached selection end (byte index) last sent to platform IME
+    #[rust]
+    last_sent_ime_sel_end: usize,
 
     #[live]
     on_change: Option<ScriptFnRef>,
@@ -1070,6 +1107,8 @@ impl TextInput {
         self.animator_play(cx, ids!(blink.on));
         cx.stop_timer(self.blink_timer);
         cx.hide_text_ime();
+        self.composition_start = 0;
+        self.composition_end = 0;
         // Only hide clipboard actions on mobile platforms where they're supported
         match cx.os_type() {
             OsType::Android(_) | OsType::Ios(_) => {
@@ -1078,6 +1117,93 @@ impl TextInput {
             _ => {}
         }
         cx.widget_action(uid, TextInputAction::KeyFocusLost);
+    }
+
+    fn has_composition(&self) -> bool {
+        self.composition_end > self.composition_start
+    }
+
+    fn get_ime_config(&self) -> TextInputConfig {
+        TextInputConfig {
+            soft_keyboard: SoftKeyboardConfig {
+                input_mode: if self.is_numeric_only && self.input_mode == InputMode::Text {
+                    InputMode::Decimal
+                } else {
+                    self.input_mode
+                },
+                autocapitalize: self.autocapitalize,
+                autocorrect: self.autocorrect,
+                return_key_type: self.return_key_type,
+            },
+            is_multiline: self.is_multiline,
+            is_secure: self.is_password,
+        }
+    }
+
+    fn update_ime_context(&mut self, cx: &mut Cx) {
+        if self.has_composition() {
+            return;
+        }
+
+        let sel_start_chars = self.text[..self.selection.start().index].chars().count();
+        let sel_end_chars = self.text[..self.selection.end().index].chars().count();
+
+        if self.text != self.last_sent_ime_text
+            || self.selection.start().index != self.last_sent_ime_sel_start
+            || self.selection.end().index != self.last_sent_ime_sel_end
+        {
+            self.last_sent_ime_text = self.text.clone();
+            self.last_sent_ime_sel_start = self.selection.start().index;
+            self.last_sent_ime_sel_end = self.selection.end().index;
+
+            cx.sync_ime_state(
+                self.text.clone(),
+                CharOffset(sel_start_chars)..CharOffset(sel_end_chars),
+                None,
+            );
+        }
+    }
+
+    fn draw_composition_underline(&mut self, cx: &mut Cx2d, text_rect: Rect) {
+        if !self.has_composition() {
+            return;
+        }
+
+        let laidout_text = self
+            .laidout_text
+            .as_ref()
+            .expect("layout should never be `None` here");
+
+        let composition_selection = Selection {
+            anchor: Cursor {
+                index: self.composition_start.min(self.text.len()),
+                prefer_next_row: false,
+            },
+            cursor: Cursor {
+                index: self.composition_end.min(self.text.len()),
+                prefer_next_row: false,
+            },
+        };
+
+        let selection = self.selection_to_password_selection(composition_selection);
+        let underline_height = 1.5 * self.draw_text.font_scale;
+
+        self.draw_composition_underline.begin_many_instances(cx);
+        for SelectionRect { rect_in_lpxs, .. } in laidout_text.selection_rects(selection) {
+            let scaled_x =
+                text_rect.pos.x + (rect_in_lpxs.origin.x * self.draw_text.font_scale) as f64;
+            let scaled_y = text_rect.pos.y
+                + ((rect_in_lpxs.origin.y + rect_in_lpxs.size.height) * self.draw_text.font_scale)
+                    as f64
+                - underline_height as f64;
+            let scaled_w = (rect_in_lpxs.size.width * self.draw_text.font_scale) as f64;
+
+            self.draw_composition_underline.draw_abs(
+                cx,
+                rect(scaled_x, scaled_y, scaled_w, underline_height as f64),
+            );
+        }
+        self.draw_composition_underline.end_many_instances(cx);
     }
 
     fn ceil_word_boundary(&self, index: usize) -> usize {
@@ -1107,26 +1233,51 @@ impl TextInput {
         if input.len() == 1 && input.chars().next().unwrap() <= '\u{1d}' {
             return String::new();
         }
-        if self.is_numeric_only {
-            let mut contains_dot = if is_set_text {
-                false
-            } else {
-                let before_selection = self.text[..self.selection.start().index].to_string();
-                let after_selection = self.text[self.selection.end().index..].to_string();
-                before_selection.contains('.') || after_selection.contains('.')
-            };
-            input
-                .chars()
-                .filter(|char| match char {
-                    '.' | ',' if !contains_dot => {
-                        contains_dot = true;
-                        true
-                    }
-                    char => char.is_ascii_digit(),
-                })
-                .collect()
+        // Use input_mode for filtering; fall back to is_numeric_only for backwards compat
+        let effective_mode = if self.is_numeric_only && self.input_mode == InputMode::Text {
+            InputMode::Decimal
         } else {
-            input.to_string()
+            self.input_mode
+        };
+        match effective_mode {
+            InputMode::Ascii => {
+                input.chars().filter(|c| c.is_ascii()).collect()
+            }
+            InputMode::Numeric => {
+                input.chars().filter(|c| c.is_ascii_digit()).collect()
+            }
+            InputMode::Decimal => {
+                let mut contains_dot = if is_set_text {
+                    false
+                } else {
+                    let before_selection = self.text[..self.selection.start().index].to_string();
+                    let after_selection = self.text[self.selection.end().index..].to_string();
+                    before_selection.contains('.') || after_selection.contains('.')
+                };
+                input
+                    .chars()
+                    .filter(|c| match c {
+                        '.' if !contains_dot => {
+                            contains_dot = true;
+                            true
+                        }
+                        '-' | '+' => true,
+                        c => c.is_ascii_digit(),
+                    })
+                    .collect()
+            }
+            InputMode::Tel => {
+                input
+                    .chars()
+                    .filter(|c| {
+                        c.is_ascii_digit()
+                            || matches!(c, '+' | '-' | ' ' | '(' | ')' | '*' | '#')
+                    })
+                    .collect()
+            }
+            InputMode::Text | InputMode::Url | InputMode::Email | InputMode::Search => {
+                input.to_string()
+            }
         }
     }
 
@@ -1232,17 +1383,23 @@ impl Widget for TextInput {
     fn draw_walk(&mut self, cx: &mut Cx2d, _scope: &mut Scope, walk: Walk) -> DrawStep {
         self.draw_bg.begin(cx, walk, self.layout);
         self.draw_selection.append_to_draw_call(cx);
+        self.draw_composition_underline.append_to_draw_call(cx);
         self.layout_text(cx);
         let text_rect = self.draw_text(cx);
         let cursor_rect = self.draw_cursor(cx, text_rect);
         self.draw_selection(cx, text_rect);
+        self.draw_composition_underline(cx, text_rect);
         self.scroll_to_cursor(cx);
         self.draw_bg.end(cx);
         if cx.has_key_focus(self.draw_bg.area()) {
+            if self.ime_update_frame != cx.redraw_id() {
+                self.update_ime_context(cx);
+            }
             let cursor_bottom_pos = cursor_rect.pos + cursor_rect.size;
-            cx.show_text_ime(
+            cx.show_text_ime_with_config(
                 self.draw_bg.area(),
                 dvec2(cursor_bottom_pos.x, cursor_bottom_pos.y - self.scroll_y),
+                self.get_ime_config(),
             );
         }
         cx.add_nav_stop(self.draw_bg.area(), NavRole::TextInput, Inset::default());
@@ -1319,6 +1476,17 @@ impl Widget for TextInput {
             Hit::KeyFocus(_) => {
                 self.animator_play(cx, ids!(focus.on));
                 self.reset_blink_timer(cx);
+                // Sync text state to platform IME before keyboard shows
+                let sel_start_chars = self.text[..self.selection.start().index].chars().count();
+                let sel_end_chars = self.text[..self.selection.end().index].chars().count();
+                cx.sync_ime_state(
+                    self.text.clone(),
+                    CharOffset(sel_start_chars)..CharOffset(sel_end_chars),
+                    None,
+                );
+                self.last_sent_ime_text = self.text.clone();
+                self.last_sent_ime_sel_start = self.selection.start().index;
+                self.last_sent_ime_sel_end = self.selection.end().index;
                 cx.widget_action(uid, TextInputAction::KeyFocus);
             }
             Hit::KeyFocusLost(_) => {
@@ -1568,8 +1736,26 @@ impl Widget for TextInput {
                 modifiers: mods @ KeyModifiers { shift: false, .. },
                 ..
             }) => {
-                cx.hide_text_ime();
-                self.emit_return(cx, uid, mods);
+                // For multiline text input, plain Return inserts a newline
+                // For single-line, Return hides the keyboard and emits Returned action
+                if self.is_multiline && !self.is_read_only {
+                    self.reset_blink_timer(cx);
+                    self.create_or_extend_edit_group(EditKind::Other);
+                    self.apply_edit(
+                        cx,
+                        Edit {
+                            start: self.selection.start().index,
+                            end: self.selection.end().index,
+                            replace_with: "\n".to_string(),
+                        },
+                    );
+                    self.draw_bg.redraw(cx);
+                    self.emit_change(cx, uid);
+                } else {
+                    cx.hide_text_ime();
+                    cx.set_key_focus(Area::Empty);
+                    self.emit_return(cx, uid, mods);
+                }
             }
 
             Hit::KeyDown(KeyEvent {
@@ -1662,51 +1848,130 @@ impl Widget for TextInput {
                 self.draw_bg.redraw(cx);
                 self.emit_change(cx, uid);
             }
-            Hit::TextInput(TextInputEvent {
-                input,
-                replace_last,
-                was_paste,
-                ..
-            }) if !self.is_read_only => {
-                let input = self.filter_input(&input, false);
-                if input.is_empty() {
-                    // Empty input with replace_last means composition was cancelled
-                    if replace_last && self.composition_length > 0 {
-                        // Remove the composition text
-                        self.create_or_extend_edit_group(EditKind::Other);
-                        self.apply_edit(
-                            cx,
-                            Edit {
-                                start: self.composition_start,
-                                end: self.composition_start + self.composition_length,
-                                replace_with: String::new(),
-                            },
-                        );
-                        self.composition_length = 0;
-                        self.draw_bg.redraw(cx);
-                        self.emit_change(cx, uid);
+            Hit::TextInput(event) if !self.is_read_only => {
+                // Text changes invalidate any preserved cursor from a pending tap gesture
+                self.preserved_selection_cursor = None;
+
+                // Handle Android full state sync (authoritative from Java InputConnection)
+                if let Some(full_state) = &event.full_state_sync {
+                    let text_changed = self.text != full_state.text;
+                    if text_changed {
+                        self.history
+                            .create_or_extend_edit_group(EditKind::Other, self.selection);
+                        self.text = full_state.text.clone();
+                        self.laidout_text = None;
+                    }
+
+                    let sel_start_byte = full_state.selection.start.to_byte_index(&self.text);
+                    let sel_end_byte = full_state.selection.end.to_byte_index(&self.text);
+                    self.selection = Selection {
+                        anchor: Cursor {
+                            index: sel_start_byte,
+                            prefer_next_row: false,
+                        },
+                        cursor: Cursor {
+                            index: sel_end_byte,
+                            prefer_next_row: false,
+                        },
+                    };
+
+                    if let Some(composition_range) = &full_state.composition {
+                        self.composition_start =
+                            composition_range.start.to_byte_index(&self.text);
+                        self.composition_end = composition_range.end.to_byte_index(&self.text);
+                    } else {
+                        self.composition_start = 0;
+                        self.composition_end = 0;
+                    }
+
+                    self.last_sent_ime_text = self.text.clone();
+                    self.last_sent_ime_sel_start = sel_start_byte;
+                    self.last_sent_ime_sel_end = sel_end_byte;
+                    self.ime_update_frame = cx.redraw_id();
+
+                    self.draw_bg.redraw(cx);
+                    self.emit_change(cx, uid);
+                    if text_changed {
+                        cx.hide_clipboard_actions();
                     }
                     return;
                 }
 
-                if replace_last {
-                    // IME composition update
-                    if self.composition_length > 0 {
-                        // Replace previous composition text
+                // Handle iOS range replacement (autocorrect/paste)
+                if let Some((start, end)) = event.replace_range {
+                    let filtered_text = self.filter_input(&event.input, false);
+                    if filtered_text.is_empty() && !event.input.is_empty() {
+                        self.update_ime_context(cx);
+                        return;
+                    }
+
+                    let byte_start = start.to_byte_index(&self.text);
+                    let byte_end = end.to_byte_index(&self.text);
+
+                    if self.has_composition() && byte_start < self.composition_start {
+                        let edit_delta =
+                            filtered_text.len() as isize - (byte_end - byte_start) as isize;
+                        self.composition_start =
+                            (self.composition_start as isize + edit_delta).max(0) as usize;
+                    }
+                    self.composition_end = self.composition_start;
+                    self.create_or_extend_edit_group(EditKind::Other);
+                    self.apply_edit(
+                        cx,
+                        Edit {
+                            start: byte_start,
+                            end: byte_end,
+                            replace_with: filtered_text,
+                        },
+                    );
+                    self.ime_update_frame = cx.redraw_id();
+
+                    self.animator_play(cx, ids!(empty.off));
+                    self.draw_bg.redraw(cx);
+                    self.emit_change(cx, uid);
+                    cx.hide_clipboard_actions();
+                    return;
+                }
+
+                // Handle regular text input and composition (all platforms)
+                let input = self.filter_input(&event.input, false);
+                if input.is_empty() {
+                    // Composition cancelled, remove preview text
+                    if event.replace_last && self.has_composition() {
                         self.create_or_extend_edit_group(EditKind::Other);
                         self.apply_edit(
                             cx,
                             Edit {
-                                start: self.composition_start,
-                                end: self.composition_start + self.composition_length,
+                                start: self.composition_start.min(self.text.len()),
+                                end: self.composition_end.min(self.text.len()),
+                                replace_with: String::new(),
+                            },
+                        );
+                        self.draw_bg.redraw(cx);
+                        self.emit_change(cx, uid);
+                    }
+                    self.composition_end = self.composition_start;
+                    return;
+                }
+
+                if event.replace_last {
+                    // IME composition preview
+                    if self.has_composition() {
+                        let start = self.composition_start.min(self.text.len());
+                        let end = self.composition_end.min(self.text.len());
+                        self.create_or_extend_edit_group(EditKind::Other);
+                        self.apply_edit(
+                            cx,
+                            Edit {
+                                start,
+                                end,
                                 replace_with: input.clone(),
                             },
                         );
-                        self.composition_length = input.len();
+                        self.composition_end = self.composition_start + input.len();
                     } else {
-                        // First composition character - record start position
                         self.composition_start = self.selection.start().index;
-                        self.composition_length = input.len();
+                        self.composition_end = self.composition_start + input.len();
                         self.create_or_extend_edit_group(EditKind::Other);
                         self.apply_edit(
                             cx,
@@ -1717,23 +1982,24 @@ impl Widget for TextInput {
                             },
                         );
                     }
+                    self.ime_update_frame = cx.redraw_id();
                 } else {
                     // Final commit or regular text input
-                    if self.composition_length > 0 {
-                        // Replace composition with final committed text
+                    if self.has_composition() {
+                        let start = self.composition_start.min(self.text.len());
+                        let end = self.composition_end.min(self.text.len());
                         self.create_or_extend_edit_group(EditKind::Other);
                         self.apply_edit(
                             cx,
                             Edit {
-                                start: self.composition_start,
-                                end: self.composition_start + self.composition_length,
+                                start,
+                                end,
                                 replace_with: input,
                             },
                         );
-                        self.composition_length = 0;
+                        self.composition_end = self.composition_start;
                     } else {
-                        // Normal text input (no active composition)
-                        self.create_or_extend_edit_group(if was_paste {
+                        self.create_or_extend_edit_group(if event.was_paste {
                             EditKind::Other
                         } else {
                             EditKind::Insert
@@ -1751,6 +2017,7 @@ impl Widget for TextInput {
                 self.animator_play(cx, ids!(empty.off));
                 self.draw_bg.redraw(cx);
                 self.emit_change(cx, uid);
+                cx.hide_clipboard_actions();
             }
             Hit::TextRangeReplace(event) if !self.is_read_only => {
                 // iOS autocorrect sends range replacement events
@@ -1768,8 +2035,11 @@ impl Widget for TextInput {
                     .map(|(i, _)| i)
                     .unwrap_or(self.text.len());
 
+                // Ensure valid range (guard against backwards indices)
+                let (byte_start, byte_end) = (byte_start.min(byte_end), byte_start.max(byte_end));
+
                 // Clear any active composition
-                self.composition_length = 0;
+                self.composition_end = self.composition_start;
 
                 // Perform the replacement
                 self.create_or_extend_edit_group(EditKind::Other);
@@ -1804,6 +2074,27 @@ impl Widget for TextInput {
                     );
                     self.draw_bg.redraw(cx);
                     self.emit_change(cx, uid);
+                }
+            }
+            Hit::ImeAction(event) => {
+                use crate::makepad_platform::event::ImeAction;
+                let mods = KeyModifiers::default();
+                match event.action {
+                    ImeAction::Done | ImeAction::Go | ImeAction::Search | ImeAction::Send => {
+                        cx.hide_text_ime();
+                        cx.set_key_focus(Area::Empty);
+                        cx.widget_action(
+                            uid,
+                            TextInputAction::Returned(self.text.clone(), mods),
+                        );
+                    }
+                    ImeAction::Next | ImeAction::Previous => {
+                        cx.widget_action(
+                            uid,
+                            TextInputAction::Returned(self.text.clone(), mods),
+                        );
+                    }
+                    ImeAction::Unspecified | ImeAction::None => {}
                 }
             }
             Hit::KeyDown(event) => {

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -229,6 +229,56 @@ pub enum WindowAction {
 }
 
 impl Window {
+    fn voice_callback_index(&self) -> usize {
+        self.window.window_id().id() % MAX_AUDIO_DEVICE_INDEX
+    }
+
+    fn key_focus_in_this_window(&self, cx: &Cx) -> bool {
+        let Some(draw_list_id) = cx.key_focus().draw_list_id() else {
+            return false;
+        };
+        let Some(draw_list) = cx.draw_lists.checked_index(draw_list_id) else {
+            return false;
+        };
+        let Some(draw_pass_id) = draw_list.draw_pass_id else {
+            return false;
+        };
+        cx.get_pass_window_id(draw_pass_id) == Some(self.window.window_id())
+    }
+
+    fn dispatch_voice_inject_events(
+        &mut self,
+        cx: &mut Cx,
+        scope: &mut Scope,
+        events: Vec<VoiceInjectEvent>,
+    ) {
+        for event in events {
+            match event {
+                VoiceInjectEvent::Text(chunk) => {
+                    let text_input = Event::TextInput(TextInputEvent {
+                        input: chunk,
+                        replace_last: false,
+                        was_paste: false,
+                        composition: None,
+                        full_state_sync: None,
+                        replace_range: None,
+                    });
+                    self.view.handle_event(cx, &text_input, scope);
+                }
+                VoiceInjectEvent::Enter => {
+                    let key = KeyEvent {
+                        key_code: KeyCode::ReturnKey,
+                        is_repeat: false,
+                        modifiers: KeyModifiers::default(),
+                        time: 0.0,
+                    };
+                    self.view.handle_event(cx, &Event::KeyDown(key), scope);
+                    self.view.handle_event(cx, &Event::KeyUp(key), scope);
+                }
+            }
+        }
+    }
+
     fn ensure_initialized(&mut self, cx: &mut Cx) {
         if self.initialized {
             return;

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -229,56 +229,6 @@ pub enum WindowAction {
 }
 
 impl Window {
-    fn voice_callback_index(&self) -> usize {
-        self.window.window_id().id() % MAX_AUDIO_DEVICE_INDEX
-    }
-
-    fn key_focus_in_this_window(&self, cx: &Cx) -> bool {
-        let Some(draw_list_id) = cx.key_focus().draw_list_id() else {
-            return false;
-        };
-        let Some(draw_list) = cx.draw_lists.checked_index(draw_list_id) else {
-            return false;
-        };
-        let Some(draw_pass_id) = draw_list.draw_pass_id else {
-            return false;
-        };
-        cx.get_pass_window_id(draw_pass_id) == Some(self.window.window_id())
-    }
-
-    fn dispatch_voice_inject_events(
-        &mut self,
-        cx: &mut Cx,
-        scope: &mut Scope,
-        events: Vec<VoiceInjectEvent>,
-    ) {
-        for event in events {
-            match event {
-                VoiceInjectEvent::Text(chunk) => {
-                    let text_input = Event::TextInput(TextInputEvent {
-                        input: chunk,
-                        replace_last: false,
-                        was_paste: false,
-                        composition: None,
-                        full_state_sync: None,
-                        replace_range: None,
-                    });
-                    self.view.handle_event(cx, &text_input, scope);
-                }
-                VoiceInjectEvent::Enter => {
-                    let key = KeyEvent {
-                        key_code: KeyCode::ReturnKey,
-                        is_repeat: false,
-                        modifiers: KeyModifiers::default(),
-                        time: 0.0,
-                    };
-                    self.view.handle_event(cx, &Event::KeyDown(key), scope);
-                    self.view.handle_event(cx, &Event::KeyUp(key), scope);
-                }
-            }
-        }
-    }
-
     fn ensure_initialized(&mut self, cx: &mut Cx) {
         if self.initialized {
             return;


### PR DESCRIPTION
This restores IME support from the previous widget and platform crates.

### Note
**Makes TextInput single-line by default.**