### PR TITLE
Font loading: defer registration to draw-time, add fast-path completeness check

### DIFF
--- a/draw/src/cx_draw.rs
+++ b/draw/src/cx_draw.rs
@@ -81,7 +81,13 @@ impl<'a> CxDraw<'a> {
             return false;
         }
         let mut fonts = Fonts::new(cx, layouter::Settings::default());
-        fonts.define_font_family(0.into(), FontFamilyDefinition { font_ids: vec![] });
+        fonts.define_font_family(
+            0.into(),
+            FontFamilyDefinition {
+                font_ids: vec![],
+                expected_member_count: 0,
+            },
+        );
         cx.set_global(Rc::new(RefCell::new(fonts)));
         true
     }

--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -540,9 +540,7 @@ impl DrawText {
         align: Align,
         text: &str,
     ) -> Rc<LaidoutText> {
-        cx.load_all_script_resources();
         self.text_style.font_family.ensure_fonts_loaded(cx);
-        CxDraw::lazy_construct_fonts(cx);
         let fonts = cx.get_global::<Rc<RefCell<Fonts>>>().clone();
         let mut fonts = fonts.borrow_mut();
 
@@ -851,15 +849,37 @@ impl FontFamily {
 
         fonts.set_font_family_definition(
             self.to_font_family_id(),
-            FontFamilyDefinition { font_ids },
+            FontFamilyDefinition {
+                font_ids,
+                expected_member_count: self.members.len(),
+            },
         );
     }
 
     fn ensure_fonts_loaded(&self, cx: &mut Cx) {
         CxDraw::lazy_construct_fonts(cx);
+
+        let family_id = self.to_font_family_id();
         let fonts = cx.get_global::<Rc<RefCell<Fonts>>>().clone();
-        let mut fonts = fonts.borrow_mut();
-        self.update_font_definitions(cx, &mut fonts);
+
+        {
+            let fonts_ref = fonts.borrow();
+            if fonts_ref.is_font_family_complete(family_id) {
+                return;
+            }
+        }
+
+        // Slow path: attempt to progress pending resource loads, then re-check.
+        cx.load_all_script_resources();
+        {
+            let fonts_ref = fonts.borrow();
+            if fonts_ref.is_font_family_complete(family_id) {
+                return;
+            }
+        }
+
+        let mut fonts_ref = fonts.borrow_mut();
+        self.update_font_definitions(cx, &mut fonts_ref);
     }
 }
 
@@ -902,12 +922,10 @@ impl ScriptHook for FontFamily {
             }
         }
 
-        let cx = vm.host.cx_mut();
-        cx.load_all_script_resources();
-        CxDraw::lazy_construct_fonts(cx);
-        let fonts = cx.get_global::<Rc<RefCell<Fonts>>>().clone();
-        let mut fonts = fonts.borrow_mut();
-        self.update_font_definitions(cx, &mut fonts);
+        // Don't eagerly register fonts here. Font registration is deferred
+        // to ensure_fonts_loaded() which is called at draw time.
+        // This avoids redundant work when the same FontFamily is applied
+        // to hundreds of widgets.
 
         true
     }

--- a/draw/src/text/fonts.rs
+++ b/draw/src/text/fonts.rs
@@ -108,6 +108,15 @@ impl Fonts {
         self.layouter.is_font_family_known(id)
     }
 
+    pub fn is_font_family_complete(&self, id: FontFamilyId) -> bool {
+        self.layouter
+            .loader
+            .font_family_definitions
+            .get(&id)
+            .map(|def| def.font_ids.len() == def.expected_member_count)
+            .unwrap_or(false)
+    }
+
     pub fn is_font_known(&self, id: FontId) -> bool {
         self.layouter.is_font_known(id)
     }

--- a/draw/src/text/layouter.rs
+++ b/draw/src/text/layouter.rs
@@ -29,7 +29,7 @@ const PTS_PER_INCH: f32 = 72.0;
 
 #[derive(Debug)]
 pub struct Layouter {
-    loader: Loader,
+    pub(crate) loader: Loader,
     cache_size: usize,
     cached_params: VecDeque<OwnedLayoutParams>,
     cached_results: HashMap<OwnedLayoutParams, Rc<LaidoutText>>,

--- a/draw/src/text/loader.rs
+++ b/draw/src/text/loader.rs
@@ -17,7 +17,7 @@ pub type FontData = Rc<Vec<u8>>;
 pub struct Loader {
     shaper: Rc<RefCell<Shaper>>,
     rasterizer: Rc<RefCell<rasterizer::Rasterizer>>,
-    font_family_definitions: HashMap<FontFamilyId, FontFamilyDefinition>,
+    pub(crate) font_family_definitions: HashMap<FontFamilyId, FontFamilyDefinition>,
     font_definitions: HashMap<FontId, FontDefinition>,
     font_family_cache: HashMap<FontFamilyId, Rc<FontFamily>>,
     font_cache: HashMap<FontId, Rc<Font>>,
@@ -42,13 +42,7 @@ impl Loader {
     }
 
     pub fn is_font_family_known(&self, id: FontFamilyId) -> bool {
-        if self.font_family_definitions.contains_key(&id) {
-            return true;
-        }
-        if self.font_family_cache.contains_key(&id) {
-            return true;
-        }
-        false
+        self.font_family_definitions.contains_key(&id) || self.font_family_cache.contains_key(&id)
     }
 
     pub fn is_font_known(&self, id: FontId) -> bool {
@@ -74,6 +68,20 @@ impl Loader {
         id: FontFamilyId,
         definition: FontFamilyDefinition,
     ) {
+        // Skip cache eviction if the definition is unchanged.
+        if let Some(existing) = self.font_family_definitions.get(&id) {
+            if *existing == definition {
+                return;
+            }
+        }
+        if let Some(cached) = self.font_family_cache.get(&id) {
+            let cached_ids: Vec<FontId> = cached.fonts().iter().map(|f| f.id()).collect();
+            if cached_ids == definition.font_ids
+                && definition.expected_member_count == definition.font_ids.len()
+            {
+                return;
+            }
+        }
         self.font_family_cache.remove(&id);
         self.font_family_definitions.insert(id, definition);
     }
@@ -101,7 +109,8 @@ impl Loader {
     fn load_font_family(&mut self, id: FontFamilyId) -> FontFamily {
         let definition = self
             .font_family_definitions
-            .remove(&id)
+            .get(&id)
+            .cloned()
             .unwrap_or_else(|| panic!("font family {:?} is not defined", id));
         FontFamily::new(
             id,
@@ -144,9 +153,10 @@ pub struct Settings {
     pub rasterizer: rasterizer::Settings,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct FontFamilyDefinition {
     pub font_ids: Vec<FontId>,
+    pub expected_member_count: usize,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Move font family registration out of on_custom_apply (script apply time) and into ensure_fonts_loaded (draw time). This avoids redundant work when the same FontFamily is applied to hundreds of widgets during a frame.

- ensure_fonts_loaded now has a fast path that checks is_font_family_complete() and returns immediately when all expected members are already registered
- FontFamilyDefinition gains expected_member_count to distinguish partial from complete registrations
- set_font_family_definition skips cache eviction when the definition or cached family is already equivalent
- load_font_family now clones the definition instead of removing it, allowing re-loads after cache eviction