### PR TITLE
cargo-makepad: isolate android/apple target dirs from desktop builds

### DIFF
--- a/tools/cargo_makepad/src/android/compile.rs
+++ b/tools/cargo_makepad/src/android/compile.rs
@@ -96,6 +96,8 @@ fn rust_build(
     urls: &AndroidSDKUrls,
 ) -> Result<(), String> {
     let cwd = std::env::current_dir().unwrap();
+    let target_dir = cargo_target_dir(&cwd);
+    let target_dir_str = target_dir.to_string_lossy().to_string();
     let (_ndk_version, ndk_prebuilt_root) =
         resolve_ndk_prebuilt_root(sdk_dir, host_os, urls.ndk_version_full)?;
     for android_target in android_targets {
@@ -114,6 +116,7 @@ fn rust_build(
 
         let toolchain = android_target.toolchain();
         let target_opt = format!("--target={toolchain}");
+        let target_dir_arg = format!("--target-dir={target_dir_str}");
 
         let base_args = &[
             "run",
@@ -123,6 +126,7 @@ fn rust_build(
             "--lib",
             "--crate-type=cdylib",
             &target_opt,
+            &target_dir_arg,
         ];
         let mut args_out = Vec::new();
         args_out.extend_from_slice(base_args);
@@ -185,6 +189,8 @@ fn rust_build(
     Ok(())
 }
 
+/// Resolve the cargo target directory for android builds.
+/// Defaults to `target/android` to avoid invalidating desktop build caches.
 fn cargo_target_dir(cwd: &Path) -> PathBuf {
     if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR") {
         let target_dir = PathBuf::from(target_dir);
@@ -194,7 +200,7 @@ fn cargo_target_dir(cwd: &Path) -> PathBuf {
             cwd.join(target_dir)
         }
     } else {
-        cwd.join("target")
+        cwd.join("target").join("android")
     }
 }
 

--- a/tools/cargo_makepad/src/apple/compile.rs
+++ b/tools/cargo_makepad/src/apple/compile.rs
@@ -5,6 +5,21 @@ use std::path::{Path, PathBuf};
 
 const IOS_DEPLOYMENT_TARGET: &str = "26.0";
 
+/// Resolve the cargo target directory for apple builds.
+/// Defaults to `target/apple` to avoid invalidating desktop build caches.
+fn cargo_target_dir(cwd: &Path) -> PathBuf {
+    if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR") {
+        let target_dir = PathBuf::from(target_dir);
+        if target_dir.is_absolute() {
+            target_dir
+        } else {
+            cwd.join(target_dir)
+        }
+    } else {
+        cwd.join("target").join("apple")
+    }
+}
+
 pub struct PlistValues {
     identifier: String,
     display_name: String,
@@ -418,6 +433,9 @@ pub fn build(
     let binary_name = get_package_binary_name(build_crate).unwrap_or_else(|| build_crate.to_string());
 
     let cwd = std::env::current_dir().unwrap();
+    let target_dir = cargo_target_dir(&cwd);
+    let target_dir_str = target_dir.to_string_lossy().to_string();
+    let target_dir_arg = format!("--target-dir={target_dir_str}");
     let target_opt = format!("--target={}", apple_target.toolchain());
 
     let base_args = &[
@@ -426,6 +444,7 @@ pub fn build(
         "cargo",
         "build",
         &target_opt,
+        &target_dir_arg,
     ];
 
     let mut args_out = Vec::new();
@@ -459,8 +478,8 @@ pub fn build(
     };
     let profile = get_profile_from_args(args);
 
-    let app_dir = cwd.join(format!(
-        "target/makepad-apple-app/{}/{profile}/{build_crate}.app",
+    let app_dir = target_dir.join(format!(
+        "makepad-apple-app/{}/{profile}/{build_crate}.app",
         apple_target.toolchain()
     ));
     mkdir(&app_dir)?;
@@ -468,9 +487,9 @@ pub fn build(
     let plist_file = app_dir.join("Info.plist");
     write_text(&plist_file, &plist.to_plist_file(apple_target.os()))?;
 
-    let build_dir = cwd.join(format!("target/{}/{profile}/", apple_target.toolchain()));
-    let src_bin = cwd.join(format!(
-        "target/{}/{profile}/{binary_name}",
+    let build_dir = target_dir.join(format!("{}/{profile}/", apple_target.toolchain()));
+    let src_bin = target_dir.join(format!(
+        "{}/{profile}/{binary_name}",
         apple_target.toolchain()
     ));
     let dst_bin = app_dir.join(binary_name.clone());
@@ -827,8 +846,9 @@ pub fn run_on_device(
         team_id: provision.team_ident.to_string(),
     };
 
-    let scent_file = cwd.join(format!(
-        "target/makepad-apple-app/{}/release/{build_crate}.scent",
+    let target_dir = cargo_target_dir(&cwd);
+    let scent_file = target_dir.join(format!(
+        "makepad-apple-app/{}/release/{build_crate}.scent",
         apple_target.toolchain()
     ));
     write_text(&scent_file, &scent.to_scent_file())?;


### PR DESCRIPTION
Uses separate target directories for Android and Apple cross-compilation builds to prevent cache invalidation of desktop builds.

Changes:
- Android: set `CARGO_TARGET_DIR` to `target/makepad_android`
- Apple: set `CARGO_TARGET_DIR` to `target/makepad_apple` for all iOS/tvOS/simulator builds