### PR TITLE
fix: map atan2 to atan in GLSL shader backend

### DIFF
--- a/platform/script/src/shader_backend.rs
+++ b/platform/script/src/shader_backend.rs
@@ -1144,6 +1144,7 @@ impl ShaderBackend {
                     // GLSL uses dFdx/dFdy natively, mod is native
                     id!(inverseSqrt) => id!(inversesqrt),
                     id!(modf) => id!(mod),
+                    id!(atan2) => id!(atan),
                     x => x,
                 }
             }


### PR DESCRIPTION
Single commit. GLSL uses atan(y,x) instead of atan2(y,x). Adds the mapping in shader_backend.rs.

Cherry-picked onto current dev, compiles independently.