### PR TITLE
fix(wayland): negate scroll axis values to match internal convention

### DIFF
--- a/platform/src/os/linux/wayland/wayland_state.rs
+++ b/platform/src/os/linux/wayland/wayland_state.rs
@@ -949,16 +949,22 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandState {
                     }
                 }
             }
+            // Wayland axis values use motion-event coordinates: positive
+            // vertical = downward on screen = content slides down = viewport
+            // moves UP. Makepad's internal convention is positive = viewport
+            // moves DOWN (matching X11 button mapping and macOS after its
+            // negation of scrollingDeltaY). Negate to align conventions,
+            // same as winit does for the same reason.
             wl_pointer::Event::Axis {
                 time: _,
                 axis,
                 value,
             } => match axis {
                 WEnum::Value(wl_pointer::Axis::VerticalScroll) => {
-                    state.scroll_accumulator.y += value;
+                    state.scroll_accumulator.y -= value;
                 }
                 WEnum::Value(wl_pointer::Axis::HorizontalScroll) => {
-                    state.scroll_accumulator.x += value;
+                    state.scroll_accumulator.x -= value;
                 }
                 _ => {}
             },


### PR DESCRIPTION
## Problem

Scrolling is reversed on Wayland — scroll wheel and touchpad both move content in the opposite direction from what the user expects.

## Cause

Wayland `wl_pointer::Axis` values use motion-event coordinates: positive vertical = downward on screen = content slides down under the pointer = **viewport moves UP**.

Makepad's internal scroll convention is positive = **viewport moves DOWN**. This matches:
- **X11**: button 4 (scroll up) maps to negative, button 5 (scroll down) maps to positive
- **macOS**: negates `scrollingDeltaY` (positive in macOS = content direction = scroll up, negated to viewport direction)
- **Web**: browser `deltaY` follows the same convention after JS processing

The Wayland backend was passing axis values through without negation, producing reversed scroll on all Wayland sessions.

## Fix

Negate both horizontal and vertical axis values at the accumulator stage, the same approach as macOS (`-dx`, `-dy`) and consistent with how winit handles the same mismatch (explicit comment in their codebase: *"Wayland sign convention is the inverse of winit"*).

## AxisRelativeDirection

The currently-ignored `AxisRelativeDirection` event is unrelated to this bug. It is a compositor hint telling clients whether natural-scrolling inversion was applied to the axis values, intended for specialized widgets (e.g. volume sliders) that should track physical finger direction regardless of scroll preference. The axis values themselves already have natural scrolling applied by the compositor before reaching the client.