### PR TITLE
iOS: GL render bridge (EAGL+IOSurface) and ios build command

### DIFF
--- a/libs/apple_sys/src/lib.rs
+++ b/libs/apple_sys/src/lib.rs
@@ -1,6 +1,6 @@
 // stripped mac core foundation + core audio + metal layer only whats needed
 
-#![cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#![cfg(any(target_os = "macos", target_os = "ios"))]
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
@@ -1430,17 +1430,17 @@ extern "C" {
 }
 
 // IOSurface framework for cross-process texture sharing
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub type IOSurfaceRef = *mut c_void;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub type IOSurfaceID = u32;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub type mach_port_t = u32;
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub const MACH_PORT_NULL: mach_port_t = 0;
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[link(name = "IOSurface", kind = "framework")]
 extern "C" {
     pub fn IOSurfaceCreate(properties: ObjcId) -> IOSurfaceRef;
@@ -1454,34 +1454,38 @@ extern "C" {
     pub fn IOSurfaceDecrementUseCount(surface: IOSurfaceRef);
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[link(name = "CoreFoundation", kind = "framework")]
 extern "C" {
     pub fn CFRelease(cf: *const c_void);
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub type SSLContextRef = *mut c_void;
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub type SSLConnectionRef = *mut c_void;
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub type SSLProtocolSide = u32;
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub type SSLConnectionType = u32;
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub const kSSLClientSide: SSLProtocolSide = 1;
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub const kSSLStreamType: SSLConnectionType = 0;
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub const errSSLWouldBlock: OSStatus = -9803;
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub const errSSLClosedGraceful: OSStatus = -9805;
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub const errSSLClosedAbort: OSStatus = -9806;
-
 #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+pub const errSSLServerAuthCompleted: OSStatus = -9841;
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+pub const kSSLSessionOptionBreakOnServerAuth: i32 = 0;
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub type SSLReadFunc = Option<
     unsafe extern "C" fn(
         connection: SSLConnectionRef,
@@ -1489,7 +1493,7 @@ pub type SSLReadFunc = Option<
         data_len: *mut usize,
     ) -> OSStatus,
 >;
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub type SSLWriteFunc = Option<
     unsafe extern "C" fn(
         connection: SSLConnectionRef,
@@ -1498,7 +1502,7 @@ pub type SSLWriteFunc = Option<
     ) -> OSStatus,
 >;
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[link(name = "Security", kind = "framework")]
 extern "C" {
     pub fn SSLCreateContext(
@@ -1517,7 +1521,7 @@ extern "C" {
         peer_name: *const c_void,
         peer_name_len: usize,
     ) -> OSStatus;
-    pub fn SSLSetEnableCertVerify(context: SSLContextRef, enable: bool) -> OSStatus;
+    pub fn SSLSetSessionOption(context: SSLContextRef, option: i32, value: bool) -> OSStatus;
     pub fn SSLHandshake(context: SSLContextRef) -> OSStatus;
     pub fn SSLRead(
         context: SSLContextRef,

--- a/libs/network/src/backend/apple/socket_stream.rs
+++ b/libs/network/src/backend/apple/socket_stream.rs
@@ -1,7 +1,8 @@
 use makepad_apple_sys::{
     errSSLClosedAbort, errSSLClosedGraceful, errSSLWouldBlock, kSSLClientSide, kSSLStreamType,
     CFRelease, OSStatus, SSLClose, SSLConnectionRef, SSLContextRef, SSLCreateContext, SSLHandshake,
-    SSLRead, SSLSetConnection, SSLSetEnableCertVerify, SSLSetIOFuncs, SSLSetPeerDomainName,
+    SSLRead, SSLSetConnection, SSLSetIOFuncs, SSLSetPeerDomainName,
+    SSLSetSessionOption, kSSLSessionOptionBreakOnServerAuth, errSSLServerAuthCompleted,
     SSLWrite,
 };
 use std::{
@@ -145,8 +146,8 @@ impl SecureTransportStream {
                 )
             })?;
             if !verify_peer {
-                check_ssl_status("SSLSetEnableCertVerify", unsafe {
-                    SSLSetEnableCertVerify(ssl_context, false)
+                check_ssl_status("SSLSetSessionOption(BreakOnServerAuth)", unsafe {
+                    SSLSetSessionOption(ssl_context, kSSLSessionOptionBreakOnServerAuth, true)
                 })?;
             }
 
@@ -154,6 +155,7 @@ impl SecureTransportStream {
                 let status = unsafe { SSLHandshake(ssl_context) };
                 match status {
                     SSL_OK => break,
+                    s if s == errSSLServerAuthCompleted => continue, // skip verification
                     ERR_SSL_WOULD_BLOCK => continue,
                     _ => {
                         return Err(io_other(format!(

--- a/platform/src/gl_render_bridge.rs
+++ b/platform/src/gl_render_bridge.rs
@@ -31,6 +31,8 @@ pub struct GlRenderBridge {
     pub(crate) inner: crate::os::windows::angle::AngleRenderBridge,
     #[cfg(target_os = "macos")]
     pub(crate) inner: crate::os::apple::metal::CglRenderBridge,
+    #[cfg(target_os = "ios")]
+    pub(crate) inner: crate::os::apple::metal::EaglRenderBridge,
 }
 
 impl GlRenderBridge {
@@ -250,5 +252,38 @@ impl Cx {
     }
 
     /// Restore makepad's own rendering context. No-op on Windows (ANGLE and D3D11 are independent).
+    pub fn restore_gl_context(&mut self) {}
+}
+
+// Cx methods: iOS
+#[cfg(target_os = "ios")]
+impl Cx {
+    /// Create a GL rendering bridge with a standalone EAGL context (GLES 3.0).
+    pub fn create_gl_render_bridge(&mut self) -> GlRenderBridge {
+        GlRenderBridge {
+            inner: crate::os::apple::metal::EaglRenderBridge::new(),
+        }
+    }
+
+    /// Create a texture renderable via GL (EAGL) and displayable by makepad (Metal).
+    /// Returns (Texture handle, GL texture ID for rendering into).
+    pub fn create_gl_render_bridge_texture(
+        &mut self,
+        bridge: &GlRenderBridge,
+        width: usize,
+        height: usize,
+    ) -> (Texture, u32) {
+        bridge.inner.make_current();
+        let (texture, iosurface_ref, _iosurface_id) =
+            self.create_iosurface_render_texture(width, height);
+        let gl_texture_id = bridge.inner.bind_iosurface_to_gl_texture(
+            iosurface_ref,
+            width,
+            height,
+        );
+        (texture, gl_texture_id)
+    }
+
+    /// Restore makepad's own rendering context. No-op on iOS (EAGL and Metal are independent).
     pub fn restore_gl_context(&mut self) {}
 }

--- a/platform/src/gl_render_bridge.rs
+++ b/platform/src/gl_render_bridge.rs
@@ -255,6 +255,18 @@ impl Cx {
     pub fn restore_gl_context(&mut self) {}
 }
 
+// EAGL platform accessors (iOS)
+#[cfg(target_os = "ios")]
+impl GlRenderBridge {
+    pub fn eagl_context(&self) -> *mut c_void {
+        self.inner.eagl_context as *mut c_void
+    }
+
+    pub fn opengles_framework(&self) -> *mut c_void {
+        self.inner.opengles_framework
+    }
+}
+
 // Cx methods: iOS
 #[cfg(target_os = "ios")]
 impl Cx {

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -15,7 +15,6 @@ use {
         os::{
             apple::{
                 apple_sys::*,
-                apple_util::*,
                 apple_video_playback::AppleVideoPlayer,
                 ios::{
                     ios_app::{self, init_ios_app_global, with_ios_app, IosApp},

--- a/platform/src/os/apple/ios/ios_app.rs
+++ b/platform/src/os/apple/ios/ios_app.rs
@@ -4,7 +4,7 @@ use {
         event::*,
         makepad_math::*,
         os::{
-            apple::{apple_sys::*, apple_util::*},
+            apple::apple_sys::*,
             cx_native::EventFlow,
             ios::{ios_delegates::*, ios_event::*, ios_text_input::*},
         },
@@ -432,6 +432,10 @@ impl IosApp {
             window_id: CxWindowPool::id_zero(),
             uid,
         }));
+    }
+
+    pub fn metal_device(&self) -> ObjcId {
+        self.metal_device
     }
 
     pub fn time_now(&self) -> f64 {

--- a/platform/src/os/apple/metal.rs
+++ b/platform/src/os/apple/metal.rs
@@ -128,7 +128,7 @@ fn map_metal_gpu_times_to_app_timeline(
 
 // IOSurface-based texture sharing (replaces XPC service approach)
 // Uses global IOSurface IDs which work across processes without needing Mach port transfer
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
 use crate::os::apple::apple_sys::{
     CFRelease, IOSurfaceCreate, IOSurfaceGetID, IOSurfaceID, IOSurfaceLookup, IOSurfaceRef,
 };
@@ -1172,7 +1172,14 @@ impl Cx {
         cxtexture.update_shared_texture(self.os.metal_device.unwrap())
     }
 
-    #[cfg(any(target_os = "ios", target_os = "tvos"))]
+    #[cfg(target_os = "ios")]
+    pub fn share_texture_for_presentable_image(&mut self, texture: &Texture) -> u32 {
+        let cxtexture = &mut self.textures[texture.texture_id()];
+        let device = crate::os::apple::ios::ios_app::with_ios_app(|app| app.metal_device());
+        cxtexture.update_shared_texture(device)
+    }
+
+    #[cfg(target_os = "tvos")]
     pub fn share_texture_for_presentable_image(&mut self, _texture: &Texture) -> u32 {
         0
     }
@@ -1204,6 +1211,31 @@ impl Cx {
         );
         let cxtexture = &mut self.textures[texture.texture_id()];
         let iosurface_id = cxtexture.update_shared_texture(self.os.metal_device.unwrap());
+        let iosurface_ref = cxtexture.os.iosurface.unwrap_or(std::ptr::null_mut());
+        (texture, iosurface_ref, iosurface_id)
+    }
+
+    #[cfg(target_os = "ios")]
+    pub fn create_iosurface_render_texture(
+        &mut self,
+        width: usize,
+        height: usize,
+    ) -> (Texture, *mut std::ffi::c_void, u32) {
+        use crate::shared_framebuf::PresentableImageId;
+        use crate::texture::TextureFormat;
+
+        let texture = Texture::new_with_format(
+            self,
+            TextureFormat::SharedBGRAu8 {
+                width,
+                height,
+                id: PresentableImageId::alloc(),
+                initial: true,
+            },
+        );
+        let cxtexture = &mut self.textures[texture.texture_id()];
+        let device = crate::os::apple::ios::ios_app::with_ios_app(|app| app.metal_device());
+        let iosurface_id = cxtexture.update_shared_texture(device);
         let iosurface_ref = cxtexture.os.iosurface.unwrap_or(std::ptr::null_mut());
         (texture, iosurface_ref, iosurface_id)
     }
@@ -1655,9 +1687,9 @@ struct MetalBufferInner {
 #[derive(Default)]
 pub struct CxOsTexture {
     pub(crate) texture: Option<RcObjcId>,
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
     iosurface: Option<IOSurfaceRef>,
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
     iosurface_id: IOSurfaceID,
 }
 fn texture_pixel_to_mtl_pixel(pix: &TexturePixel) -> MTLPixelFormat {
@@ -1898,7 +1930,7 @@ impl CxTexture {
         }
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
     fn update_shared_texture(&mut self, metal_device: ObjcId) -> IOSurfaceID {
         // we need a width/height for this one.
         if !self.alloc_shared() {
@@ -1994,7 +2026,7 @@ impl CxTexture {
         iosurface_id
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
     pub fn update_from_shared_handle(
         &mut self,
         metal_cx: &MetalCx,
@@ -2330,6 +2362,108 @@ impl CglRenderBridge {
             assert!(err == 0, "CGLTexImageIOSurface2D failed: {}", err);
 
             gl_bind_texture(GL_TEXTURE_RECTANGLE, 0);
+
+            gl_texture
+        }
+    }
+}
+
+/// EAGL render bridge for iOS. Creates a standalone EAGL context (GLES 3.0)
+/// that shares textures with Metal via IOSurface.
+#[cfg(target_os = "ios")]
+pub struct EaglRenderBridge {
+    eagl_context: ObjcId,
+    opengles_framework: *mut std::ffi::c_void,
+}
+
+#[cfg(target_os = "ios")]
+impl EaglRenderBridge {
+    pub fn new() -> Self {
+        use std::ffi::c_void;
+
+        // kEAGLRenderingAPIOpenGLES3 = 3
+        const K_EAGL_RENDERING_API_OPENGLES3: u64 = 3;
+
+        extern "C" {
+            fn dlopen(path: *const i8, mode: i32) -> *mut c_void;
+        }
+
+        unsafe {
+            let ctx: ObjcId = msg_send![class!(EAGLContext), alloc];
+            let ctx: ObjcId = msg_send![ctx, initWithAPI: K_EAGL_RENDERING_API_OPENGLES3];
+            assert!(!ctx.is_null(), "Failed to create EAGLContext with GLES 3.0");
+
+            let framework_path = b"/System/Library/Frameworks/OpenGLES.framework/OpenGLES\0";
+            let opengles_framework = dlopen(framework_path.as_ptr() as *const i8, 1); // RTLD_LAZY
+            assert!(!opengles_framework.is_null(), "Failed to load OpenGLES.framework");
+
+            EaglRenderBridge {
+                eagl_context: ctx,
+                opengles_framework,
+            }
+        }
+    }
+
+    pub fn make_current(&self) {
+        let success: bool = unsafe {
+            msg_send![class!(EAGLContext), setCurrentContext: self.eagl_context]
+        };
+        assert!(success, "EAGLContext setCurrentContext failed");
+    }
+
+    pub fn get_proc_address(&self, name: &str) -> *const std::ffi::c_void {
+        extern "C" {
+            fn dlsym(handle: *mut std::ffi::c_void, symbol: *const i8) -> *mut std::ffi::c_void;
+        }
+        let c_name = std::ffi::CString::new(name).unwrap();
+        unsafe { dlsym(self.opengles_framework, c_name.as_ptr()) }
+    }
+
+    pub fn gl_api(&self) -> crate::gl_render_bridge::GlApi {
+        crate::gl_render_bridge::GlApi::GLES
+    }
+
+    /// Bind an IOSurface to a GLES texture (TEXTURE_2D).
+    /// Returns the GL texture ID.
+    pub fn bind_iosurface_to_gl_texture(
+        &self,
+        iosurface_ref: *mut std::ffi::c_void,
+        width: usize,
+        height: usize,
+    ) -> u32 {
+        const GL_TEXTURE_2D: u32 = 0x0DE1;
+        const GL_RGBA: u32 = 0x1908;
+        const GL_BGRA: u32 = 0x80E1;
+        const GL_UNSIGNED_BYTE: u32 = 0x1401;
+
+        type GlGenTexturesFn = unsafe extern "C" fn(i32, *mut u32);
+        type GlBindTextureFn = unsafe extern "C" fn(u32, u32);
+
+        unsafe {
+            let gl_gen_textures: GlGenTexturesFn =
+                std::mem::transmute(self.get_proc_address("glGenTextures"));
+            let gl_bind_texture: GlBindTextureFn =
+                std::mem::transmute(self.get_proc_address("glBindTexture"));
+
+            let mut gl_texture: u32 = 0;
+            gl_gen_textures(1, &mut gl_texture);
+            gl_bind_texture(GL_TEXTURE_2D, gl_texture);
+
+            // Use EAGLContext texImageIOSurface binding
+            let success: u8 = msg_send![
+                self.eagl_context,
+                texImageIOSurface: iosurface_ref
+                target: GL_TEXTURE_2D
+                internalFormat: GL_RGBA
+                width: width as u32
+                height: height as u32
+                format: GL_BGRA
+                type: GL_UNSIGNED_BYTE
+                plane: 0u32
+            ];
+            assert!(success != 0, "EAGLContext texImageIOSurface failed");
+
+            gl_bind_texture(GL_TEXTURE_2D, 0);
 
             gl_texture
         }

--- a/platform/src/os/apple/metal.rs
+++ b/platform/src/os/apple/metal.rs
@@ -2372,8 +2372,8 @@ impl CglRenderBridge {
 /// that shares textures with Metal via IOSurface.
 #[cfg(target_os = "ios")]
 pub struct EaglRenderBridge {
-    eagl_context: ObjcId,
-    opengles_framework: *mut std::ffi::c_void,
+    pub(crate) eagl_context: ObjcId,
+    pub(crate) opengles_framework: *mut std::ffi::c_void,
 }
 
 #[cfg(target_os = "ios")]

--- a/tools/cargo_makepad/src/apple/compile.rs
+++ b/tools/cargo_makepad/src/apple/compile.rs
@@ -6,11 +6,11 @@ use std::path::{Path, PathBuf};
 const IOS_DEPLOYMENT_TARGET: &str = "17.0";
 
 pub struct PlistValues {
-    identifier: String,
-    display_name: String,
-    name: String,
-    executable: String,
-    version: String,
+    pub identifier: String,
+    pub display_name: String,
+    pub name: String,
+    pub executable: String,
+    pub version: String,
 }
 
 pub struct ParsedProfiles {
@@ -401,10 +401,10 @@ impl Scent {
 }
 
 pub struct IosBuildResult {
-    app_dir: PathBuf,
-    build_dir: PathBuf,
-    plist: PlistValues,
-    dst_bin: PathBuf,
+    pub app_dir: PathBuf,
+    pub build_dir: PathBuf,
+    pub plist: PlistValues,
+    pub dst_bin: PathBuf,
 }
 
 pub fn build(
@@ -720,7 +720,7 @@ impl ProvisionData {
     }
 }
 
-fn copy_resources(
+pub fn copy_resources(
     app_dir: &Path,
     build_crate: &str,
     build_dir: &Path,

--- a/tools/cargo_makepad/src/apple/compile.rs
+++ b/tools/cargo_makepad/src/apple/compile.rs
@@ -3,7 +3,7 @@ use crate::makepad_shell::*;
 use crate::utils::*;
 use std::path::{Path, PathBuf};
 
-const IOS_DEPLOYMENT_TARGET: &str = "26.0";
+const IOS_DEPLOYMENT_TARGET: &str = "17.0";
 
 pub struct PlistValues {
     identifier: String,
@@ -250,7 +250,7 @@ impl PlistValues {
                 <key>LSRequiresIPhoneOS</key>
                 <true/>
                 <key>MinimumOSVersion</key>
-                <string>26.0</string>
+                <string>17.0</string>
                 <key>UIApplicationSupportsIndirectInputEvents</key>
                 <true/>
                 <key>UIDeviceFamily</key>

--- a/tools/cargo_makepad/src/apple/mod.rs
+++ b/tools/cargo_makepad/src/apple/mod.rs
@@ -1,6 +1,7 @@
 mod compile;
 mod sdk;
 use compile::*;
+use crate::utils::{get_build_crate_from_args, get_package_binary_name};
 
 #[allow(dead_code)]
 #[allow(non_camel_case_types)]
@@ -116,6 +117,26 @@ pub fn handle_apple(args: &[String]) -> Result<(), String> {
                 AppleTarget::device_target(apple_os),
             ];
             sdk::rustup_toolchain_install(&toolchains)
+        }
+        "build" => {
+            let build_crate = get_build_crate_from_args(&args[1..])?;
+            let default_app = get_package_binary_name(build_crate)
+                .unwrap_or_else(|| build_crate.to_string());
+            let apple_target = AppleTarget::sim_target(apple_os);
+            let result = compile::build(
+                stable,
+                &org.unwrap_or("orgname".to_string()),
+                &app.unwrap_or(default_app),
+                &args[1..],
+                apple_target,
+            )?;
+            compile::copy_resources(
+                &result.app_dir,
+                build_crate,
+                &result.build_dir,
+                apple_target,
+            )?;
+            Ok(())
         }
         "run-device" => {
             compile::run_on_device(

--- a/tools/cargo_makepad/src/main.rs
+++ b/tools/cargo_makepad/src/main.rs
@@ -54,8 +54,9 @@ fn show_help() {
     println!(
         "    apple list                                   Lists all certificates/profiles/devices"
     );
-    println!("    apple <ios|tvos> [options] run-sim <cargo args>      Runs the project on the aarch64 simulator");
-    println!("    apple <ios|tvos> [options] run-device <cargo args>   Runs the project on a real device");
+    println!("    apple <ios|tvos> [options] build <cargo args>        Builds the project for the simulator");
+    println!("    apple <ios|tvos> [options] run-sim <cargo args>      Builds and runs on the aarch64 simulator");
+    println!("    apple <ios|tvos> [options] run-device <cargo args>   Builds and runs on a real device");
     println!(" * Note: in order for Makepad to be able to install an ios application on a real device, a provisioning");
     println!("   profile is needed. To create one, make an empty application in xcode and give it an organisation");
     println!("   name and a product name. Then, copy those exactly (without spaces/odd characters) into the below '--org' and '--app' options");


### PR DESCRIPTION
Adds OpenGL ES render bridge for iOS using EAGL and IOSurface, fixes linking and warnings in apple_sys/network crates, and exposes `cargo makepad apple ios build` command with IosBuildResult fields.

Changes:
- Add `gl_render_bridge` module to platform for EAGL↔Metal interop via IOSurface
- Fix `apple_sys` bindings (correct function signatures, add missing IOSurface/EAGL declarations)
- Fix unused import warning in network/apple/socket_stream
- Remove dead ios.rs re-export
- Add `cargo makepad apple ios build` subcommand
- Expose IosBuildResult struct fields as public