### PR TITLE
Restore StackNavigation widget, add examples to ui-zoo

### DIFF
--- a/examples/uizoo/src/app.rs
+++ b/examples/uizoo/src/app.rs
@@ -54,6 +54,8 @@ script_mod! {
                 @tScrollbar
                 @tSlider
                 @tSlidesView
+                @tStackNavigation
+                @tAdaptiveView
                 @tTextInput
                 @tVideo
                 @tView
@@ -91,6 +93,8 @@ script_mod! {
         tScrollbar := DockTab{name: "Scrollbar" template: @PermanentTab kind: @TabScrollbar}
         tSlider := DockTab{name: "Slider" template: @PermanentTab kind: @TabSlider}
         tSlidesView := DockTab{name: "SlidesView" template: @PermanentTab kind: @TabSlidesView}
+        tStackNavigation := DockTab{name: "StackNavigation" template: @PermanentTab kind: @TabStackNavigation}
+        tAdaptiveView := DockTab{name: "AdaptiveView" template: @PermanentTab kind: @TabAdaptiveView}
         tTextInput := DockTab{name: "TextInput" template: @PermanentTab kind: @TabTextInput}
         tVideo := DockTab{name: "Video" template: @PermanentTab kind: @TabVideo}
         tView := DockTab{name: "View" template: @PermanentTab kind: @TabView}
@@ -118,6 +122,8 @@ script_mod! {
         TabScrollbar := UIZooTab{DemoScrollBar{}}
         TabSlider := UIZooTab{DemoSlider{}}
         TabSlidesView := UIZooTab{DemoSlidesView{}}
+        TabStackNavigation := UIZooTab{DemoStackNavigation{}}
+        TabAdaptiveView := UIZooTab{DemoAdaptiveView{}}
         TabTextInput := UIZooTab{DemoTextInput{}}
         TabVideo := UIZooTab{DemoVideo{}}
         TabView := UIZooTab{DemoView{}}
@@ -169,6 +175,8 @@ impl App {
         crate::tab_scrollbar::script_mod(vm);
         crate::tab_slider::script_mod(vm);
         crate::tab_slidesview::script_mod(vm);
+        crate::tab_stacknavigation::script_mod(vm);
+        crate::tab_adaptiveview::script_mod(vm);
         crate::tab_textinput::script_mod(vm);
         crate::tab_video::script_mod(vm);
         crate::tab_view::script_mod(vm);
@@ -296,6 +304,64 @@ impl MatchEvent for App {
             self.counter += 1;
             let lbl = self.ui.label(cx, ids!(simplecheckbox_output));
             lbl.set_text(cx, &format!("{} {}", self.counter, check));
+        }
+
+        // StackNavigation demo handlers
+        let stack_nav = self.ui.stack_navigation(cx, ids!(stack_nav_demo));
+
+        if self.ui.button(cx, ids!(push_view_a)).clicked(&actions) {
+            stack_nav.push(cx, live_id!(stack_view_a));
+        }
+        if self.ui.button(cx, ids!(push_view_b)).clicked(&actions) {
+            stack_nav.push(cx, live_id!(stack_view_b));
+        }
+        if self.ui.button(cx, ids!(push_view_c)).clicked(&actions) {
+            stack_nav.push(cx, live_id!(stack_view_c));
+        }
+        if self.ui.button(cx, ids!(push_nested_from_a)).clicked(&actions) {
+            stack_nav.push(cx, live_id!(stack_view_b));
+        }
+        if self.ui.button(cx, ids!(push_nested_from_b)).clicked(&actions) {
+            stack_nav.push(cx, live_id!(stack_view_c));
+        }
+        if self.ui.button(cx, ids!(pop_to_root_btn)).clicked(&actions) {
+            stack_nav.pop_to_root(cx);
+        }
+
+        // Responsive Nav demo: desktop click handlers
+        let desktop_items = [
+            (ids!(desktop_item_1), "Settings"),
+            (ids!(desktop_item_2), "Profile"),
+            (ids!(desktop_item_3), "Notifications"),
+        ];
+        for (item_id, title) in desktop_items {
+            if let Some(_) = self.ui.view(cx, item_id).finger_down(actions) {
+                self.ui.label(cx, ids!(desktop_detail_title)).set_text(cx, title);
+                self.ui.label(cx, ids!(desktop_detail_body)).set_text(
+                    cx,
+                    &format!("{} detail content.\n\nOn Desktop, the list and detail are visible side-by-side.", title),
+                );
+            }
+        }
+
+        // Responsive Nav demo: mobile StackNavigation handlers
+        let mobile_nav = self.ui.stack_navigation(cx, ids!(mobile_nav));
+
+        let mobile_items = [
+            (ids!(mobile_item_1), "Settings"),
+            (ids!(mobile_item_2), "Profile"),
+            (ids!(mobile_item_3), "Notifications"),
+        ];
+        for (item_id, title) in mobile_items {
+            if let Some(_) = self.ui.view(cx, item_id).finger_down(actions) {
+                mobile_nav.set_title(cx, live_id!(mobile_detail_view), title);
+                self.ui.label(cx, ids!(mobile_detail_title)).set_text(cx, title);
+                self.ui.label(cx, ids!(mobile_detail_body)).set_text(
+                    cx,
+                    &format!("{} detail content.\n\nOn Mobile, this was pushed onto the navigation stack.", title),
+                );
+                mobile_nav.push(cx, live_id!(mobile_detail_view));
+            }
         }
     }
 }

--- a/examples/uizoo/src/lib.rs
+++ b/examples/uizoo/src/lib.rs
@@ -27,5 +27,7 @@ pub mod tab_slidesview;
 pub mod tab_spinner;
 pub mod tab_textinput;
 pub mod tab_video;
+pub mod tab_adaptiveview;
+pub mod tab_stacknavigation;
 pub mod tab_view;
 pub mod tab_widgetsoverview;

--- a/examples/uizoo/src/tab_adaptiveview.rs
+++ b/examples/uizoo/src/tab_adaptiveview.rs
@@ -1,0 +1,66 @@
+use crate::makepad_widgets::*;
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use mod.widgets.*
+
+    let ViewA = RoundedView{
+        width: 200 height: Fill
+        show_bg: true
+        draw_bg.color: #176951
+        padding: 10.
+        align: Align{x: 0.5 y: 0.5}
+        Label{text: "View A"}
+    }
+
+    let ViewB = RoundedView{
+        width: Fill height: Fill
+        show_bg: true
+        draw_bg.color: #1f3a67
+        padding: 10.
+        flow: Down
+        spacing: 5.
+        align: Align{x: 0.5 y: 0.5}
+        Label{text: "View B"}
+    }
+
+    mod.widgets.DemoAdaptiveView = UIZooTabLayout_B{
+        desc +: {
+            Markdown{body: "# AdaptiveView\n\nAdaptiveView adapts its content based on the current context, automatically switching between layout variants.\n\n## Features\n- Define named variants (default: `Desktop` / `Mobile`)\n- Automatic switching based on screen width (>= 860px = Desktop)\n- Custom variant selectors with access to `Cx` and parent size\n- Parent-size-relative breakpoints (not just window size)\n- Any number of custom-named variants\n- Optional state retention for unused variants\n- Responds to window resize and parent size changes\n\n## Default Selector\nSwitches at 860px window width. Override with `set_variant_selector`.\n\n## Custom Variants (Rust)\n```rust\n// Parent-size-based with custom names:\nself.adaptive_view(ids!(my_view))\n  .set_variant_selector(\n    |_cx, parent_size| {\n      match parent_size.x {\n        w if w <= 70.0  => id!(OnlyIcon),\n        w if w <= 200.0 => id!(Compact),\n        _ => id!(Full),\n      }\n    }\n  );\n```\nThe selector receives `&mut Cx` and the parent container size (`&Vec2d`), so variants can adapt to the available space, not just the window.\n\n## API\n- `set_variant_selector(closure)` - Custom selector\n- `set_default_variant_selector()` - Reset to default\n- `retain_unused_variants` - Preserve inactive variant state"}
+        }
+        demos +: {
+            H4{text: "Default Desktop/Mobile"}
+            Label{
+                width: Fill height: Fit
+                text: "Resize the window below 860px width to see it switch to Mobile."
+            }
+
+            RoundedView{
+                width: Fill height: 200
+                show_bg: true
+                draw_bg.color: theme.color_bg_app
+                padding: 10.
+
+                AdaptiveView{
+                    Desktop := View{
+                        flow: Right
+                        align: Align{x: 0.0 y: 0.5}
+                        spacing: 20.
+
+                        ViewA{}
+                        ViewB{}
+                    }
+
+                    Mobile := View{
+                        flow: Down
+                        align: Align{x: 0.5 y: 0.0}
+                        spacing: 10.
+
+                        ViewA{}
+                        ViewB{}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/uizoo/src/tab_stacknavigation.rs
+++ b/examples/uizoo/src/tab_stacknavigation.rs
@@ -1,0 +1,112 @@
+use crate::makepad_widgets::*;
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use mod.widgets.*
+
+    let StackNavDemoButton = Button{
+        width: Fit height: Fit
+        padding: Inset{top: 10. bottom: 10. left: 20. right: 20.}
+        margin: Inset{top: 5. bottom: 5.}
+    }
+
+    mod.widgets.DemoStackNavigation = UIZooTabLayout_B{
+        desc +: {
+            Markdown{body: "# StackNavigation\n\nStackNavigation provides a stack-based navigation pattern with slide-in/slide-out transitions.\n\n## Features\n- Push views onto a navigation stack\n- Pop views with back button or swipe\n- Slide animation transitions (full screen mode)\n- Nested navigation support\n- Built-in header with back button\n\n## Usage\nClick the buttons in the root view to push different views onto the stack. Use the back button (top-left) or mouse back button to pop.\n\n## Note\nThis demo uses `full_screen: false` to stay within the dock tab. In a real app, full-screen mode slides views across the entire window.\n\n## API\n- `push(cx, view_id)` - Navigate to view\n- `pop(cx)` - Go back one level\n- `pop_to_root(cx)` - Return to root\n- `depth()` - Stack depth\n- `can_pop()` - Check if back is possible"}
+        }
+        demos +: {
+            stack_nav_demo := StackNavigation{
+                width: Fill height: Fill
+
+                root_view +: {
+                    flow: Down
+                    align: Align{x: 0.5 y: 0.3}
+                    spacing: 10.
+                    padding: 20.
+
+                    H3{text: "Root View"}
+                    Label{text: "This is the root of the StackNavigation."}
+
+                    push_view_a := StackNavDemoButton{
+                        text: "Push View A"
+                    }
+                    push_view_b := StackNavDemoButton{
+                        text: "Push View B"
+                    }
+                    push_view_c := StackNavDemoButton{
+                        text: "Push View C"
+                    }
+                }
+
+                stack_view_a := StackNavigationView{
+                    full_screen: false
+                    header +: {
+                        content +: {
+                            title_container +: {
+                                title +: {text: "View A"}
+                            }
+                        }
+                    }
+                    body +: {
+                        flow: Down
+                        align: Align{x: 0.5 y: 0.3}
+                        spacing: 10.
+                        padding: 20.
+
+                        H3{text: "View A"}
+                        Label{text: "This view was pushed onto the stack.\nUse the back button (top-left) or mouse back to pop."}
+                        push_nested_from_a := StackNavDemoButton{
+                            text: "Push View B from here"
+                        }
+                    }
+                }
+
+                stack_view_b := StackNavigationView{
+                    full_screen: false
+                    header +: {
+                        content +: {
+                            title_container +: {
+                                title +: {text: "View B"}
+                            }
+                        }
+                    }
+                    body +: {
+                        flow: Down
+                        align: Align{x: 0.5 y: 0.3}
+                        spacing: 10.
+                        padding: 20.
+
+                        H3{text: "View B"}
+                        Label{text: "Another stack view.\nYou can push more views from here."}
+                        push_nested_from_b := StackNavDemoButton{
+                            text: "Push View C from here"
+                        }
+                    }
+                }
+
+                stack_view_c := StackNavigationView{
+                    full_screen: false
+                    header +: {
+                        content +: {
+                            title_container +: {
+                                title +: {text: "View C"}
+                            }
+                        }
+                    }
+                    body +: {
+                        flow: Down
+                        align: Align{x: 0.5 y: 0.3}
+                        spacing: 10.
+                        padding: 20.
+
+                        H3{text: "View C"}
+                        Label{text: "Deepest view in this demo."}
+                        pop_to_root_btn := StackNavDemoButton{
+                            text: "Pop to Root"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/widgets/resources/icons/back.svg
+++ b/widgets/resources/icons/back.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+<svg width="800px" height="800px" viewBox="0 0 480 510" xmlns="http://www.w3.org/2000/svg">
   <path d="M 353.56 52.54 L 112.646 233.14 L 82.765 255.541 L 112.842 277.727 L 355.107 456.442 L 395.549 411.711 L 183.36 255.183 L 394.393 96.983 L 353.56 52.54 Z"/>
 </svg>

--- a/widgets/src/stack_navigation.rs
+++ b/widgets/src/stack_navigation.rs
@@ -36,14 +36,15 @@ script_mod! {
             }
 
             button_container := View{
-                left_button := Button{
-                    width: Fit height: 68
-                    icon_walk: Walk{width: 10 height: 68}
-                    draw_bg +: {
-                        pixel: fn() {
-                            let sdf = Sdf2d.viewport(self.pos * self.rect_size)
-                            return sdf.result
-                        }
+                height: Fit width: Fit
+                left_button := ButtonFlatterIcon{
+                    width: 68 height: 68
+                    icon_walk: Walk{
+                        height: 10 width: Fit
+                    }
+                    draw_icon +: {
+                        color: theme.color_label_inner
+                        svg: crate_resource("self:resources/icons/back.svg")
                     }
                 }
             }
@@ -56,7 +57,12 @@ script_mod! {
         flow: Overlay
 
         show_bg: true
-        draw_bg.color: theme.color_white
+        draw_bg +: {
+            color: instance(theme.color_bg_app)
+            pixel: fn() {
+                return Pal.premul(self.color)
+            }
+        }
 
         // Empty slot to place a generic full-screen background
         background := View{
@@ -148,6 +154,9 @@ pub struct StackNavigationView {
     offset: f64,
 
     /// Whether the stack view should take over the entire screen.
+    ///
+    /// If false, the stack view will be constrained to the size of the parent view,
+    /// and no animations will be played when navigating.
     #[live(true)]
     full_screen: bool,
 
@@ -165,9 +174,6 @@ pub struct StackNavigationView {
     /// The UID of the parent navigation.
     #[rust]
     parent_navigation_uid: Option<WidgetUid>,
-
-    #[live(true)]
-    visible: bool,
 }
 
 impl Widget for StackNavigationView {
@@ -183,10 +189,6 @@ impl Widget for StackNavigationView {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        if !self.visible {
-            return DrawStep::done();
-        }
-
         let abs_pos = if self.full_screen {
             // In full screen mode, position at the offset.
             Vec2d {
@@ -195,9 +197,7 @@ impl Widget for StackNavigationView {
             }
         } else {
             let parent_rect = cx.peek_walk_turtle(walk);
-
-            // Not in full screen mode, position at the parent ignoring the offset
-            // (offset ignored since we're not animating the slide-in).
+            // Non-fullscreen: ignore offset, position at parent.
             Vec2d {
                 x: parent_rect.pos.x,
                 y: parent_rect.pos.y,
@@ -213,7 +213,7 @@ impl StackNavigationView {
         if self.full_screen {
             self.animator_play(cx, ids!(slide.hide));
         } else {
-            // Cut straight into the hide state without animating the slide-out.
+            // Non-fullscreen: cut instantly (no animation).
             self.animator_cut(cx, ids!(slide.hide));
         }
 
@@ -248,7 +248,7 @@ impl StackNavigationView {
             && self.animator.in_state(cx, ids!(slide.hide))
         {
             if self.offset > self.offset_to_hide {
-                self.visible = false;
+                self.view.visible = false;
                 self.redraw(cx);
 
                 // Dispatch HideEnd with the parent navigation's UID
@@ -275,6 +275,7 @@ impl StackNavigationView {
             && self.animator.in_state(cx, ids!(slide.show))
         {
             const OPENING_OFFSET_THRESHOLD: f64 = 0.5;
+            // Non-fullscreen: consider fully opened immediately (offset ignored in draw_walk).
             if self.offset < OPENING_OFFSET_THRESHOLD || !self.full_screen {
                 cx.widget_action(self.widget_uid(), StackNavigationTransitionAction::ShowDone);
                 self.state = StackNavigationViewState::Active;
@@ -283,15 +284,15 @@ impl StackNavigationView {
     }
 
     fn is_animating(&self) -> bool {
-        self.animator.is_animating()
+        self.animator.is_track_animating(live_id!(slide))
     }
 }
 
 impl StackNavigationViewRef {
     pub fn show(&self, cx: &mut Cx, root_width: f64) {
         if let Some(mut inner) = self.borrow_mut() {
+            inner.view.visible = true;
             inner.offset = root_width;
-            inner.visible = true;
             inner.offset_to_hide = root_width;
             inner.animator_play(cx, ids!(slide.show));
             inner.redraw(cx);
@@ -300,7 +301,8 @@ impl StackNavigationViewRef {
 
     pub fn is_showing(&self, cx: &mut Cx) -> bool {
         if let Some(inner) = self.borrow() {
-            inner.animator.in_state(cx, ids!(slide.show)) || inner.is_animating()
+            inner.animator.in_state(cx, ids!(slide.show))
+                || inner.is_animating()
         } else {
             false
         }
@@ -385,7 +387,7 @@ impl NavigationStack {
     }
 }
 
-#[derive(Script, ScriptHook, WidgetRef, WidgetSet, WidgetRegister)]
+#[derive(Script, WidgetRef, WidgetSet, WidgetRegister)]
 pub struct StackNavigation {
     #[deref]
     view: View,
@@ -395,6 +397,29 @@ pub struct StackNavigation {
 
     #[rust]
     navigation_stack: NavigationStack,
+}
+
+impl ScriptHook for StackNavigation {
+    fn on_after_apply(
+        &mut self,
+        _vm: &mut ScriptVm,
+        apply: &Apply,
+        _scope: &mut Scope,
+        _value: ScriptValue,
+    ) {
+        if apply.is_new() {
+            self.navigation_stack = NavigationStack::default();
+        } else if apply.is_reload() {
+            // Make sure current stack view is visible when code reloads
+            if let Some(current_entry) = self.navigation_stack.current() {
+                let stack_view_ref = self.stack_navigation_view(_vm.cx_mut(), &[current_entry.view_id]);
+                if let Some(mut inner) = stack_view_ref.borrow_mut() {
+                    inner.view.visible = true;
+                    inner.offset = 0.0;
+                };
+            }
+        }
+    }
 }
 
 impl Widget for StackNavigation {


### PR DESCRIPTION
### Summary

Restores StackNavigation widget, which broke when ported from the previous widgets crate. 
Added StackNavigation and AdaptiveView examples to UI Zoo app.