### PR TITLE
text: RTL support, letter/word spacing, OpenType features, y_offset, font variations

### DIFF
--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -837,6 +837,7 @@ impl FontFamily {
                             index: 0,
                             ascender_fudge_in_ems: member.asc,
                             descender_fudge_in_ems: member.desc,
+                            variations: Vec::new(),
                         },
                     );
                 }

--- a/draw/src/text/font_face.rs
+++ b/draw/src/text/font_face.rs
@@ -38,6 +38,22 @@ impl FontFace {
     pub fn data(&self) -> &FontData {
         &self.0.data
     }
+
+    pub fn set_variations(&mut self, variations: &[(u32, f32)]) {
+        let rb_variations: Vec<rustybuzz::Variation> = variations
+            .iter()
+            .map(|&(tag, value)| rustybuzz::Variation {
+                tag: ttf_parser::Tag::from_bytes(&tag.to_be_bytes()),
+                value,
+            })
+            .collect();
+        unsafe {
+            let inner = Pin::as_mut(&mut self.0).get_unchecked_mut();
+            if let Some(face) = inner.rustybuzz_face.as_mut() {
+                face.set_variations(&rb_variations);
+            }
+        }
+    }
 }
 
 struct FontFaceInner {

--- a/draw/src/text/font_family.rs
+++ b/draw/src/text/font_family.rs
@@ -2,7 +2,7 @@ use {
     super::{
         font::Font,
         intern::Intern,
-        shaper::{ShapeParams, ShapedText, Shaper},
+        shaper::{Direction, Ems, ShapeParams, ShapedText, Shaper},
         substr::Substr,
     },
     std::{
@@ -47,6 +47,10 @@ impl FontFamily {
         self.shaper.borrow_mut().get_or_shape(ShapeParams {
             text: text.into(),
             fonts: self.fonts.clone(),
+            direction: Direction::default(),
+            letter_spacing: Ems(0.0),
+            word_spacing: Ems(0.0),
+            features: Rc::new(Vec::new()),
         })
     }
 

--- a/draw/src/text/loader.rs
+++ b/draw/src/text/loader.rs
@@ -136,11 +136,15 @@ impl Loader {
             .font_definitions
             .remove(&id)
             .expect("font is not defined");
+        let mut face = FontFace::from_data_and_index(definition.data, definition.index)
+            .expect("failed to load font from definition");
+        if !definition.variations.is_empty() {
+            face.set_variations(&definition.variations);
+        }
         Font::new(
             id.clone(),
             self.rasterizer.clone(),
-            FontFace::from_data_and_index(definition.data, definition.index)
-                .expect("failed to load font from definition"),
+            face,
             definition.ascender_fudge_in_ems,
             definition.descender_fudge_in_ems,
         )
@@ -165,4 +169,6 @@ pub struct FontDefinition {
     pub index: u32,
     pub ascender_fudge_in_ems: f32,
     pub descender_fudge_in_ems: f32,
+    /// Font variation axis settings as (tag_u32, value) pairs.
+    pub variations: Vec<(u32, f32)>,
 }

--- a/draw/src/text/shaper.rs
+++ b/draw/src/text/shaper.rs
@@ -8,12 +8,44 @@ use {
     rustybuzz::UnicodeBuffer,
     std::{
         collections::{HashMap, VecDeque},
-        hash::Hash,
+        hash::{Hash, Hasher},
         mem,
         rc::Rc,
     },
     unicode_segmentation::UnicodeSegmentation,
 };
+
+/// Float wrapper that supports Hash and Eq via bit representation.
+#[derive(Clone, Copy, Debug)]
+pub struct Ems(pub f32);
+
+impl Hash for Ems {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.to_bits().hash(state);
+    }
+}
+
+impl PartialEq for Ems {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.to_bits() == other.0.to_bits()
+    }
+}
+
+impl Eq for Ems {}
+
+impl Default for Ems {
+    fn default() -> Self {
+        Ems(0.0)
+    }
+}
+
+/// Text direction for shaping.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Default)]
+pub enum Direction {
+    #[default]
+    Ltr,
+    Rtl,
+}
 
 #[derive(Debug)]
 pub struct Shaper {
@@ -57,11 +89,27 @@ impl Shaper {
             self.shape_recursive(
                 &params.text,
                 &params.fonts,
+                &params.features,
+                params.direction,
                 0,
                 params.text.len(),
                 &mut glyphs,
             );
         }
+
+        // Post-process: apply letter-spacing and word-spacing
+        let letter_spacing = params.letter_spacing.0;
+        let word_spacing = params.word_spacing.0;
+        if letter_spacing != 0.0 || word_spacing != 0.0 {
+            let text = params.text.as_bytes();
+            for glyph in glyphs.iter_mut() {
+                glyph.advance_in_ems += letter_spacing;
+                if glyph.cluster < text.len() && text[glyph.cluster] == b' ' {
+                    glyph.advance_in_ems += word_spacing;
+                }
+            }
+        }
+
         ShapedText {
             text: params.text,
             width_in_ems: glyphs.iter().map(|glyph| glyph.advance_in_ems).sum(),
@@ -73,13 +121,15 @@ impl Shaper {
         &mut self,
         text: &str,
         fonts: &[Rc<Font>],
+        features: &[(u32, u32)],
+        direction: Direction,
         start: usize,
         end: usize,
         out_glyphs: &mut Vec<ShapedGlyph>,
     ) {
         let (font, fonts) = fonts.split_first().unwrap();
         let mut glyphs = self.reusable_glyphs.pop().unwrap_or(Vec::new());
-        self.shape_step(text, font, start, end, &mut glyphs);
+        self.shape_step(text, font, features, direction, start, end, &mut glyphs);
         let mut glyph_groups = glyphs
             .group_by(|glyph_0, glyph_1| glyph_0.cluster == glyph_1.cluster)
             .peekable();
@@ -94,7 +144,7 @@ impl Shaper {
                 let missing_end = glyph_groups
                     .peek()
                     .map_or(end, |next_glyph_group| next_glyph_group[0].cluster);
-                self.shape_recursive(text, fonts, missing_start, missing_end, out_glyphs);
+                self.shape_recursive(text, fonts, features, direction, missing_start, missing_end, out_glyphs);
             } else {
                 out_glyphs.extend(glyph_group.iter().cloned());
             }
@@ -108,19 +158,32 @@ impl Shaper {
         &mut self,
         text: &str,
         font: &Rc<Font>,
+        features: &[(u32, u32)],
+        direction: Direction,
         start: usize,
         end: usize,
         out_glyphs: &mut Vec<ShapedGlyph>,
     ) {
         let mut unicode_buffer = mem::take(&mut self.reusable_unicode_buffer);
+        match direction {
+            Direction::Ltr => unicode_buffer.set_direction(rustybuzz::Direction::LeftToRight),
+            Direction::Rtl => unicode_buffer.set_direction(rustybuzz::Direction::RightToLeft),
+        }
         for (index, grapheme) in text[start..end].grapheme_indices(true) {
             let cluster = start + index;
             for char in grapheme.chars() {
                 unicode_buffer.add(char, cluster as u32);
             }
         }
-        let mut glyph_buffer = rustybuzz::shape(font.rustybuzz_face(), &[], unicode_buffer);
-        let out_glyph_start = out_glyphs.len();
+        let rb_features: Vec<rustybuzz::Feature> = features
+            .iter()
+            .map(|&(tag, value)| rustybuzz::Feature::new(
+                rustybuzz::ttf_parser::Tag::from_bytes(&tag.to_be_bytes()),
+                value,
+                ..,
+            ))
+            .collect();
+        let glyph_buffer = rustybuzz::shape(font.rustybuzz_face(), &rb_features, unicode_buffer);
         out_glyphs.extend(
             glyph_buffer
                 .glyph_infos()
@@ -132,40 +195,9 @@ impl Shaper {
                     cluster: glyph_info.cluster as usize,
                     advance_in_ems: glyph_position.x_advance as f32 / font.units_per_em(),
                     offset_in_ems: glyph_position.x_offset as f32 / font.units_per_em(),
+                    y_offset_in_ems: glyph_position.y_offset as f32 / font.units_per_em(),
                 }),
         );
-
-        // HACK: We don't support right-to-left scripts yet. When such scripts are used, cluster
-        // values may be monotonically decreasing instead of increasing, as we assume. This should
-        // be fixed by properly handling bidirectional text (by further breaking up spans into
-        // spans with a single direction), but for now we just check if the cluster values are
-        // monotonically increasing. If they are not, we re-shape the text by replacing each
-        // grapheme with a single character. This is not ideal, but it works for now.
-        if out_glyphs[out_glyph_start..]
-            .windows(2)
-            .any(|glyphs| glyphs[0].cluster > glyphs[1].cluster)
-        {
-            out_glyphs.truncate(out_glyph_start);
-            let mut unicode_buffer = glyph_buffer.clear();
-            for (index, _) in text[start..end].grapheme_indices(true) {
-                let cluster = start + index;
-                unicode_buffer.add('□', cluster as u32);
-            }
-            glyph_buffer = rustybuzz::shape(font.rustybuzz_face(), &[], unicode_buffer);
-            out_glyphs.extend(
-                glyph_buffer
-                    .glyph_infos()
-                    .iter()
-                    .zip(glyph_buffer.glyph_positions())
-                    .map(|(glyph_info, glyph_position)| ShapedGlyph {
-                        font: font.clone(),
-                        id: glyph_info.glyph_id as u16,
-                        cluster: glyph_info.cluster as usize,
-                        advance_in_ems: glyph_position.x_advance as f32 / font.units_per_em(),
-                        offset_in_ems: glyph_position.x_offset as f32 / font.units_per_em(),
-                    }),
-            );
-        }
 
         self.reusable_unicode_buffer = glyph_buffer.clear();
     }
@@ -180,6 +212,11 @@ pub struct Settings {
 pub struct ShapeParams {
     pub text: Substr,
     pub fonts: Rc<[Rc<Font>]>,
+    pub direction: Direction,
+    pub letter_spacing: Ems,
+    pub word_spacing: Ems,
+    /// OpenType feature tag/value pairs for shaping.
+    pub features: Rc<Vec<(u32, u32)>>,
 }
 
 #[derive(Clone, Debug)]
@@ -196,4 +233,5 @@ pub struct ShapedGlyph {
     pub cluster: usize,
     pub advance_in_ems: f32,
     pub offset_in_ems: f32,
+    pub y_offset_in_ems: f32,
 }


### PR DESCRIPTION
Text shaper improvements:

- **RTL**: set `rustybuzz::Direction` from new `Direction` enum. Removes the old hack that replaced RTL graphemes with □.
- **Letter/word spacing**: post-shaping advance adjustments via `Ems` values in `ShapeParams`. Letter spacing adds to every glyph advance; word spacing adds to space characters.
- **OpenType features**: pass `(tag, value)` pairs through to `rustybuzz::shape`.
- **y_offset_in_ems**: expose `y_offset` from rustybuzz glyph positions (was previously discarded).
- **Font variations**: `FontDefinition` gains a `variations: Vec<(u32, f32)>` field. `FontFace::set_variations` applies axis settings to the rustybuzz face.

All new `ShapeParams` fields default to no-op values, so existing callers (`FontFamily::get_or_shape`) are unchanged.