### PR TITLE
Video Widget: Support on MacOS & iOS

### DIFF
--- a/examples/scratchpad/src/app.rs
+++ b/examples/scratchpad/src/app.rs
@@ -76,18 +76,6 @@ script_mod! {
                         }
                     }
                     Hr{}
-                    View{
-                        width: Fill height: Fit padding: 16 flow: Down spacing: 8
-                        Label{text: "Video Test" draw_text.color: #xddd draw_text.text_style: theme.font_bold{font_size: 14}}
-                        Video{
-                            source: VideoDataSource.Network { url: "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"}
-                            height: 240
-                            width: Fill
-                            is_looping: true
-                            autoplay: true
-                        }
-                    }
-                    Hr{}
                     results_view := ScrollYView{
                         width: Fill height: Fill padding: 16 flow: Down spacing: 10
                         new_batch: true

--- a/examples/scratchpad/src/app.rs
+++ b/examples/scratchpad/src/app.rs
@@ -76,6 +76,18 @@ script_mod! {
                         }
                     }
                     Hr{}
+                    View{
+                        width: Fill height: Fit padding: 16 flow: Down spacing: 8
+                        Label{text: "Video Test" draw_text.color: #xddd draw_text.text_style: theme.font_bold{font_size: 14}}
+                        Video{
+                            source: VideoDataSource.Network { url: "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"}
+                            height: 240
+                            width: Fill
+                            is_looping: true
+                            autoplay: true
+                        }
+                    }
+                    Hr{}
                     results_view := ScrollYView{
                         width: Fill height: Fill padding: 16 flow: Down spacing: 10
                         new_batch: true

--- a/examples/uizoo/src/app.rs
+++ b/examples/uizoo/src/app.rs
@@ -55,6 +55,7 @@ script_mod! {
                 @tSlider
                 @tSlidesView
                 @tTextInput
+                @tVideo
                 @tView
             ]
             selected: 0
@@ -91,6 +92,7 @@ script_mod! {
         tSlider := DockTab{name: "Slider" template: @PermanentTab kind: @TabSlider}
         tSlidesView := DockTab{name: "SlidesView" template: @PermanentTab kind: @TabSlidesView}
         tTextInput := DockTab{name: "TextInput" template: @PermanentTab kind: @TabTextInput}
+        tVideo := DockTab{name: "Video" template: @PermanentTab kind: @TabVideo}
         tView := DockTab{name: "View" template: @PermanentTab kind: @TabView}
 
         TabOverview := UIZooTab{WidgetsOverview{}}
@@ -117,6 +119,7 @@ script_mod! {
         TabSlider := UIZooTab{DemoSlider{}}
         TabSlidesView := UIZooTab{DemoSlidesView{}}
         TabTextInput := UIZooTab{DemoTextInput{}}
+        TabVideo := UIZooTab{DemoVideo{}}
         TabView := UIZooTab{DemoView{}}
     }
 
@@ -167,6 +170,7 @@ impl App {
         crate::tab_slider::script_mod(vm);
         crate::tab_slidesview::script_mod(vm);
         crate::tab_textinput::script_mod(vm);
+        crate::tab_video::script_mod(vm);
         crate::tab_view::script_mod(vm);
         crate::tab_widgetsoverview::script_mod(vm);
         App::from_script_mod(vm, self::script_mod)

--- a/examples/uizoo/src/lib.rs
+++ b/examples/uizoo/src/lib.rs
@@ -26,5 +26,6 @@ pub mod tab_slider;
 pub mod tab_slidesview;
 pub mod tab_spinner;
 pub mod tab_textinput;
+pub mod tab_video;
 pub mod tab_view;
 pub mod tab_widgetsoverview;

--- a/examples/uizoo/src/tab_video.rs
+++ b/examples/uizoo/src/tab_video.rs
@@ -11,12 +11,10 @@ script_mod! {
         demos +: {
             H4{text: "Network Video (autoplay, looping)"}
             Video{
-                source: VideoDataSource.Network { url: "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"}
+                source: VideoDataSource.Network { url: "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/TearsOfSteel.mp4"}
                 height: 240
                 width: 426
-                is_looping: true
-                hold_to_pause: true
-                autoplay: true
+                show_idle_thumbnail: true
             }
         }
     }

--- a/examples/uizoo/src/tab_video.rs
+++ b/examples/uizoo/src/tab_video.rs
@@ -1,0 +1,23 @@
+use crate::makepad_widgets::*;
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use mod.widgets.*
+
+    mod.widgets.DemoVideo = UIZooTabLayout_B{
+        desc +: {
+            Markdown{body: "# Video\n\nVideo widget for hardware-accelerated video playback."}
+        }
+        demos +: {
+            H4{text: "Network Video (autoplay, looping)"}
+            Video{
+                source: VideoDataSource.Network { url: "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"}
+                height: 240
+                width: 426
+                is_looping: true
+                hold_to_pause: true
+                autoplay: true
+            }
+        }
+    }
+}

--- a/old/widgets/src/video.rs
+++ b/old/widgets/src/video.rs
@@ -124,7 +124,7 @@ pub struct Video {
     video_texture: Option<Texture>,
     #[rust]
     video_texture_handle: Option<u32>,
-    /// Requires [`show_thumbnail_before_playback`] to be `true`.
+    /// Requires [`show_idle_thumbnail`] to be `true`.
     #[live]
     thumbnail_source: Option<LiveDependency>,
     #[rust]
@@ -147,7 +147,7 @@ pub struct Video {
     audio_state: AudioState,
     /// Whether to show the provided thumbnail when the video has not yet started playing.
     #[live(false)]
-    show_thumbnail_before_playback: bool,
+    show_idle_thumbnail: bool,
 
     // Actions
     #[rust(false)]
@@ -364,7 +364,7 @@ impl LiveHook for Video {
         self.draw_bg
             .set_uniform(cx, ids!(target_size), &[target_w as f32, target_h as f32]);
 
-        if self.show_thumbnail_before_playback {
+        if self.show_idle_thumbnail {
             self.load_thumbnail_image(cx);
             self.draw_bg.set_uniform(cx, ids!(show_thumbnail), &[1.0]);
         }

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -18,7 +18,7 @@ use {
         makepad_live_id::*,
         makepad_math::{Rect, Vec2d},
         makepad_script::value::ScriptHandle,
-        texture::Texture,
+        texture::{Texture, TextureId},
         window::WindowId,
     },
     std::{
@@ -127,7 +127,7 @@ pub enum CxOsOp {
         request_id: LiveId,
     },
 
-    PrepareVideoPlayback(LiveId, VideoSource, u32, bool, bool),
+    PrepareVideoPlayback(LiveId, VideoSource, u32, TextureId, bool, bool),
     BeginVideoPlayback(LiveId),
     PauseVideoPlayback(LiveId),
     ResumeVideoPlayback(LiveId),
@@ -869,6 +869,7 @@ impl Cx {
         video_id: LiveId,
         source: VideoSource,
         external_texture_id: u32,
+        texture_id: TextureId,
         autoplay: bool,
         should_loop: bool,
     ) {
@@ -876,6 +877,7 @@ impl Cx {
             video_id,
             source,
             external_texture_id,
+            texture_id,
             autoplay,
             should_loop,
         ));

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -134,6 +134,7 @@ pub enum CxOsOp {
     MuteVideoPlayback(LiveId),
     UnmuteVideoPlayback(LiveId),
     CleanupVideoPlaybackResources(LiveId),
+    SeekVideoPlayback(LiveId, u64),
     UpdateVideoSurfaceTexture(LiveId),
 
     CreateWebView {
@@ -203,6 +204,7 @@ impl std::fmt::Debug for CxOsOp {
             Self::MuteVideoPlayback(..) => write!(f, "MuteVideoPlayback"),
             Self::UnmuteVideoPlayback(..) => write!(f, "UnmuteVideoPlayback"),
             Self::CleanupVideoPlaybackResources(..) => write!(f, "CleanupVideoPlaybackResources"),
+            Self::SeekVideoPlayback(..) => write!(f, "SeekVideoPlayback"),
             Self::UpdateVideoSurfaceTexture(..) => write!(f, "UpdateVideoSurfaceTexture"),
             Self::CreateWebView { .. } => write!(f, "CreateWebView"),
             Self::UpdateWebView { .. } => write!(f, "UpdateWebView"),
@@ -908,6 +910,11 @@ impl Cx {
     pub fn cleanup_video_playback_resources(&mut self, video_id: LiveId) {
         self.platform_ops
             .push(CxOsOp::CleanupVideoPlaybackResources(video_id));
+    }
+
+    pub fn seek_video_playback(&mut self, video_id: LiveId, position_ms: u64) {
+        self.platform_ops
+            .push(CxOsOp::SeekVideoPlayback(video_id, position_ms));
     }
 
     pub fn println_resources(&self) {

--- a/platform/src/draw_shader.rs
+++ b/platform/src/draw_shader.rs
@@ -282,13 +282,19 @@ impl DrawShaderInputs {
                 self.total_slots += slots;
             }
             DrawShaderInputPacking::UniformsMetal => {
+                // Metal struct alignment rules:
+                // float (1 slot): 4-byte aligned (1-float)
+                // float2 (2 slots): 8-byte aligned (2-float)
+                // float3/float4 (3-4 slots): 16-byte aligned (4-float)
+                // larger (matrices, arrays): 16-byte aligned (4-float)
                 let aligned_slots = if slots == 3 { 4 } else { slots };
-                if aligned_slots > 4 {
-                    if (self.total_slots & 3) != 0 {
-                        self.total_slots += 4 - (self.total_slots & 3);
-                    }
-                } else if (self.total_slots & 3) + aligned_slots > 4 {
-                    self.total_slots += 4 - (self.total_slots & 3);
+                let alignment = match aligned_slots {
+                    1 => 1,
+                    2 => 2,
+                    _ => 4,
+                };
+                if self.total_slots % alignment != 0 {
+                    self.total_slots += alignment - (self.total_slots % alignment);
                 }
                 self.inputs.push(DrawShaderInput {
                     id,

--- a/platform/src/event/video_playback.rs
+++ b/platform/src/event/video_playback.rs
@@ -14,6 +14,7 @@ pub struct VideoPlaybackPreparedEvent {
 #[derive(Clone, Debug)]
 pub struct VideoTextureUpdatedEvent {
     pub video_id: LiveId,
+    pub current_position_ms: u128,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/platform/src/os/apple/apple_sys.rs
+++ b/platform/src/os/apple/apple_sys.rs
@@ -1423,7 +1423,7 @@ extern "C" {
     pub fn IOSurfaceDecrementUseCount(surface: IOSurfaceRef);
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[link(name = "CoreFoundation", kind = "framework")]
 extern "C" {
     pub fn CFRelease(cf: *const c_void);

--- a/platform/src/os/apple/apple_sys.rs
+++ b/platform/src/os/apple/apple_sys.rs
@@ -227,6 +227,7 @@ pub const kCMVideoCodecType_JPEG_OpenDML: u32 = four_char_as_u32("dmb1");
 pub const kCMPixelFormat_8IndexedGray_WhiteIsZero: u32 = 0x00000028;
 pub const kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange: u32 = four_char_as_u32("420v");
 pub const kCVPixelFormatType_420YpCbCr8BiPlanarFullRange: u32 = four_char_as_u32("420f");
+pub const kCVPixelFormatType_32BGRA: u32 = four_char_as_u32("BGRA");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -269,6 +270,8 @@ pub type CVImageBufferRef = CVBufferRef;
 pub type CVPixelBufferRef = CVImageBufferRef;
 pub type CVPixelBufferLockFlags = u64;
 pub type CVReturn = i32;
+pub type CVMetalTextureCacheRef = *mut c_void;
+pub type CVMetalTextureRef = *mut c_void;
 
 #[link(name = "CoreMedia", kind = "framework")]
 extern "C" {
@@ -277,6 +280,8 @@ extern "C" {
     ) -> CMVideoDimensions;
     pub fn CMFormatDescriptionGetMediaSubType(desc: CMFormatDescriptionRef) -> u32;
     pub fn CMSampleBufferGetImageBuffer(sbuf: CMSampleBufferRef) -> CVImageBufferRef;
+    pub fn CMTimeMakeWithSeconds(seconds: f64, preferredTimescale: i32) -> CMTime;
+    pub fn CMTimeGetSeconds(time: CMTime) -> f64;
 }
 
 #[link(name = "CoreVideo", kind = "framework")]
@@ -298,6 +303,30 @@ extern "C" {
     pub fn CVPixelBufferGetHeight(pixelBuffer: CVPixelBufferRef) -> usize;
     pub fn CVPixelBufferGetBytesPerRow(pixelBuffer: CVPixelBufferRef) -> usize;
     pub fn CVPixelBufferIsPlanar(pixelBuffer: CVPixelBufferRef) -> bool;
+
+    pub fn CVMetalTextureCacheCreate(
+        allocator: *mut c_void,
+        cacheAttributes: *mut c_void,
+        metalDevice: ObjcId,
+        textureAttributes: *mut c_void,
+        cacheOut: *mut CVMetalTextureCacheRef,
+    ) -> CVReturn;
+
+    pub fn CVMetalTextureCacheCreateTextureFromImage(
+        allocator: *mut c_void,
+        textureCache: CVMetalTextureCacheRef,
+        sourceImage: CVImageBufferRef,
+        textureAttributes: *mut c_void,
+        pixelFormat: u64,
+        width: usize,
+        height: usize,
+        planeIndex: usize,
+        textureOut: *mut CVMetalTextureRef,
+    ) -> CVReturn;
+
+    pub fn CVMetalTextureGetTexture(texture: CVMetalTextureRef) -> ObjcId;
+
+    pub fn CVMetalTextureCacheFlush(textureCache: CVMetalTextureCacheRef, options: u64);
 }
 
 // Foundation

--- a/platform/src/os/apple/apple_video_playback.rs
+++ b/platform/src/os/apple/apple_video_playback.rs
@@ -1,0 +1,385 @@
+use {
+    crate::{
+        makepad_live_id::LiveId,
+        makepad_error_log::*,
+        event::video_playback::VideoSource,
+        os::apple::apple_sys::*,
+        texture::{TextureId, TextureAlloc, TexturePixel, TextureCategory, CxTexturePool},
+    },
+    std::{
+        ffi::c_void,
+        ptr::NonNull,
+    },
+};
+
+pub struct AppleVideoPlayer {
+    player: RcObjcId,
+    player_item: RcObjcId,
+    video_output: RcObjcId,
+    texture_cache: CVMetalTextureCacheRef,
+    cv_texture: CVMetalTextureRef,
+    pub(crate) video_id: LiveId,
+    texture_id: TextureId,
+    is_prepared: bool,
+    prepare_notified: bool,
+    autoplay: bool,
+    is_looping: bool,
+    temp_file_path: Option<std::path::PathBuf>,
+}
+
+impl AppleVideoPlayer {
+    pub fn new(
+        metal_device: ObjcId,
+        video_id: LiveId,
+        texture_id: TextureId,
+        source: VideoSource,
+        autoplay: bool,
+        is_looping: bool,
+    ) -> Self {
+        unsafe {
+            // Create CVMetalTextureCache
+            let mut texture_cache: CVMetalTextureCacheRef = std::ptr::null_mut();
+            let status = CVMetalTextureCacheCreate(
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                metal_device,
+                std::ptr::null_mut(),
+                &mut texture_cache,
+            );
+            if status != 0 {
+                error!("CVMetalTextureCacheCreate failed with status {}", status);
+            }
+
+            // Create URL from source
+            let (url, temp_file_path) = Self::url_from_source(&source);
+
+            // Create AVPlayerItem
+            let player_item: ObjcId = msg_send![class!(AVPlayerItem), playerItemWithURL: url];
+            let _: () = msg_send![player_item, retain];
+
+            // Create AVPlayerItemVideoOutput with BGRA pixel format
+            let pixel_format_key: ObjcId = msg_send![
+                class!(NSNumber),
+                numberWithUnsignedInt: kCVPixelFormatType_32BGRA
+            ];
+
+            let keys: &[ObjcId] = &[kCVPixelBufferPixelFormatTypeKey as ObjcId];
+            let values: &[ObjcId] = &[pixel_format_key];
+            let pixel_attrs: ObjcId = msg_send![
+                class!(NSDictionary),
+                dictionaryWithObjects: values.as_ptr()
+                forKeys: keys.as_ptr()
+                count: 1usize
+            ];
+
+            let video_output: ObjcId = msg_send![class!(AVPlayerItemVideoOutput), alloc];
+            let video_output: ObjcId = msg_send![
+                video_output,
+                initWithPixelBufferAttributes: pixel_attrs
+            ];
+
+            // Add output to player item
+            let _: () = msg_send![player_item, addOutput: video_output];
+
+            // Create AVPlayer
+            let player: ObjcId = msg_send![
+                class!(AVPlayer),
+                playerWithPlayerItem: player_item
+            ];
+            let _: () = msg_send![player, retain];
+
+            // If source was InMemory, we created a temp file - the URL retains it
+
+            let mut this = Self {
+                player: RcObjcId::from_unowned(NonNull::new(player).unwrap()),
+                player_item: RcObjcId::from_unowned(NonNull::new(player_item).unwrap()),
+                video_output: RcObjcId::from_unowned(NonNull::new(video_output).unwrap()),
+                texture_cache,
+                cv_texture: std::ptr::null_mut(),
+                video_id,
+                texture_id,
+                is_prepared: false,
+                prepare_notified: false,
+                autoplay,
+                is_looping,
+                temp_file_path,
+            };
+
+            this
+        }
+    }
+
+    unsafe fn url_from_source(source: &VideoSource) -> (ObjcId, Option<std::path::PathBuf>) {
+        match source {
+            VideoSource::Network(url_string) => {
+                let ns_string = Self::to_nsstring(url_string);
+                let url: ObjcId = msg_send![class!(NSURL), URLWithString: ns_string];
+                let _: () = msg_send![ns_string, release];
+                (url, None)
+            }
+            VideoSource::Filesystem(path) => {
+                let ns_string = Self::to_nsstring(path);
+                let url: ObjcId = msg_send![class!(NSURL), fileURLWithPath: ns_string];
+                let _: () = msg_send![ns_string, release];
+                (url, None)
+            }
+            VideoSource::InMemory(data) => {
+                // Write data to a temporary file (deleted on cleanup)
+                let tmp_path = std::env::temp_dir().join(format!("makepad_video_{}.mp4", LiveId::unique().0));
+                let tmp_path_str = tmp_path.to_string_lossy().to_string();
+                std::fs::write(&tmp_path, data.as_ref()).unwrap_or_else(|e| {
+                    error!("Failed to write video to temp file: {}", e);
+                });
+                let ns_string = Self::to_nsstring(&tmp_path_str);
+                let url: ObjcId = msg_send![class!(NSURL), fileURLWithPath: ns_string];
+                let _: () = msg_send![ns_string, release];
+                (url, Some(tmp_path))
+            }
+        }
+    }
+
+    unsafe fn to_nsstring(s: &str) -> ObjcId {
+        let ns_string: ObjcId = msg_send![class!(NSString), alloc];
+        msg_send![
+            ns_string,
+            initWithBytes: s.as_ptr()
+            length: s.len()
+            encoding: 4u64 // NSUTF8StringEncoding
+        ]
+    }
+
+    /// Check if playback reached end and loop back to start if needed.
+    /// Called during poll_frame.
+    unsafe fn check_looping(&self) {
+        if !self.is_looping || !self.is_prepared {
+            return;
+        }
+        // Check if player rate is 0 (paused/ended) while we expect it to be playing
+        let rate: f32 = msg_send![self.player.as_id(), rate];
+        if rate == 0.0 {
+            // Check if we're at or near the end
+            let current: CMTime = msg_send![self.player_item.as_id(), currentTime];
+            let duration: CMTime = msg_send![self.player_item.as_id(), duration];
+            let current_sec = CMTimeGetSeconds(current);
+            let duration_sec = CMTimeGetSeconds(duration);
+            if duration_sec.is_finite() && current_sec >= duration_sec - 0.1 {
+                // Seek back to beginning and play
+                let zero = CMTimeMakeWithSeconds(0.0, 600);
+                let _: () = msg_send![self.player_item.as_id(), seekToTime: zero];
+                let _: () = msg_send![self.player.as_id(), play];
+            }
+        }
+    }
+
+    /// Check if the player item has become ready to play.
+    /// Returns (width, height, duration_ms) if newly prepared.
+    pub fn check_prepared(&mut self) -> Option<(u32, u32, u128)> {
+        if self.prepare_notified {
+            return None;
+        }
+
+        unsafe {
+            let status: i64 = msg_send![self.player_item.as_id(), status];
+            // AVPlayerItemStatusReadyToPlay = 1
+            if status == 1 && !self.is_prepared {
+                self.is_prepared = true;
+                self.prepare_notified = true;
+
+                // Get video dimensions from the asset's video track
+                let asset: ObjcId = msg_send![self.player_item.as_id(), asset];
+                let media_type = Self::to_nsstring("vide");
+                let tracks: ObjcId = msg_send![asset, tracksWithMediaType: media_type];
+                let _: () = msg_send![media_type, release];
+
+                let track_count: usize = msg_send![tracks, count];
+                let (width, height) = if track_count > 0 {
+                    let track: ObjcId = msg_send![tracks, objectAtIndex: 0usize];
+                    let size: NSSize = msg_send![track, naturalSize];
+                    (size.width as u32, size.height as u32)
+                } else {
+                    (1920, 1080) // fallback
+                };
+
+                // Get duration
+                let duration: CMTime = msg_send![self.player_item.as_id(), duration];
+                let duration_seconds = CMTimeGetSeconds(duration);
+                let duration_ms = if duration_seconds.is_finite() && duration_seconds > 0.0 {
+                    (duration_seconds * 1000.0) as u128
+                } else {
+                    0u128
+                };
+
+                if self.autoplay {
+                    self.play();
+                }
+
+                return Some((width, height, duration_ms));
+            }
+
+            // AVPlayerItemStatusFailed = 2
+            if status == 2 {
+                let error: ObjcId = msg_send![self.player_item.as_id(), error];
+                if error != nil {
+                    let desc: ObjcId = msg_send![error, localizedDescription];
+                    let c_str: *const u8 = msg_send![desc, UTF8String];
+                    if !c_str.is_null() {
+                        let err_str = std::ffi::CStr::from_ptr(c_str as *const _)
+                            .to_string_lossy()
+                            .to_string();
+                        error!("AVPlayer failed to prepare: {}", err_str);
+                    }
+                }
+                self.prepare_notified = true;
+            }
+        }
+        None
+    }
+
+    /// Poll for a new video frame. Returns true if a new frame was bound to the texture.
+    pub fn poll_frame(&mut self, textures: &mut CxTexturePool) -> bool {
+        if !self.is_prepared {
+            return false;
+        }
+
+        unsafe { self.check_looping(); }
+
+        unsafe {
+            let current_time: CMTime = msg_send![self.player_item.as_id(), currentTime];
+            let has_new: BOOL = msg_send![
+                self.video_output.as_id(),
+                hasNewPixelBufferForItemTime: current_time
+            ];
+
+            if has_new == NO {
+                return false;
+            }
+
+            let pixel_buffer: CVPixelBufferRef = msg_send![
+                self.video_output.as_id(),
+                copyPixelBufferForItemTime: current_time
+                itemTimeForDisplay: std::ptr::null_mut::<CMTime>()
+            ];
+
+            if pixel_buffer.is_null() {
+                return false;
+            }
+
+            let width = CVPixelBufferGetWidth(pixel_buffer);
+            let height = CVPixelBufferGetHeight(pixel_buffer);
+
+            // Create CVMetalTexture from the pixel buffer (zero-copy)
+            let mut cv_texture: CVMetalTextureRef = std::ptr::null_mut();
+            let status = CVMetalTextureCacheCreateTextureFromImage(
+                std::ptr::null_mut(),
+                self.texture_cache,
+                pixel_buffer,
+                std::ptr::null_mut(),
+                MTLPixelFormat::BGRA8Unorm as u64,
+                width,
+                height,
+                0, // planeIndex
+                &mut cv_texture,
+            );
+
+            // Release the pixel buffer (CVMetalTexture retains what it needs)
+            CFRelease(pixel_buffer as *const c_void);
+
+            if status != 0 {
+                error!("CVMetalTextureCacheCreateTextureFromImage failed: {}", status);
+                return false;
+            }
+
+            // Get the MTLTexture from the CVMetalTexture
+            let mtl_texture: ObjcId = CVMetalTextureGetTexture(cv_texture);
+            if mtl_texture.is_null() {
+                CFRelease(cv_texture as *const c_void);
+                return false;
+            }
+
+            // Retain the MTLTexture since CVMetalTexture owns it
+            let _: () = msg_send![mtl_texture, retain];
+
+            // Release previous CVMetalTexture
+            if !self.cv_texture.is_null() {
+                CFRelease(self.cv_texture as *const c_void);
+            }
+            self.cv_texture = cv_texture;
+
+            // Swap the backing MTLTexture in the Makepad texture pool
+            let cxtexture = &mut textures[self.texture_id];
+            cxtexture.os.texture = Some(RcObjcId::from_owned(
+                NonNull::new(mtl_texture).unwrap()
+            ));
+            cxtexture.alloc = Some(TextureAlloc {
+                width,
+                height,
+                pixel: TexturePixel::VideoRGB,
+                category: TextureCategory::Video,
+            });
+
+            true
+        }
+    }
+
+    pub fn play(&self) {
+        unsafe {
+            let _: () = msg_send![self.player.as_id(), play];
+        }
+    }
+
+    pub fn pause(&self) {
+        unsafe {
+            let _: () = msg_send![self.player.as_id(), pause];
+        }
+    }
+
+    pub fn resume(&self) {
+        self.play();
+    }
+
+    pub fn mute(&self) {
+        unsafe {
+            let _: () = msg_send![self.player.as_id(), setMuted: YES];
+        }
+    }
+
+    pub fn unmute(&self) {
+        unsafe {
+            let _: () = msg_send![self.player.as_id(), setMuted: NO];
+        }
+    }
+
+    pub fn cleanup(&mut self) {
+        unsafe {
+            // Pause playback
+            let _: () = msg_send![self.player.as_id(), pause];
+
+            // Remove video output from player item
+            let _: () = msg_send![self.player_item.as_id(), removeOutput: self.video_output.as_id()];
+
+            // Release CVMetalTexture
+            if !self.cv_texture.is_null() {
+                CFRelease(self.cv_texture as *const c_void);
+                self.cv_texture = std::ptr::null_mut();
+            }
+
+            // Flush texture cache
+            if !self.texture_cache.is_null() {
+                CVMetalTextureCacheFlush(self.texture_cache, 0);
+                CFRelease(self.texture_cache as *const c_void);
+                self.texture_cache = std::ptr::null_mut();
+            }
+        }
+
+        // Clean up temp file from InMemory source
+        if let Some(path) = self.temp_file_path.take() {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+impl Drop for AppleVideoPlayer {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
+}

--- a/platform/src/os/apple/apple_video_playback.rs
+++ b/platform/src/os/apple/apple_video_playback.rs
@@ -90,7 +90,7 @@ impl AppleVideoPlayer {
 
             // If source was InMemory, we created a temp file - the URL retains it
 
-            let mut this = Self {
+            Self {
                 player: RcObjcId::from_unowned(NonNull::new(player).unwrap()),
                 player_item: RcObjcId::from_unowned(NonNull::new(player_item).unwrap()),
                 video_output: RcObjcId::from_unowned(NonNull::new(video_output).unwrap()),
@@ -103,9 +103,7 @@ impl AppleVideoPlayer {
                 autoplay,
                 is_looping,
                 temp_file_path,
-            };
-
-            this
+            }
         }
     }
 

--- a/platform/src/os/apple/apple_video_playback.rs
+++ b/platform/src/os/apple/apple_video_playback.rs
@@ -319,6 +319,22 @@ impl AppleVideoPlayer {
         }
     }
 
+    pub fn current_position_ms(&self) -> u128 {
+        unsafe {
+            let current: CMTime = msg_send![self.player_item.as_id(), currentTime];
+            let seconds = CMTimeGetSeconds(current);
+            if seconds.is_finite() && seconds >= 0.0 { (seconds * 1000.0) as u128 } else { 0 }
+        }
+    }
+
+    pub fn seek_to(&self, position_ms: u64) {
+        unsafe {
+            let seconds = position_ms as f64 / 1000.0;
+            let time = CMTimeMakeWithSeconds(seconds, 600);
+            let _: () = msg_send![self.player.as_id(), seekToTime: time];
+        }
+    }
+
     pub fn play(&self) {
         unsafe {
             let _: () = msg_send![self.player.as_id(), play];

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -250,6 +250,7 @@ impl Cx {
                         if player.poll_frame(&mut self.textures) {
                             video_events.push(Event::VideoTextureUpdated(VideoTextureUpdatedEvent {
                                 video_id: player.video_id,
+                                current_position_ms: player.current_position_ms(),
                             }));
                         }
                     }
@@ -453,6 +454,11 @@ impl Cx {
                         self.call_event_handler(&Event::VideoPlaybackResourcesReleased(
                             VideoPlaybackResourcesReleasedEvent { video_id }
                         ));
+                    }
+                }
+                CxOsOp::SeekVideoPlayback(video_id, position_ms) => {
+                    if let Some(player) = self.os.video_players.get(&video_id) {
+                        player.seek_to(position_ms);
                     }
                 }
                 e => {

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -3,13 +3,20 @@ use {
         cx::{Cx, IosParams, OsType},
         cx_api::{CxOsApi, CxOsOp, OpenUrlInPlace},
         draw_pass::CxDrawPassParent,
-        event::{Event, KeyEvent, NetworkResponseChannel, TextInputEvent, TextRangeReplaceEvent},
+        event::{
+            Event, KeyEvent, NetworkResponseChannel, TextInputEvent, TextRangeReplaceEvent,
+            video_playback::{
+                VideoPlaybackPreparedEvent, VideoTextureUpdatedEvent,
+                VideoPlaybackResourcesReleasedEvent,
+            },
+        },
         makepad_live_id::*,
         makepad_objc_sys::objc_block,
         os::{
             apple::{
                 apple_sys::*,
                 apple_util::*,
+                apple_video_playback::AppleVideoPlayer,
                 ios::{
                     ios_app::{self, init_ios_app_global, with_ios_app, IosApp},
                     ios_event::IosEvent,
@@ -27,6 +34,7 @@ use {
     },
     std::{
         cell::RefCell,
+        collections::HashMap,
         rc::Rc,
         sync::mpsc::{channel, Receiver, Sender},
         time::Instant,
@@ -227,6 +235,29 @@ impl Cx {
                 self.redraw_all();
             }
             IosEvent::Paint => {
+                // Poll video players for new frames and preparation status
+                if !self.os.video_players.is_empty() {
+                    let mut video_events = Vec::new();
+                    for (_video_id, player) in self.os.video_players.iter_mut() {
+                        if let Some((width, height, duration)) = player.check_prepared() {
+                            video_events.push(Event::VideoPlaybackPrepared(VideoPlaybackPreparedEvent {
+                                video_id: player.video_id,
+                                video_width: width,
+                                video_height: height,
+                                duration,
+                            }));
+                        }
+                        if player.poll_frame(&mut self.textures) {
+                            video_events.push(Event::VideoTextureUpdated(VideoTextureUpdatedEvent {
+                                video_id: player.video_id,
+                            }));
+                        }
+                    }
+                    for event in video_events {
+                        self.call_event_handler(&event);
+                    }
+                }
+
                 let time_now = with_ios_app(|app| app.time_now());
                 if self.new_next_frames.len() != 0 {
                     self.call_next_frame_event(time_now);
@@ -298,6 +329,7 @@ impl Cx {
             || self.new_next_frames.len() != 0
             || paint_dirty
             || self.demo_time_repaint
+            || !self.os.video_players.is_empty()
         {
             EventFlow::Poll
         } else {
@@ -305,7 +337,7 @@ impl Cx {
         }
     }
 
-    fn handle_platform_ops(&mut self, _metal_cx: &MetalCx) {
+    fn handle_platform_ops(&mut self, metal_cx: &MetalCx) {
         while let Some(op) = self.platform_ops.pop() {
             match op {
                 CxOsOp::CreateWindow(window_id) => {
@@ -378,6 +410,50 @@ impl Cx {
                 }
                 CxOsOp::SetCursor(_) => {
                     // no need
+                }
+                CxOsOp::PrepareVideoPlayback(video_id, source, _gl_handle, texture_id, autoplay, should_loop) => {
+                    let player = AppleVideoPlayer::new(
+                        metal_cx.device,
+                        video_id,
+                        texture_id,
+                        source,
+                        autoplay,
+                        should_loop,
+                    );
+                    self.os.video_players.insert(video_id, player);
+                }
+                CxOsOp::BeginVideoPlayback(video_id) => {
+                    if let Some(player) = self.os.video_players.get(&video_id) {
+                        player.play();
+                    }
+                }
+                CxOsOp::PauseVideoPlayback(video_id) => {
+                    if let Some(player) = self.os.video_players.get(&video_id) {
+                        player.pause();
+                    }
+                }
+                CxOsOp::ResumeVideoPlayback(video_id) => {
+                    if let Some(player) = self.os.video_players.get(&video_id) {
+                        player.resume();
+                    }
+                }
+                CxOsOp::MuteVideoPlayback(video_id) => {
+                    if let Some(player) = self.os.video_players.get(&video_id) {
+                        player.mute();
+                    }
+                }
+                CxOsOp::UnmuteVideoPlayback(video_id) => {
+                    if let Some(player) = self.os.video_players.get(&video_id) {
+                        player.unmute();
+                    }
+                }
+                CxOsOp::CleanupVideoPlaybackResources(video_id) => {
+                    if let Some(mut player) = self.os.video_players.remove(&video_id) {
+                        player.cleanup();
+                        self.call_event_handler(&Event::VideoPlaybackResourcesReleased(
+                            VideoPlaybackResourcesReleasedEvent { video_id }
+                        ));
+                    }
                 }
                 e => {
                     crate::error!("Not implemented on this platform: CxOsOp::{:?}", e);
@@ -560,6 +636,7 @@ pub struct CxOs {
     pub(crate) http_requests: AppleHttpRequests,
     pub(crate) permission_response: PermissionResultChannel,
     pub(crate) apple_game_input: Option<crate::os::apple::apple_game_input::AppleGameInput>,
+    pub(crate) video_players: HashMap<LiveId, AppleVideoPlayer>,
 }
 
 pub struct PermissionResultChannel {

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -444,6 +444,7 @@ impl Cx {
                         if player.poll_frame(&mut self.textures) {
                             video_events.push(Event::VideoTextureUpdated(VideoTextureUpdatedEvent {
                                 video_id: player.video_id,
+                                current_position_ms: player.current_position_ms(),
                             }));
                         }
                     }
@@ -787,6 +788,11 @@ impl Cx {
                         self.call_event_handler(&Event::VideoPlaybackResourcesReleased(
                             VideoPlaybackResourcesReleasedEvent { video_id }
                         ));
+                    }
+                }
+                CxOsOp::SeekVideoPlayback(video_id, position_ms) => {
+                    if let Some(player) = self.os.video_players.get(&video_id) {
+                        player.seek_to(position_ms);
                     }
                 }
                 e => {

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -7,6 +7,10 @@ use {
         event::{
             Event, GameInputEventChannel, MouseButton, MouseUpEvent, NetworkResponseChannel,
             WindowGeom,
+            video_playback::{
+                VideoPlaybackPreparedEvent, VideoTextureUpdatedEvent,
+                VideoPlaybackResourcesReleasedEvent,
+            },
         },
         makepad_live_id::*,
         makepad_math::*,
@@ -15,6 +19,7 @@ use {
                 apple_classes::init_apple_classes_global,
                 apple_game_input::AppleGameInput,
                 apple_sys::*,
+                apple_video_playback::AppleVideoPlayer,
                 macos::{
                     macos_app::{init_macos_app_global, with_macos_app, MacosApp},
                     macos_event::MacosEvent,
@@ -31,7 +36,7 @@ use {
         window::{CxWindowPool, WindowId},
     },
     makepad_objc_sys::{msg_send, objc_block, sel, sel_impl},
-    std::{cell::RefCell, rc::Rc, time::Instant},
+    std::{cell::RefCell, collections::HashMap, rc::Rc, time::Instant},
 };
 
 #[derive(Clone)]
@@ -318,6 +323,7 @@ impl Cx {
                         || self.need_redrawing()
                         || !self.new_next_frames.is_empty()
                         || self.demo_time_repaint
+                        || !self.os.video_players.is_empty()
                     {
                         needs_timer = true;
                     }
@@ -422,6 +428,30 @@ impl Cx {
                 }
             }
             MacosEvent::Paint => {
+                // Poll video players for new frames and preparation status
+                let has_video_players = !self.os.video_players.is_empty();
+                if has_video_players {
+                    let mut video_events = Vec::new();
+                    for (_video_id, player) in self.os.video_players.iter_mut() {
+                        if let Some((width, height, duration)) = player.check_prepared() {
+                            video_events.push(Event::VideoPlaybackPrepared(VideoPlaybackPreparedEvent {
+                                video_id: player.video_id,
+                                video_width: width,
+                                video_height: height,
+                                duration,
+                            }));
+                        }
+                        if player.poll_frame(&mut self.textures) {
+                            video_events.push(Event::VideoTextureUpdated(VideoTextureUpdatedEvent {
+                                video_id: player.video_id,
+                            }));
+                        }
+                    }
+                    for event in video_events {
+                        self.call_event_handler(&event);
+                    }
+                }
+
                 let has_next_frames = self.new_next_frames.len() != 0;
                 let time_now = with_macos_app(|app| app.time_now());
                 if has_next_frames {
@@ -440,6 +470,7 @@ impl Cx {
                     || self.screenshot_requests.len() > 0
                     || self.os.keep_alive_counter > 0
                     || self.demo_time_repaint
+                    || has_video_players
                 {
                     self.os.timer0_idle_since = None;
                     self.ensure_timer0_started();
@@ -712,6 +743,52 @@ impl Cx {
                 } => {
                     self.handle_permission_request(permission, request_id);
                 }
+                CxOsOp::PrepareVideoPlayback(video_id, source, _gl_handle, texture_id, autoplay, should_loop) => {
+                    let player = AppleVideoPlayer::new(
+                        metal_cx.device,
+                        video_id,
+                        texture_id,
+                        source,
+                        autoplay,
+                        should_loop,
+                    );
+                    self.os.video_players.insert(video_id, player);
+                    // Keep timer alive so we can poll for video frames
+                    self.ensure_timer0_started();
+                }
+                CxOsOp::BeginVideoPlayback(video_id) => {
+                    if let Some(player) = self.os.video_players.get(&video_id) {
+                        player.play();
+                    }
+                }
+                CxOsOp::PauseVideoPlayback(video_id) => {
+                    if let Some(player) = self.os.video_players.get(&video_id) {
+                        player.pause();
+                    }
+                }
+                CxOsOp::ResumeVideoPlayback(video_id) => {
+                    if let Some(player) = self.os.video_players.get(&video_id) {
+                        player.resume();
+                    }
+                }
+                CxOsOp::MuteVideoPlayback(video_id) => {
+                    if let Some(player) = self.os.video_players.get(&video_id) {
+                        player.mute();
+                    }
+                }
+                CxOsOp::UnmuteVideoPlayback(video_id) => {
+                    if let Some(player) = self.os.video_players.get(&video_id) {
+                        player.unmute();
+                    }
+                }
+                CxOsOp::CleanupVideoPlaybackResources(video_id) => {
+                    if let Some(mut player) = self.os.video_players.remove(&video_id) {
+                        player.cleanup();
+                        self.call_event_handler(&Event::VideoPlaybackResourcesReleased(
+                            VideoPlaybackResourcesReleasedEvent { video_id }
+                        ));
+                    }
+                }
                 e => {
                     crate::error!("Not implemented on this platform: CxOsOp::{:?}", e);
                 }
@@ -922,4 +999,5 @@ pub struct CxOs {
     pub metal_device: Option<ObjcId>,
     pub(crate) game_input_events: GameInputEventChannel,
     pub(crate) apple_game_input: Option<AppleGameInput>,
+    pub(crate) video_players: HashMap<LiveId, AppleVideoPlayer>,
 }

--- a/platform/src/os/apple/metal.rs
+++ b/platform/src/os/apple/metal.rs
@@ -1581,7 +1581,7 @@ struct MetalBufferInner {
 
 #[derive(Default)]
 pub struct CxOsTexture {
-    texture: Option<RcObjcId>,
+    pub(crate) texture: Option<RcObjcId>,
     #[cfg(target_os = "macos")]
     iosurface: Option<IOSurfaceRef>,
     #[cfg(target_os = "macos")]
@@ -1596,6 +1596,7 @@ fn texture_pixel_to_mtl_pixel(pix: &TexturePixel) -> MTLPixelFormat {
         TexturePixel::RGu8 => MTLPixelFormat::RG8Unorm,
         TexturePixel::Rf32 => MTLPixelFormat::R32Float,
         TexturePixel::D32 => MTLPixelFormat::Depth32Float,
+        TexturePixel::VideoRGB => MTLPixelFormat::BGRA8Unorm,
     }
 }
 impl CxTexture {

--- a/platform/src/os/apple/mod.rs
+++ b/platform/src/os/apple/mod.rs
@@ -18,6 +18,8 @@ mod apple_resources;
 pub mod apple_classes;
 pub mod apple_game_input;
 pub mod apple_media;
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+pub mod apple_video_playback;
 #[cfg(target_os = "macos")]
 pub mod audio_tap;
 pub mod audio_unit;

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -842,7 +842,11 @@ impl Cx {
         // Video updates
         let to_dispatch = self.get_video_updates();
         for video_id in to_dispatch {
-            let e = Event::VideoTextureUpdated(VideoTextureUpdatedEvent { video_id });
+            let current_position_ms = unsafe {
+                let env = attach_jni_env();
+                android_jni::to_java_get_video_position(env, video_id) as u128
+            };
+            let e = Event::VideoTextureUpdated(VideoTextureUpdatedEvent { video_id, current_position_ms });
             self.call_event_handler(&e);
         }
 
@@ -1381,6 +1385,10 @@ impl Cx {
                 CxOsOp::CleanupVideoPlaybackResources(video_id) => unsafe {
                     let env = attach_jni_env();
                     android_jni::to_java_cleanup_video_playback_resources(env, video_id);
+                },
+                CxOsOp::SeekVideoPlayback(video_id, position_ms) => unsafe {
+                    let env = attach_jni_env();
+                    android_jni::to_java_seek_video_playback(env, video_id, position_ms);
                 },
                 CxOsOp::XrStartPresenting => {
                     self.os.ignore_destroy = true;

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -1344,6 +1344,7 @@ impl Cx {
                     video_id,
                     source,
                     external_texture_id,
+                    _texture_id,
                     autoplay,
                     should_loop,
                 ) => unsafe {

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -1176,6 +1176,27 @@ pub unsafe fn to_java_unmute_video_playback(env: *mut jni_sys::JNIEnv, video_id:
     ndk_utils::call_void_method!(env, get_activity(), "unmuteVideoPlayback", "(J)V", video_id);
 }
 
+pub unsafe fn to_java_seek_video_playback(env: *mut jni_sys::JNIEnv, video_id: LiveId, position_ms: u64) {
+    ndk_utils::call_void_method!(
+        env,
+        get_activity(),
+        "seekVideoPlayback",
+        "(JJ)V",
+        video_id,
+        position_ms as jni_sys::jlong
+    );
+}
+
+pub unsafe fn to_java_get_video_position(env: *mut jni_sys::JNIEnv, video_id: LiveId) -> i64 {
+    ndk_utils::call_long_method!(
+        env,
+        get_activity(),
+        "getVideoPlaybackPosition",
+        "(J)J",
+        video_id
+    )
+}
+
 pub unsafe fn to_java_cleanup_video_playback_resources(
     env: *mut jni_sys::JNIEnv,
     video_id: LiveId,

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -2284,7 +2284,9 @@ impl CxTexture {
                         ptr::null(),
                     );
                 },
-                _ => panic!(),
+                _ => {
+                    crate::error!("Unsupported texture pixel format for OpenGL render target allocation");
+                },
             }
             unsafe {
                 (gl.glBindTexture)(gl_sys::TEXTURE_2D, 0);

--- a/platform/src/os/windows/d3d11.rs
+++ b/platform/src/os/windows/d3d11.rs
@@ -597,6 +597,7 @@ fn texture_pixel_to_dx11_pixel(pix: &TexturePixel) -> DXGI_FORMAT {
         TexturePixel::RGu8 => DXGI_FORMAT_R8G8_UNORM,
         TexturePixel::Rf32 => DXGI_FORMAT_R32_FLOAT,
         TexturePixel::D32 => DXGI_FORMAT_D32_FLOAT,
+        TexturePixel::VideoRGB => DXGI_FORMAT_B8G8R8A8_UNORM, // video not supported on Windows; fallback value
     }
 }
 

--- a/platform/src/texture.rs
+++ b/platform/src/texture.rs
@@ -175,7 +175,6 @@ pub enum TextureFormat {
         id: crate::cx_stdin::PresentableImageId,
         initial: bool,
     },
-    #[cfg(any(target_os = "android", target_os = "linux"))]
     VideoRGB,
 }
 
@@ -224,7 +223,6 @@ impl std::fmt::Debug for TextureFormat {
                 f,
                 "TextureFormat::SharedBGRAu8(width:{width},height:{height})"
             ),
-            #[cfg(any(target_os = "android", target_os = "linux"))]
             TextureFormat::VideoRGB => write!(f, "TextureFormat::VideoRGB"),
         }
     }
@@ -348,7 +346,6 @@ pub(crate) enum TexturePixel {
     RGu8,
     Rf32,
     D32,
-    #[cfg(any(target_os = "android", target_os = "linux"))]
     VideoRGB,
 }
 
@@ -461,7 +458,6 @@ impl CxTexture {
         false
     }
 
-    #[cfg(any(target_os = "android", target_os = "linux"))]
     #[allow(unused)]
     pub(crate) fn alloc_video(&mut self) -> bool {
         if let Some(alloc) = self.format.as_video_alloc() {
@@ -511,7 +507,6 @@ impl TextureFormat {
     }
 
     pub fn is_video(&self) -> bool {
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         if let Self::VideoRGB = self {
             return true;
         }
@@ -629,7 +624,6 @@ impl TextureFormat {
         }
     }
 
-    #[cfg(any(target_os = "android", target_os = "linux"))]
     #[allow(unused)]
     pub(crate) fn as_video_alloc(&self) -> Option<TextureAlloc> {
         match self {
@@ -658,11 +652,7 @@ impl TextureFormat {
 
     #[allow(unused)]
     fn is_compatible_with(&self, other: &Self) -> bool {
-        #[cfg(any(target_os = "android", target_os = "linux"))]
-        {
-            return !(self.is_video() ^ other.is_video());
-        }
-        true
+        !(self.is_video() ^ other.is_video())
     }
 }
 

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -1256,6 +1256,21 @@ public class MakepadActivity
         }
     }
 
+    public void seekVideoPlayback(long videoId, long positionMs) {
+        VideoPlayerRunnable runnable = mVideoPlayerRunnables.get(videoId);
+        if(runnable != null) {
+            runnable.seekToPosition(positionMs);
+        }
+    }
+
+    public long getVideoPlaybackPosition(long videoId) {
+        VideoPlayerRunnable runnable = mVideoPlayerRunnables.get(videoId);
+        if(runnable != null) {
+            return runnable.getCurrentPositionMs();
+        }
+        return 0;
+    }
+
     public void cleanupVideoPlaybackResources(long videoId) {
         VideoPlayerRunnable runnable = mVideoPlayerRunnables.remove(videoId);
         if(runnable != null) {

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayer.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayer.java
@@ -147,6 +147,18 @@ public class VideoPlayer {
         }
     }
 
+    public void seekToPosition(long positionMs) {
+        if (mMediaPlayer != null) {
+            mMediaPlayer.seekTo((int) positionMs);
+        }
+    }
+
+    public long getCurrentPositionMs() {
+        if (mMediaPlayer != null && mIsPrepared) {
+            return (long) mMediaPlayer.getCurrentPosition();
+        }
+        return 0;
+    }
 
     public void stopAndCleanup() {
         // stop and release MediaPlayer

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayerRunnable.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/VideoPlayerRunnable.java
@@ -38,6 +38,14 @@ public class VideoPlayerRunnable implements Runnable {
         mVideoPlayer.unmute();
     }
 
+    public void seekToPosition(long positionMs) {
+        mVideoPlayer.seekToPosition(positionMs);
+    }
+
+    public long getCurrentPositionMs() {
+        return mVideoPlayer.getCurrentPositionMs();
+    }
+
     public void cleanupVideoPlaybackResources() {
         mVideoPlayer.stopAndCleanup();
         mVideoPlayer = null;

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -107,7 +107,6 @@ pub mod page_flip;
 pub mod popup_notification;
 pub mod slides_view;
 pub mod tooltip;
-#[cfg(target_os = "android")]
 pub mod video;
 
 pub mod command_text_input;
@@ -238,7 +237,6 @@ pub use crate::widgets_3d::*;
 
 pub use crate::chart::*;
 
-#[cfg(target_os = "android")]
 pub use crate::video::*;
 
 
@@ -347,7 +345,6 @@ pub fn widgets_mod(vm: &mut ScriptVm) {
     crate::modal::script_mod(vm);
     crate::tooltip::script_mod(vm);
     crate::popup_notification::script_mod(vm);
-    #[cfg(target_os = "android")]
     crate::video::script_mod(vm);
     crate::page_flip::script_mod(vm);
     crate::file_tree::script_mod(vm);

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -2,7 +2,7 @@ use crate::{
     image_cache::ImageCacheImpl, makepad_derive_widget::*, makepad_draw::*,
     makepad_platform::event::video_playback::*, widget::*,
 };
-//use std::sync::Arc;
+
 
 script_mod! {
     use mod.prelude.widgets_internal.*
@@ -29,7 +29,7 @@ script_mod! {
             get_color_scale_pan: fn() {
                 // Early return for default scaling and panning,
                 // used when walk size is not specified or non-fixed.
-                if self.target_size.x <= 0.0 && self.target_size.y <= 0.0 {
+                if self.target_size.x <= 0.0 || self.target_size.y <= 0.0 {
                     if self.show_thumbnail > 0.0 {
                         return self.thumbnail_texture.sample_as_bgra(self.pos).xyzw
                     } else {
@@ -77,8 +77,6 @@ script_mod! {
         }
     }
 }
-
-/// Currently only supported on Android
 
 /// DSL Usage
 ///
@@ -187,6 +185,10 @@ impl ScriptHook for Video {
     ) {
         vm.with_cx_mut(|cx| {
             self.apply_thumbnail_settings(cx);
+            // On macOS/iOS there's no TextureHandleReady event (Metal doesn't use GL external textures),
+            // so trigger playback preparation here after all DSL properties have been applied.
+            self.should_prepare_playback = self.autoplay;
+            self.maybe_prepare_playback(cx);
         });
     }
 }
@@ -444,29 +446,23 @@ impl Video {
     fn init_video_texture(&mut self, cx: &mut Cx) {
         self.id = LiveId::unique();
 
-        #[cfg(target_os = "android")]
-        {
-            if self.video_texture.is_none() {
-                let new_texture = Texture::new_with_format(cx, TextureFormat::VideoRGB);
-                self.video_texture = Some(new_texture);
-            }
-            let texture = self.video_texture.as_mut().unwrap();
-            self.draw_bg.draw_vars.set_texture(0, &texture);
+        if self.video_texture.is_none() {
+            let new_texture = Texture::new_with_format(cx, TextureFormat::VideoRGB);
+            self.video_texture = Some(new_texture);
         }
+        let texture = self.video_texture.as_mut().unwrap();
+        self.draw_bg.draw_vars.set_texture(0, &texture);
 
-        #[cfg(not(target_os = "android"))]
-        error!("Video Widget is currently only supported on Android.");
-
+        #[cfg(target_os = "android")]
         match cx.os_type() {
-            OsType::Android(params) => {
-                if params.is_emulator {
-                    panic!("Video Widget is currently only supported on real devices. (unreliable support for external textures on some emulators hosts)");
-                }
+            OsType::Android(params) if params.is_emulator => {
+                panic!("Video Widget is currently only supported on real devices. (unreliable support for external textures on some emulators hosts)");
             }
             _ => {}
         }
 
         self.should_prepare_playback = self.autoplay;
+        self.maybe_prepare_playback(cx);
     }
 
     fn apply_thumbnail_settings(&mut self, cx: &mut Cx) {
@@ -486,6 +482,8 @@ impl Video {
 
     fn maybe_prepare_playback(&mut self, cx: &mut Cx) {
         if self.playback_state == PlaybackState::Unprepared && self.should_prepare_playback {
+            // On Android, wait for GL texture handle before preparing
+            #[cfg(target_os = "android")]
             if self.video_texture_handle.is_none() {
                 // texture is not yet ready, this method will be called again on TextureHandleReady
                 return;
@@ -511,10 +509,14 @@ impl Video {
                 VideoDataSource::Filesystem { path } => VideoSource::Filesystem(path.to_string()),
             };
 
+            let Some(texture) = self.video_texture.as_ref() else {
+                return;
+            };
             cx.prepare_video_playback(
                 self.id,
                 source,
-                self.video_texture_handle.unwrap(),
+                self.video_texture_handle.unwrap_or(0),
+                texture.texture_id(),
                 self.autoplay,
                 self.is_looping,
             );

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -1129,7 +1129,10 @@ impl Video {
         } else {
             "\u{f028}" // fa-volume-up
         };
-        self.draw_volume_icon.draw_walk(cx, icon_walk, Align::default(), volume_glyph);
+        self.draw_volume_icon.draw_walk(cx, Walk {
+            width: Size::Fixed(14.0),
+            ..icon_walk
+        }, Align::default(), volume_glyph);
 
         // Progress bar track (Fill width to take remaining space)
         self.draw_progress_bg.draw_walk(cx, Walk {

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -816,13 +816,18 @@ impl Video {
 
     fn handle_gestures(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         match event.hits(cx, self.draw_bg.area()) {
-            Hit::FingerHoverIn(_) => {
+            Hit::FingerHoverIn(fhe) => {
                 if self.show_controls {
                     self.controls_hover = true;
                     self.animator_play(cx, ids!(hover.on));
                 }
+                self.update_cursor(cx, fhe.abs);
+            }
+            Hit::FingerHoverOver(fhe) => {
+                self.update_cursor(cx, fhe.abs);
             }
             Hit::FingerHoverOut(_) => {
+                cx.set_cursor(MouseCursor::Arrow);
                 if self.show_controls {
                     self.controls_hover = false;
                     // Don't hide controls if they're pinned visible or during drag
@@ -1118,7 +1123,10 @@ impl Video {
         } else {
             "\u{f04b}" // fa-play
         };
-        self.draw_play_icon.draw_walk(cx, icon_walk, Align::default(), play_glyph);
+        self.draw_play_icon.draw_walk(cx, Walk {
+            width: Size::Fixed(14.0),
+            ..icon_walk
+        }, Align::default(), play_glyph);
 
         // Restart icon (FontAwesome)
         self.draw_restart_icon.draw_walk(cx, icon_walk, Align::default(), "\u{f048}"); // fa-backward-step
@@ -1222,6 +1230,17 @@ impl Video {
         self.current_position_ms = position_ms as u128;
         self.seek_cooldown = 5;
         self.redraw(cx);
+    }
+
+    fn update_cursor(&self, cx: &mut Cx, abs: Vec2d) {
+        if self.should_show_center_play() {
+            // Center play button visible — whole area is clickable
+            cx.set_cursor(MouseCursor::Hand);
+        } else if self.controls_interactable() && self.hit_test_controls(cx, abs) {
+            cx.set_cursor(MouseCursor::Hand);
+        } else {
+            cx.set_cursor(MouseCursor::Arrow);
+        }
     }
 
     fn hit_test_controls(&self, cx: &Cx, abs: Vec2d) -> bool {

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -1,4 +1,6 @@
+use std::time::Instant;
 use crate::{
+    animator::{Animator, AnimatorAction, AnimatorImpl},
     image_cache::ImageCacheImpl, makepad_derive_widget::*, makepad_draw::*,
     makepad_platform::event::video_playback::*, widget::*,
 };
@@ -75,6 +77,161 @@ script_mod! {
                 return Pal.premul(vec4(color.xyz, color.w * self.opacity))
             }
         }
+
+        draw_center_play_bg +: {
+            pixel: fn() {
+                let sdf = Sdf2d.viewport(self.pos * self.rect_size)
+                let c = self.rect_size * 0.5
+                let r = min(c.x, c.y)
+                sdf.circle(c.x, c.y, r)
+                sdf.fill(Pal.premul(vec4(0.0, 0.0, 0.0, 0.5)))
+                return sdf.result
+            }
+        }
+
+        draw_center_play_icon +: {
+            color: #fff
+            text_style: theme.font_icons{
+                font_size: 20.0
+            }
+        }
+
+        draw_controls_bg +: {
+            controls_opacity: instance(0.0)
+            pixel: fn() {
+                return vec4(0.0, 0.0, 0.0, 0.6 * self.controls_opacity)
+            }
+        }
+
+        draw_play_icon +: {
+            color: #0000
+            text_style: theme.font_icons{
+                font_size: 11.0
+            }
+        }
+
+        draw_restart_icon +: {
+            color: #0000
+            text_style: theme.font_icons{
+                font_size: 10.0
+            }
+        }
+
+        draw_volume_icon +: {
+            color: #0000
+            text_style: theme.font_icons{
+                font_size: 10.0
+            }
+        }
+
+        draw_time_text +: {
+            color: #0000
+            text_style: theme.font_regular{
+                font_size: 8.0
+            }
+        }
+
+        draw_progress_bg +: {
+            controls_opacity: instance(0.0)
+            pixel: fn() {
+                return Pal.premul(vec4(1.0, 1.0, 1.0, 0.3 * self.controls_opacity))
+            }
+        }
+
+        draw_progress_fill +: {
+            controls_opacity: instance(0.0)
+            pixel: fn() {
+                return Pal.premul(vec4(1.0, 1.0, 1.0, 0.9 * self.controls_opacity))
+            }
+        }
+
+        draw_progress_thumb +: {
+            controls_opacity: instance(0.0)
+            pixel: fn() {
+                let sdf = Sdf2d.viewport(self.pos * self.rect_size)
+                let c = self.rect_size * 0.5
+                let r = min(c.x, c.y)
+                sdf.circle(c.x, c.y, r)
+                sdf.fill(#fff)
+                return sdf.result * self.controls_opacity
+            }
+        }
+
+        draw_seek_indicator +: {
+            indicator_opacity: instance(0.0)
+            direction: uniform(0.0)
+            pixel: fn() {
+                let sdf = Sdf2d.viewport(self.pos * self.rect_size)
+                let c = self.rect_size * 0.5
+                let sz = min(self.rect_size.x, self.rect_size.y) * 0.3
+                if self.direction > 0.5 {
+                    // Right arrow (fast-forward) - CCW winding
+                    sdf.move_to(c.x - sz, c.y - sz)
+                    sdf.line_to(c.x + sz, c.y)
+                    sdf.line_to(c.x - sz, c.y + sz)
+                    sdf.close_path()
+                    sdf.fill(#fff)
+                } else {
+                    // Left arrow (rewind) - CCW winding
+                    sdf.move_to(c.x + sz, c.y + sz)
+                    sdf.line_to(c.x - sz, c.y)
+                    sdf.line_to(c.x + sz, c.y - sz)
+                    sdf.close_path()
+                    sdf.fill(#fff)
+                }
+                return sdf.result * self.indicator_opacity
+            }
+        }
+
+        controls_height: 32.0
+        show_controls: true
+
+        animator: Animator{
+            hover: {
+                default: @off
+                off: AnimatorState{
+                    from: {all: Forward {duration: 0.3}}
+                    apply: {
+                        draw_controls_bg: {controls_opacity: 0.0}
+                        draw_play_icon: {color: #0000}
+                        draw_restart_icon: {color: #0000}
+                        draw_volume_icon: {color: #0000}
+                        draw_progress_bg: {controls_opacity: 0.0}
+                        draw_progress_fill: {controls_opacity: 0.0}
+                        draw_progress_thumb: {controls_opacity: 0.0}
+                        draw_time_text: {color: #0000}
+                    }
+                }
+                on: AnimatorState{
+                    from: {all: Forward {duration: 0.15}}
+                    apply: {
+                        draw_controls_bg: {controls_opacity: 1.0}
+                        draw_play_icon: {color: #fff}
+                        draw_restart_icon: {color: #fff}
+                        draw_volume_icon: {color: #fff}
+                        draw_progress_bg: {controls_opacity: 1.0}
+                        draw_progress_fill: {controls_opacity: 1.0}
+                        draw_progress_thumb: {controls_opacity: 1.0}
+                        draw_time_text: {color: #fff}
+                    }
+                }
+            }
+            seek_indicator: {
+                default: @hidden
+                hidden: AnimatorState{
+                    from: {all: Forward {duration: 0.4}}
+                    apply: {
+                        draw_seek_indicator: {indicator_opacity: 0.0}
+                    }
+                }
+                show: AnimatorState{
+                    from: {all: Snap}
+                    apply: {
+                        draw_seek_indicator: {indicator_opacity: 0.8}
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -92,18 +249,19 @@ script_mod! {
 /// `hold_to_pause` - determines if the video should be paused when the user hold the pause button. defaults to false.
 ///
 /// `autoplay` - determines if the video should start playback when the widget is created. defaults to false.
+///
+/// `show_idle_thumbnail` - when true and a `thumbnail_source` is provided, shows the thumbnail while the video is idle. defaults to false.
+
+/// `show_controls` - determines if overlay controls (play/pause, restart, progress bar) appear on hover. defaults to true.
+///
+/// `controls_height` - height of the controls bar in logical pixels. defaults to 32.0.
 
 /// Not yet supported:
-/// UI
-///  - Playback controls
-///  - Progress/seek-to bar
-
 /// Widget API
-///  - Seek to timestamp
-///  - Option to restart playback manually when not looping.
+///  - Seek to arbitrary timestamp
 ///  - Hotswap video source, `set_source(VideoDataSource)` only works if video is in Unprepared state.
 
-#[derive(Script, Widget)]
+#[derive(Script, Widget, Animator)]
 pub struct Video {
     #[uid]
     uid: WidgetUid,
@@ -121,6 +279,41 @@ pub struct Video {
     #[live]
     scale: f64,
 
+    // Center play button overlay
+    #[live]
+    draw_center_play_bg: DrawQuad,
+    #[live]
+    draw_center_play_icon: DrawText,
+
+    // Controls overlay drawing
+    #[live]
+    draw_controls_bg: DrawColor,
+    #[live]
+    draw_play_icon: DrawText,
+    #[live]
+    draw_restart_icon: DrawText,
+    #[live]
+    draw_volume_icon: DrawText,
+    #[live]
+    draw_progress_bg: DrawColor,
+    #[live]
+    draw_progress_fill: DrawColor,
+    #[live]
+    draw_progress_thumb: DrawQuad,
+    #[live]
+    draw_time_text: DrawText,
+    #[live]
+    draw_seek_indicator: DrawQuad,
+
+    // Controls config
+    #[live(true)]
+    show_controls: bool,
+    #[live(32.0)]
+    controls_height: f64,
+    // Animator for hover fade
+    #[apply_default]
+    animator: Animator,
+
     // Textures
     #[live]
     source: VideoDataSource,
@@ -128,7 +321,7 @@ pub struct Video {
     video_texture: Option<Texture>,
     #[rust]
     video_texture_handle: Option<u32>,
-    /// Requires [`show_thumbnail_before_playback`] to be `true`.
+    /// Requires [`show_idle_thumbnail`] to be `true`.
     #[live]
     thumbnail_source: Option<ScriptHandleRef>,
     #[rust]
@@ -151,7 +344,7 @@ pub struct Video {
     audio_state: AudioState,
     /// Whether to show the provided thumbnail when the video has not yet started playing.
     #[live(false)]
-    show_thumbnail_before_playback: bool,
+    show_idle_thumbnail: bool,
 
     // Actions
     #[rust(false)]
@@ -164,6 +357,30 @@ pub struct Video {
     video_height: usize,
     #[rust]
     total_duration: u128,
+
+    // Playback position tracking
+    #[rust]
+    current_position_ms: u128,
+
+    // Interaction state
+    #[rust]
+    is_dragging_progress: bool,
+    #[rust]
+    seek_indicator_direction: f64,
+    /// Whether controls are pinned visible (for touch, or click-to-pin on desktop).
+    #[rust]
+    controls_visible: bool,
+    /// Whether the mouse is currently hovering over the video (desktop only).
+    #[rust]
+    controls_hover: bool,
+    /// Number of position updates to skip after a seek (prevents stale platform positions from reverting the progress bar).
+    #[rust]
+    seek_cooldown: u32,
+    /// Manual double-tap tracking (fallback for unreliable platform tap_count on touch).
+    #[rust]
+    last_tap_time: Option<Instant>,
+    #[rust]
+    last_tap_abs: DVec2,
 
     #[rust]
     id: LiveId,
@@ -185,9 +402,11 @@ impl ScriptHook for Video {
     ) {
         vm.with_cx_mut(|cx| {
             self.apply_thumbnail_settings(cx);
+            // Prepare the video when autoplay is enabled (so it starts immediately) or when
+            // show_idle_thumbnail is true (so the first frame is available as a thumbnail).
             // On macOS/iOS there's no TextureHandleReady event (Metal doesn't use GL external textures),
             // so trigger playback preparation here after all DSL properties have been applied.
-            self.should_prepare_playback = self.autoplay;
+            self.should_prepare_playback = self.autoplay || self.show_idle_thumbnail;
             self.maybe_prepare_playback(cx);
         });
     }
@@ -375,11 +594,25 @@ impl Widget for Video {
             self.draw_bg.draw_vars.set_texture(1, texture);
         }
 
-        self.draw_bg.draw_walk(cx, walk);
+        self.draw_bg.begin(cx, walk, self.layout);
+        self.draw_bg.end(cx);
+
+        if self.show_controls {
+            self.draw_center_play_button(cx);
+            self.draw_controls(cx);
+        }
+
+        // Draw seek indicator overlay (centered on left or right half of video)
+        self.draw_seek_indicator(cx);
+
         DrawStep::done()
     }
 
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        if self.animator_handle_event(cx, event).must_redraw() {
+            self.draw_bg.redraw(cx);
+        }
+
         let uid = self.widget_uid();
         match event {
             Event::VideoPlaybackPrepared(event) => {
@@ -390,8 +623,19 @@ impl Widget for Video {
             }
             Event::VideoTextureUpdated(event) => {
                 if event.video_id == self.id {
+                    // Don't overwrite local position while dragging or right after a seek —
+                    // the platform may still report stale positions before the seek takes effect.
+                    // Also skip 0 when we have a meaningful position — handles platforms that
+                    // don't track position (Android always reports 0).
+                    if self.is_dragging_progress {
+                        // Keep our drag-set position
+                    } else if self.seek_cooldown > 0 {
+                        self.seek_cooldown -= 1;
+                    } else if event.current_position_ms > 0 {
+                        self.current_position_ms = event.current_position_ms;
+                    }
                     self.redraw(cx);
-                    if self.playback_state == PlaybackState::Prepared {
+                    if self.playback_state == PlaybackState::Prepared && self.autoplay {
                         self.playback_state = PlaybackState::Playing;
                         cx.widget_action(uid, VideoAction::PlaybackBegan);
                         self.draw_bg.set_uniform(cx, id!(show_thumbnail), &[0.0]);
@@ -474,9 +718,13 @@ impl Video {
         self.draw_bg
             .set_uniform(cx, id!(target_size), &[target_w as f32, target_h as f32]);
 
-        if self.show_thumbnail_before_playback {
-            self.load_thumbnail_image(cx);
-            self.draw_bg.set_uniform(cx, id!(show_thumbnail), &[1.0]);
+        if self.show_idle_thumbnail {
+            let loaded = self.load_thumbnail_image(cx);
+            // Only enable the thumbnail shader path if a thumbnail was actually loaded;
+            // otherwise the shader would sample from an empty texture.
+            if loaded {
+                self.draw_bg.set_uniform(cx, id!(show_thumbnail), &[1.0]);
+            }
         }
     }
 
@@ -543,27 +791,150 @@ impl Video {
         }
     }
 
+    fn controls_interactable(&self) -> bool {
+        self.show_controls && (self.controls_visible || self.controls_hover)
+    }
+
+    /// Manual double-tap detection as a fallback for unreliable platform tap_count on touch.
+    /// Returns true if a double-tap is detected, and clears the tracking state.
+    /// Otherwise records this tap for future detection.
+    fn check_double_tap(&mut self, abs: DVec2) -> bool {
+        if let Some(last_time) = self.last_tap_time {
+            let elapsed = last_time.elapsed().as_secs_f64();
+            let dx = abs.x - self.last_tap_abs.x;
+            let dy = abs.y - self.last_tap_abs.y;
+            let dist = (dx * dx + dy * dy).sqrt();
+            if elapsed < 0.4 && dist < 80.0 {
+                self.last_tap_time = None;
+                return true;
+            }
+        }
+        self.last_tap_time = Some(Instant::now());
+        self.last_tap_abs = abs;
+        false
+    }
+
     fn handle_gestures(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         match event.hits(cx, self.draw_bg.area()) {
+            Hit::FingerHoverIn(_) => {
+                if self.show_controls {
+                    self.controls_hover = true;
+                    self.animator_play(cx, ids!(hover.on));
+                }
+            }
+            Hit::FingerHoverOut(_) => {
+                if self.show_controls {
+                    self.controls_hover = false;
+                    // Don't hide controls if they're pinned visible or during drag
+                    if !self.is_dragging_progress && !self.controls_visible {
+                        self.animator_play(cx, ids!(hover.off));
+                    }
+                }
+            }
             Hit::FingerDown(fe) if fe.is_primary_hit() => {
-                if self.hold_to_pause {
+                cx.set_key_focus(self.draw_bg.area());
+
+                // Double-tap detection: use platform tap_count OR manual fallback
+                let is_double_tap = if fe.tap_count >= 2 {
+                    self.last_tap_time = None;
+                    true
+                } else {
+                    self.check_double_tap(fe.abs)
+                };
+
+                // Double-tap on video area: seek forward/backward
+                // Only when actively playing/paused (not when center play button is showing)
+                if self.show_controls && is_double_tap
+                    && !self.should_show_center_play()
+                    && !(self.controls_interactable() && self.hit_test_controls(cx, fe.abs))
+                {
+                    let video_rect = self.draw_bg.area().rect(cx);
+                    let mid_x = video_rect.pos.x + video_rect.size.x * 0.5;
+                    if fe.abs.x < mid_x {
+                        self.seek_backward(cx);
+                    } else {
+                        self.seek_forward(cx);
+                    }
+                } else if self.controls_interactable() && self.hit_test_progress_bar(cx, fe.abs) {
+                    // Start dragging progress bar
+                    self.is_dragging_progress = true;
+                    self.seek_to_position_from_x(cx, fe.abs.x);
+                } else if self.controls_interactable() && self.hit_test_controls(cx, fe.abs) {
+                    // Will be handled on FingerUp
+                } else if !self.show_controls && self.hold_to_pause {
                     self.pause_playback(cx);
+                }
+            }
+            Hit::FingerMove(fe) => {
+                if self.is_dragging_progress {
+                    self.seek_to_position_from_x(cx, fe.abs.x);
+                }
+            }
+            Hit::FingerUp(fe) if fe.is_primary_hit() => {
+                if self.is_dragging_progress {
+                    self.is_dragging_progress = false;
+                    self.seek_to_position_from_x(cx, fe.abs.x);
+                } else if self.should_show_center_play() && fe.tap_count < 2 {
+                    // Center play button is showing — tap anywhere to start playback
+                    self.toggle_play_pause(cx);
+                } else if self.controls_interactable() && self.hit_test_controls_click(cx, fe.abs) {
+                    // Control click handled
+                } else if self.show_controls && fe.tap_count < 2 && !self.hit_test_controls(cx, fe.abs) {
+                    // Single tap outside controls bar: toggle pinned visibility
+                    self.controls_visible = !self.controls_visible;
+                    if self.controls_visible {
+                        self.animator_play(cx, ids!(hover.on));
+                    } else if !self.controls_hover {
+                        self.animator_play(cx, ids!(hover.off));
+                    }
+                } else if !self.show_controls && self.hold_to_pause {
+                    self.resume_playback(cx);
                 }
             }
             Hit::FingerDown(fe) if fe.mouse_button().is_some_and(|mb| mb.is_secondary()) => {
                 self.handle_secondary_click(cx, scope, fe.abs, fe.modifiers);
             }
             Hit::FingerLongPress(lp) => {
-                // TODO: here we could offer some customization, e.g., setting playback speed to 2x.
-                // For now, we treat a long press just like a secondary click.
                 self.handle_secondary_click(cx, scope, lp.abs, Default::default());
             }
-            Hit::FingerUp(fe) if fe.is_primary_hit() => {
-                if self.hold_to_pause {
-                    self.resume_playback(cx);
-                }
+            Hit::KeyDown(ke) => {
+                self.handle_key_seek(cx, &ke);
             }
             _ => (),
+        }
+    }
+
+    fn seek_backward(&mut self, cx: &mut Cx) {
+        let seek_step_ms: u128 = 5000;
+        let new_pos = self.current_position_ms.saturating_sub(seek_step_ms);
+        cx.seek_video_playback(self.id, new_pos as u64);
+        self.current_position_ms = new_pos;
+        self.seek_cooldown = 5;
+        self.seek_indicator_direction = 0.0;
+        self.animator_play(cx, ids!(seek_indicator.show));
+        self.animator_play(cx, ids!(seek_indicator.hidden));
+        self.redraw(cx);
+    }
+
+    fn seek_forward(&mut self, cx: &mut Cx) {
+        let seek_step_ms: u128 = 5000;
+        let new_pos = (self.current_position_ms + seek_step_ms).min(self.total_duration);
+        cx.seek_video_playback(self.id, new_pos as u64);
+        self.current_position_ms = new_pos;
+        self.seek_cooldown = 5;
+        self.seek_indicator_direction = 1.0;
+        self.animator_play(cx, ids!(seek_indicator.show));
+        self.animator_play(cx, ids!(seek_indicator.hidden));
+        self.redraw(cx);
+    }
+
+    fn handle_key_seek(&mut self, cx: &mut Cx, ke: &KeyEvent) {
+        match ke.key_code {
+            KeyCode::ArrowLeft => self.seek_backward(cx),
+            KeyCode::ArrowRight => self.seek_forward(cx),
+            KeyCode::Space => self.toggle_play_pause(cx),
+            KeyCode::KeyM => self.toggle_mute(cx),
+            _ => {}
         }
     }
 
@@ -675,20 +1046,286 @@ impl Video {
         }
     }
 
-    fn load_thumbnail_image(&mut self, cx: &mut Cx) {
+    fn should_show_center_play(&self) -> bool {
+        matches!(
+            self.playback_state,
+            PlaybackState::Unprepared | PlaybackState::Preparing | PlaybackState::Prepared | PlaybackState::Completed
+        )
+    }
+
+    fn draw_center_play_button(&mut self, cx: &mut Cx2d) {
+        if !self.should_show_center_play() {
+            return;
+        }
+
+        let video_rect = self.draw_bg.area().rect(cx);
+        if video_rect.size.x <= 0.0 || video_rect.size.y <= 0.0 {
+            return;
+        }
+
+        let btn_size = 48.0;
+        let btn_x = video_rect.pos.x + (video_rect.size.x - btn_size) * 0.5;
+        let btn_y = video_rect.pos.y + (video_rect.size.y - btn_size) * 0.5;
+
+        // Draw semi-transparent circle background
+        self.draw_center_play_bg.draw_abs(cx, Rect {
+            pos: dvec2(btn_x, btn_y),
+            size: dvec2(btn_size, btn_size),
+        });
+
+        // Measure the glyph to center it precisely within the circle
+        let glyph = "\u{f04b}"; // fa-play
+        let laid_out = self.draw_center_play_icon.layout(cx, 0.0, 0.0, None, false, Align::default(), glyph);
+        let glyph_w = laid_out.size_in_lpxs.width as f64;
+        let glyph_h = laid_out.size_in_lpxs.height as f64;
+        // Nudge right by 2px — play triangles are geometrically centered but
+        // perceptually look left-shifted due to the pointed right edge.
+        let icon_x = btn_x + (btn_size - glyph_w) * 0.5 + 2.0;
+        let icon_y = btn_y + (btn_size - glyph_h) * 0.5;
+        self.draw_center_play_icon.draw_abs(cx, dvec2(icon_x, icon_y), glyph);
+    }
+
+    fn draw_controls(&mut self, cx: &mut Cx2d) {
+        let video_rect = self.draw_bg.area().rect(cx);
+        if video_rect.size.x <= 0.0 || video_rect.size.y <= 0.0 {
+            return;
+        }
+
+        let ch = self.controls_height;
+        let bar_y = video_rect.pos.y + video_rect.size.y - ch;
+
+        // Begin the controls bar as a layout at absolute position (bottom of video)
+        self.draw_controls_bg.begin(cx, Walk {
+            abs_pos: Some(dvec2(video_rect.pos.x, bar_y)),
+            width: Size::Fixed(video_rect.size.x),
+            height: Size::Fixed(ch),
+            ..Walk::default()
+        }, Layout {
+            flow: Flow::right(),
+            align: Align { x: 0.0, y: 0.5 },
+            spacing: 8.0,
+            padding: Inset { left: 8.0, right: 12.0, top: 0.0, bottom: 0.0 },
+            clip_x: true,
+            clip_y: true,
+            ..Layout::default()
+        });
+
+        let icon_walk = Walk::fit();
+
+        // Play/pause icon (FontAwesome)
+        let play_glyph = if matches!(self.playback_state, PlaybackState::Playing) {
+            "\u{f04c}" // fa-pause
+        } else {
+            "\u{f04b}" // fa-play
+        };
+        self.draw_play_icon.draw_walk(cx, icon_walk, Align::default(), play_glyph);
+
+        // Restart icon (FontAwesome)
+        self.draw_restart_icon.draw_walk(cx, icon_walk, Align::default(), "\u{f048}"); // fa-backward-step
+
+        // Volume icon (FontAwesome)
+        let volume_glyph = if self.audio_state == AudioState::Muted {
+            "\u{f6a9}" // fa-volume-mute
+        } else {
+            "\u{f028}" // fa-volume-up
+        };
+        self.draw_volume_icon.draw_walk(cx, icon_walk, Align::default(), volume_glyph);
+
+        // Progress bar track (Fill width to take remaining space)
+        self.draw_progress_bg.draw_walk(cx, Walk {
+            width: Size::fill(),
+            height: Size::Fixed(4.0),
+            margin: Inset { left: 0.0, right: 4.0, top: 0.0, bottom: 0.0 },
+            ..Walk::default()
+        });
+
+        // Time text (fixed width so fill doesn't consume its space)
+        let time_text = format!(
+            "{} / {}",
+            Self::format_time_ms(self.current_position_ms),
+            Self::format_time_ms(self.total_duration),
+        );
+        self.draw_time_text.draw_walk(cx, Walk {
+            width: Size::Fixed(80.0),
+            height: Size::fit(),
+            ..Walk::default()
+        }, Align::default(), &time_text);
+
+        self.draw_controls_bg.end(cx);
+
+        // Draw progress fill and thumb AFTER end() so the layout alignment is finalized
+        let progress_rect = self.draw_progress_bg.area().rect(cx);
+        if progress_rect.size.x > 0.0 {
+            let progress = if self.total_duration > 0 {
+                (self.current_position_ms as f64) / (self.total_duration as f64)
+            } else {
+                0.0
+            };
+            let fill_w = progress_rect.size.x * progress.min(1.0);
+            self.draw_progress_fill.draw_abs(cx, Rect {
+                pos: progress_rect.pos,
+                size: dvec2(fill_w, progress_rect.size.y),
+            });
+
+            let thumb_size = 10.0;
+            self.draw_progress_thumb.draw_abs(cx, Rect {
+                pos: dvec2(
+                    progress_rect.pos.x + fill_w - thumb_size * 0.5,
+                    progress_rect.pos.y + (progress_rect.size.y - thumb_size) * 0.5,
+                ),
+                size: dvec2(thumb_size, thumb_size),
+            });
+        }
+    }
+
+    fn format_time_ms(ms: u128) -> String {
+        let total_seconds = (ms / 1000) as u64;
+        let minutes = total_seconds / 60;
+        let seconds = total_seconds % 60;
+        format!("{:02}:{:02}", minutes, seconds)
+    }
+
+    fn draw_seek_indicator(&mut self, cx: &mut Cx2d) {
+        let video_rect = self.draw_bg.area().rect(cx);
+        if video_rect.size.x <= 0.0 || video_rect.size.y <= 0.0 {
+            return;
+        }
+
+        let indicator_size = 48.0;
+        let center_y = video_rect.pos.y + (video_rect.size.y - indicator_size) * 0.5;
+
+        // Position on left or right half depending on direction
+        let center_x = if self.seek_indicator_direction > 0.5 {
+            video_rect.pos.x + video_rect.size.x * 0.75 - indicator_size * 0.5
+        } else {
+            video_rect.pos.x + video_rect.size.x * 0.25 - indicator_size * 0.5
+        };
+
+        self.draw_seek_indicator.set_uniform(cx, id!(direction), &[self.seek_indicator_direction as f32]);
+        self.draw_seek_indicator.draw_abs(cx, Rect {
+            pos: dvec2(center_x, center_y),
+            size: dvec2(indicator_size, indicator_size),
+        });
+    }
+
+    fn seek_to_position_from_x(&mut self, cx: &mut Cx, abs_x: f64) {
+        let progress_rect = self.draw_progress_bg.area().rect(cx);
+        if progress_rect.size.x <= 0.0 || self.total_duration == 0 {
+            return;
+        }
+        let fraction = ((abs_x - progress_rect.pos.x) / progress_rect.size.x).clamp(0.0, 1.0);
+        let position_ms = (fraction * self.total_duration as f64) as u64;
+        cx.seek_video_playback(self.id, position_ms);
+        self.current_position_ms = position_ms as u128;
+        self.seek_cooldown = 5;
+        self.redraw(cx);
+    }
+
+    fn hit_test_controls(&self, cx: &Cx, abs: Vec2d) -> bool {
+        let bar_rect = self.draw_controls_bg.area().rect(cx);
+        abs.x >= bar_rect.pos.x && abs.x <= bar_rect.pos.x + bar_rect.size.x
+            && abs.y >= bar_rect.pos.y && abs.y <= bar_rect.pos.y + bar_rect.size.y
+    }
+
+    fn hit_test_progress_bar(&self, cx: &Cx, abs: Vec2d) -> bool {
+        let bar_rect = self.draw_controls_bg.area().rect(cx);
+        let progress_rect = self.draw_progress_bg.area().rect(cx);
+        // Use full bar height for easier click target, but progress bar x range
+        abs.y >= bar_rect.pos.y && abs.y <= bar_rect.pos.y + bar_rect.size.y
+            && abs.x >= progress_rect.pos.x && abs.x <= progress_rect.pos.x + progress_rect.size.x
+    }
+
+    fn hit_test_controls_click(&mut self, cx: &mut Cx, abs: Vec2d) -> bool {
+        if !self.hit_test_controls(cx, abs) {
+            return false;
+        }
+
+        // Play/pause button — use the draw area from layout
+        let play_rect = self.draw_play_icon.area().rect(cx);
+        if abs.x >= play_rect.pos.x && abs.x <= play_rect.pos.x + play_rect.size.x {
+            self.toggle_play_pause(cx);
+            return true;
+        }
+
+        // Restart button
+        let restart_rect = self.draw_restart_icon.area().rect(cx);
+        if abs.x >= restart_rect.pos.x && abs.x <= restart_rect.pos.x + restart_rect.size.x {
+            cx.seek_video_playback(self.id, 0);
+            self.current_position_ms = 0;
+            self.seek_cooldown = 5;
+            if self.playback_state == PlaybackState::Completed {
+                self.resume_playback(cx);
+            }
+            self.redraw(cx);
+            return true;
+        }
+
+        // Volume button
+        let volume_rect = self.draw_volume_icon.area().rect(cx);
+        if abs.x >= volume_rect.pos.x && abs.x <= volume_rect.pos.x + volume_rect.size.x {
+            self.toggle_mute(cx);
+            return true;
+        }
+
+        // Progress bar region - click to seek
+        if self.hit_test_progress_bar(cx, abs) {
+            self.seek_to_position_from_x(cx, abs.x);
+            return true;
+        }
+
+        true // Click was in bar, consume it
+    }
+
+    fn toggle_play_pause(&mut self, cx: &mut Cx) {
+        match self.playback_state {
+            PlaybackState::Playing => self.pause_playback(cx),
+            PlaybackState::Paused => self.resume_playback(cx),
+            PlaybackState::Unprepared => {
+                self.begin_playback(cx);
+            }
+            PlaybackState::Prepared => {
+                cx.begin_video_playback(self.id);
+                self.playback_state = PlaybackState::Playing;
+                if self.show_idle_thumbnail {
+                    self.draw_bg.set_uniform(cx, id!(show_thumbnail), &[0.0]);
+                }
+            }
+            PlaybackState::Completed => {
+                cx.seek_video_playback(self.id, 0);
+                self.current_position_ms = 0;
+                self.seek_cooldown = 5;
+                cx.resume_video_playback(self.id);
+                self.playback_state = PlaybackState::Playing;
+            }
+            _ => {}
+        }
+        self.redraw(cx);
+    }
+
+    fn toggle_mute(&mut self, cx: &mut Cx) {
+        if self.audio_state == AudioState::Muted {
+            self.unmute_playback(cx);
+        } else {
+            self.mute_playback(cx);
+        }
+        self.redraw(cx);
+    }
+
+    fn load_thumbnail_image(&mut self, cx: &mut Cx) -> bool {
         if let Some(ref handle_ref) = self.thumbnail_source {
             let handle = handle_ref.as_handle();
             if let Some(data) = cx.get_resource(handle) {
                 // Try to load as PNG first, then JPG
                 if self.load_png_from_data(cx, &data, 0).is_ok() {
-                    return;
+                    return true;
                 }
                 if self.load_jpg_from_data(cx, &data, 0).is_ok() {
-                    return;
+                    return true;
                 }
                 error!("Failed to load thumbnail image: unsupported format");
             }
         }
+        false
     }
 }
 


### PR DESCRIPTION
### Summary

- Added macOS & iOS video playback via AVPlayer + CVMetalTextureCache, shared implementation in apple_video_playback.rs with platform-specific event loop integration in macos.rs and ios.rs
- Added Video overlay controls: play/pause, restart, volume, progress bar with seek, and time display, all rendered as an overlay with hover fade animation
- Added a play button when video is idle (not yet playing or completed); tap anywhere to start playback
- Added Seek support: double-tap left/right halves for 5s rewind/forward, keyboard arrows, draggable progress bar, and platform seek_to / current_position_ms plumbing (macOS, iOS, Android)
- Renamed.`show_thumbnail_before_playback` to `show_idle_thumbnail`

- Android additions: SeekVideoPlayback op, currentPositionMs JNI plumbing
- UI Zoo: added Video demo tab (has some issues like missing controls but those are related to ui-zoo styling)
  
### Other
Fixed a Metal uniform alignment bug: float2 uniforms now get 2-float aligned in the CPU-side packing (UniformsMetal), matching Metal's struct alignment rules. Previously, a vec2 uniform after an odd
scalar would read garbage on GPU, causing garbled rendering with fixed-size video widgets.

### Recording

Screen recording on macOS

https://github.com/user-attachments/assets/c282caf4-0c87-41fb-9b1b-8b88eeff8d7b


