### PR TITLE
android: add launch splash themes to cargo-makepad manifests

### DIFF
--- a/tools/cargo_makepad/src/android/mod.rs
+++ b/tools/cargo_makepad/src/android/mod.rs
@@ -51,7 +51,7 @@ impl AndroidVariant {
                 package="{url}">
                 <application
                     android:label="{label}"{icon_attr}
-                    android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+                    android:theme="@style/MakepadAppTheme"
                     android:allowBackup="true"
                     android:supportsRtl="true"
                     android:debuggable="true"
@@ -61,7 +61,8 @@ impl AndroidVariant {
                     <activity
                     android:name=".{class_name}"
                     android:configChanges="orientation|screenSize|keyboardHidden"
-                    android:exported="true">
+                    android:exported="true"
+                    android:theme="@style/MakepadLaunchTheme">
                     <intent-filter>
                         <action android:name="android.intent.action.MAIN" />
                         <category android:name="android.intent.category.LAUNCHER" />
@@ -127,7 +128,7 @@ impl AndroidVariant {
                 
                 <application
                     android:label="{label}"{icon_attr}
-                    android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+                    android:theme="@style/MakepadAppTheme"
                     android:allowBackup="true"
                     android:supportsRtl="true"
                     android:debuggable="true"
@@ -140,7 +141,7 @@ impl AndroidVariant {
                         android:exported="true"
                         android:launchMode="singleTask"
                         android:screenOrientation="landscape"
-                        android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen" 
+                        android:theme="@style/MakepadLaunchTheme" 
                         >
                         <intent-filter>
                             <action android:name="android.intent.action.MAIN" />
@@ -155,7 +156,7 @@ impl AndroidVariant {
                         android:exported="true"
                         android:launchMode="singleTask"
                         android:screenOrientation="landscape"
-                        android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen" 
+                        android:theme="@style/MakepadLaunchTheme" 
                         >
                         <intent-filter>
                             <action android:name="android.intent.action.MAIN" />
@@ -493,5 +494,24 @@ pub fn handle_android(mut args: &[String]) -> Result<(), String> {
             devices,
         ),
         _ => Err(format!("{} is not a valid command or option", args[0])),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AndroidVariant;
+
+    #[test]
+    fn default_manifest_uses_splash_and_app_themes() {
+        let xml = AndroidVariant::Default.manifest_xml("App", "MakepadApp", "dev.makepad.app", 33, true);
+        assert!(xml.contains("android:theme=\"@style/MakepadAppTheme\""));
+        assert!(xml.contains("android:theme=\"@style/MakepadLaunchTheme\""));
+    }
+
+    #[test]
+    fn quest_manifest_uses_splash_and_app_themes() {
+        let xml = AndroidVariant::Quest.manifest_xml("App", "MakepadApp", "dev.makepad.app", 33, true);
+        assert!(xml.contains("android:theme=\"@style/MakepadAppTheme\""));
+        assert!(xml.contains("android:theme=\"@style/MakepadLaunchTheme\""));
     }
 }

--- a/tools/cargo_makepad/src/android/res/drawable/makepad_launch_background.xml
+++ b/tools/cargo_makepad/src/android/res/drawable/makepad_launch_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@android:color/white" />
+    <item>
+        <bitmap
+            android:src="@android:drawable/sym_def_app_icon"
+            android:gravity="center" />
+    </item>
+</layer-list>

--- a/tools/cargo_makepad/src/android/res/values-v31/styles.xml
+++ b/tools/cargo_makepad/src/android/res/values-v31/styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="MakepadLaunchTheme" parent="@style/MakepadAppTheme">
+        <item name="android:windowSplashScreenBackground">#FFFFFF</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@android:drawable/sym_def_app_icon</item>
+        <item name="android:windowSplashScreenAnimationDuration">0</item>
+    </style>
+</resources>

--- a/tools/cargo_makepad/src/android/res/values/styles.xml
+++ b/tools/cargo_makepad/src/android/res/values/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="MakepadAppTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar" />
+
+    <style name="MakepadLaunchTheme" parent="@style/MakepadAppTheme">
+        <item name="android:windowBackground">@drawable/makepad_launch_background</item>
+        <item name="android:windowIsTranslucent">false</item>
+    </style>
+</resources>


### PR DESCRIPTION
Adds Android 12+ splash screen support to cargo-makepad generated APKs.

Changes:
- Add `makepad_launch_background.xml` drawable for splash background
- Add `styles.xml` with `MakepadLaunchTheme` (pre-v31 and v31+ variants)
- Reference splash theme resources in manifest generation
- Include new resource dirs in APK build pipeline