### PR TITLE
defer aux-channel accept until binary starts running

### DIFF
--- a/studio/src/build_manager/build_server.rs
+++ b/studio/src/build_manager/build_server.rs
@@ -154,8 +154,17 @@ impl BuildConnection {
         }
 
         let env: Vec<(String, String)> = env.into_iter().collect();
-        let process = ChildProcess::start("cargo", &args, path.to_path_buf(), &env, is_in_studio)
-            .expect("Cannot start process");
+        let mut process = match ChildProcess::start("cargo", &args, path.to_path_buf(), &env, is_in_studio) {
+            Ok(p) => p,
+            Err(err) => {
+                msg_sender.send_bare_message(
+                    cmd_id,
+                    LogLevel::Error,
+                    format!("Cannot start process: {err}"),
+                );
+                return;
+            }
+        };
 
         shared.write().unwrap().processes.insert(
             cmd_id,
@@ -165,21 +174,9 @@ impl BuildConnection {
             },
         );
 
-        // HACK(eddyb) do this first, as there is no way to actually send the
-        // initial swapchain to the client at all, unless we have this first
-        // (thankfully sending this before we ever read from the client means
-        // it will definitely arrive before C->H ReadyToStart triggers anything)
-        if is_in_studio {
-            msg_sender.send_message(BuildClientMessageWrap {
-                cmd_id,
-                message: BuildClientMessage::AuxChanHostEndpointCreated(
-                    process.aux_chan_host_endpoint.clone().unwrap(),
-                ),
-            });
-        }
-
         // let mut stderr_state = StdErrState::First;
         //let stdin_sender = process.stdin_sender.clone();
+        let mut aux_chan_listener = process.aux_chan_listener.take();
         std::thread::spawn(move || {
             // lets create a BuildProcess and run it
             while let Ok(line) = process.line_receiver.recv() {
@@ -212,7 +209,29 @@ impl BuildConnection {
                     }
                     ChildStdIO::StdErr(line) => {
                         if line.trim().starts_with("Running ") {
-                            msg_sender.send_bare_message(cmd_id, LogLevel::Wait, line);
+                            msg_sender.send_bare_message(cmd_id, LogLevel::Wait, line.clone());
+                            // Accept aux channel here, after cargo finishes
+                            // compiling and the binary starts. Accepting at
+                            // spawn time would hit the 10s timeout in
+                            // accept_host_endpoint for any build longer than
+                            // that.
+                            if let Some(listener) = aux_chan_listener.take() {
+                                match listener.accept_host_endpoint() {
+                                    Ok(endpoint) => {
+                                        msg_sender.send_message(BuildClientMessageWrap {
+                                            cmd_id,
+                                            message: BuildClientMessage::AuxChanHostEndpointCreated(endpoint),
+                                        });
+                                    }
+                                    Err(err) => {
+                                        msg_sender.send_bare_message(
+                                            cmd_id,
+                                            LogLevel::Error,
+                                            format!("aux-channel connect failed: {err}"),
+                                        );
+                                    }
+                                }
+                            }
                         } else if line.trim().starts_with("Compiling ") {
                             msg_sender.send_bare_message(cmd_id, LogLevel::Wait, line);
                         } else if line

--- a/studio/src/build_manager/child_process.rs
+++ b/studio/src/build_manager/child_process.rs
@@ -16,7 +16,7 @@ pub struct ChildProcess {
     pub stdin_sender: Sender<ChildStdIn>,
     pub line_sender: Sender<ChildStdIO>,
     pub line_receiver: Receiver<ChildStdIO>,
-    pub aux_chan_host_endpoint: Option<aux_chan::HostEndpoint>,
+    pub aux_chan_listener: Option<aux_chan::ExternalEndpointListener>,
 }
 
 pub enum ChildStdIO {
@@ -39,7 +39,7 @@ impl ChildProcess {
         env: &[(String, String)],
         aux_chan: bool,
     ) -> Result<ChildProcess, std::io::Error> {
-        let (mut child, aux_chan_host_endpoint) = if aux_chan {
+        let (mut child, aux_chan_listener) = if aux_chan {
             let studio_addr = env
                 .iter()
                 .find_map(|(key, value)| if key == "STUDIO" { Some(value.clone()) } else { None })
@@ -82,16 +82,8 @@ impl ChildProcess {
             }
 
             prepare_child_process_stdio_isolation(&mut cmd_build);
-            let mut child = cmd_build.spawn()?;
-            let aux_chan_host_endpoint = match aux_chan_listener.accept_host_endpoint() {
-                Ok(endpoint) => endpoint,
-                Err(err) => {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return Err(err);
-                }
-            };
-            (child, Some(aux_chan_host_endpoint))
+            let child = cmd_build.spawn()?;
+            (child, Some(aux_chan_listener))
         } else {
             let mut cmd_build = Command::new(cmd);
             cmd_build
@@ -180,7 +172,7 @@ impl ChildProcess {
             line_sender,
             child,
             line_receiver,
-            aux_chan_host_endpoint,
+            aux_chan_listener,
         })
     }
 


### PR DESCRIPTION
Single commit. Moves aux-channel host endpoint acceptance in build_server/child_process to after the binary is confirmed running, avoiding races on startup.

Cherry-picked onto current dev, compiles independently.