### PR TITLE
widgets: expose Label and View fields for external composition

### DIFF
--- a/widgets/src/label.rs
+++ b/widgets/src/label.rs
@@ -217,12 +217,12 @@ pub struct Label {
     uid: WidgetUid,
     #[redraw]
     #[live]
-    draw_text: DrawText,
+    pub draw_text: DrawText,
 
     #[walk]
-    walk: Walk,
+    pub walk: Walk,
     #[live]
-    align: Align,
+    pub align: Align,
     #[live(Flow::right_wrap())]
     flow: Flow,
     #[live]

--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -70,7 +70,7 @@ pub struct View {
     #[uid]
     uid: WidgetUid,
     #[source]
-    source: ScriptObjectRef,
+    pub source: ScriptObjectRef,
     // draw info per UI element
     #[live]
     pub draw_bg: DrawQuad,
@@ -109,7 +109,7 @@ pub struct View {
     #[live(false)]
     block_signal_event: bool,
     #[live]
-    cursor: Option<MouseCursor>,
+    pub cursor: Option<MouseCursor>,
     #[live(false)]
     capture_overload: bool,
     #[live]


### PR DESCRIPTION
Single commit. Makes Label text and View fields pub for external widget composition.

Cherry-picked onto current dev, compiles independently.