### PR TITLE
changes required for servo

### DIFF
--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -26,7 +26,7 @@ use {
             ScriptVm,
         },
         script::vm::ScriptVmCx,
-        texture::{CxTexture, Texture, TextureFormat, TexturePixel, TextureUpdated},
+        texture::{CxTexture, Texture, TextureFormat, TexturePixel, TextureSize, TextureUpdated},
     },
     gl_sys::LibGl,
     std::{
@@ -882,6 +882,23 @@ impl Cx {
         // Temporary warning for Adreno failing at compiling shaders that use samplerExternalOES.
 
     }*/
+
+    /// Create a render texture and immediately allocate its GL resources.
+    /// Returns the Texture handle and the GL texture ID, which is valid in any shared EGL context.
+    /// Used by Servo integration: Makepad owns the texture, Servo renders into it via its FBO.
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    pub fn create_gl_render_texture(&mut self, width: usize, height: usize) -> (Texture, u32) {
+        let texture = Texture::new_with_format(self, TextureFormat::RenderBGRAu8 {
+            size: TextureSize::Fixed { width, height },
+            initial: true,
+        });
+        let gl = self.os.gl();
+        let cxtexture = &mut self.textures[texture.texture_id()];
+        cxtexture.update_render_target(gl, width, height);
+        let gl_id = cxtexture.os.gl_texture.unwrap();
+        (texture, gl_id)
+    }
+
 }
 
 const NUM_SHADER_VARIANTS: usize = 2;

--- a/platform/src/os/linux/windowing_backend.rs
+++ b/platform/src/os/linux/windowing_backend.rs
@@ -179,7 +179,7 @@ pub struct CxOs {
     pub(crate) network_response: NetworkResponseChannel,
     pub(crate) stdin_timers: PollTimers,
     pub(crate) start_time: Option<Instant>,
-    pub(super) opengl_cx: Option<OpenglCx>,
+    pub opengl_cx: Option<OpenglCx>,
 }
 
 impl CxOs {

--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -344,6 +344,12 @@ impl Image {
                 let scale_y = h as f32 / height as f32;
                 self.draw_bg.image_scale = vec2(scale_x, scale_y);
                 (w, h)
+            } else if image_texture.get_format(cx).is_render() {
+                // GL render target textures use Y-up (bottom-left origin) convention.
+                // Flip Y so the image displays correctly in Makepad's Y-down coordinate system.
+                self.draw_bg.image_scale = vec2(1.0, -1.0);
+                self.draw_bg.image_pan = vec2(0.0, 1.0);
+                (width as f64 * self.width_scale, height as f64)
             } else {
                 (width as f64 * self.width_scale, height as f64)
             }


### PR DESCRIPTION
 ### Why we changed Makepad (3 files, +25/-2 lines)

 Change 1: pub opengl_cx — windowing_backend.rs (1 char)

 Servo needs Makepad's EGL display, context, platform enum, and native display pointer to create a shared GL context. Two of these (egl_platform, egl_platform_display) have no EGL query to retrieve them — they're known only to whoever
 created the display, which is Makepad. The field was pub(super), more restrictive than its siblings which are all pub(crate). The OpenglCx struct itself already has all fields pub and no invariants. We widened it to pub to match
 Makepad's convention of direct field access (no accessors anywhere in the codebase).

 Change 2: create_gl_render_texture() — opengl.rs (18 lines)

 Makepad allocates GL textures lazily during its render loop (draw_pass_to_texture → update_render_target). Servo needs the GL texture ID at init time to attach it to its FBO before the first paint. There's no existing API to eagerly
 allocate, and the two internal functions needed (update_render_target, cx.os.gl()) are both pub(crate). We can't work around this from outside: creating the GL texture in Servo's context and poking the ID into
 cx.textures[id].os.gl_texture would get silently overwritten on the next frame because Makepad's alloc field (pub(crate)) would still be None, triggering reallocation.

 Change 3: is_render() Y-flip — image.rs (6 lines)

 OpenGL FBO render targets are Y-up; Makepad's coordinate system is Y-down. Makepad's own CachedView handles this via sample2d_rt() in its shader, but the Image widget was never tested with render textures — no existing Makepad code
 puts a RenderBGRAu8 into an Image. The widget's set_texture() accepts any texture but only samples correctly for CPU-uploaded textures. Setting scale/pan from outside doesn't work because the Image overwrites those values during its
 draw pass. A Servo-side glBlitFramebuffer flip would add per-frame GPU cost at the wrong layer. This is a genuine gap in the Image widget worth upstreaming.