### PR TITLE
Add HideWindowButtons/ShowWindowButtons platform op

### DIFF
--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -81,6 +81,8 @@ pub enum CxOsOp {
     NormalizeWindow(WindowId),
     RestoreWindow(WindowId),
     HideWindow(WindowId),
+    HideWindowButtons(WindowId),
+    ShowWindowButtons(WindowId),
     SetTopmost(WindowId, bool),
     ShowInDock(bool),
 
@@ -173,6 +175,8 @@ impl std::fmt::Debug for CxOsOp {
             Self::NormalizeWindow(..) => write!(f, "NormalizeWindow"),
             Self::RestoreWindow(..) => write!(f, "RestoreWindow"),
             Self::HideWindow(..) => write!(f, "HideWindow"),
+            Self::HideWindowButtons(..) => write!(f, "HideWindowButtons"),
+            Self::ShowWindowButtons(..) => write!(f, "ShowWindowButtons"),
             Self::SetTopmost(..) => write!(f, "SetTopmost"),
             Self::ShowInDock(..) => write!(f, "ShowInDock"),
 

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -630,6 +630,20 @@ impl Cx {
                         metal_window.cocoa_window.hide();
                     }
                 }
+                CxOsOp::HideWindowButtons(window_id) => {
+                    if let Some(metal_window) =
+                        metal_windows.iter_mut().find(|w| w.window_id == window_id)
+                    {
+                        metal_window.cocoa_window.set_window_buttons_visible(false);
+                    }
+                }
+                CxOsOp::ShowWindowButtons(window_id) => {
+                    if let Some(metal_window) =
+                        metal_windows.iter_mut().find(|w| w.window_id == window_id)
+                    {
+                        metal_window.cocoa_window.set_window_buttons_visible(true);
+                    }
+                }
                 CxOsOp::ShowTextIME(area, pos, _config) => {
                     let pos = area.clipped_rect(self).pos + pos;
                     metal_windows.iter_mut().for_each(|w| {

--- a/platform/src/os/apple/macos/macos_window.rs
+++ b/platform/src/os/apple/macos/macos_window.rs
@@ -221,6 +221,18 @@ impl MacosWindow {
         }
     }
 
+    pub fn set_window_buttons_visible(&mut self, visible: bool) {
+        unsafe {
+            let close: ObjcId = msg_send![self.window, standardWindowButton: 0u64];
+            let miniaturize: ObjcId = msg_send![self.window, standardWindowButton: 1u64];
+            let zoom: ObjcId = msg_send![self.window, standardWindowButton: 2u64];
+            let hidden = if visible { NO } else { YES };
+            let () = msg_send![close, setHidden: hidden];
+            let () = msg_send![miniaturize, setHidden: hidden];
+            let () = msg_send![zoom, setHidden: hidden];
+        }
+    }
+
     pub fn time_now(&self) -> f64 {
         with_macos_app(|app| app.time_now())
     }

--- a/platform/src/os/linux/wayland/linux_wayland.rs
+++ b/platform/src/os/linux/wayland/linux_wayland.rs
@@ -364,6 +364,8 @@ impl WaylandCx {
                 }
                 CxOsOp::Deminiaturize(_window_id) => todo!(),
                 CxOsOp::HideWindow(_window_id) => todo!(),
+                CxOsOp::HideWindowButtons(_) => {},
+                CxOsOp::ShowWindowButtons(_) => {},
                 CxOsOp::MaximizeWindow(window_id) => {
                     if let Some(window) = state.windows.iter().find(|w| w.window_id == window_id) {
                         window.toplevel.set_maximized();

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -393,6 +393,8 @@ impl X11Cx {
                 }
                 CxOsOp::Deminiaturize(_window_id) => todo!(),
                 CxOsOp::HideWindow(_window_id) => todo!(),
+                CxOsOp::HideWindowButtons(_) => {},
+                CxOsOp::ShowWindowButtons(_) => {},
                 CxOsOp::MaximizeWindow(window_id) => {
                     if let Some(window) =
                         opengl_windows.iter_mut().find(|w| w.window_id == window_id)

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -366,6 +366,8 @@ impl Cx {
                 }
                 CxOsOp::Deminiaturize(_window_id) => todo!(),
                 CxOsOp::HideWindow(_window_id) => todo!(),
+                CxOsOp::HideWindowButtons(_) => {},
+                CxOsOp::ShowWindowButtons(_) => {},
                 CxOsOp::MaximizeWindow(window_id) => {
                     if let Some(window) =
                         d3d11_windows.iter_mut().find(|w| w.window_id == window_id)


### PR DESCRIPTION
Add platform operations to hide and show the standard macOS window buttons (close, miniaturize, zoom). Useful for apps that provide their own window controls.

**macOS**: Calls `setHidden:` on `standardWindowButton:` for close, miniaturize, and zoom buttons.

**Linux/Windows**: No-op (no equivalent native window buttons to hide).