### PR TITLE
Add cross-platform GL render bridge for external GL consumers

### DIFF
--- a/platform/src/gl_render_bridge.rs
+++ b/platform/src/gl_render_bridge.rs
@@ -1,0 +1,166 @@
+use std::ffi::c_void;
+
+use crate::cx::Cx;
+use crate::texture::Texture;
+
+/// GL API type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GlApi {
+    /// Desktop OpenGL (macOS).
+    GL,
+    /// OpenGL ES (Linux, Android, Windows via ANGLE).
+    GLES,
+}
+
+/// Cross-platform GL rendering bridge.
+///
+/// Manages a GL context that shares GPU memory with makepad's native renderer.
+/// External code renders via GL; makepad displays the result with zero-copy.
+///
+/// Platform backends:
+/// - Linux/Android: wraps makepad's existing EGL context
+/// - Windows: ANGLE EGL context on makepad's D3D11 device (via libEGL.dll)
+/// - macOS: standalone CGL context bridged to Metal via IOSurface
+pub struct GlRenderBridge {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub(crate) inner: crate::os::linux::opengl::EglRenderBridge,
+    #[cfg(target_os = "windows")]
+    pub(crate) inner: crate::os::windows::angle::AngleRenderBridge,
+    #[cfg(target_os = "macos")]
+    pub(crate) inner: crate::os::apple::metal::CglRenderBridge,
+}
+
+impl GlRenderBridge {
+    /// Make this GL context current on the calling thread.
+    pub fn make_current(&self) {
+        self.inner.make_current()
+    }
+
+    /// Look up a GL/EGL function by name.
+    pub fn get_proc_address(&self, name: &str) -> *const c_void {
+        self.inner.get_proc_address(name)
+    }
+
+    /// GL API type (GL on macOS, GLES on Linux/Android/Windows).
+    pub fn gl_api(&self) -> GlApi {
+        self.inner.gl_api()
+    }
+}
+
+// EGL platform accessors (Linux, Android, Windows)
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
+impl GlRenderBridge {
+    pub fn egl_display(&self) -> *mut c_void {
+        self.inner.egl_display()
+    }
+
+    pub fn egl_config(&self) -> *mut c_void {
+        self.inner.egl_config()
+    }
+
+    pub fn egl_context(&self) -> *mut c_void {
+        self.inner.egl_context()
+    }
+}
+
+// CGL platform accessors (macOS)
+#[cfg(target_os = "macos")]
+impl GlRenderBridge {
+    pub fn cgl_pixel_format(&self) -> *mut c_void {
+        self.inner.cgl_pixel_format()
+    }
+
+    pub fn cgl_context(&self) -> *mut c_void {
+        self.inner.cgl_context()
+    }
+}
+
+// Cx methods: Linux/Android
+#[cfg(any(target_os = "linux", target_os = "android"))]
+impl Cx {
+    /// Create a GL rendering bridge wrapping makepad's existing EGL context.
+    pub fn create_gl_render_bridge(&mut self) -> GlRenderBridge {
+        let opengl_cx = self.os.opengl_cx.as_ref().expect("OpenGL context not initialized");
+        GlRenderBridge {
+            inner: crate::os::linux::opengl::EglRenderBridge::new(opengl_cx),
+        }
+    }
+
+    /// Create a texture renderable via GL and displayable by makepad.
+    /// Returns (Texture handle, GL texture ID).
+    pub fn create_gl_render_bridge_texture(
+        &mut self,
+        _bridge: &GlRenderBridge,
+        width: usize,
+        height: usize,
+    ) -> (Texture, u32) {
+        self.create_gl_render_texture(width, height)
+    }
+
+    /// Restore makepad's own GL context as current.
+    pub fn restore_gl_context(&mut self) {
+        let opengl_cx = self.os.opengl_cx.as_ref().expect("OpenGL context not initialized");
+        opengl_cx.make_current();
+    }
+}
+
+// Cx methods: macOS
+#[cfg(target_os = "macos")]
+impl Cx {
+    /// Create a GL rendering bridge with a standalone CGL context (GL 3.2 Core).
+    pub fn create_gl_render_bridge(&mut self) -> GlRenderBridge {
+        GlRenderBridge {
+            inner: crate::os::apple::metal::CglRenderBridge::new(),
+        }
+    }
+
+    /// Create a texture renderable via GL (CGL) and displayable by makepad (Metal).
+    /// Returns (Texture handle, GL texture ID for rendering into).
+    pub fn create_gl_render_bridge_texture(
+        &mut self,
+        bridge: &GlRenderBridge,
+        width: usize,
+        height: usize,
+    ) -> (Texture, u32) {
+        bridge.inner.make_current();
+        let (texture, iosurface_ref, _iosurface_id) =
+            self.create_iosurface_render_texture(width, height);
+        let gl_texture_id = bridge.inner.bind_iosurface_to_gl_texture(
+            iosurface_ref,
+            width,
+            height,
+        );
+        (texture, gl_texture_id)
+    }
+
+    /// Restore makepad's own rendering context. No-op on macOS (CGL and Metal are independent).
+    pub fn restore_gl_context(&mut self) {}
+}
+
+// Cx methods: Windows
+#[cfg(target_os = "windows")]
+impl Cx {
+    /// Create a GL rendering bridge via ANGLE on makepad's D3D11 device.
+    pub fn create_gl_render_bridge(&mut self) -> GlRenderBridge {
+        let d3d11_device = self.os.d3d11_device.as_ref()
+            .expect("D3D11 device not initialized")
+            .clone();
+        GlRenderBridge {
+            inner: crate::os::windows::angle::AngleRenderBridge::new(d3d11_device),
+        }
+    }
+
+    /// Create a D3D11 render target texture importable into ANGLE as a GL texture.
+    /// Returns (Texture handle, GL texture ID).
+    pub fn create_gl_render_bridge_texture(
+        &mut self,
+        bridge: &GlRenderBridge,
+        width: usize,
+        height: usize,
+    ) -> (Texture, u32) {
+        bridge.inner.create_render_texture(self, width, height)
+    }
+
+    /// Restore makepad's own rendering context. No-op on Windows (ANGLE and D3D11 are independent).
+    pub fn restore_gl_context(&mut self) {}
+}

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -1,5 +1,6 @@
 //#![cfg_attr(all(unix), feature(unix_socket_ancillary_data))]
 pub mod os;
+pub mod gl_render_bridge;
 
 #[macro_use]
 pub mod log;
@@ -72,6 +73,8 @@ pub use makepad_network;
 
 // Re-export trap module for Script derive macro error macros that use crate::trap::ScriptTrap
 pub use makepad_script::trap;
+
+pub use crate::gl_render_bridge::{GlApi, GlRenderBridge};
 
 pub use {
     crate::{

--- a/platform/src/os/apple/metal.rs
+++ b/platform/src/os/apple/metal.rs
@@ -2163,3 +2163,182 @@ pub fn get_all_metal_devices() -> Vec<ObjcId> {
         ret
     }
 }
+
+/// CGL render bridge for macOS. Creates a standalone CGL context (GL 3.2 Core)
+/// that shares textures with Metal via IOSurface.
+#[cfg(target_os = "macos")]
+pub struct CglRenderBridge {
+    cgl_context: *mut std::ffi::c_void,
+    cgl_pixel_format: *mut std::ffi::c_void,
+    opengl_framework: *mut std::ffi::c_void,
+}
+
+#[cfg(target_os = "macos")]
+impl CglRenderBridge {
+    pub fn new() -> Self {
+        use std::ffi::c_void;
+
+        // CGL constants
+        const K_CGL_PFA_OPENGL_PROFILE: u32 = 99;
+        const K_CGL_OGL_PVERSION_3_2_CORE: u32 = 0x3200;
+        const K_CGL_PFA_COLOR_SIZE: u32 = 8;
+        const K_CGL_PFA_DEPTH_SIZE: u32 = 12;
+        const K_CGL_PFA_STENCIL_SIZE: u32 = 13;
+        const K_CGL_PFA_ACCELERATED: u32 = 73;
+        const K_CGL_PFA_DOUBLE_BUFFER: u32 = 5;
+
+        type CGLPixelFormatObj = *mut c_void;
+        type CGLContextObj = *mut c_void;
+
+        extern "C" {
+            fn CGLChoosePixelFormat(
+                attribs: *const u32,
+                pix: *mut CGLPixelFormatObj,
+                npix: *mut i32,
+            ) -> i32;
+            fn CGLCreateContext(
+                pix: CGLPixelFormatObj,
+                share: CGLContextObj,
+                ctx: *mut CGLContextObj,
+            ) -> i32;
+            fn CGLSetCurrentContext(ctx: CGLContextObj) -> i32;
+        }
+
+        unsafe {
+            let attribs: &[u32] = &[
+                K_CGL_PFA_OPENGL_PROFILE, K_CGL_OGL_PVERSION_3_2_CORE,
+                K_CGL_PFA_COLOR_SIZE, 24,
+                K_CGL_PFA_DEPTH_SIZE, 24,
+                K_CGL_PFA_STENCIL_SIZE, 8,
+                K_CGL_PFA_ACCELERATED,
+                K_CGL_PFA_DOUBLE_BUFFER,
+                0,
+            ];
+
+            let mut pix: CGLPixelFormatObj = std::ptr::null_mut();
+            let mut npix: i32 = 0;
+            let err = CGLChoosePixelFormat(attribs.as_ptr(), &mut pix, &mut npix);
+            assert!(err == 0 && !pix.is_null(), "CGLChoosePixelFormat failed: {}", err);
+
+            let mut ctx: CGLContextObj = std::ptr::null_mut();
+            let err = CGLCreateContext(pix, std::ptr::null_mut(), &mut ctx);
+            assert!(err == 0 && !ctx.is_null(), "CGLCreateContext failed: {}", err);
+
+            // Load OpenGL.framework for dlsym-based proc address lookup
+            extern "C" {
+                fn dlopen(path: *const i8, mode: i32) -> *mut c_void;
+            }
+            let framework_path = b"/System/Library/Frameworks/OpenGL.framework/OpenGL\0";
+            let opengl_framework = dlopen(framework_path.as_ptr() as *const i8, 1); // RTLD_LAZY
+            assert!(!opengl_framework.is_null(), "Failed to load OpenGL.framework");
+
+            CglRenderBridge {
+                cgl_context: ctx,
+                cgl_pixel_format: pix,
+                opengl_framework,
+            }
+        }
+    }
+
+    pub fn make_current(&self) {
+        extern "C" {
+            fn CGLSetCurrentContext(ctx: *mut std::ffi::c_void) -> i32;
+        }
+        unsafe {
+            CGLSetCurrentContext(self.cgl_context);
+        }
+    }
+
+    pub fn get_proc_address(&self, name: &str) -> *const std::ffi::c_void {
+        extern "C" {
+            fn dlsym(handle: *mut std::ffi::c_void, symbol: *const i8) -> *mut std::ffi::c_void;
+        }
+        let c_name = std::ffi::CString::new(name).unwrap();
+        unsafe { dlsym(self.opengl_framework, c_name.as_ptr()) }
+    }
+
+    pub fn gl_api(&self) -> crate::gl_render_bridge::GlApi {
+        crate::gl_render_bridge::GlApi::GL
+    }
+
+    pub fn cgl_pixel_format(&self) -> *mut std::ffi::c_void {
+        self.cgl_pixel_format
+    }
+
+    pub fn cgl_context(&self) -> *mut std::ffi::c_void {
+        self.cgl_context
+    }
+
+    /// Bind an IOSurface to a GL texture in this CGL context.
+    /// Returns the GL texture ID.
+    pub fn bind_iosurface_to_gl_texture(
+        &self,
+        iosurface_ref: *mut std::ffi::c_void,
+        width: usize,
+        height: usize,
+    ) -> u32 {
+        use std::ffi::c_void;
+
+        // GL constants for TEXTURE_RECTANGLE (macOS CGL uses rectangle textures for IOSurface)
+        const GL_TEXTURE_RECTANGLE: u32 = 0x84F5;
+        const GL_RGBA: u32 = 0x1908;
+        const GL_BGRA: u32 = 0x80E1;
+        const GL_UNSIGNED_INT_8_8_8_8_REV: u32 = 0x8367;
+        const GL_FRAMEBUFFER: u32 = 0x8D40;
+        const GL_COLOR_ATTACHMENT0: u32 = 0x8CE0;
+
+        type GLuint = u32;
+        type GLint = i32;
+        type GLenum = u32;
+        type GLsizei = i32;
+
+        // Load GL functions via dlsym
+        type GlGenTexturesFn = unsafe extern "C" fn(GLsizei, *mut GLuint);
+        type GlBindTextureFn = unsafe extern "C" fn(GLenum, GLuint);
+        type GlGenFramebuffersFn = unsafe extern "C" fn(GLsizei, *mut GLuint);
+        type GlBindFramebufferFn = unsafe extern "C" fn(GLenum, GLuint);
+        type GlFramebufferTexture2DFn = unsafe extern "C" fn(GLenum, GLenum, GLenum, GLuint, GLint);
+
+        extern "C" {
+            fn CGLTexImageIOSurface2D(
+                ctx: *mut c_void,
+                target: GLenum,
+                internal_format: GLenum,
+                width: GLsizei,
+                height: GLsizei,
+                format: GLenum,
+                ty: GLenum,
+                iosurface: *mut c_void,
+                plane: GLuint,
+            ) -> i32;
+        }
+
+        unsafe {
+            let gl_gen_textures: GlGenTexturesFn =
+                std::mem::transmute(self.get_proc_address("glGenTextures"));
+            let gl_bind_texture: GlBindTextureFn =
+                std::mem::transmute(self.get_proc_address("glBindTexture"));
+
+            let mut gl_texture: GLuint = 0;
+            gl_gen_textures(1, &mut gl_texture);
+            gl_bind_texture(GL_TEXTURE_RECTANGLE, gl_texture);
+
+            let err = CGLTexImageIOSurface2D(
+                self.cgl_context,
+                GL_TEXTURE_RECTANGLE,
+                GL_RGBA,
+                width as GLsizei,
+                height as GLsizei,
+                GL_BGRA,
+                GL_UNSIGNED_INT_8_8_8_8_REV,
+                iosurface_ref,
+                0,
+            );
+            assert!(err == 0, "CGLTexImageIOSurface2D failed: {}", err);
+
+            gl_bind_texture(GL_TEXTURE_RECTANGLE, 0);
+
+            gl_texture
+        }
+    }
+}

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -2439,3 +2439,61 @@ impl OpenglBuffer {
         }
     }
 }
+
+/// EGL render bridge wrapping references to makepad's existing OpenGL context.
+pub struct EglRenderBridge {
+    egl_display: crate::egl_sys::EGLDisplay,
+    egl_config: crate::egl_sys::EGLConfig,
+    egl_context: crate::egl_sys::EGLContext,
+    egl_get_proc_address: unsafe extern "C" fn(*const std::ffi::c_char) -> *mut std::ffi::c_void,
+    egl_make_current: unsafe extern "C" fn(
+        *mut std::ffi::c_void,
+        *mut std::ffi::c_void,
+        *mut std::ffi::c_void,
+        *mut std::ffi::c_void,
+    ) -> u32,
+}
+
+impl EglRenderBridge {
+    pub fn new(opengl_cx: &crate::os::linux::opengl_cx::OpenglCx) -> Self {
+        Self {
+            egl_display: opengl_cx.egl_display,
+            egl_config: opengl_cx.egl_config,
+            egl_context: opengl_cx.egl_context,
+            egl_get_proc_address: opengl_cx.libegl.eglGetProcAddress.unwrap(),
+            egl_make_current: opengl_cx.libegl.eglMakeCurrent.unwrap(),
+        }
+    }
+
+    pub fn make_current(&self) {
+        unsafe {
+            (self.egl_make_current)(
+                self.egl_display,
+                std::ptr::null_mut(), // EGL_NO_SURFACE
+                std::ptr::null_mut(), // EGL_NO_SURFACE
+                self.egl_context,
+            );
+        }
+    }
+
+    pub fn get_proc_address(&self, name: &str) -> *const std::ffi::c_void {
+        let c_name = std::ffi::CString::new(name).unwrap();
+        unsafe { (self.egl_get_proc_address)(c_name.as_ptr()) as *const _ }
+    }
+
+    pub fn gl_api(&self) -> crate::gl_render_bridge::GlApi {
+        crate::gl_render_bridge::GlApi::GLES
+    }
+
+    pub fn egl_display(&self) -> *mut std::ffi::c_void {
+        self.egl_display
+    }
+
+    pub fn egl_config(&self) -> *mut std::ffi::c_void {
+        self.egl_config
+    }
+
+    pub fn egl_context(&self) -> *mut std::ffi::c_void {
+        self.egl_context
+    }
+}

--- a/platform/src/os/windows/angle.rs
+++ b/platform/src/os/windows/angle.rs
@@ -1,0 +1,390 @@
+use {
+    crate::{
+        cx::Cx,
+        texture::{Texture, TextureFormat, TextureSize},
+    },
+    std::ffi::{c_void, CString},
+};
+
+// EGL types
+type EGLBoolean = u32;
+type EGLint = i32;
+type EGLenum = u32;
+type EGLAttrib = isize;
+type EGLDisplay = *mut c_void;
+type EGLConfig = *mut c_void;
+type EGLContext = *mut c_void;
+type EGLSurface = *mut c_void;
+type EGLDeviceEXT = *mut c_void;
+
+// EGL constants
+const EGL_TRUE: EGLBoolean = 1;
+const EGL_NONE: EGLint = 0x3038;
+const EGL_NO_CONTEXT: EGLContext = std::ptr::null_mut();
+const EGL_NO_SURFACE: EGLSurface = std::ptr::null_mut();
+const EGL_OPENGL_ES_API: EGLenum = 0x30A0;
+const EGL_OPENGL_ES2_BIT: EGLint = 0x0004;
+const EGL_RED_SIZE: EGLint = 0x3024;
+const EGL_GREEN_SIZE: EGLint = 0x3025;
+const EGL_BLUE_SIZE: EGLint = 0x3026;
+const EGL_ALPHA_SIZE: EGLint = 0x3028;
+const EGL_DEPTH_SIZE: EGLint = 0x3025;
+const EGL_STENCIL_SIZE: EGLint = 0x3026;
+const EGL_RENDERABLE_TYPE: EGLint = 0x3040;
+const EGL_CONTEXT_MAJOR_VERSION: EGLint = 0x3098;
+const EGL_CONTEXT_MINOR_VERSION: EGLint = 0x30FB;
+
+// ANGLE extension constants
+const EGL_D3D11_DEVICE_ANGLE: EGLenum = 0x33A1;
+const EGL_PLATFORM_DEVICE_EXT: EGLenum = 0x313F;
+const EGL_D3D11_TEXTURE_ANGLE: EGLenum = 0x3484;
+
+// GL constants
+const GL_TEXTURE_2D: u32 = 0x0DE1;
+
+// EGL function pointer types
+type FnGetProcAddress = unsafe extern "system" fn(*const i8) -> *const c_void;
+type FnGetPlatformDisplayEXT = unsafe extern "system" fn(EGLenum, *mut c_void, *const EGLint) -> EGLDisplay;
+type FnInitialize = unsafe extern "system" fn(EGLDisplay, *mut EGLint, *mut EGLint) -> EGLBoolean;
+type FnTerminate = unsafe extern "system" fn(EGLDisplay) -> EGLBoolean;
+type FnBindAPI = unsafe extern "system" fn(EGLenum) -> EGLBoolean;
+type FnChooseConfig = unsafe extern "system" fn(EGLDisplay, *const EGLint, *mut EGLConfig, EGLint, *mut EGLint) -> EGLBoolean;
+type FnCreateContext = unsafe extern "system" fn(EGLDisplay, EGLConfig, EGLContext, *const EGLint) -> EGLContext;
+type FnDestroyContext = unsafe extern "system" fn(EGLDisplay, EGLContext) -> EGLBoolean;
+type FnMakeCurrent = unsafe extern "system" fn(EGLDisplay, EGLSurface, EGLSurface, EGLContext) -> EGLBoolean;
+type FnCreateDeviceANGLE = unsafe extern "system" fn(EGLenum, *mut c_void, *const EGLAttrib) -> EGLDeviceEXT;
+type FnReleaseDeviceANGLE = unsafe extern "system" fn(EGLDeviceEXT) -> EGLBoolean;
+
+/// EGL function table loaded from libEGL.dll at runtime.
+struct EglFns {
+    get_proc_address: FnGetProcAddress,
+    get_platform_display_ext: FnGetPlatformDisplayEXT,
+    initialize: FnInitialize,
+    terminate: FnTerminate,
+    bind_api: FnBindAPI,
+    choose_config: FnChooseConfig,
+    create_context: FnCreateContext,
+    destroy_context: FnDestroyContext,
+    make_current: FnMakeCurrent,
+    create_device_angle: FnCreateDeviceANGLE,
+    release_device_angle: FnReleaseDeviceANGLE,
+}
+
+impl EglFns {
+    /// Load EGL functions from libEGL.dll.
+    ///
+    /// The DLL is expected to be in the executable directory (shipped by servo/havi
+    /// via mozangle's build_dlls feature). The library handle is intentionally leaked
+    /// so the DLL stays loaded for the process lifetime.
+    fn load() -> Self {
+        use windows::Win32::System::LibraryLoader::{LoadLibraryA, GetProcAddress};
+        use windows::core::PCSTR;
+
+        let module = unsafe { LoadLibraryA(PCSTR::from_raw(b"libEGL.dll\0".as_ptr())) }
+            .expect("Failed to load libEGL.dll — ANGLE DLLs must be present");
+
+        let get = |name: &str| -> *const c_void {
+            let cname = CString::new(name).unwrap();
+            let ptr = unsafe { GetProcAddress(module, PCSTR::from_raw(cname.as_ptr() as *const u8)) };
+            match ptr {
+                Some(f) => f as *const c_void,
+                None => panic!("libEGL.dll missing symbol: {name}"),
+            }
+        };
+
+        let get_proc_address: FnGetProcAddress = unsafe { std::mem::transmute(get("eglGetProcAddress")) };
+
+        // Some ANGLE extension functions are only available via eglGetProcAddress.
+        let get_ext = |name: &str| -> *const c_void {
+            let cname = CString::new(name).unwrap();
+            let ptr = unsafe { (get_proc_address)(cname.as_ptr()) };
+            assert!(!ptr.is_null(), "eglGetProcAddress returned null for: {name}");
+            ptr
+        };
+
+        EglFns {
+            get_proc_address,
+            get_platform_display_ext: unsafe { std::mem::transmute(get_ext("eglGetPlatformDisplayEXT")) },
+            initialize: unsafe { std::mem::transmute(get("eglInitialize")) },
+            terminate: unsafe { std::mem::transmute(get("eglTerminate")) },
+            bind_api: unsafe { std::mem::transmute(get("eglBindAPI")) },
+            choose_config: unsafe { std::mem::transmute(get("eglChooseConfig")) },
+            create_context: unsafe { std::mem::transmute(get("eglCreateContext")) },
+            destroy_context: unsafe { std::mem::transmute(get("eglDestroyContext")) },
+            make_current: unsafe { std::mem::transmute(get("eglMakeCurrent")) },
+            create_device_angle: unsafe { std::mem::transmute(get_ext("eglCreateDeviceANGLE")) },
+            release_device_angle: unsafe { std::mem::transmute(get_ext("eglReleaseDeviceANGLE")) },
+        }
+    }
+
+    /// Resolve an EGL/GL extension function by name.
+    fn get_proc_address(&self, name: &str) -> *const c_void {
+        let cname = CString::new(name).unwrap();
+        unsafe { (self.get_proc_address)(cname.as_ptr()) }
+    }
+}
+
+/// ANGLE-based EGL render bridge on Windows.
+/// Creates an EGL display on top of makepad's D3D11 device.
+/// Loads ANGLE from libEGL.dll / libGLESv2.dll at runtime (shipped by servo).
+pub struct AngleRenderBridge {
+    egl: EglFns,
+    egl_device: EGLDeviceEXT,
+    egl_display: EGLDisplay,
+    egl_config: EGLConfig,
+    egl_context: EGLContext,
+    _d3d11_device: windows::Win32::Graphics::Direct3D11::ID3D11Device,
+}
+
+impl AngleRenderBridge {
+    pub fn new(d3d11_device: windows::Win32::Graphics::Direct3D11::ID3D11Device) -> Self {
+        let egl = EglFns::load();
+
+        unsafe {
+            // Create EGL device from D3D11 device
+            let d3d11_raw = std::mem::transmute_copy::<
+                windows::Win32::Graphics::Direct3D11::ID3D11Device,
+                *mut c_void,
+            >(&d3d11_device);
+            let egl_device = (egl.create_device_angle)(
+                EGL_D3D11_DEVICE_ANGLE,
+                d3d11_raw,
+                std::ptr::null(),
+            );
+            assert!(!egl_device.is_null(), "eglCreateDeviceANGLE failed");
+
+            // Create EGL display from device
+            let display_attribs: &[EGLint] = &[EGL_NONE];
+            let egl_display = (egl.get_platform_display_ext)(
+                EGL_PLATFORM_DEVICE_EXT,
+                egl_device,
+                display_attribs.as_ptr(),
+            );
+            assert!(!egl_display.is_null(), "eglGetPlatformDisplayEXT failed");
+
+            // Initialize
+            let mut major: EGLint = 0;
+            let mut minor: EGLint = 0;
+            let ok = (egl.initialize)(egl_display, &mut major, &mut minor);
+            assert_eq!(ok, EGL_TRUE, "eglInitialize failed");
+
+            // Bind OpenGL ES API
+            (egl.bind_api)(EGL_OPENGL_ES_API);
+
+            // Choose config
+            let config_attribs: &[EGLint] = &[
+                EGL_RED_SIZE, 8,
+                EGL_GREEN_SIZE, 8,
+                EGL_BLUE_SIZE, 8,
+                EGL_ALPHA_SIZE, 8,
+                EGL_DEPTH_SIZE, 24,
+                EGL_STENCIL_SIZE, 8,
+                EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+                EGL_NONE,
+            ];
+
+            let mut egl_config: EGLConfig = std::ptr::null_mut();
+            let mut num_configs: EGLint = 0;
+            let ok = (egl.choose_config)(
+                egl_display,
+                config_attribs.as_ptr(),
+                &mut egl_config,
+                1,
+                &mut num_configs,
+            );
+            assert_eq!(ok, EGL_TRUE, "eglChooseConfig failed");
+            assert!(num_configs > 0, "No matching EGL configs");
+
+            // Create GLES 3.0 context
+            let context_attribs: &[EGLint] = &[
+                EGL_CONTEXT_MAJOR_VERSION, 3,
+                EGL_CONTEXT_MINOR_VERSION, 0,
+                EGL_NONE,
+            ];
+
+            let egl_context = (egl.create_context)(
+                egl_display,
+                egl_config,
+                EGL_NO_CONTEXT,
+                context_attribs.as_ptr(),
+            );
+            assert!(!egl_context.is_null(), "eglCreateContext failed");
+
+            AngleRenderBridge {
+                egl,
+                egl_device,
+                egl_display,
+                egl_config,
+                egl_context,
+                _d3d11_device: d3d11_device,
+            }
+        }
+    }
+
+    pub fn make_current(&self) {
+        unsafe {
+            let ok = (self.egl.make_current)(
+                self.egl_display,
+                EGL_NO_SURFACE,
+                EGL_NO_SURFACE,
+                self.egl_context,
+            );
+            assert_eq!(ok, EGL_TRUE, "eglMakeCurrent failed");
+        }
+    }
+
+    pub fn get_proc_address(&self, name: &str) -> *const c_void {
+        self.egl.get_proc_address(name)
+    }
+
+    pub fn gl_api(&self) -> crate::gl_render_bridge::GlApi {
+        crate::gl_render_bridge::GlApi::GLES
+    }
+
+    pub fn egl_display(&self) -> *mut c_void {
+        self.egl_display
+    }
+
+    pub fn egl_config(&self) -> *mut c_void {
+        self.egl_config
+    }
+
+    pub fn egl_context(&self) -> *mut c_void {
+        self.egl_context
+    }
+
+    /// Create a D3D11 render target texture and import it into ANGLE as a GL texture.
+    /// The D3D11 texture is stored in the makepad Texture's CxOsTexture.
+    /// Returns (Texture, GL texture ID).
+    pub fn create_render_texture(
+        &self,
+        cx: &mut Cx,
+        width: usize,
+        height: usize,
+    ) -> (Texture, u32) {
+        // Make ANGLE context current
+        self.make_current();
+
+        // Create a makepad render target texture (D3D11 texture with RTV + SRV)
+        let texture = Texture::new_with_format(cx, TextureFormat::RenderBGRAu8 {
+            size: TextureSize::Fixed { width, height },
+            initial: true,
+        });
+
+        // Force allocation of the D3D11 texture
+        {
+            let d3d11_device = cx.os.d3d11_device.as_ref().unwrap();
+            let cxtexture = &mut cx.textures[texture.texture_id()];
+
+            use windows::Win32::Graphics::Direct3D11::{
+                D3D11_TEXTURE2D_DESC, D3D11_BIND_RENDER_TARGET, D3D11_BIND_SHADER_RESOURCE,
+                D3D11_USAGE_DEFAULT, ID3D11Resource,
+            };
+            use windows::Win32::Graphics::Dxgi::Common::{
+                DXGI_FORMAT_B8G8R8A8_UNORM, DXGI_SAMPLE_DESC,
+            };
+            use windows::core::Interface;
+
+            let texture_desc = D3D11_TEXTURE2D_DESC {
+                Width: width as u32,
+                Height: height as u32,
+                MipLevels: 1,
+                ArraySize: 1,
+                Format: DXGI_FORMAT_B8G8R8A8_UNORM,
+                SampleDesc: DXGI_SAMPLE_DESC { Count: 1, Quality: 0 },
+                Usage: D3D11_USAGE_DEFAULT,
+                BindFlags: (D3D11_BIND_RENDER_TARGET.0 | D3D11_BIND_SHADER_RESOURCE.0) as u32,
+                CPUAccessFlags: 0,
+                MiscFlags: 0,
+            };
+
+            let mut d3d11_texture = None;
+            unsafe {
+                d3d11_device.CreateTexture2D(&texture_desc, None, Some(&mut d3d11_texture)).unwrap();
+            }
+            let d3d11_texture = d3d11_texture.unwrap();
+
+            // Create shader resource view for makepad rendering
+            let resource: ID3D11Resource = d3d11_texture.clone().cast().unwrap();
+            let mut shader_resource_view = None;
+            unsafe {
+                d3d11_device.CreateShaderResourceView(&resource, None, Some(&mut shader_resource_view)).unwrap();
+            }
+
+            cxtexture.os.texture = Some(d3d11_texture.clone());
+            cxtexture.os.shader_resource_view = shader_resource_view;
+
+            // Import the D3D11 texture into ANGLE via EGLImage
+            let d3d11_texture_raw: *mut c_void = unsafe { std::mem::transmute_copy(&d3d11_texture) };
+
+            // Load extension functions via eglGetProcAddress
+            type EglCreateImageKHRFn = unsafe extern "system" fn(
+                *mut c_void, *mut c_void, u32, *mut c_void, *const i32,
+            ) -> *mut c_void;
+            type GlEGLImageTargetTexture2DOESFn = unsafe extern "system" fn(u32, *mut c_void);
+            type GlGenTexturesFn = unsafe extern "system" fn(i32, *mut u32);
+            type GlBindTextureFn = unsafe extern "system" fn(u32, u32);
+
+            let egl_create_image_khr: EglCreateImageKHRFn = unsafe {
+                std::mem::transmute(self.egl.get_proc_address("eglCreateImageKHR"))
+            };
+            let gl_egl_image_target_texture_2d_oes: GlEGLImageTargetTexture2DOESFn = unsafe {
+                std::mem::transmute(self.egl.get_proc_address("glEGLImageTargetTexture2DOES"))
+            };
+            let gl_gen_textures: GlGenTexturesFn = unsafe {
+                std::mem::transmute(self.egl.get_proc_address("glGenTextures"))
+            };
+            let gl_bind_texture: GlBindTextureFn = unsafe {
+                std::mem::transmute(self.egl.get_proc_address("glBindTexture"))
+            };
+
+            // Create EGLImage from D3D11 texture
+            let image_attribs: &[EGLint] = &[EGL_NONE];
+            let egl_image = unsafe {
+                egl_create_image_khr(
+                    self.egl_display,
+                    EGL_NO_CONTEXT,
+                    EGL_D3D11_TEXTURE_ANGLE,
+                    d3d11_texture_raw,
+                    image_attribs.as_ptr(),
+                )
+            };
+            assert!(!egl_image.is_null(), "eglCreateImageKHR failed");
+
+            // Create GL texture and bind the EGLImage to it
+            let mut gl_texture_id: u32 = 0;
+            unsafe {
+                gl_gen_textures(1, &mut gl_texture_id);
+                gl_bind_texture(GL_TEXTURE_2D, gl_texture_id);
+                gl_egl_image_target_texture_2d_oes(GL_TEXTURE_2D, egl_image);
+                gl_bind_texture(GL_TEXTURE_2D, 0);
+            }
+
+            // Force the alloc info so makepad knows the dimensions
+            cxtexture.alloc = Some(crate::texture::TextureAlloc {
+                category: crate::texture::TextureCategory::Render,
+                pixel: crate::texture::TexturePixel::BGRAu8,
+                width,
+                height,
+            });
+
+            return (texture, gl_texture_id);
+        }
+    }
+}
+
+impl Drop for AngleRenderBridge {
+    fn drop(&mut self) {
+        unsafe {
+            (self.egl.make_current)(
+                self.egl_display,
+                EGL_NO_SURFACE,
+                EGL_NO_SURFACE,
+                EGL_NO_CONTEXT,
+            );
+            (self.egl.destroy_context)(self.egl_display, self.egl_context);
+            (self.egl.terminate)(self.egl_display);
+            (self.egl.release_device_angle)(self.egl_device);
+        }
+    }
+}

--- a/platform/src/os/windows/d3d11.rs
+++ b/platform/src/os/windows/d3d11.rs
@@ -937,9 +937,9 @@ impl D3d11Buffer {
 
 #[derive(Default)]
 pub struct CxOsTexture {
-    texture: Option<ID3D11Texture2D>,
+    pub(crate) texture: Option<ID3D11Texture2D>,
     pub shared_handle: HANDLE,
-    shader_resource_view: Option<ID3D11ShaderResourceView>,
+    pub(crate) shader_resource_view: Option<ID3D11ShaderResourceView>,
     render_target_view: Option<ID3D11RenderTargetView>,
     depth_stencil_view: Option<ID3D11DepthStencilView>,
 }

--- a/platform/src/os/windows/mod.rs
+++ b/platform/src/os/windows/mod.rs
@@ -14,6 +14,7 @@ pub mod windows_media;
 pub mod winrt_midi;
 
 //pub mod com_sys;
+pub mod angle;
 pub mod d3d11;
 pub mod windows;
 pub mod windows_game_input;


### PR DESCRIPTION
Adds `GlRenderBridge`: a cross-platform abstraction for sharing GPU resources between makepad's native renderer and external OpenGL consumers (e.g. embedded browser engines).

**Platform backends:**
- **Linux/Android**: wraps makepad's existing EGL context
- **macOS**: CGL context bridged to Metal via IOSurface (zero-copy)
- **Windows**: ANGLE EGL context on makepad's D3D11 device

**ANGLE on Windows** loads `libEGL.dll` at runtime via `LoadLibrary`/`GetProcAddress` instead of statically compiling ANGLE through mozangle. This avoids adding a heavy build dependency (~386 C++ files, `cc`, `bindgen`, `gl_generator`, `libz-sys`) to makepad-platform. The ANGLE DLLs are expected to be shipped by the consumer application.

Also makes `CxOsTexture::texture` and `CxOsTexture::shader_resource_view` fields `pub(crate)` for cross-module access within the platform crate.