### PR TITLE
linux: wayland, stdin routing, control channel, studio crash fix, Y-flip fix

### DIFF
--- a/platform/script/src/shader_backend.rs
+++ b/platform/script/src/shader_backend.rs
@@ -1144,6 +1144,7 @@ impl ShaderBackend {
                     // GLSL uses dFdx/dFdy natively, mod is native
                     id!(inverseSqrt) => id!(inversesqrt),
                     id!(modf) => id!(mod),
+                    id!(atan2) => id!(atan),
                     x => x,
                 }
             }

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -318,6 +318,7 @@ impl Cx {
                         self.handle_action_receiver();
                         needs_timer = true;
                     }
+                    self.poll_control_channel();
 
                     if self.any_passes_dirty()
                         || self.need_redrawing()

--- a/platform/src/os/apple/macos/macos_stdin.rs
+++ b/platform/src/os/apple/macos/macos_stdin.rs
@@ -4,8 +4,7 @@ use {
         cx_api::{CxOsApi, CxOsOp},
         draw_pass::{CxDrawPassColorTexture, CxDrawPassParent, DrawPassClearColor},
         event::Event,
-        event::{TextClipboardEvent, WindowGeom, WindowGeomChangeEvent},
-        makepad_live_id::*,
+        event::{WindowGeom, WindowGeomChangeEvent},
         makepad_math::*,
         makepad_micro_serde::*,
         os::{
@@ -18,7 +17,7 @@ use {
         web_socket::WebSocketMessage,
         window::CxWindowPool,
     },
-    std::{cell::RefCell, rc::Rc},
+
 };
 
 /// Local swapchain for client-side texture management
@@ -178,52 +177,20 @@ impl Cx {
         stdin_windows: &mut Vec<StdinWindow>,
     ) -> bool {
         match msg {
-            StudioToApp::KeyDown(e) => {
-                self.call_event_handler(&Event::KeyDown(e));
-            }
-            StudioToApp::KeyUp(e) => {
-                self.call_event_handler(&Event::KeyUp(e));
-            }
-            StudioToApp::TextInput(e) => {
-                self.call_event_handler(&Event::TextInput(e));
-            }
-            StudioToApp::TextCopy => {
-                let response = Rc::new(RefCell::new(None));
-                self.call_event_handler(&Event::TextCopy(TextClipboardEvent {
-                    response: response.clone(),
-                }));
-                let text = response.borrow().clone();
-                if let Some(text) = text {
-                    Self::stdin_send_to_host(AppToStudio::SetClipboard(text));
-                }
-            }
-            StudioToApp::TextCut => {
-                let response = Rc::new(RefCell::new(None));
-                self.call_event_handler(&Event::TextCut(TextClipboardEvent {
-                    response: response.clone(),
-                }));
-                let text = response.borrow().clone();
-                if let Some(text) = text {
-                    Self::stdin_send_to_host(AppToStudio::SetClipboard(text));
-                }
-            }
-            StudioToApp::MouseDown(e) => {
-                self.fingers.process_tap_count(dvec2(e.x, e.y), e.time);
+            // Mouse events: resolve window_id from coordinates (stdin mode
+            // supports multiple virtual windows).
+            StudioToApp::MouseDown(ref e) => {
                 let (window_id, pos) = self.windows.window_id_contains(dvec2(e.x, e.y));
-                let mouse_down_event = e.into_event(window_id, pos);
-                self.fingers.mouse_down(mouse_down_event.button, window_id);
-                self.call_event_handler(&Event::MouseDown(mouse_down_event));
+                return self.dispatch_studio_msg(msg, window_id, pos);
             }
-            StudioToApp::MouseMove(e) => {
+            StudioToApp::MouseMove(ref e) => {
                 let (window_id, pos) = if let Some((_, window_id)) = self.fingers.first_mouse_button
                 {
                     (window_id, self.windows[window_id].window_geom.position)
                 } else {
                     self.windows.window_id_contains(dvec2(e.x, e.y))
                 };
-                self.call_event_handler(&Event::MouseMove(e.into_event(window_id, pos)));
-                self.fingers.cycle_hover_area(live_id!(mouse).into());
-                self.fingers.switch_captures();
+                return self.dispatch_studio_msg(msg, window_id, pos);
             }
             StudioToApp::TweakRay(e) => {
                 let (window_id, pos) = self.windows.window_id_contains(dvec2(e.x, e.y));
@@ -231,23 +198,20 @@ impl Cx {
                 let tweak_ray = e.into_event(window_id, pos, dpi_factor);
                 self.call_event_handler(&Event::TweakRay(tweak_ray));
             }
-            StudioToApp::MouseUp(e) => {
+            StudioToApp::MouseUp(ref e) => {
                 let (window_id, pos) = if let Some((_, window_id)) = self.fingers.first_mouse_button
                 {
                     (window_id, self.windows[window_id].window_geom.position)
                 } else {
                     self.windows.window_id_contains(dvec2(e.x, e.y))
                 };
-                let mouse_up_event = e.into_event(window_id, pos);
-                let button = mouse_up_event.button;
-                self.call_event_handler(&Event::MouseUp(mouse_up_event));
-                self.fingers.mouse_up(button);
-                self.fingers.cycle_hover_area(live_id!(mouse).into());
+                return self.dispatch_studio_msg(msg, window_id, pos);
             }
-            StudioToApp::Scroll(e) => {
+            StudioToApp::Scroll(ref e) => {
                 let (window_id, pos) = self.windows.window_id_contains(dvec2(e.x, e.y));
-                self.call_event_handler(&Event::Scroll(e.into_event(window_id, pos)));
+                return self.dispatch_studio_msg(msg, window_id, pos);
             }
+            // Stdin-specific: window geometry and swapchain management.
             StudioToApp::WindowGeomChange {
                 dpi_factor,
                 left: _left,
@@ -374,19 +338,14 @@ impl Cx {
                     Self::stdin_send_to_host(AppToStudio::RequestAnimationFrame);
                 }
             }
-            StudioToApp::Screenshot(request) => {
-                self.screenshot_requests.push(request);
-            }
-            StudioToApp::WidgetTreeDump(request) => {
-                self.send_studio_widget_tree_dump_response(request.request_id);
-            }
-            StudioToApp::KeepAlive => {}
-            StudioToApp::Kill => {
-                self.call_event_handler(&Event::Shutdown);
-                return true;
-            }
-            other @ (StudioToApp::LiveChange { .. } | StudioToApp::None) => {
-                self.action(other);
+            // All other variants (Key*, Text*, Screenshot, WidgetTreeDump,
+            // Kill, KeepAlive, LiveChange, None) handled by shared dispatch.
+            other => {
+                return self.dispatch_studio_msg(
+                    other,
+                    CxWindowPool::id_zero(),
+                    dvec2(0.0, 0.0),
+                );
             }
         }
         false

--- a/platform/src/os/apple/metal.rs
+++ b/platform/src/os/apple/metal.rs
@@ -1138,6 +1138,34 @@ impl Cx {
     pub fn share_texture_for_presentable_image(&mut self, _texture: &Texture) -> u32 {
         0
     }
+
+    /// Create an IOSurface-backed texture for embedding Servo's CGL rendering
+    /// in Makepad's Metal pipeline. Returns the Makepad Texture handle, the
+    /// IOSurfaceRef pointer (for CGL binding), and the IOSurface ID.
+    ///
+    /// The IOSurface is created by Makepad and owned by the returned Texture.
+    /// The caller (Servo's MacosRenderingContext) binds to the same IOSurface
+    /// via CGLTexImageIOSurface2D for zero-copy cross-API rendering.
+    #[cfg(target_os = "macos")]
+    pub fn create_iosurface_render_texture(
+        &mut self,
+        width: usize,
+        height: usize,
+    ) -> (Texture, *mut std::ffi::c_void, u32) {
+        use crate::texture::TextureFormat;
+        use crate::shared_framebuf::PresentableImageId;
+
+        let texture = Texture::new_with_format(self, TextureFormat::SharedBGRAu8 {
+            width,
+            height,
+            id: PresentableImageId::alloc(),
+            initial: true,
+        });
+        let cxtexture = &mut self.textures[texture.texture_id()];
+        let iosurface_id = cxtexture.update_shared_texture(self.os.metal_device.unwrap());
+        let iosurface_ref = cxtexture.os.iosurface.unwrap_or(std::ptr::null_mut());
+        (texture, iosurface_ref, iosurface_id)
+    }
 }
 
 #[derive(Clone)]
@@ -1894,7 +1922,7 @@ impl CxTexture {
         let _: () =
             unsafe { msg_send![descriptor.as_id(), setStorageMode: MTLStorageMode::Private] };
         let _: () =
-            unsafe { msg_send![descriptor.as_id(), setUsage: MTLTextureUsage::RenderTarget] };
+            unsafe { msg_send![descriptor.as_id(), setUsage: (MTLTextureUsage::RenderTarget as u64 | MTLTextureUsage::ShaderRead as u64)] };
         let _: () = unsafe {
             msg_send![descriptor.as_id(), setPixelFormat: texture_pixel_to_mtl_pixel(&alloc.pixel)]
         };
@@ -1951,7 +1979,7 @@ impl CxTexture {
         let _: () =
             unsafe { msg_send![descriptor.as_id(), setStorageMode: MTLStorageMode::Private] };
         let _: () =
-            unsafe { msg_send![descriptor.as_id(), setUsage: MTLTextureUsage::RenderTarget] };
+            unsafe { msg_send![descriptor.as_id(), setUsage: (MTLTextureUsage::RenderTarget as u64 | MTLTextureUsage::ShaderRead as u64)] };
         let _: () =
             unsafe { msg_send![descriptor.as_id(), setPixelFormat: MTLPixelFormat::BGRA8Unorm] };
 

--- a/platform/src/os/cx_shared.rs
+++ b/platform/src/os/cx_shared.rs
@@ -3,12 +3,19 @@ use {
         cx::Cx,
         cx_api::CxOsApi,
         draw_pass::{CxDrawPassParent, DrawPassId},
-        event::{DrawEvent, Event, KeyFocusEvent, NextFrameEvent, TimerEvent, TriggerEvent},
+        event::{
+            DrawEvent, Event, KeyFocusEvent, NextFrameEvent, TextClipboardEvent, TimerEvent,
+            TriggerEvent,
+        },
+        makepad_live_id::{live_id, LiveId},
         studio::{
-            AppToStudio, EventSample, ScreenshotResponse, WidgetTreeDumpResponse,
+            AppToStudio, EventSample, ScreenshotResponse, StudioToApp,
+            WidgetTreeDumpResponse,
         },
     },
+    std::cell::RefCell,
     std::collections::{HashMap, HashSet},
+    std::rc::Rc,
 };
 
 impl Cx {
@@ -186,6 +193,142 @@ impl Cx {
                 dump: dump.clone(),
             }));
         }
+    }
+
+    /// Dispatch a StudioToApp message as an event. Handles input, clipboard,
+    /// screenshot, widget dump, and kill. Returns true on Kill (caller should
+    /// shut down). Callers handle stdin-specific variants (Swapchain,
+    /// WindowGeomChange, Tick) before delegating here.
+    pub fn dispatch_studio_msg(
+        &mut self,
+        msg: StudioToApp,
+        window_id: crate::window::WindowId,
+        pos: crate::makepad_math::DVec2,
+    ) -> bool {
+        match msg {
+            StudioToApp::MouseDown(e) => {
+                let event = e.into_event(window_id, pos);
+                self.fingers.process_tap_count(event.abs, event.time);
+                self.fingers.mouse_down(event.button, window_id);
+                self.call_event_handler(&Event::MouseDown(event));
+            }
+            StudioToApp::MouseMove(e) => {
+                self.call_event_handler(&Event::MouseMove(e.into_event(window_id, pos)));
+                self.fingers.cycle_hover_area(live_id!(mouse).into());
+                self.fingers.switch_captures();
+            }
+            StudioToApp::MouseUp(e) => {
+                let event = e.into_event(window_id, pos);
+                let button = event.button;
+                self.call_event_handler(&Event::MouseUp(event));
+                self.fingers.mouse_up(button);
+                self.fingers.cycle_hover_area(live_id!(mouse).into());
+            }
+            StudioToApp::Scroll(e) => {
+                self.call_event_handler(&Event::Scroll(e.into_event(window_id, pos)));
+            }
+            StudioToApp::KeyDown(e) => {
+                self.keyboard.process_key_down(e.clone());
+                self.call_event_handler(&Event::KeyDown(e));
+            }
+            StudioToApp::KeyUp(e) => {
+                self.keyboard.process_key_up(e.clone());
+                self.call_event_handler(&Event::KeyUp(e));
+            }
+            StudioToApp::TextInput(e) => {
+                self.call_event_handler(&Event::TextInput(e));
+            }
+            StudioToApp::TextCopy => {
+                let response = Rc::new(RefCell::new(None));
+                self.call_event_handler(&Event::TextCopy(TextClipboardEvent {
+                    response: response.clone(),
+                }));
+                let text = response.borrow().clone();
+                if let Some(text) = text {
+                    Cx::send_studio_message(AppToStudio::SetClipboard(text));
+                }
+            }
+            StudioToApp::TextCut => {
+                let response = Rc::new(RefCell::new(None));
+                self.call_event_handler(&Event::TextCut(TextClipboardEvent {
+                    response: response.clone(),
+                }));
+                let text = response.borrow().clone();
+                if let Some(text) = text {
+                    Cx::send_studio_message(AppToStudio::SetClipboard(text));
+                }
+            }
+            StudioToApp::Screenshot(request) => {
+                self.screenshot_requests.push(request);
+            }
+            StudioToApp::WidgetTreeDump(request) => {
+                self.send_studio_widget_tree_dump_response(request.request_id);
+            }
+            StudioToApp::Kill => {
+                self.call_event_handler(&Event::Shutdown);
+                return true;
+            }
+            StudioToApp::KeepAlive | StudioToApp::None => {}
+            other @ StudioToApp::LiveChange { .. } => {
+                self.action(other);
+            }
+            // Stdin-specific: Tick, Swapchain, WindowGeomChange are handled
+            // by callers before delegating here. In windowed mode they are
+            // no-ops (the native event loop handles them).
+            StudioToApp::Tick
+            | StudioToApp::Swapchain(_)
+            | StudioToApp::WindowGeomChange { .. }
+            | StudioToApp::TweakRay(_) => {}
+        }
+        false
+    }
+
+    /// Drain the global control channel and dispatch each message as an event.
+    /// Must be called from the event loop (not from inside an event handler).
+    pub fn poll_control_channel(&mut self) {
+        use crate::makepad_math::dvec2;
+        use crate::web_socket::CONTROL_CHANNEL;
+        use crate::window::CxWindowPool;
+        let msgs: Vec<StudioToApp> = {
+            let lock = CONTROL_CHANNEL.lock().unwrap();
+            if let Some(rx) = lock.as_ref() {
+                rx.try_iter().collect()
+            } else {
+                return;
+            }
+        };
+        let window_id = CxWindowPool::id_zero();
+        let pos = dvec2(0.0, 0.0);
+        for msg in msgs {
+            self.dispatch_studio_msg(msg, window_id, pos);
+        }
+    }
+
+    // Same logic as headless::raster::encode_png_rgba which is behind
+    // cfg(headless) and unavailable to the windowed backend.
+    #[allow(dead_code)]
+    pub fn encode_rgba_as_png(
+        width: u32,
+        height: u32,
+        rgba: &[u8],
+    ) -> Result<Vec<u8>, String> {
+        use makepad_zune_png::{
+            makepad_zune_core::{
+                bit_depth::BitDepth, colorspace::ColorSpace, options::EncoderOptions,
+            },
+            PngEncoder,
+        };
+        let options = EncoderOptions::default()
+            .set_width(width as usize)
+            .set_height(height as usize)
+            .set_depth(BitDepth::Eight)
+            .set_colorspace(ColorSpace::RGBA);
+        let mut encoder = PngEncoder::new(rgba, options);
+        let mut out = Vec::new();
+        encoder
+            .encode(&mut out)
+            .map_err(|err| format!("png encode failed: {err:?}"))?;
+        Ok(out)
     }
 
     // event handler wrappers

--- a/platform/src/os/linux/opengl_cx.rs
+++ b/platform/src/os/linux/opengl_cx.rs
@@ -329,6 +329,39 @@ impl Cx {
             );
         }
 
+        // Studio screenshot readback: read framebuffer pixels before swap.
+        let request_ids = self.take_studio_screenshot_request_ids(0);
+        if !request_ids.is_empty() {
+            let w = pix_width.floor() as u32;
+            let h = pix_height.floor() as u32;
+            let mut pixels = vec![0u8; (w * h * 4) as usize];
+            unsafe {
+                let gl = self.os.gl();
+                (gl.glReadPixels)(
+                    0,
+                    0,
+                    w as i32,
+                    h as i32,
+                    gl_sys::RGBA,
+                    gl_sys::UNSIGNED_BYTE,
+                    pixels.as_mut_ptr() as *mut _,
+                );
+            }
+            // OpenGL reads bottom-up; flip rows for top-down PNG.
+            let stride = (w * 4) as usize;
+            for y in 0..(h as usize / 2) {
+                let top = y * stride;
+                let bot = ((h as usize) - 1 - y) * stride;
+                for x in 0..stride {
+                    pixels.swap(top + x, bot + x);
+                }
+            }
+            // Encode as PNG.
+            if let Ok(png) = Self::encode_rgba_as_png(w, h, &pixels) {
+                Self::send_studio_screenshot_response(request_ids, w, h, png);
+            }
+        }
+
         unsafe {
             let opengl_cx = self.os.opengl_cx.as_ref().unwrap();
             let swap_ok =

--- a/platform/src/os/linux/wayland/linux_wayland.rs
+++ b/platform/src/os/linux/wayland/linux_wayland.rs
@@ -285,6 +285,7 @@ impl WaylandCx {
                     if SignalToUI::check_and_clear_action_signal() {
                         cx.handle_action_receiver();
                     }
+                    cx.poll_control_channel();
                     cx.handle_networking_events();
                 } else {
                     cx.handle_script_timer(&e);

--- a/platform/src/os/linux/wayland/wayland_state.rs
+++ b/platform/src/os/linux/wayland/wayland_state.rs
@@ -43,9 +43,9 @@ use wayland_protocols::{
 };
 
 use crate::{
-    cx_native::EventFlow, event::WindowGeom, select_timer::SelectTimers,
-    wayland::wayland_app::WaylandApp, x11::xlib_event::XlibEvent, KeyCode,
-    WindowCloseRequestedEvent, WindowGeomChangeEvent, WindowId, WindowMovedEvent,
+    cx_native::EventFlow, event::ScrollEvent, event::WindowGeom,
+    select_timer::SelectTimers, wayland::wayland_app::WaylandApp, x11::xlib_event::XlibEvent,
+    KeyCode, WindowCloseRequestedEvent, WindowGeomChangeEvent, WindowId, WindowMovedEvent,
 };
 
 use super::opengl_wayland::WaylandWindow;
@@ -90,8 +90,12 @@ pub(crate) struct WaylandState {
     pub(crate) xkb_cx: xkb_sys::XkbContext,
     pub(crate) text_input: Option<zwp_text_input_v3::ZwpTextInputV3>,
     pub(crate) text_input_manager: Option<zwp_text_input_manager_v3::ZwpTextInputManagerV3>,
+    pub(crate) last_resize_edge: Option<xdg_toplevel::ResizeEdge>,
     event_callback: Option<Box<dyn FnMut(&mut WaylandState, XlibEvent)>>,
 
+    pub(crate) scroll_accumulator: Vec2d,
+    pub(crate) scroll_is_wheel: bool,
+    pub(crate) last_scroll_time: f64,
     pub(crate) event_flow: EventFlow,
     pub(crate) event_loop_running: bool,
 }
@@ -127,8 +131,12 @@ impl WaylandState {
             text_input: None,
             text_input_manager: None,
             last_mouse_pos: dvec2(0., 0.),
+            last_resize_edge: None,
             timers: SelectTimers::new(),
             event_callback: Some(event_callback),
+            scroll_accumulator: dvec2(0.0, 0.0),
+            scroll_is_wheel: false,
+            last_scroll_time: 0.0,
             event_flow: EventFlow::Wait,
             event_loop_running: true,
         }
@@ -162,7 +170,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
                     state.wm_base = Some(wm_base);
                 }
                 "wl_seat" => {
-                    let seat = wl_registry.bind::<wl_seat::WlSeat, _, _>(name, 1, qhandle, ());
+                    let seat = wl_registry.bind::<wl_seat::WlSeat, _, _>(name, version.min(5), qhandle, ());
                     state.seat = Some(seat);
                     state.ensure_data_device(qhandle);
                 }
@@ -763,6 +771,52 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandState {
                 if let Some(window_id) = state.current_window {
                     let pos = dvec2(surface_x as f64, surface_y as f64);
                     state.last_mouse_pos = pos;
+
+                    // Edge-resize detection (matches X11 backend thresholds)
+                    let window_size = state
+                        .windows
+                        .iter()
+                        .find(|w| w.window_id == window_id)
+                        .map(|w| w.window_geom.inner_size);
+                    if let Some(ws) = window_size {
+                        let edge = if pos.x < 10.0 && pos.y < 10.0 {
+                            Some((xdg_toplevel::ResizeEdge::TopLeft, wp_cursor_shape_device_v1::Shape::NwResize))
+                        } else if pos.x < 10.0 && pos.y >= ws.y - 10.0 {
+                            Some((xdg_toplevel::ResizeEdge::BottomLeft, wp_cursor_shape_device_v1::Shape::SwResize))
+                        } else if pos.x < 5.0 {
+                            Some((xdg_toplevel::ResizeEdge::Left, wp_cursor_shape_device_v1::Shape::WResize))
+                        } else if pos.x >= ws.x - 10.0 && pos.y < 10.0 {
+                            Some((xdg_toplevel::ResizeEdge::TopRight, wp_cursor_shape_device_v1::Shape::NeResize))
+                        } else if pos.x >= ws.x - 10.0 && pos.y >= ws.y - 10.0 {
+                            Some((xdg_toplevel::ResizeEdge::BottomRight, wp_cursor_shape_device_v1::Shape::SeResize))
+                        } else if pos.x >= ws.x - 5.0 {
+                            Some((xdg_toplevel::ResizeEdge::Right, wp_cursor_shape_device_v1::Shape::EResize))
+                        } else if pos.y < 5.0 {
+                            Some((xdg_toplevel::ResizeEdge::Top, wp_cursor_shape_device_v1::Shape::NResize))
+                        } else if pos.y >= ws.y - 5.0 {
+                            Some((xdg_toplevel::ResizeEdge::Bottom, wp_cursor_shape_device_v1::Shape::SResize))
+                        } else {
+                            None
+                        };
+                        if let Some((resize_edge, cursor_shape)) = edge {
+                            state.last_resize_edge = Some(resize_edge);
+                            if let (Some(cursor_dev), Some(serial)) =
+                                (state.cursor_shape.as_ref(), state.pointer_serial)
+                            {
+                                cursor_dev.set_shape(serial, cursor_shape);
+                            }
+                        } else {
+                            if state.last_resize_edge.is_some() {
+                                if let (Some(cursor_dev), Some(serial)) =
+                                    (state.cursor_shape.as_ref(), state.pointer_serial)
+                                {
+                                    cursor_dev.set_shape(serial, wp_cursor_shape_device_v1::Shape::Default);
+                                }
+                            }
+                            state.last_resize_edge = None;
+                        }
+                    }
+
                     state.do_callback(XlibEvent::MouseMove(MouseMoveEvent {
                         abs: pos,
                         window_id: window_id,
@@ -793,6 +847,20 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandState {
                         match key_state {
                             WEnum::Value(ButtonState::Pressed) => {
                                 if btn == MouseButton::PRIMARY {
+                                    // Edge resize takes priority
+                                    if let Some(resize_edge) = state.last_resize_edge.take() {
+                                        if let (Some(seat), Some(window)) = (
+                                            state.seat.as_ref(),
+                                            state
+                                                .windows
+                                                .iter()
+                                                .find(|win| win.window_id == window_id),
+                                        ) {
+                                            window.toplevel.resize(seat, serial, resize_edge);
+                                            return;
+                                        }
+                                    }
+
                                     let response =
                                         Rc::new(Cell::new(WindowDragQueryResponse::NoAnswer));
                                     state.do_callback(XlibEvent::WindowDragQuery(
@@ -849,13 +917,52 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandState {
                     }
                 }
             }
-            wl_pointer::Event::Axis { time, axis, value } => {}
-            wl_pointer::Event::Frame => {}
-            wl_pointer::Event::AxisSource { axis_source } => {}
-            wl_pointer::Event::AxisStop { time, axis } => {}
-            wl_pointer::Event::AxisDiscrete { axis, discrete } => {}
-            wl_pointer::Event::AxisValue120 { axis, value120 } => {}
-            wl_pointer::Event::AxisRelativeDirection { axis, direction } => {}
+            wl_pointer::Event::Axis { time: _, axis, value } => {
+                match axis {
+                    WEnum::Value(wl_pointer::Axis::VerticalScroll) => {
+                        state.scroll_accumulator.y += value;
+                    }
+                    WEnum::Value(wl_pointer::Axis::HorizontalScroll) => {
+                        state.scroll_accumulator.x += value;
+                    }
+                    _ => {}
+                }
+            }
+            wl_pointer::Event::AxisSource { axis_source } => {
+                state.scroll_is_wheel = axis_source == WEnum::Value(wl_pointer::AxisSource::Wheel);
+            }
+            wl_pointer::Event::Frame => {
+                let acc = state.scroll_accumulator;
+                if acc.x != 0.0 || acc.y != 0.0 {
+                    if let Some(window_id) = state.current_window {
+                        let time_now = state.time_now();
+                        let scroll = if state.scroll_is_wheel {
+                            let last = state.last_scroll_time;
+                            state.last_scroll_time = time_now;
+                            let speed = 1200.0 * (0.2 - 2.0 * (time_now - last)).max(0.01);
+                            dvec2(acc.x.signum() * speed, acc.y.signum() * speed)
+                        } else {
+                            acc
+                        };
+                        state.do_callback(XlibEvent::Scroll(ScrollEvent {
+                            window_id,
+                            scroll,
+                            abs: state.last_mouse_pos,
+                            modifiers: state.modifiers,
+                            is_mouse: state.scroll_is_wheel,
+                            handled_x: Cell::new(false),
+                            handled_y: Cell::new(false),
+                            time: time_now,
+                        }));
+                    }
+                }
+                state.scroll_accumulator = dvec2(0.0, 0.0);
+                state.scroll_is_wheel = false;
+            }
+            wl_pointer::Event::AxisStop { time: _, axis: _ } => {}
+            wl_pointer::Event::AxisDiscrete { axis: _, discrete: _ } => {}
+            wl_pointer::Event::AxisValue120 { axis: _, value120: _ } => {}
+            wl_pointer::Event::AxisRelativeDirection { axis: _, direction: _ } => {}
             _ => {}
         }
     }

--- a/platform/src/os/linux/web_socket.rs
+++ b/platform/src/os/linux/web_socket.rs
@@ -45,8 +45,8 @@ impl OsWebSocket {
     ) -> OsWebSocket {
         let split = request.split_url();
         let is_tls = match split.proto {
-            "ws" => false,
-            "wss" => true,
+            "ws" | "http" => false,
+            "wss" | "https" => true,
             _ => {
                 let _ = rx_sender.send(WebSocketMessage::Error(format!(
                     "unsupported websocket scheme: {}",

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -278,6 +278,7 @@ impl X11Cx {
                     if SignalToUI::check_and_clear_action_signal() {
                         cx.handle_action_receiver();
                     }
+                    cx.poll_control_channel();
                     cx.handle_networking_events();
                 } else {
                     cx.handle_script_timer(&e);

--- a/platform/src/os/linux/x11/linux_x11_stdin.rs
+++ b/platform/src/os/linux/x11/linux_x11_stdin.rs
@@ -3,9 +3,8 @@ use {
         cx::Cx,
         cx_api::CxOsOp,
         draw_pass::{CxDrawPassColorTexture, CxDrawPassParent, DrawPassClearColor},
-        event::{Event, TextClipboardEvent, WindowGeom},
+        event::{Event, WindowGeom, WindowGeomChangeEvent},
         gl_sys,
-        makepad_live_id::*,
         makepad_math::*,
         makepad_micro_serde::*,
         os::shared_framebuf::{
@@ -19,7 +18,6 @@ use {
         window::CxWindowPool,
         CxOsApi,
     },
-    std::{cell::RefCell, rc::Rc},
 };
 
 #[derive(Default)]
@@ -245,52 +243,20 @@ impl Cx {
         stdin_windows: &mut Vec<StdinWindow>,
     ) -> bool {
         match msg {
-            StudioToApp::KeyDown(e) => {
-                self.call_event_handler(&Event::KeyDown(e));
-            }
-            StudioToApp::KeyUp(e) => {
-                self.call_event_handler(&Event::KeyUp(e));
-            }
-            StudioToApp::TextInput(e) => {
-                self.call_event_handler(&Event::TextInput(e));
-            }
-            StudioToApp::TextCopy => {
-                let response = Rc::new(RefCell::new(None));
-                self.call_event_handler(&Event::TextCopy(TextClipboardEvent {
-                    response: response.clone(),
-                }));
-                let text = response.borrow().clone();
-                if let Some(text) = text {
-                    Self::stdin_send_to_host(AppToStudio::SetClipboard(text));
-                }
-            }
-            StudioToApp::TextCut => {
-                let response = Rc::new(RefCell::new(None));
-                self.call_event_handler(&Event::TextCut(TextClipboardEvent {
-                    response: response.clone(),
-                }));
-                let text = response.borrow().clone();
-                if let Some(text) = text {
-                    Self::stdin_send_to_host(AppToStudio::SetClipboard(text));
-                }
-            }
-            StudioToApp::MouseDown(e) => {
-                self.fingers.process_tap_count(dvec2(e.x, e.y), e.time);
+            // Mouse events: resolve window_id from coordinates (stdin mode
+            // supports multiple virtual windows).
+            StudioToApp::MouseDown(ref e) => {
                 let (window_id, pos) = self.windows.window_id_contains(dvec2(e.x, e.y));
-                let mouse_down_event = e.into_event(window_id, pos);
-                self.fingers.mouse_down(mouse_down_event.button, window_id);
-                self.call_event_handler(&Event::MouseDown(mouse_down_event));
+                return self.dispatch_studio_msg(msg, window_id, pos);
             }
-            StudioToApp::MouseMove(e) => {
+            StudioToApp::MouseMove(ref e) => {
                 let (window_id, pos) = if let Some((_, window_id)) = self.fingers.first_mouse_button
                 {
                     (window_id, self.windows[window_id].window_geom.position)
                 } else {
                     self.windows.window_id_contains(dvec2(e.x, e.y))
                 };
-                self.call_event_handler(&Event::MouseMove(e.into_event(window_id, pos)));
-                self.fingers.cycle_hover_area(live_id!(mouse).into());
-                self.fingers.switch_captures();
+                return self.dispatch_studio_msg(msg, window_id, pos);
             }
             StudioToApp::TweakRay(e) => {
                 let (window_id, pos) = self.windows.window_id_contains(dvec2(e.x, e.y));
@@ -298,23 +264,20 @@ impl Cx {
                 let tweak_ray = e.into_event(window_id, pos, dpi_factor);
                 self.call_event_handler(&Event::TweakRay(tweak_ray));
             }
-            StudioToApp::MouseUp(e) => {
+            StudioToApp::MouseUp(ref e) => {
                 let (window_id, pos) = if let Some((_, window_id)) = self.fingers.first_mouse_button
                 {
                     (window_id, self.windows[window_id].window_geom.position)
                 } else {
                     self.windows.window_id_contains(dvec2(e.x, e.y))
                 };
-                let mouse_up_event = e.into_event(window_id, pos);
-                let button = mouse_up_event.button;
-                self.call_event_handler(&Event::MouseUp(mouse_up_event));
-                self.fingers.mouse_up(button);
-                self.fingers.cycle_hover_area(live_id!(mouse).into());
+                return self.dispatch_studio_msg(msg, window_id, pos);
             }
-            StudioToApp::Scroll(e) => {
+            StudioToApp::Scroll(ref e) => {
                 let (window_id, pos) = self.windows.window_id_contains(dvec2(e.x, e.y));
-                self.call_event_handler(&Event::Scroll(e.into_event(window_id, pos)));
+                return self.dispatch_studio_msg(msg, window_id, pos);
             }
+            // Stdin-specific: window geometry and swapchain management.
             StudioToApp::WindowGeomChange {
                 dpi_factor,
                 left: _left,
@@ -323,13 +286,24 @@ impl Cx {
                 height,
                 window_id,
             } => {
-                self.windows[CxWindowPool::from_usize(window_id)].window_geom = WindowGeom {
+                let window_id = CxWindowPool::from_usize(window_id);
+                let old_geom = self.windows[window_id].window_geom.clone();
+                let new_geom = WindowGeom {
                     dpi_factor,
                     position: dvec2(0.0, 0.0),
                     inner_size: dvec2(width, height),
                     ..Default::default()
                 };
-                self.redraw_all();
+                self.windows[window_id].window_geom = new_geom.clone();
+                if old_geom.dpi_factor != new_geom.dpi_factor
+                    || old_geom.inner_size != new_geom.inner_size
+                    || old_geom.position != new_geom.position
+                {
+                    self.redraw_all();
+                    self.call_event_handler(&Event::WindowGeomChange(
+                        WindowGeomChangeEvent { window_id, new_geom, old_geom },
+                    ));
+                }
             }
             StudioToApp::Swapchain(new_swapchain) => {
                 let window_id = new_swapchain.window_id;
@@ -485,19 +459,14 @@ impl Cx {
                     }));
                 }
             }
-            StudioToApp::Screenshot(request) => {
-                self.screenshot_requests.push(request);
-            }
-            StudioToApp::WidgetTreeDump(request) => {
-                self.send_studio_widget_tree_dump_response(request.request_id);
-            }
-            StudioToApp::KeepAlive => {}
-            StudioToApp::Kill => {
-                self.call_event_handler(&Event::Shutdown);
-                return true;
-            }
-            other @ (StudioToApp::LiveChange { .. } | StudioToApp::None) => {
-                self.action(other);
+            // All other variants (Key*, Text*, Screenshot, WidgetTreeDump,
+            // Kill, KeepAlive, LiveChange, None) handled by shared dispatch.
+            other => {
+                return self.dispatch_studio_msg(
+                    other,
+                    CxWindowPool::id_zero(),
+                    dvec2(0.0, 0.0),
+                );
             }
         }
         false

--- a/platform/src/os/linux/x11/opengl_x11.rs
+++ b/platform/src/os/linux/x11/opengl_x11.rs
@@ -175,14 +175,10 @@ impl Cx {
             );
             return;
         }
-        let row_len = width as usize * 4;
-        let mut flipped = vec![0u8; expected_len];
-        for y in 0..height as usize {
-            let src = y * row_len;
-            let dst = (height as usize - 1 - y) * row_len;
-            flipped[dst..dst + row_len].copy_from_slice(&pixels[src..src + row_len]);
-        }
-
+        // Upload pixels without row-flip.  OpenGL FBO content has
+        // bottom-left origin; the RunView shader flips Y when sampling
+        // (via the y_flip instance), keeping both the DMA-buf and
+        // software-fallback paths consistent.
         let opengl_cx = self.os.opengl_cx.as_ref().unwrap();
         opengl_cx.make_current();
 
@@ -205,7 +201,7 @@ impl Cx {
                 height as i32,
                 gl_sys::RGBA,
                 gl_sys::UNSIGNED_BYTE,
-                flipped.as_ptr() as *const c_void,
+                pixels.as_ptr() as *const c_void,
             );
             (gl.glBindTexture)(gl_sys::TEXTURE_2D, 0);
         }

--- a/platform/src/os/windows/windows_stdin.rs
+++ b/platform/src/os/windows/windows_stdin.rs
@@ -4,8 +4,7 @@ use {
         cx_api::CxOsOp,
         draw_pass::CxDrawPassParent,
         event::Event,
-        event::{TextClipboardEvent, WindowGeom},
-        makepad_live_id::*,
+        event::WindowGeom,
         makepad_math::*,
         makepad_micro_serde::*,
         os::{
@@ -21,7 +20,7 @@ use {
         windows::Win32::Foundation::HANDLE,
         CxOsApi,
     },
-    std::{cell::RefCell, ffi::c_void, rc::Rc},
+    std::ffi::c_void,
 };
 
 struct LocalPresentableImage {
@@ -182,52 +181,20 @@ impl Cx {
         time: &Win32Time,
     ) -> bool {
         match msg {
-            StudioToApp::KeyDown(e) => {
-                self.call_event_handler(&Event::KeyDown(e));
-            }
-            StudioToApp::KeyUp(e) => {
-                self.call_event_handler(&Event::KeyUp(e));
-            }
-            StudioToApp::TextInput(e) => {
-                self.call_event_handler(&Event::TextInput(e));
-            }
-            StudioToApp::TextCopy => {
-                let response = Rc::new(RefCell::new(None));
-                self.call_event_handler(&Event::TextCopy(TextClipboardEvent {
-                    response: response.clone(),
-                }));
-                let text = response.borrow().clone();
-                if let Some(text) = text {
-                    Self::stdin_send_to_host(AppToStudio::SetClipboard(text));
-                }
-            }
-            StudioToApp::TextCut => {
-                let response = Rc::new(RefCell::new(None));
-                self.call_event_handler(&Event::TextCut(TextClipboardEvent {
-                    response: response.clone(),
-                }));
-                let text = response.borrow().clone();
-                if let Some(text) = text {
-                    Self::stdin_send_to_host(AppToStudio::SetClipboard(text));
-                }
-            }
-            StudioToApp::MouseDown(e) => {
-                self.fingers.process_tap_count(dvec2(e.x, e.y), e.time);
+            // Mouse events: resolve window_id from coordinates (stdin mode
+            // supports multiple virtual windows).
+            StudioToApp::MouseDown(ref e) => {
                 let (window_id, pos) = self.windows.window_id_contains(dvec2(e.x, e.y));
-                let mouse_down_event = e.into_event(window_id, pos);
-                self.fingers.mouse_down(mouse_down_event.button, window_id);
-                self.call_event_handler(&Event::MouseDown(mouse_down_event));
+                return self.dispatch_studio_msg(msg, window_id, pos);
             }
-            StudioToApp::MouseMove(e) => {
+            StudioToApp::MouseMove(ref e) => {
                 let (window_id, pos) = if let Some((_, window_id)) = self.fingers.first_mouse_button
                 {
                     (window_id, self.windows[window_id].window_geom.position)
                 } else {
                     self.windows.window_id_contains(dvec2(e.x, e.y))
                 };
-                self.call_event_handler(&Event::MouseMove(e.into_event(window_id, pos)));
-                self.fingers.cycle_hover_area(live_id!(mouse).into());
-                self.fingers.switch_captures();
+                return self.dispatch_studio_msg(msg, window_id, pos);
             }
             StudioToApp::TweakRay(e) => {
                 let (window_id, pos) = self.windows.window_id_contains(dvec2(e.x, e.y));
@@ -235,23 +202,20 @@ impl Cx {
                 let tweak_ray = e.into_event(window_id, pos, dpi_factor);
                 self.call_event_handler(&Event::TweakRay(tweak_ray));
             }
-            StudioToApp::MouseUp(e) => {
+            StudioToApp::MouseUp(ref e) => {
                 let (window_id, pos) = if let Some((_, window_id)) = self.fingers.first_mouse_button
                 {
                     (window_id, self.windows[window_id].window_geom.position)
                 } else {
                     self.windows.window_id_contains(dvec2(e.x, e.y))
                 };
-                let mouse_up_event = e.into_event(window_id, pos);
-                let button = mouse_up_event.button;
-                self.call_event_handler(&Event::MouseUp(mouse_up_event));
-                self.fingers.mouse_up(button);
-                self.fingers.cycle_hover_area(live_id!(mouse).into());
+                return self.dispatch_studio_msg(msg, window_id, pos);
             }
-            StudioToApp::Scroll(e) => {
+            StudioToApp::Scroll(ref e) => {
                 let (window_id, pos) = self.windows.window_id_contains(dvec2(e.x, e.y));
-                self.call_event_handler(&Event::Scroll(e.into_event(window_id, pos)));
+                return self.dispatch_studio_msg(msg, window_id, pos);
             }
+            // Stdin-specific: window geometry and swapchain management.
             StudioToApp::WindowGeomChange {
                 dpi_factor,
                 left: _left,
@@ -350,19 +314,14 @@ impl Cx {
                     }
                 }
             }
-            StudioToApp::Screenshot(request) => {
-                self.screenshot_requests.push(request);
-            }
-            StudioToApp::WidgetTreeDump(request) => {
-                self.send_studio_widget_tree_dump_response(request.request_id);
-            }
-            StudioToApp::KeepAlive => {}
-            StudioToApp::Kill => {
-                self.call_event_handler(&Event::Shutdown);
-                return true;
-            }
-            other @ (StudioToApp::LiveChange { .. } | StudioToApp::None) => {
-                self.action(other);
+            // All other variants (Key*, Text*, Screenshot, WidgetTreeDump,
+            // Kill, KeepAlive, LiveChange, None) handled by shared dispatch.
+            other => {
+                return self.dispatch_studio_msg(
+                    other,
+                    CxWindowPool::id_zero(),
+                    dvec2(0.0, 0.0),
+                );
             }
         }
         false

--- a/platform/src/web_socket.rs
+++ b/platform/src/web_socket.rs
@@ -59,7 +59,10 @@ pub(crate) static WEB_SOCKET_THREAD_SENDER: Mutex<Option<Sender<WebSocketThreadM
     Mutex::new(None);
 pub(crate) static WEB_SOCKET_ID: AtomicU64 = AtomicU64::new(0);
 pub(crate) static HAS_STUDIO_WEB_SOCKET: AtomicBool = AtomicBool::new(false);
+pub(crate) static STUDIO_STDOUT_MODE: AtomicBool = AtomicBool::new(false);
 pub(crate) static LOCAL_PROFILE_CAPTURE_ENABLED: AtomicBool = AtomicBool::new(false);
+pub(crate) static CONTROL_CHANNEL: Mutex<Option<Receiver<crate::studio::StudioToApp>>> =
+    Mutex::new(None);
 pub(crate) static LOCAL_PROFILE_SAMPLES: Mutex<Vec<LocalProfileSample>> = Mutex::new(Vec::new());
 const LOCAL_PROFILE_SAMPLE_BUFFER_LIMIT: usize = 16_384;
 
@@ -71,6 +74,23 @@ impl Drop for WebSocket {
 impl Cx {
     pub fn has_studio_web_socket() -> bool {
         HAS_STUDIO_WEB_SOCKET.load(Ordering::SeqCst)
+    }
+
+    /// Enable stdout mode for studio messages. When enabled,
+    /// `send_studio_message` writes JSON lines to stdout instead of
+    /// the websocket. Also sets `HAS_STUDIO_WEB_SOCKET` so that
+    /// internal code paths (screenshots, widget dumps, event profiling)
+    /// remain active.
+    pub fn set_studio_stdout_mode(enabled: bool) {
+        STUDIO_STDOUT_MODE.store(enabled, Ordering::SeqCst);
+        HAS_STUDIO_WEB_SOCKET.store(enabled, Ordering::SeqCst);
+    }
+
+    /// Set a control channel for receiving StudioToApp messages.
+    /// Messages are polled by the event loop and dispatched as events.
+    /// The sender should call `SignalToUI::set_ui_signal()` after sending.
+    pub fn set_control_channel(rx: Receiver<crate::studio::StudioToApp>) {
+        *CONTROL_CHANNEL.lock().unwrap() = Some(rx);
     }
 
     pub fn local_profile_capture_enabled() -> bool {
@@ -305,6 +325,12 @@ impl Cx {
 
     pub fn send_studio_message(msg: AppToStudio) {
         Self::capture_local_profile_sample(&msg);
+        if STUDIO_STDOUT_MODE.load(Ordering::SeqCst) {
+            use std::io::Write;
+            let _ = std::io::stdout().write_all(msg.to_json().as_bytes());
+            let _ = std::io::stdout().flush();
+            return;
+        }
         if !Cx::has_studio_web_socket() {
             return;
         }

--- a/studio/src/build_manager/build_client.rs
+++ b/studio/src/build_manager/build_client.rs
@@ -32,7 +32,9 @@ pub struct BuildClient {
 impl BuildClient {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn send_cmd_with_id(&self, cmd_id: LiveId, cmd: BuildCmd) {
-        self.cmd_sender.send(BuildCmdWrap { cmd_id, cmd }).unwrap();
+        if let Err(err) = self.cmd_sender.send(BuildCmdWrap { cmd_id, cmd }) {
+            crate::log!("build server channel closed, dropping command: {:?}", err.0.cmd);
+        }
     }
 
     #[cfg(target_arch = "wasm32")]

--- a/studio/src/build_manager/build_server.rs
+++ b/studio/src/build_manager/build_server.rs
@@ -154,8 +154,17 @@ impl BuildConnection {
         }
 
         let env: Vec<(String, String)> = env.into_iter().collect();
-        let process = ChildProcess::start("cargo", &args, path.to_path_buf(), &env, is_in_studio)
-            .expect("Cannot start process");
+        let mut process = match ChildProcess::start("cargo", &args, path.to_path_buf(), &env, is_in_studio) {
+            Ok(p) => p,
+            Err(err) => {
+                msg_sender.send_bare_message(
+                    cmd_id,
+                    LogLevel::Error,
+                    format!("Cannot start process: {err}"),
+                );
+                return;
+            }
+        };
 
         shared.write().unwrap().processes.insert(
             cmd_id,
@@ -165,21 +174,9 @@ impl BuildConnection {
             },
         );
 
-        // HACK(eddyb) do this first, as there is no way to actually send the
-        // initial swapchain to the client at all, unless we have this first
-        // (thankfully sending this before we ever read from the client means
-        // it will definitely arrive before C->H ReadyToStart triggers anything)
-        if is_in_studio {
-            msg_sender.send_message(BuildClientMessageWrap {
-                cmd_id,
-                message: BuildClientMessage::AuxChanHostEndpointCreated(
-                    process.aux_chan_host_endpoint.clone().unwrap(),
-                ),
-            });
-        }
-
         // let mut stderr_state = StdErrState::First;
         //let stdin_sender = process.stdin_sender.clone();
+        let mut aux_chan_listener = process.aux_chan_listener.take();
         std::thread::spawn(move || {
             // lets create a BuildProcess and run it
             while let Ok(line) = process.line_receiver.recv() {
@@ -212,7 +209,29 @@ impl BuildConnection {
                     }
                     ChildStdIO::StdErr(line) => {
                         if line.trim().starts_with("Running ") {
-                            msg_sender.send_bare_message(cmd_id, LogLevel::Wait, line);
+                            msg_sender.send_bare_message(cmd_id, LogLevel::Wait, line.clone());
+                            // Accept aux channel here, after cargo finishes
+                            // compiling and the binary starts. Accepting at
+                            // spawn time would hit the 10s timeout in
+                            // accept_host_endpoint for any build longer than
+                            // that.
+                            if let Some(listener) = aux_chan_listener.take() {
+                                match listener.accept_host_endpoint() {
+                                    Ok(endpoint) => {
+                                        msg_sender.send_message(BuildClientMessageWrap {
+                                            cmd_id,
+                                            message: BuildClientMessage::AuxChanHostEndpointCreated(endpoint),
+                                        });
+                                    }
+                                    Err(err) => {
+                                        msg_sender.send_bare_message(
+                                            cmd_id,
+                                            LogLevel::Error,
+                                            format!("aux-channel connect failed: {err}"),
+                                        );
+                                    }
+                                }
+                            }
                         } else if line.trim().starts_with("Compiling ") {
                             msg_sender.send_bare_message(cmd_id, LogLevel::Wait, line);
                         } else if line

--- a/studio/src/build_manager/child_process.rs
+++ b/studio/src/build_manager/child_process.rs
@@ -16,7 +16,7 @@ pub struct ChildProcess {
     pub stdin_sender: Sender<ChildStdIn>,
     pub line_sender: Sender<ChildStdIO>,
     pub line_receiver: Receiver<ChildStdIO>,
-    pub aux_chan_host_endpoint: Option<aux_chan::HostEndpoint>,
+    pub aux_chan_listener: Option<aux_chan::ExternalEndpointListener>,
 }
 
 pub enum ChildStdIO {
@@ -39,7 +39,7 @@ impl ChildProcess {
         env: &[(String, String)],
         aux_chan: bool,
     ) -> Result<ChildProcess, std::io::Error> {
-        let (mut child, aux_chan_host_endpoint) = if aux_chan {
+        let (mut child, aux_chan_listener) = if aux_chan {
             let studio_addr = env
                 .iter()
                 .find_map(|(key, value)| if key == "STUDIO" { Some(value.clone()) } else { None })
@@ -82,16 +82,8 @@ impl ChildProcess {
             }
 
             prepare_child_process_stdio_isolation(&mut cmd_build);
-            let mut child = cmd_build.spawn()?;
-            let aux_chan_host_endpoint = match aux_chan_listener.accept_host_endpoint() {
-                Ok(endpoint) => endpoint,
-                Err(err) => {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return Err(err);
-                }
-            };
-            (child, Some(aux_chan_host_endpoint))
+            let child = cmd_build.spawn()?;
+            (child, Some(aux_chan_listener))
         } else {
             let mut cmd_build = Command::new(cmd);
             cmd_build
@@ -180,7 +172,7 @@ impl ChildProcess {
             line_sender,
             child,
             line_receiver,
-            aux_chan_host_endpoint,
+            aux_chan_listener,
         })
     }
 

--- a/studio/src/run_view.rs
+++ b/studio/src/run_view.rs
@@ -20,13 +20,15 @@ script_mod! {
             started: instance(0.0)
             tex_scale: instance(vec2(0.0, 0.0))
             tex_size: instance(vec2(0.0, 0.0))
+            y_flip: instance(0.0)
             pixel: fn() {
                 let tp1 = self.tex.sample(vec2(0.5/self.tex_size.x,0.5/self.tex_size.y))
                 let tp2 = self.tex.sample(vec2(1.5/self.tex_size.x,0.5/self.tex_size.y))
                 let tp = vec2(tp1.r*65280.0 + tp1.b*255.0,tp2.r*65280.0 + tp2.b*255.0)
                 let counter = (self.rect_size * self.draw_pass.dpi_factor) / tp
                 let tex_scale = tp / self.tex_size
-                let fb = self.tex.sample(self.pos * tex_scale * counter)
+                let uv = vec2(self.pos.x, self.pos.y + self.y_flip - 2.0 * self.y_flip * self.pos.y)
+                let fb = self.tex.sample(uv * tex_scale * counter)
                 if fb.r == 1.0 && fb.g == 0.0 && fb.b == 1.0 {
                     return #2
                 }
@@ -204,6 +206,10 @@ impl RunView {
                         (swapchain.alloc_width as f32),
                         (swapchain.alloc_height as f32),
                     ],
+                );
+                #[cfg(target_os = "linux")]
+                self.draw_app.draw_vars.set_dyn_instance(
+                    cx, id!(y_flip), &[1.0f32],
                 );
 
                 if !self.started {

--- a/widgets/src/label.rs
+++ b/widgets/src/label.rs
@@ -217,12 +217,12 @@ pub struct Label {
     uid: WidgetUid,
     #[redraw]
     #[live]
-    draw_text: DrawText,
+    pub draw_text: DrawText,
 
     #[walk]
-    walk: Walk,
+    pub walk: Walk,
     #[live]
-    align: Align,
+    pub align: Align,
     #[live(Flow::right_wrap())]
     flow: Flow,
     #[live]

--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -70,7 +70,7 @@ pub struct View {
     #[uid]
     uid: WidgetUid,
     #[source]
-    source: ScriptObjectRef,
+    pub source: ScriptObjectRef,
     // draw info per UI element
     #[live]
     pub draw_bg: DrawQuad,
@@ -109,7 +109,7 @@ pub struct View {
     #[live(false)]
     block_signal_event: bool,
     #[live]
-    cursor: Option<MouseCursor>,
+    pub cursor: Option<MouseCursor>,
     #[live(false)]
     capture_overload: bool,
     #[live]


### PR DESCRIPTION
Linux and platform improvements:

- **wayland**: edge-resize, scroll events (wheel/touchpad distinction), wl_seat v5 binding, time-based scroll acceleration for discrete wheel
- **stdin bugfix**: route all StudioToApp variants through stdin_handle_host_to_stdin — fixes dead match arms where Screenshot, WidgetTreeDump, Kill were unreachable (linux + windows)
- **widgets**: expose Label and View fields for external composition
- **platform**: stdin/stdout control channel for windowed apps — lets windowed apps receive StudioToApp messages via a channel and emit AppToStudio on stdout. Includes GL readback for windowed-mode screenshots.
- **unified dispatch**: extract shared dispatch_studio_msg() in cx_shared.rs so both stdin mode and the control channel use the same StudioToApp handler. Eliminates ~130 lines of duplicated dispatch logic. Control channel polling now hooked into all backends (X11, Wayland, macOS).
- **atan2 fix**: map atan2 to atan in GLSL shader backend
- **WindowGeomChange**: stdin emits WindowGeomChange event on geometry updates
- **aux-channel**: defer aux-channel accept until after build finishes — prevents race where Studio connects before the app is ready
- **Y-flip fix**: fix RunView Y-flip on Linux by flipping in shader instead of CPU readback
- **Studio crash fix**: fix Studio crash on child process failure