### PR TITLE
fix Studio crash on child process failure

### DIFF
--- a/studio/src/build_manager/build_client.rs
+++ b/studio/src/build_manager/build_client.rs
@@ -32,7 +32,9 @@ pub struct BuildClient {
 impl BuildClient {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn send_cmd_with_id(&self, cmd_id: LiveId, cmd: BuildCmd) {
-        self.cmd_sender.send(BuildCmdWrap { cmd_id, cmd }).unwrap();
+        if let Err(err) = self.cmd_sender.send(BuildCmdWrap { cmd_id, cmd }) {
+            crate::log!("build server channel closed, dropping command: {:?}", err.0.cmd);
+        }
     }
 
     #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
Single commit. Fixes a panic in build_client.rs when a child process fails during startup.

Cherry-picked onto current dev, compiles independently.