### PR TITLE
widget_tree: fix compact_dump scale field

### DIFF
--- a/widgets/src/widget_tree.rs
+++ b/widgets/src/widget_tree.rs
@@ -1523,7 +1523,7 @@ impl WidgetTree {
         let mut out = String::new();
         let _ = writeln!(&mut out, "W3 {}", dump_nodes.len());
         // Keep the origin metadata line for protocol compatibility.
-        let _ = writeln!(&mut out, "O 0 0 1000");
+        let _ = writeln!(&mut out, "O 0 0 1");
         for (new_index, node) in dump_nodes.iter().enumerate() {
             let mut parent = node.parent;
             let mut parent_index = -1i64;


### PR DESCRIPTION
The O line's scale field was 1000 (a leftover from when coordinates were in physical pixels and scale encoded `dpi * 1000`). Coordinates are now logical, so scale should be 1.