### PR TITLE
Remove left margin from window caption label

### DIFF
--- a/examples/splash/src/app.rs
+++ b/examples/splash/src/app.rs
@@ -1545,6 +1545,7 @@ script_mod! {
             main_window := Window{
                 pass.clear_color: vec4(0.3 0.3 0.3 1.0)
                 window.inner_size: vec2(1000 700)
+                window.title: "Splash Example"
                 body +: {
                     padding: 4
                     dock := AppDock{}
@@ -1596,7 +1597,11 @@ impl MatchEvent for App {
         }
 
         // Tooltip demo - show tooltips on button click
-        if self.ui.button(cx, ids!(normal_tooltip_button)).clicked(actions) {
+        if self
+            .ui
+            .button(cx, ids!(normal_tooltip_button))
+            .clicked(actions)
+        {
             log!("Showing normal tooltip");
             self.ui.tooltip(cx, ids!(normal_tooltip)).show_with_options(
                 cx,

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -35,7 +35,7 @@ script_mod! {
             caption_label := View {
                 width: Fill height: Fill
                 align: Center
-                label := Label {text: "Makepad" margin: Inset{left: 100}}
+                label := Label {text: "Makepad"}
             }
             voice_wave := VoiceWave {}
             windows_buttons := View {

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "voice")]
 use crate::voice_wave::VoiceWaveWidgetExt;
 use crate::{
-    desktop_button::DesktopButtonWidgetExt, makepad_derive_widget::*, makepad_draw::*,
+    desktop_button::DesktopButtonWidgetExt, label::*, makepad_derive_widget::*, makepad_draw::*,
     nav_control::NavControl, view::*, widget::*,
 };
 
@@ -282,6 +282,15 @@ impl Window {
                 // self.frame.get_view(ids!(caption_bar)).set_visible(false);
             }
             _ => (),
+        }
+
+        // Update the caption label with the window title if set
+        let title = cx.windows[self.window.handle.window_id()]
+            .create_title
+            .clone();
+        if !title.is_empty() {
+            self.label(cx, ids!(caption_label.label))
+                .set_text(cx, &title);
         }
     }
 


### PR DESCRIPTION
1. Delete the hardcoded Inset{left: 100} margin on the caption Label in widgets/src/window.rs so the label can be centered by the parent layout. This cleans up alignment and removes an unnecessary offset in the window header.
2. Make windows title update the caption

The title had left margin so it was not center aligned, and there was no way to modify the title of the window as it used label with hardcoded makepad. The following screenshot shows the both fix in action.

Before:
<img width="1014" height="176" alt="image" src="https://github.com/user-attachments/assets/4e85b291-bc03-417c-919f-b05673f5fdd8" />

After:
<img width="1005" height="162" alt="image" src="https://github.com/user-attachments/assets/a32400c6-a61f-4989-a94c-dfd8b00f113f" />
