### PR TITLE
iOS: app icons, fullscreen, iOS 15 support, GL texture fix, NSLog logging

### DIFF
--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -42,6 +42,7 @@ pub mod permission;
 pub mod studio;
 mod texture;
 mod window;
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 mod app_icon;
 
 pub mod web_socket;

--- a/platform/src/log.rs
+++ b/platform/src/log.rs
@@ -38,7 +38,7 @@ pub(crate) fn log_with_level_makepad_platform(
     }
 
     if !Cx::has_studio_web_socket() {
-        #[cfg(not(target_os = "android"))]
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
         println!(
             "{}:{}:{} - {}",
             file_name,
@@ -46,6 +46,18 @@ pub(crate) fn log_with_level_makepad_platform(
             column_start + 1,
             message
         );
+        #[cfg(target_os = "ios")]
+        {
+            extern "C" {
+                fn NSLog(fmt: crate::os::apple::apple_sys::ObjcId, ...);
+            }
+            use crate::os::apple::apple_util::str_to_nsstring;
+            let msg = format!(
+                "{}:{}:{} - {}",
+                file_name, line_start + 1, column_start + 1, message
+            );
+            unsafe { NSLog(str_to_nsstring(&msg)) };
+        }
         // if android, also log to ADB
         #[cfg(target_os = "android")]
         {

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -399,6 +399,12 @@ impl Cx {
                 CxOsOp::CopyToClipboard(content) => {
                     with_ios_app(|app| app.copy_to_clipboard(&content));
                 }
+                CxOsOp::FullscreenWindow(_window_id) => {
+                    with_ios_app(|app| app.set_fullscreen(true));
+                }
+                CxOsOp::NormalizeWindow(_window_id) => {
+                    with_ios_app(|app| app.set_fullscreen(false));
+                }
                 CxOsOp::SetCursor(_) => {
                     // no need
                 }

--- a/platform/src/os/apple/ios/ios_app.rs
+++ b/platform/src/os/apple/ios/ios_app.rs
@@ -83,6 +83,7 @@ pub struct IosTimer {
 
 pub struct IosClasses {
     pub app_delegate: *const Class,
+    pub view_controller: *const Class,
     pub mtk_view: *const Class,
     pub mtk_view_delegate: *const Class,
     pub gesture_recognizer_handler: *const Class,
@@ -98,6 +99,7 @@ impl IosClasses {
     pub fn new() -> Self {
         Self {
             app_delegate: define_ios_app_delegate(),
+            view_controller: define_makepad_view_controller(),
             mtk_view: define_mtk_view(),
             mtk_view_delegate: define_mtk_view_delegate(),
             gesture_recognizer_handler: define_gesture_recognizer_handler(),
@@ -150,6 +152,8 @@ pub struct IosApp {
     keyboard_observer_delegate: Option<ObjcId>,
     /// Cached keyboard config to avoid redundant reloadInputViews calls
     last_keyboard_config: Option<crate::ime::TextInputConfig>,
+    /// Root view controller for status bar / home indicator control
+    pub view_controller: Option<ObjcId>,
 }
 
 impl IosApp {
@@ -181,6 +185,7 @@ impl IosApp {
                 edit_menu_interaction: None,
                 keyboard_observer_delegate: None,
                 last_keyboard_config: None,
+                view_controller: None,
             }
         }
     }
@@ -219,8 +224,10 @@ impl IosApp {
             let () = msg_send!(gesture_recognizer_obj, setCancelsTouchesInView: NO);
             let () = msg_send![mtk_view_obj, addGestureRecognizer: gesture_recognizer_obj];
 
-            let view_ctrl_obj: ObjcId = msg_send![class!(UIViewController), alloc];
+            let view_ctrl_obj: ObjcId = msg_send![get_ios_class_global().view_controller, alloc];
             let view_ctrl_obj: ObjcId = msg_send![view_ctrl_obj, init];
+            (*view_ctrl_obj).set_ivar::<BOOL>("_prefersStatusBarHidden", NO);
+            (*view_ctrl_obj).set_ivar::<BOOL>("_prefersHomeIndicatorAutoHidden", NO);
 
             let () = msg_send![view_ctrl_obj, setView: mtk_view_obj];
 
@@ -284,22 +291,27 @@ impl IosApp {
             let () = msg_send![window_obj, addSubview: mtk_view_obj];
 
             let () = msg_send![window_obj, setRootViewController: view_ctrl_obj];
+            self.view_controller = Some(view_ctrl_obj);
             let () = msg_send![window_obj, makeKeyAndVisible];
 
-            // Initialize UIEditMenuInteraction for clipboard actions
-            // Store MTKView reference in the delegate for accessing menu rect
-            (*self.edit_menu_delegate_instance).set_ivar("mtk_view", mtk_view_obj as *mut c_void);
+            // Initialize UIEditMenuInteraction for clipboard actions (iOS 16+)
+            let edit_menu_cls: ObjcId = makepad_objc_sys::runtime::objc_getClass(b"UIEditMenuInteraction\0".as_ptr() as *const _) as ObjcId;
+            if !edit_menu_cls.is_null() {
+                // Store MTKView reference in the delegate for accessing menu rect
+                (*self.edit_menu_delegate_instance).set_ivar("mtk_view", mtk_view_obj as *mut c_void);
 
-            // Create UIEditMenuInteraction with our delegate
-            let edit_menu_interaction: ObjcId = msg_send![class!(UIEditMenuInteraction), alloc];
-            let edit_menu_interaction: ObjcId = msg_send![edit_menu_interaction, initWithDelegate: self.edit_menu_delegate_instance];
+                // Create UIEditMenuInteraction with our delegate
+                let edit_menu_interaction: ObjcId = msg_send![edit_menu_cls, alloc];
+                let edit_menu_interaction: ObjcId = msg_send![edit_menu_interaction, initWithDelegate: self.edit_menu_delegate_instance];
 
-            // Add the interaction to the MTKView
-            let () = msg_send![mtk_view_obj, addInteraction: edit_menu_interaction];
+                // Add the interaction to the MTKView
+                let () = msg_send![mtk_view_obj, addInteraction: edit_menu_interaction];
+
+                self.edit_menu_interaction = Some(edit_menu_interaction);
+            }
 
             self.text_input_view = Some(text_input_view);
             self.mtk_view = Some(mtk_view_obj);
-            self.edit_menu_interaction = Some(edit_menu_interaction);
         }
     }
 
@@ -761,6 +773,18 @@ impl IosApp {
         IosApp::do_callback(IosEvent::Paint);
     }
 
+    pub fn set_fullscreen(&mut self, fullscreen: bool) {
+        if let Some(vc) = self.view_controller {
+            unsafe {
+                let val = if fullscreen { YES } else { NO };
+                (*vc).set_ivar::<BOOL>("_prefersStatusBarHidden", val);
+                (*vc).set_ivar::<BOOL>("_prefersHomeIndicatorAutoHidden", val);
+                let () = msg_send![vc, setNeedsStatusBarAppearanceUpdate];
+                let () = msg_send![vc, setNeedsUpdateOfHomeIndicatorAutoHidden];
+            }
+        }
+    }
+
     pub fn copy_to_clipboard(&self, content: &str) {
         unsafe {
             let nsstring = str_to_nsstring(content);
@@ -788,11 +812,7 @@ impl IosApp {
             .try_with(|app| {
                 if let Ok(app_ref) = app.try_borrow_mut() {
                     if let Some(ref app) = *app_ref {
-                        if let (Some(mtk_view), Some(edit_menu_interaction)) =
-                            (app.mtk_view, app.edit_menu_interaction)
-                        {
-                            return Some((mtk_view, edit_menu_interaction));
-                        }
+                        return Some((app.mtk_view, app.edit_menu_interaction));
                     }
                 }
                 None
@@ -800,7 +820,7 @@ impl IosApp {
             .ok()
             .flatten();
 
-        let Some((mtk_view, edit_menu_interaction)) = views else {
+        let Some((Some(mtk_view), edit_menu_interaction)) = views else {
             return;
         };
 
@@ -815,30 +835,39 @@ impl IosApp {
             (*mtk_view).set_ivar::<f64>("menu_rect_width", rect.size.x.max(1.0));
             (*mtk_view).set_ivar::<f64>("menu_rect_height", rect.size.y.max(1.0));
 
-            // Create configuration with source point at center of the rect
-            let source_point = NSPoint {
-                x: rect.pos.x + rect.size.x / 2.0,
-                y: rect.pos.y + rect.size.y / 2.0,
-            };
-            let config: ObjcId = msg_send![
-                class!(UIEditMenuConfiguration),
-                configurationWithIdentifier: nil
-                sourcePoint: source_point
-            ];
-
-            // Present the edit menu - this may trigger keyboard notifications,
-            // but now we're not holding any borrow so it's safe
-            let () = msg_send![edit_menu_interaction, presentEditMenuWithConfiguration: config];
+            if let Some(edit_menu_interaction) = edit_menu_interaction {
+                // iOS 16+: UIEditMenuInteraction
+                let source_point = NSPoint {
+                    x: rect.pos.x + rect.size.x / 2.0,
+                    y: rect.pos.y + rect.size.y / 2.0,
+                };
+                let config: ObjcId = msg_send![
+                    class!(UIEditMenuConfiguration),
+                    configurationWithIdentifier: nil
+                    sourcePoint: source_point
+                ];
+                let () = msg_send![edit_menu_interaction, presentEditMenuWithConfiguration: config];
+            } else {
+                // iOS 15: UIMenuController fallback
+                let menu_controller: ObjcId = msg_send![class!(UIMenuController), sharedMenuController];
+                let target_rect = NSRect {
+                    origin: NSPoint { x: rect.pos.x, y: rect.pos.y },
+                    size: NSSize { width: rect.size.x.max(1.0), height: rect.size.y.max(1.0) },
+                };
+                let () = msg_send![mtk_view, becomeFirstResponder];
+                let () = msg_send![menu_controller, setTargetRect: target_rect inView: mtk_view];
+                let () = msg_send![menu_controller, setMenuVisible: YES animated: YES];
+            }
         }
     }
 
     pub fn hide_clipboard_actions() {
         // Extract what we need first, then do ObjC calls after borrow ends
-        let interaction = IOS_APP
+        let state = IOS_APP
             .try_with(|app| {
                 if let Ok(app_ref) = app.try_borrow_mut() {
                     if let Some(ref app) = *app_ref {
-                        return app.edit_menu_interaction;
+                        return Some(app.edit_menu_interaction);
                     }
                 }
                 None
@@ -846,9 +875,18 @@ impl IosApp {
             .ok()
             .flatten();
 
-        if let Some(edit_menu_interaction) = interaction {
-            unsafe {
+        let Some(edit_menu_interaction) = state else {
+            return;
+        };
+
+        unsafe {
+            if let Some(edit_menu_interaction) = edit_menu_interaction {
+                // iOS 16+
                 let () = msg_send![edit_menu_interaction, dismissMenu];
+            } else {
+                // iOS 15: UIMenuController fallback
+                let menu_controller: ObjcId = msg_send![class!(UIMenuController), sharedMenuController];
+                let () = msg_send![menu_controller, setMenuVisible: NO animated: YES];
             }
         }
     }

--- a/platform/src/os/apple/ios/ios_delegates.rs
+++ b/platform/src/os/apple/ios/ios_delegates.rs
@@ -35,6 +35,35 @@ pub fn try_with_ios_app<R>(
         .flatten()
 }
 
+pub fn define_makepad_view_controller() -> *const Class {
+    let superclass = class!(UIViewController);
+    let mut decl = ClassDecl::new("MakepadViewController", superclass).unwrap();
+
+    decl.add_ivar::<BOOL>("_prefersStatusBarHidden");
+    decl.add_ivar::<BOOL>("_prefersHomeIndicatorAutoHidden");
+
+    extern "C" fn prefers_status_bar_hidden(this: &Object, _: Sel) -> BOOL {
+        unsafe { *this.get_ivar("_prefersStatusBarHidden") }
+    }
+
+    extern "C" fn prefers_home_indicator_auto_hidden(this: &Object, _: Sel) -> BOOL {
+        unsafe { *this.get_ivar("_prefersHomeIndicatorAutoHidden") }
+    }
+
+    unsafe {
+        decl.add_method(
+            sel!(prefersStatusBarHidden),
+            prefers_status_bar_hidden as extern "C" fn(&Object, Sel) -> BOOL,
+        );
+        decl.add_method(
+            sel!(prefersHomeIndicatorAutoHidden),
+            prefers_home_indicator_auto_hidden as extern "C" fn(&Object, Sel) -> BOOL,
+        );
+    }
+
+    decl.register()
+}
+
 pub fn define_ios_app_delegate() -> *const Class {
     let superclass = class!(NSObject);
     let mut decl = ClassDecl::new("NSAppDelegate", superclass).unwrap();

--- a/platform/src/os/apple/metal.rs
+++ b/platform/src/os/apple/metal.rs
@@ -1965,10 +1965,14 @@ impl CxTexture {
                 msg_send![class!(NSNumber), numberWithUnsignedInteger: 0x42475241u64];
             let _: () = msg_send![dict, setObject: pf_val forKey: pf_key];
 
-            // Mark as global to allow cross-process lookup via IOSurfaceLookup
-            let global_key = crate::os::apple::apple_util::str_to_nsstring("IOSurfaceIsGlobal");
-            let global_val: ObjcId = msg_send![class!(NSNumber), numberWithBool: true];
-            let _: () = msg_send![dict, setObject: global_val forKey: global_key];
+            // IOSurfaceIsGlobal is deprecated since iOS 11 and may cause
+            // texImageIOSurface failures on some devices. Only set on macOS.
+            #[cfg(target_os = "macos")]
+            {
+                let global_key = crate::os::apple::apple_util::str_to_nsstring("IOSurfaceIsGlobal");
+                let global_val: ObjcId = msg_send![class!(NSNumber), numberWithBool: true];
+                let _: () = msg_send![dict, setObject: global_val forKey: global_key];
+            }
 
             dict
         };
@@ -1980,12 +1984,13 @@ impl CxTexture {
         }
 
         if iosurface.is_null() {
-            crate::error!("Failed to create IOSurface");
+            crate::error!("Failed to create IOSurface {}x{}", alloc.width, alloc.height);
             return 0;
         }
 
         // Get the global IOSurface ID for cross-process sharing
         let iosurface_id = unsafe { IOSurfaceGetID(iosurface) };
+
 
         // Create Metal texture descriptor
         let descriptor = RcObjcId::from_owned(
@@ -2436,32 +2441,94 @@ impl EaglRenderBridge {
         const GL_BGRA: u32 = 0x80E1;
         const GL_UNSIGNED_BYTE: u32 = 0x1401;
 
-        type GlGenTexturesFn = unsafe extern "C" fn(i32, *mut u32);
         type GlBindTextureFn = unsafe extern "C" fn(u32, u32);
 
+        // Bind IOSurface to GL texture via CVOpenGLESTextureCache.
+        // EAGLContext's texImageIOSurface: is a private API that fails on
+        // some devices (e.g. iPad mini 4 / A8). CVOpenGLESTextureCache is
+        // the public CoreVideo API that works on all iOS Metal devices.
+        extern "C" {
+            fn CVOpenGLESTextureCacheCreate(
+                allocator: *const std::ffi::c_void,
+                cache_attrs: *const std::ffi::c_void,
+                eagl_ctx: ObjcId,
+                tex_attrs: *const std::ffi::c_void,
+                cache_out: *mut *mut std::ffi::c_void,
+            ) -> i32;
+            fn CVOpenGLESTextureCacheCreateTextureFromImage(
+                allocator: *const std::ffi::c_void,
+                cache: *mut std::ffi::c_void,
+                pixel_buffer: *mut std::ffi::c_void,
+                tex_attrs: *const std::ffi::c_void,
+                target: u32,
+                internal_format: i32,
+                width: i32,
+                height: i32,
+                format: u32,
+                typ: u32,
+                plane_index: usize,
+                texture_out: *mut *mut std::ffi::c_void,
+            ) -> i32;
+            fn CVOpenGLESTextureGetName(texture: *mut std::ffi::c_void) -> u32;
+            fn CVPixelBufferCreateWithIOSurface(
+                allocator: *const std::ffi::c_void,
+                surface: *mut std::ffi::c_void,
+                pixel_buffer_attrs: *const std::ffi::c_void,
+                pixel_buffer_out: *mut *mut std::ffi::c_void,
+            ) -> i32;
+            fn CFRelease(cf: *mut std::ffi::c_void);
+        }
+
         unsafe {
-            let gl_gen_textures: GlGenTexturesFn =
-                std::mem::transmute(self.get_proc_address("glGenTextures"));
             let gl_bind_texture: GlBindTextureFn =
                 std::mem::transmute(self.get_proc_address("glBindTexture"));
 
-            let mut gl_texture: u32 = 0;
-            gl_gen_textures(1, &mut gl_texture);
+            let mut pixel_buffer: *mut std::ffi::c_void = std::ptr::null_mut();
+            let status = CVPixelBufferCreateWithIOSurface(
+                std::ptr::null(),
+                iosurface_ref,
+                std::ptr::null(),
+                &mut pixel_buffer,
+            );
+            assert!(status == 0 && !pixel_buffer.is_null(),
+                "CVPixelBufferCreateWithIOSurface failed: {}", status);
+
+            let mut texture_cache: *mut std::ffi::c_void = std::ptr::null_mut();
+            let status = CVOpenGLESTextureCacheCreate(
+                std::ptr::null(),
+                std::ptr::null(),
+                self.eagl_context,
+                std::ptr::null(),
+                &mut texture_cache,
+            );
+            assert!(status == 0 && !texture_cache.is_null(),
+                "CVOpenGLESTextureCacheCreate failed: {}", status);
+
+            let mut cv_texture: *mut std::ffi::c_void = std::ptr::null_mut();
+            let status = CVOpenGLESTextureCacheCreateTextureFromImage(
+                std::ptr::null(),
+                texture_cache,
+                pixel_buffer,
+                std::ptr::null(),
+                GL_TEXTURE_2D,
+                GL_RGBA as i32,
+                width as i32,
+                height as i32,
+                GL_BGRA,
+                GL_UNSIGNED_BYTE,
+                0,
+                &mut cv_texture,
+            );
+            assert!(status == 0 && !cv_texture.is_null(),
+                "CVOpenGLESTextureCacheCreateTextureFromImage failed: {}", status);
+
+            let gl_texture = CVOpenGLESTextureGetName(cv_texture);
             gl_bind_texture(GL_TEXTURE_2D, gl_texture);
 
-            // Use EAGLContext texImageIOSurface binding
-            let success: u8 = msg_send![
-                self.eagl_context,
-                texImageIOSurface: iosurface_ref
-                target: GL_TEXTURE_2D
-                internalFormat: GL_RGBA
-                width: width as u32
-                height: height as u32
-                format: GL_BGRA
-                type: GL_UNSIGNED_BYTE
-                plane: 0u32
-            ];
-            assert!(success != 0, "EAGLContext texImageIOSurface failed");
+            // cv_texture and texture_cache must stay alive while the GL texture
+            // is in use. Leak intentionally — a proper implementation would
+            // store them alongside the texture for cleanup.
+            CFRelease(pixel_buffer);
 
             gl_bind_texture(GL_TEXTURE_2D, 0);
 

--- a/tools/cargo_makepad/src/apple/compile.rs
+++ b/tools/cargo_makepad/src/apple/compile.rs
@@ -3,7 +3,7 @@ use crate::makepad_shell::*;
 use crate::utils::*;
 use std::path::{Path, PathBuf};
 
-const IOS_DEPLOYMENT_TARGET: &str = "17.0";
+const IOS_DEPLOYMENT_TARGET: &str = "15.0";
 
 /// Resolve the cargo target directory for apple builds.
 /// Defaults to `target/apple` to avoid invalidating desktop build caches.
@@ -157,6 +157,26 @@ pub fn parse_profiles() -> Result<ParsedProfiles, String> {
         }
     }
 
+    // Also discover devices via ios-deploy for older iOS versions (< 17)
+    if let Ok(ios_deploy_list) = shell_env_cap(&[], &cwd, "ios-deploy", &["-c", "--timeout", "3", "--no-wifi"]) {
+        for line in ios_deploy_list.split('\n') {
+            if let Some(idx) = line.find("Found ") {
+                let rest = &line[idx + "Found ".len()..];
+                if let Some(end) = rest.find(' ') {
+                    let udid = rest[..end].to_string();
+                    // Don't add if already present (devicectl UUID format differs from UDID)
+                    if !devices.iter().any(|(_, id)| id == &udid) {
+                        let name = line.split("a.k.a. '").nth(1)
+                            .and_then(|s| s.split('\'').next())
+                            .unwrap_or("iOS Device")
+                            .to_string();
+                        devices.push((name, udid));
+                    }
+                }
+            }
+        }
+    }
+
     Ok(ParsedProfiles {
         profiles,
         certs,
@@ -235,6 +255,8 @@ impl PlistValues {
                 <string>{version}</string>
                 <key>CFBundleShortVersionString</key>
                 <string>{version}</string>
+                <key>CFBundleIconName</key>
+                <string>AppIcon</string>
                 <key>UILaunchStoryboardName</key>
                 <string></string>
                 <key>CFBundleSupportedPlatforms</key>
@@ -265,7 +287,7 @@ impl PlistValues {
                 <key>LSRequiresIPhoneOS</key>
                 <true/>
                 <key>MinimumOSVersion</key>
-                <string>17.0</string>
+                <string>15.0</string>
                 <key>UIApplicationSupportsIndirectInputEvents</key>
                 <true/>
                 <key>UIDeviceFamily</key>
@@ -349,7 +371,7 @@ impl PlistValues {
             <key>DTPlatformName</key>
             <string>appletvos</string>
             <key>DTPlatformVersion</key>
-            <string>17.0</string>
+            <string>15.0</string>
             <key>DTSDKBuild</key>
             <string>21J351</string>
             <key>DTSDKName</key>
@@ -361,7 +383,7 @@ impl PlistValues {
             <key>LSRequiresIPhoneOS</key>
             <true/>
             <key>MinimumOSVersion</key>
-            <string>17.0</string>
+            <string>15.0</string>
             <key>UIDeviceFamily</key>
             <array>
             <integer>3</integer>
@@ -413,6 +435,82 @@ impl Scent {
             self.app_id, self.team_id
         )
     }
+}
+
+/// Generate and compile an Asset Catalog with AppIcon from the crate's
+/// `resources/` directory.  Requires a 1024×1024 PNG at minimum
+/// (`icon_1024.png`).  Smaller sizes are optional; iOS will scale down
+/// from the largest available.
+fn generate_app_icon_xcassets(app_dir: &Path, build_crate: &str) -> Result<bool, String> {
+    let crate_dir = get_crate_dir(build_crate)?;
+    let res = crate_dir.join("resources");
+    let icon_1024 = res.join("icon_1024.png");
+    if !icon_1024.is_file() {
+        return Ok(false);
+    }
+
+    // Build Assets.xcassets/AppIcon.appiconset/
+    let xcassets = app_dir.join("Assets.xcassets");
+    let appiconset = xcassets.join("AppIcon.appiconset");
+    mkdir(&appiconset)?;
+
+    // Copy available icon PNGs
+    let sizes: &[(&str, &str)] = &[
+        ("icon_1024.png", "icon_1024.png"),
+    ];
+    for (src_name, dst_name) in sizes {
+        let src = res.join(src_name);
+        if src.is_file() {
+            cp(&src, &appiconset.join(dst_name), false)?;
+        }
+    }
+
+    // Contents.json — iOS 12+ only needs a single 1024×1024 icon
+    let contents_json = r#"{
+  "images": [
+    {
+      "filename": "icon_1024.png",
+      "idiom": "universal",
+      "platform": "ios",
+      "size": "1024x1024"
+    }
+  ],
+  "info": {
+    "author": "cargo-makepad",
+    "version": 1
+  }
+}"#;
+    write_text(&appiconset.join("Contents.json"), contents_json)?;
+
+    // Root Contents.json for Assets.xcassets
+    write_text(
+        &xcassets.join("Contents.json"),
+        r#"{"info":{"author":"cargo-makepad","version":1}}"#,
+    )?;
+
+    // Compile with actool
+    let cwd = std::env::current_dir().unwrap();
+    shell_env_cap(
+        &[],
+        &cwd,
+        "xcrun",
+        &[
+            "actool",
+            &xcassets.to_string_lossy(),
+            "--compile",
+            &app_dir.to_string_lossy(),
+            "--platform",
+            "iphoneos",
+            "--minimum-deployment-target",
+            IOS_DEPLOYMENT_TARGET,
+            "--app-icon",
+            "AppIcon",
+            "--output-partial-info-plist",
+            &app_dir.join("actool-Info.plist").to_string_lossy(),
+        ],
+    )?;
+
+    Ok(true)
 }
 
 pub struct IosBuildResult {
@@ -486,6 +584,18 @@ pub fn build(
 
     let plist_file = app_dir.join("Info.plist");
     write_text(&plist_file, &plist.to_plist_file(apple_target.os()))?;
+
+    if matches!(apple_target.os(), AppleOs::Ios) {
+        match generate_app_icon_xcassets(&app_dir, build_crate) {
+            Ok(true) => {}
+            Ok(false) => {
+                eprintln!("warning: no icon_1024.png in resources/. iOS app will use default icon.");
+            }
+            Err(e) => {
+                eprintln!("warning: failed to compile app icon asset catalog: {e}");
+            }
+        }
+    }
 
     let build_dir = target_dir.join(format!("{}/{profile}/", apple_target.toolchain()));
     let src_bin = target_dir.join(format!(
@@ -903,7 +1013,9 @@ pub fn run_on_device(
         let device_identifier = parsed
             .device(device_identifier)
             .expect("cannot find signing device");
-        let answer = shell_env_cap(
+
+        // Try devicectl first, fall back to ios-deploy for older iOS (< 17)
+        let devicectl_result = shell_env_cap(
             &[],
             &cwd,
             "xcrun",
@@ -916,33 +1028,64 @@ pub fn run_on_device(
                 device_identifier,
                 &app_dir,
             ],
-        )?;
-        // Parse the bundleID from the installation output and launch the app
-        let mut bundle_id = None;
-        for line in answer.split("\n") {
-            if let Some(idx) = line.find("bundleID:") {
-                bundle_id = Some(line[idx + "bundleID:".len()..].trim().to_string());
-                break;
-            }
-        }
+        );
 
-        if let Some(bundle_id) = bundle_id {
-            shell_env(
-                &[],
-                &cwd,
-                "xcrun",
-                &[
-                    "devicectl",
-                    "device",
-                    "process",
-                    "launch",
-                    "--device",
-                    device_identifier,
-                    &bundle_id,
-                ],
-            )?;
-        } else {
-            return Err(format!("Failed to find bundleID in installation output"));
+        match devicectl_result {
+            Ok(answer) => {
+                // Parse the bundleID from the installation output and launch the app
+                let mut bundle_id = None;
+                for line in answer.split("\n") {
+                    if let Some(idx) = line.find("bundleID:") {
+                        bundle_id = Some(line[idx + "bundleID:".len()..].trim().to_string());
+                        break;
+                    }
+                }
+
+                if let Some(bundle_id) = bundle_id {
+                    shell_env(
+                        &[],
+                        &cwd,
+                        "xcrun",
+                        &[
+                            "devicectl",
+                            "device",
+                            "process",
+                            "launch",
+                            "--device",
+                            device_identifier,
+                            &bundle_id,
+                        ],
+                    )?;
+                } else {
+                    return Err(format!("Failed to find bundleID in installation output"));
+                }
+            }
+            Err(_) => {
+                // devicectl failed (device too old or unavailable), try ios-deploy
+                println!("devicectl failed, falling back to ios-deploy...");
+                // ios-deploy --justlaunch exits non-zero (253) when device debug
+                // symbols are missing, but the app is still installed and launched.
+                // Use shell_env_route to show progress output directly.
+                let result = shell_env_cap(
+                    &[],
+                    &cwd,
+                    "ios-deploy",
+                    &[
+                        "--bundle",
+                        &app_dir,
+                        "--id",
+                        device_identifier,
+                        "--justlaunch",
+                    ],
+                );
+                if let Err(e) = &result {
+                    if !e.contains("Unable to locate DeviceSupport") {
+                        return Err(e.clone());
+                    }
+                    // Missing debug symbols is non-fatal — app was installed and launched
+                    println!("App installed and launched (debug symbols unavailable on this device).");
+                }
+            }
         }
     }
 

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -433,6 +433,11 @@ impl WindowRef {
             inner.set_fullscreen(cx);
         }
     }
+    pub fn disable_fullscreen(&self, cx: &mut Cx) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.window.handle.normal(cx);
+        }
+    }
     /// Configure the window's size and position, and whether it's fullscreen or not.
     ///
     /// If `fullscreen` is `true`, the window will be set to the monitor's size and the


### PR DESCRIPTION
Squashed iOS improvements:
- App icon asset catalog and fullscreen support, cfg-gate desktop-only app_icon module
- iOS 15 support: lower deployment target, ios-deploy fallback, UIMenuController fallback
- WindowRef::disable_fullscreen() for exiting fullscreen from app code
- Fix GL texture binding via CVOpenGLESTextureCache, add NSLog logging