### PR TITLE
cargo-makepad android: use crate name for Rust .so lookup

### DIFF
--- a/tools/cargo_makepad/src/android/compile.rs
+++ b/tools/cargo_makepad/src/android/compile.rs
@@ -1015,6 +1015,7 @@ pub fn build(
     let build_crate = get_build_crate_from_args(args)?;
     let binary_name = get_package_binary_name(build_crate).unwrap_or_else(|| build_crate.to_string());
     let underscore_binary_name = binary_name.replace('-', "_");
+    let underscore_build_crate = build_crate.replace('-', "_");
 
     let java_url = package_name.unwrap_or_else(|| format!("dev.makepad.{underscore_binary_name}"));
     let app_label = app_label.unwrap_or_else(|| underscore_binary_name.clone());
@@ -1038,7 +1039,7 @@ pub fn build(
     let build_dir = add_rust_library(
         sdk_dir,
         host_os,
-        &underscore_binary_name,
+        &underscore_build_crate,
         &build_paths,
         android_targets,
         args,


### PR DESCRIPTION
## Summary
Fix Android APK packaging in cargo-makepad when the package binary name differs from the crate name.

The Rust shared library path is produced from the crate/package name (`lib<crate>.so`), but packaging code was using the binary name. This caused packaging to look for a missing `.so` (for example `libhavi.so` instead of `libhavishell.so`).

## Change
- In `tools/cargo_makepad/src/android/compile.rs`, use `build_crate` (underscore-normalized) for `add_rust_library` lookup.
- Keep binary-name behavior for app label/package defaults unchanged.

## Validation
- `./mach-havi build android aarch64 --release`
- APK packaging now completes without symlink hacks.
