### PR TITLE
restore set_window_icon lost during rebase of #877

### DIFF
--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -173,7 +173,7 @@ pub use {
         video::*,
         web_socket::{WebSocket, WebSocketMessage},
         window::{CxWindowPool, ScriptWindowHandle, WindowHandle, WindowIcon, WindowIconBuffer, WindowId},
-        window_icon::default_window_icon,
+        window_icon::{default_window_icon, set_window_icon},
     },
     app_main::*,
     arc_string_mut::ArcStringMut,

--- a/platform/src/window_icon.rs
+++ b/platform/src/window_icon.rs
@@ -1,8 +1,27 @@
+use std::sync::OnceLock;
 use crate::window::{WindowIcon, WindowIconBuffer};
+
+/// Global icon override. When set, `default_window_icon()` returns this
+/// instead of the built-in "M" icon.
+static GLOBAL_ICON: OnceLock<WindowIcon> = OnceLock::new();
+
+/// Set a global window icon that all new windows will use.
+/// Must be called before the first window is created.
+pub fn set_window_icon(icon: WindowIcon) {
+    let _ = GLOBAL_ICON.set(icon);
+}
+
+/// Return the global icon override if set, otherwise the built-in "M" icon.
+pub fn default_window_icon() -> WindowIcon {
+    if let Some(icon) = GLOBAL_ICON.get() {
+        return icon.clone();
+    }
+    default_makepad_icon()
+}
 
 /// Generate the default Makepad window icon (64x64 RGBA8).
 /// A simple "M" glyph on a dark background.
-pub fn default_window_icon() -> WindowIcon {
+fn default_makepad_icon() -> WindowIcon {
     const SIZE: u32 = 64;
     let mut data = vec![0u8; (SIZE * SIZE * 4) as usize];
 


### PR DESCRIPTION
The rebase squash into 26318769 used the early draft of window_icon.rs, dropping the OnceLock-based global setter added in the fixup commit.

Restores:
- `static GLOBAL_ICON: OnceLock<WindowIcon>`
- `pub fn set_window_icon(icon: WindowIcon)` — global setter for window icon override
- `default_window_icon()` refactored to check global override first, falling back to built-in icon
- re-export `set_window_icon` from platform lib.rs