### PR TITLE
script: panic on nil return from script_mod! in from_script_mod

### DIFF
--- a/platform/script/src/traits.rs
+++ b/platform/script/src/traits.rs
@@ -334,6 +334,13 @@ where
         Self: Sized,
     {
         let value = f(vm);
+        if value.is_nil() {
+            panic!(
+                "script_mod! returned nil — the script block must end with an expression \
+                 that evaluates to the app value (e.g. add `app` as the last line after \
+                 `let app = startup() do ...{{ }}`)."
+            );
+        }
         Self::script_from_value(vm, value)
     }
 


### PR DESCRIPTION
## Summary

When `script_mod!` is used with `let app = startup() do ...` but the block omits the final `app` expression, the module returns nil. This silently creates an App with an empty `WidgetRef` — no window, no UI, no error. The app runs indefinitely doing nothing.

This is a footgun that is difficult to debug. Panic with an actionable message instead of silently succeeding.

## Validation

- Builds cleanly on Linux (`cargo build --workspace --exclude 'makepad-example-*'`)
- Single commit on top of `dev`