### PR TITLE
platform: popup/context menu window API

### DIFF
--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -88,6 +88,13 @@ impl std::fmt::Debug for AccessibilityUpdatePayload {
 #[derive(PartialEq)]
 pub enum CxOsOp {
     CreateWindow(WindowId),
+    CreatePopupWindow {
+        window_id: WindowId,
+        parent_window_id: WindowId,
+        position: Vec2d,
+        size: Vec2d,
+        grab_keyboard: bool,
+    },
     ResizeWindow(WindowId, Vec2d),
     RepositionWindow(WindowId, Vec2d),
     CloseWindow(WindowId),
@@ -190,6 +197,7 @@ impl std::fmt::Debug for CxOsOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::CreateWindow(..) => write!(f, "CreateWindow"),
+            Self::CreatePopupWindow { .. } => write!(f, "CreatePopupWindow"),
             Self::CloseWindow(..) => write!(f, "CloseWindow"),
             Self::MinimizeWindow(..) => write!(f, "MinimizeWindow"),
             Self::Deminiaturize(..) => write!(f, "Deminiaturize"),

--- a/platform/src/event/event.rs
+++ b/platform/src/event/event.rs
@@ -136,6 +136,7 @@ pub enum Event {
     WindowDragQuery(WindowDragQueryEvent),
     WindowCloseRequested(WindowCloseRequestedEvent),
     WindowClosed(WindowClosedEvent),
+    PopupDismissed(PopupDismissedEvent),
     WindowGeomChange(WindowGeomChangeEvent),
     VirtualKeyboard(VirtualKeyboardEvent),
     ClearAtlasses,
@@ -314,6 +315,7 @@ impl Event {
             57 => "XrLocal",
             58 => "ImeAction",
             60 => "Custom",
+            61 => "PopupDismissed",
             62 => "SelectionHandleDrag",
             _ => panic!(),
         }
@@ -344,6 +346,7 @@ impl Event {
             Self::WindowGeomChange(_) => 17,
             Self::VirtualKeyboard(_) => 18,
             Self::ClearAtlasses => 19,
+            Self::PopupDismissed(_) => 61,
 
             Self::MouseDown(_) => 20,
             Self::MouseMove(_) => 21,

--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -92,7 +92,7 @@ pub struct LongPressEvent {
 
 // Touch events
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TouchState {
     Start,
     Stop,

--- a/platform/src/event/window.rs
+++ b/platform/src/event/window.rs
@@ -40,6 +40,31 @@ pub struct WindowCloseRequestedEvent {
 pub struct WindowClosedEvent {
     pub window_id: WindowId,
 }
+
+#[derive(Clone, Debug)]
+pub enum PopupDismissReason {
+    FocusLost,
+    OutsideClick,
+    Escape,
+    Compositor,
+    ParentClosed,
+}
+
+/// Notification that a popup window should be closed.
+///
+/// The app **must** call `WindowHandle::close()` to actually close the popup.
+/// The framework does not auto-close popup windows on dismissal.
+///
+/// On Wayland the compositor may force-close the surface (`PopupDone`); in
+/// that case `PopupDismissed` fires after the surface is already gone.
+///
+/// Common reasons: `OutsideClick`, `FocusLost`, `Escape`, `Compositor`,
+/// `ParentClosed`.
+#[derive(Clone, Debug)]
+pub struct PopupDismissedEvent {
+    pub window_id: WindowId,
+    pub reason: PopupDismissReason,
+}
 /*
 #[derive(Clone, Debug)]
 pub struct WindowResizeLoopEvent {

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -101,9 +101,24 @@ impl Cx {
             self.passes[*draw_pass_id].set_time(with_ios_app(|app| app.time_now() as f32));
             match self.passes[*draw_pass_id].parent.clone() {
                 CxDrawPassParent::Xr => {}
-                CxDrawPassParent::Window(_window_id) => {
+                CxDrawPassParent::Window(window_id) => {
+                    // Skip popup window passes — drawn as overlays after parent.
+                    if self.windows[window_id].is_popup {
+                        continue;
+                    }
                     let mtk_view = with_ios_app(|app| app.mtk_view.unwrap());
                     self.draw_pass(*draw_pass_id, metal_cx, DrawPassMode::MTKView(mtk_view));
+
+                    // Draw popup window passes as overlays on the same MTKView
+                    for popup_pass_id in &passes_todo.clone() {
+                        if let CxDrawPassParent::Window(pw_id) = self.passes[*popup_pass_id].parent {
+                            let pw = &self.windows[pw_id];
+                            if pw.is_popup && pw.popup_parent == Some(window_id) {
+                                let mtk_view = with_ios_app(|app| app.mtk_view.unwrap());
+                                self.draw_pass(*popup_pass_id, metal_cx, DrawPassMode::MTKView(mtk_view));
+                            }
+                        }
+                    }
                 }
                 CxDrawPassParent::DrawPass(_) => {
                     self.draw_pass(*draw_pass_id, metal_cx, DrawPassMode::Texture);
@@ -265,6 +280,12 @@ impl Cx {
                 self.handle_repaint(metal_cx);
             }
             IosEvent::TouchUpdate(e) => {
+                // Check for outside-click popup dismiss on touch start
+                if e.touches.iter().any(|t| t.state == crate::event::TouchState::Start) {
+                    if let Some(popup_window_id) = self.find_popup_to_dismiss_on_touch(&e.touches) {
+                        self.dismiss_popup_window(popup_window_id, crate::event::PopupDismissReason::OutsideClick);
+                    }
+                }
                 self.fingers.process_touch_update_start(e.time, &e.touches);
                 let e = Event::TouchUpdate(e);
                 self.call_event_handler(&e);
@@ -279,6 +300,10 @@ impl Cx {
                 self.call_event_handler(&Event::LongPress(e.into()));
             }
             IosEvent::MouseDown(e) => {
+                // Check for outside-click popup dismiss
+                if let Some(popup_window_id) = self.find_popup_to_dismiss_on_mouse(e.abs) {
+                    self.dismiss_popup_window(popup_window_id, crate::event::PopupDismissReason::OutsideClick);
+                }
                 self.fingers.process_tap_count(e.abs, e.time);
                 self.fingers.mouse_down(e.button, e.window_id);
                 self.call_event_handler(&Event::MouseDown(e.into()))
@@ -338,6 +363,26 @@ impl Cx {
                 CxOsOp::CreateWindow(window_id) => {
                     let window = &mut self.windows[window_id];
                     window.window_geom = with_ios_app(|app| app.last_window_geom.clone());
+                    window.is_created = true;
+                }
+                CxOsOp::CreatePopupWindow {
+                    window_id,
+                    parent_window_id,
+                    position,
+                    size,
+                    grab_keyboard,
+                } => {
+                    let mut geom = with_ios_app(|app| app.last_window_geom.clone());
+                    geom.position = position;
+                    geom.inner_size = size;
+                    geom.outer_size = size;
+                    let window = &mut self.windows[window_id];
+                    window.window_geom = geom;
+                    window.is_popup = true;
+                    window.popup_parent = Some(parent_window_id);
+                    window.popup_position = Some(position);
+                    window.popup_size = Some(size);
+                    window.popup_grab_keyboard = grab_keyboard;
                     window.is_created = true;
                 }
                 CxOsOp::ShowTextIME(_area, pos, config) => {
@@ -469,6 +514,16 @@ impl Cx {
                         player.seek_to(position_ms);
                     }
                 }
+                CxOsOp::CloseWindow(window_id) => {
+                    let window = &mut self.windows[window_id];
+                    if window.is_popup {
+                        window.is_created = false;
+                        window.is_popup = false;
+                        window.popup_parent = None;
+                        window.popup_position = None;
+                        window.popup_size = None;
+                    }
+                }
                 e => {
                     crate::error!("Not implemented on this platform: CxOsOp::{:?}", e);
                 }
@@ -586,6 +641,71 @@ impl Cx {
 
             let () = msg_send![av_audio_session, requestRecordPermission: &completion_handler];
         }
+    }
+}
+
+impl Cx {
+    fn find_popup_to_dismiss_on_touch(&self, touches: &[crate::event::TouchPoint]) -> Option<crate::window::WindowId> {
+        use crate::window::CxWindowPool;
+        for i in (0..self.windows.len()).rev() {
+            let window_id = CxWindowPool::from_usize(i);
+            let window = &self.windows[window_id];
+            if !window.is_created || !window.is_popup {
+                continue;
+            }
+            if let (Some(pos), Some(size)) = (window.popup_position, window.popup_size) {
+                let rect = Rect { pos, size };
+                for touch in touches {
+                    if touch.state == crate::event::TouchState::Start && !rect.contains(touch.abs) {
+                        return Some(window_id);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn find_popup_to_dismiss_on_mouse(&self, abs: DVec2) -> Option<crate::window::WindowId> {
+        use crate::window::CxWindowPool;
+        for i in (0..self.windows.len()).rev() {
+            let window_id = CxWindowPool::from_usize(i);
+            let window = &self.windows[window_id];
+            if !window.is_created || !window.is_popup {
+                continue;
+            }
+            if let (Some(pos), Some(size)) = (window.popup_position, window.popup_size) {
+                let rect = Rect { pos, size };
+                if !rect.contains(abs) {
+                    return Some(window_id);
+                }
+            }
+        }
+        None
+    }
+
+    fn dismiss_popup_window(&mut self, window_id: crate::window::WindowId, reason: crate::event::PopupDismissReason) {
+        use crate::window::CxWindowPool;
+        // First dismiss any child popups
+        let children: Vec<crate::window::WindowId> = (0..self.windows.len())
+            .filter_map(|i| {
+                let child_id = CxWindowPool::from_usize(i);
+                let w = &self.windows[child_id];
+                if w.is_created && w.is_popup && w.popup_parent == Some(window_id) {
+                    Some(child_id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for child_id in children {
+            self.dismiss_popup_window(child_id, crate::event::PopupDismissReason::ParentClosed);
+        }
+        self.call_event_handler(&Event::PopupDismissed(crate::event::PopupDismissedEvent {
+            window_id,
+            reason,
+        }));
+        self.call_event_handler(&Event::WindowClosed(crate::event::WindowClosedEvent { window_id }));
+        self.windows[window_id].is_created = false;
     }
 }
 

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -90,6 +90,47 @@ impl MetalWindow {
         }
     }
 
+    pub(crate) fn new_popup(
+        window_id: WindowId,
+        metal_cx: &MetalCx,
+        size: Vec2d,
+        position: Vec2d,
+        parent_window: ObjcId,
+    ) -> MetalWindow {
+        let ca_layer: ObjcId = unsafe { msg_send![class!(CAMetalLayer), new] };
+
+        let mut cocoa_window = Box::new(MacosWindow::new(window_id));
+
+        cocoa_window.init_popup(size, position, parent_window);
+        unsafe {
+            let () = msg_send![ca_layer, setDevice: metal_cx.device];
+            let () = msg_send![ca_layer, setPixelFormat: MTLPixelFormat::BGRA8Unorm];
+            let () = msg_send![ca_layer, setPresentsWithTransaction: NO];
+            let () = msg_send![ca_layer, setMaximumDrawableCount: 3];
+            let () = msg_send![ca_layer, setDisplaySyncEnabled: YES];
+            let () = msg_send![ca_layer, setNeedsDisplayOnBoundsChange: YES];
+            let () = msg_send![ca_layer, setAutoresizingMask: (1 << 4) | (1 << 1)];
+            let () = msg_send![ca_layer, setAllowsNextDrawableTimeout: NO];
+            let () = msg_send![ca_layer, setDelegate: cocoa_window.view];
+            let () = msg_send![ca_layer, setBackgroundColor: CGColorCreateGenericRGB(0.0, 0.0, 0.0, 1.0)];
+
+            let view = cocoa_window.view;
+            let () = msg_send![view, setWantsBestResolutionOpenGLSurface: YES];
+            let () = msg_send![view, setWantsLayer: YES];
+            let () = msg_send![view, setLayerContentsPlacement: 11];
+            let () = msg_send![view, setLayer: ca_layer];
+        }
+
+        MetalWindow {
+            is_resizing: false,
+            window_id,
+            cal_size: Vec2d::default(),
+            ca_layer,
+            window_geom: cocoa_window.get_window_geom(),
+            cocoa_window,
+        }
+    }
+
     pub(crate) fn start_resize(&mut self) {
         self.is_resizing = true;
         let () = unsafe { msg_send![self.ca_layer, setPresentsWithTransaction: YES] };
@@ -368,6 +409,9 @@ impl Cx {
             MacosEvent::WindowLostFocus(window_id) => {
                 self.call_event_handler(&Event::WindowLostFocus(window_id));
             }
+            MacosEvent::PopupDismissed(event) => {
+                self.call_event_handler(&Event::PopupDismissed(event));
+            }
             MacosEvent::WindowResizeLoopStart(window_id) => {
                 if let Some(window) = metal_windows.iter_mut().find(|w| w.window_id == window_id) {
                     window.start_resize();
@@ -592,6 +636,31 @@ impl Cx {
                         &window.create_title,
                         window.is_fullscreen,
                     );
+                    window.window_geom = metal_window.window_geom.clone();
+                    metal_windows.push(metal_window);
+                    window.is_created = true;
+                }
+                CxOsOp::CreatePopupWindow {
+                    window_id,
+                    parent_window_id,
+                    position,
+                    size,
+                    grab_keyboard,
+                } => {
+                    let window = &mut self.windows[window_id];
+                    window.is_popup = true;
+                    window.popup_parent = Some(parent_window_id);
+                    window.popup_position = Some(position);
+                    window.popup_size = Some(size);
+                    window.popup_grab_keyboard = grab_keyboard;
+                    // Find the parent NSWindow handle for coordinate conversion
+                    let parent_ns_window = metal_windows
+                        .iter()
+                        .find(|w| w.window_id == parent_window_id)
+                        .map(|w| w.cocoa_window.window)
+                        .unwrap_or(nil);
+                    let metal_window =
+                        MetalWindow::new_popup(window_id, &metal_cx, size, position, parent_ns_window);
                     window.window_geom = metal_window.window_geom.clone();
                     metal_windows.push(metal_window);
                     window.is_created = true;

--- a/platform/src/os/apple/macos/macos_event.rs
+++ b/platform/src/os/apple/macos/macos_event.rs
@@ -4,6 +4,7 @@ use crate::{
         MouseUpEvent, ScrollEvent, TextClipboardEvent, TextInputEvent, TimerEvent,
         WindowCloseRequestedEvent, WindowClosedEvent, WindowDragQueryEvent, WindowGeomChangeEvent,
     },
+    event::window::PopupDismissedEvent,
     makepad_live_id::*,
     permission::PermissionResult,
     window::WindowId,
@@ -11,6 +12,7 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub enum MacosEvent {
+    PopupDismissed(PopupDismissedEvent),
     WindowGotFocus(WindowId),
     WindowLostFocus(WindowId),
     WindowResizeLoopStart(WindowId),

--- a/platform/src/os/apple/macos/macos_stdin.rs
+++ b/platform/src/os/apple/macos/macos_stdin.rs
@@ -370,6 +370,12 @@ impl Cx {
                         kind_id: window.kind_id,
                     });
                 }
+                CxOsOp::CreatePopupWindow { window_id, .. } => {
+                    while window_id.id() >= stdin_windows.len() {
+                        stdin_windows.push(StdinWindow::new());
+                    }
+                    self.windows[window_id].is_created = true;
+                }
                 CxOsOp::SetCursor(cursor) => {
                     Self::stdin_send_to_host(AppToStudio::SetCursor(cursor.into()));
                 }

--- a/platform/src/os/apple/macos/macos_window.rs
+++ b/platform/src/os/apple/macos/macos_window.rs
@@ -30,6 +30,7 @@ pub struct MacosWindow {
     // When ime_active is false, key events are not forward to NSTextInputContext so IME dose not active.
     pub(crate) ime_active: bool,
     pub(crate) is_fullscreen: bool,
+    pub(crate) is_popup: bool,
     pub(crate) last_mouse_pos: Vec2d,
     window_delegate: ObjcId,
     live_resize_timer: ObjcId,
@@ -49,6 +50,7 @@ impl MacosWindow {
             with_macos_app(|app| app.cocoa_windows.push((window, view)));
             MacosWindow {
                 is_fullscreen: false,
+                is_popup: false,
                 live_resize_timer: nil,
                 window_delegate: window_delegate,
                 window: window,
@@ -149,6 +151,97 @@ impl MacosWindow {
 
             // Set application icon from default icon
             Self::set_application_icon();
+
+            let () = msg_send![pool, drain];
+        }
+    }
+
+    /// Initialize as a popup window (borderless NSPanel at popup menu level).
+    /// `position` is in screen coordinates. `parent_window` is the parent NSWindow for coordinate conversion.
+    pub fn init_popup(&mut self, size: Vec2d, position: Vec2d, parent_window: ObjcId) {
+        self.is_popup = true;
+        unsafe {
+            let pool: ObjcId = msg_send![class!(NSAutoreleasePool), new];
+
+            // set the backpointers
+            (*self.window_delegate).set_ivar("macos_window_ptr", self as *mut _ as *mut c_void);
+            let () = msg_send![self.view, initWithPtr: self as *mut _ as *mut c_void];
+
+            // Convert position from parent-client coordinates to screen coordinates.
+            // The position is relative to the parent window's content view origin (top-left).
+            let parent_frame: NSRect = msg_send![parent_window, frame];
+            let parent_content: NSRect = msg_send![parent_window, contentLayoutRect];
+            // macOS screen coordinates: origin at bottom-left.
+            // Parent content top-left in screen coords:
+            let screen_x = parent_frame.origin.x + parent_content.origin.x + position.x;
+            // Flip Y: parent content top is at frame.origin.y + frame.size.height - titlebar
+            let parent_content_top = parent_frame.origin.y + parent_frame.size.height
+                - parent_content.origin.y;
+            let screen_y = parent_content_top - position.y - size.y;
+
+            let ns_size = NSSize {
+                width: size.x as f64,
+                height: size.y as f64,
+            };
+            let window_frame = NSRect {
+                origin: NSPoint {
+                    x: screen_x,
+                    y: screen_y,
+                },
+                size: ns_size,
+            };
+
+            // NSPanel with borderless style
+            let window_masks = NSWindowStyleMask::NSBorderlessWindowMask as u64
+                | NSWindowStyleMask::NSFullSizeContentViewWindowMask as u64;
+
+            let () = msg_send![
+                self.window,
+                initWithContentRect: window_frame
+                styleMask: window_masks as u64
+                backing: NSBackingStoreType::NSBackingStoreBuffered as u64
+                defer: NO
+            ];
+
+            let () = msg_send![self.window, setDelegate: self.window_delegate];
+            let () = msg_send![self.window, setReleasedWhenClosed: NO];
+
+            // NSPopUpMenuWindowLevel = 101
+            let () = msg_send![self.window, setLevel: 101i64];
+            let () = msg_send![self.window, setHasShadow: YES];
+
+            let () = msg_send![self.window, setAcceptsMouseMovedEvents: YES];
+
+            let () = msg_send![self.view, setLayerContentsRedrawPolicy: 2]; //duringViewResize
+
+            let () = msg_send![self.window, setContentView: self.view];
+            let () = msg_send![self.window, makeFirstResponder: self.view];
+
+            // orderFront instead of makeKeyAndOrderFront to avoid stealing key focus initially
+            // Then makeKey so we get resignKey on focus loss
+            let () = msg_send![self.window, orderFront: nil];
+            let () = msg_send![self.window, makeKeyWindow];
+
+            let rect = NSRect {
+                origin: NSPoint { x: 0., y: 0. },
+                size: ns_size,
+            };
+            let track: ObjcId = msg_send![class!(NSTrackingArea), alloc];
+            let track: ObjcId = msg_send![
+                track,
+                initWithRect: rect
+                options: NSTrackignActiveAlways
+                    | NSTrackingInVisibleRect
+                    | NSTrackingMouseEnteredAndExited
+                    | NSTrackingMouseMoved
+                    | NSTrackingCursorUpdate
+                owner: self.view
+                userInfo: nil
+            ];
+            let () = msg_send![self.view, addTrackingArea: track];
+
+            let input_context: ObjcId = msg_send![self.view, inputContext];
+            let () = msg_send![input_context, invalidateCharacterCoordinates];
 
             let () = msg_send![pool, drain];
         }
@@ -392,6 +485,15 @@ impl MacosWindow {
     }
 
     pub fn send_lost_focus_event(&mut self) {
+        if self.is_popup {
+            self.do_callback(MacosEvent::PopupDismissed(
+                crate::event::window::PopupDismissedEvent {
+                    window_id: self.window_id,
+                    reason: crate::event::window::PopupDismissReason::FocusLost,
+                },
+            ));
+            return;
+        }
         self.do_callback(MacosEvent::WindowLostFocus(self.window_id));
     }
 

--- a/platform/src/os/apple/tvos/tvos.rs
+++ b/platform/src/os/apple/tvos/tvos.rs
@@ -209,6 +209,26 @@ impl Cx {
                     window.window_geom = get_tvos_app_global().last_window_geom.clone();
                     window.is_created = true;
                 }
+                CxOsOp::CreatePopupWindow {
+                    window_id,
+                    parent_window_id,
+                    position,
+                    size,
+                    grab_keyboard,
+                } => {
+                    let mut geom = get_tvos_app_global().last_window_geom.clone();
+                    geom.position = position;
+                    geom.inner_size = size;
+                    geom.outer_size = size;
+                    let window = &mut self.windows[window_id];
+                    window.window_geom = geom;
+                    window.is_popup = true;
+                    window.popup_parent = Some(parent_window_id);
+                    window.popup_position = Some(position);
+                    window.popup_size = Some(size);
+                    window.popup_grab_keyboard = grab_keyboard;
+                    window.is_created = true;
+                }
                 CxOsOp::StartTimer {
                     timer_id,
                     interval,

--- a/platform/src/os/headless/event_loop.rs
+++ b/platform/src/os/headless/event_loop.rs
@@ -462,6 +462,34 @@ impl Cx {
                     }
                     self.redraw_all();
                 }
+                CxOsOp::CreatePopupWindow {
+                    window_id,
+                    parent_window_id,
+                    position,
+                    size,
+                    grab_keyboard,
+                } => {
+                    while window_id.id() >= windows.len() {
+                        windows.push(Default::default());
+                    }
+                    let state = &mut windows[window_id.id()];
+                    state.created = true;
+                    state.width = size.x.max(1.0) as u32;
+                    state.height = size.y.max(1.0) as u32;
+                    state.ensure_size_defaults();
+
+                    let window = &mut self.windows[window_id];
+                    window.is_created = true;
+                    window.window_geom.position = position;
+                    window.window_geom.inner_size = size;
+                    window.window_geom.outer_size = size;
+                    window.is_popup = true;
+                    window.popup_parent = Some(parent_window_id);
+                    window.popup_position = Some(position);
+                    window.popup_size = Some(size);
+                    window.popup_grab_keyboard = grab_keyboard;
+                    self.redraw_all();
+                }
                 CxOsOp::ResizeWindow(window_id, size) => {
                     if self.windows.is_valid(window_id) {
                         self.windows[window_id].window_geom.inner_size = size;

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -312,13 +312,17 @@ impl Cx {
                 let window = &mut self.windows[CxWindowPool::id_zero()];
                 let dpi_factor = window.dpi_override.unwrap_or(self.os.dpi_factor);
                 for touch in &mut touches {
-                    // When the software keyboard shifted the UI in the vertical axis,
-                    //we need to make the math here to keep touch events positions synchronized.
-                    //if self.os.keyboard_visible {touch.abs.y += self.os.keyboard_panning_offset as f64};
-                    //crate::log!("{} {:?} {} {}", time, touch.state, touch.uid, touch.abs);
                     touch.abs /= dpi_factor;
                     touch.radius /= dpi_factor;
                 }
+
+                // Check for outside-click popup dismiss on touch start
+                if touches.iter().any(|t| t.state == crate::event::finger::TouchState::Start) {
+                    if let Some(popup_window_id) = self.find_popup_to_dismiss_on_touch(&touches) {
+                        self.dismiss_popup_window(popup_window_id, crate::event::PopupDismissReason::OutsideClick);
+                    }
+                }
+
                 self.fingers.process_touch_update_start(time, &touches);
                 let e = Event::TouchUpdate(TouchUpdateEvent {
                     time,
@@ -1215,11 +1219,29 @@ impl Cx {
                 CxDrawPassParent::Xr => {
                     // cant happen
                 }
-                CxDrawPassParent::Window(_) => {
-                    //let window = &self.windows[window_id];
+                CxDrawPassParent::Window(window_id) => {
+                    // Skip popup window passes — they are drawn as overlays
+                    // after their parent window pass below.
+                    if self.windows[window_id].is_popup {
+                        continue;
+                    }
                     let start = self.seconds_since_app_start();
                     let metrics = self.collect_gpu_pass_metrics(*draw_pass_id);
                     self.draw_pass_to_window_for_active_backend(*draw_pass_id);
+
+                    // Draw popup window passes as overlays on the same surface
+                    for popup_pass_id in &passes_todo.clone() {
+                        if let CxDrawPassParent::Window(pw_id) = self.passes[*popup_pass_id].parent {
+                            let pw = &self.windows[pw_id];
+                            if pw.is_popup && pw.popup_parent == Some(window_id) {
+                                let saved = self.passes[*popup_pass_id].dont_clear;
+                                self.passes[*popup_pass_id].dont_clear = true;
+                                self.draw_pass_to_fullscreen(*popup_pass_id);
+                                self.passes[*popup_pass_id].dont_clear = saved;
+                            }
+                        }
+                    }
+
                     let end = self.seconds_since_app_start();
                     Cx::send_studio_message(AppToStudio::GPUSample(GPUSample {
                         start,
@@ -1272,6 +1294,44 @@ impl Cx {
                         new_geom,
                         old_geom,
                     }));
+                }
+                CxOsOp::CreatePopupWindow {
+                    window_id,
+                    parent_window_id,
+                    position,
+                    size,
+                    grab_keyboard,
+                } => {
+                    let dpi_factor = self.windows[parent_window_id]
+                        .dpi_override
+                        .unwrap_or(self.os.dpi_factor);
+                    let window = &mut self.windows[window_id];
+                    window.window_geom = WindowGeom {
+                        dpi_factor,
+                        can_fullscreen: false,
+                        xr_is_presenting: false,
+                        is_fullscreen: false,
+                        is_topmost: true,
+                        position,
+                        inner_size: size,
+                        outer_size: size,
+                    };
+                    window.is_popup = true;
+                    window.popup_parent = Some(parent_window_id);
+                    window.popup_position = Some(position);
+                    window.popup_size = Some(size);
+                    window.popup_grab_keyboard = grab_keyboard;
+                    window.is_created = true;
+                }
+                CxOsOp::CloseWindow(window_id) => {
+                    let window = &mut self.windows[window_id];
+                    if window.is_popup {
+                        window.is_created = false;
+                        window.is_popup = false;
+                        window.popup_parent = None;
+                        window.popup_position = None;
+                        window.popup_size = None;
+                    }
                 }
                 CxOsOp::StartTimer {
                     timer_id,
@@ -1493,6 +1553,49 @@ fn to_android_permission(permission: crate::permission::Permission) -> &'static 
 }
 
 impl Cx {
+    fn find_popup_to_dismiss_on_touch(&self, touches: &[crate::event::finger::TouchPoint]) -> Option<crate::window::WindowId> {
+        for i in (0..self.windows.len()).rev() {
+            let window_id = CxWindowPool::from_usize(i);
+            let window = &self.windows[window_id];
+            if !window.is_created || !window.is_popup {
+                continue;
+            }
+            if let (Some(pos), Some(size)) = (window.popup_position, window.popup_size) {
+                let rect = Rect { pos: pos, size: size };
+                for touch in touches {
+                    if touch.state == crate::event::finger::TouchState::Start && !rect.contains(touch.abs) {
+                        return Some(window_id);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn dismiss_popup_window(&mut self, window_id: crate::window::WindowId, reason: crate::event::PopupDismissReason) {
+        // First dismiss any child popups
+        let children: Vec<crate::window::WindowId> = (0..self.windows.len())
+            .filter_map(|i| {
+                let child_id = CxWindowPool::from_usize(i);
+                let w = &self.windows[child_id];
+                if w.is_created && w.is_popup && w.popup_parent == Some(window_id) {
+                    Some(child_id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for child_id in children {
+            self.dismiss_popup_window(child_id, crate::event::PopupDismissReason::ParentClosed);
+        }
+        self.call_event_handler(&Event::PopupDismissed(crate::event::PopupDismissedEvent {
+            window_id,
+            reason,
+        }));
+        self.call_event_handler(&Event::WindowClosed(crate::event::WindowClosedEvent { window_id }));
+        self.windows[window_id].is_created = false;
+    }
+
     fn check_audio_permission_status(&self) -> crate::permission::PermissionStatus {
         unsafe {
             let status = android_jni::to_java_check_permission("android.permission.RECORD_AUDIO");

--- a/platform/src/os/linux/direct/linux_direct.rs
+++ b/platform/src/os/linux/direct/linux_direct.rs
@@ -289,6 +289,31 @@ impl Cx {
                     };
                     window.is_created = true;
                 }
+                CxOsOp::CreatePopupWindow {
+                    window_id,
+                    parent_window_id,
+                    position,
+                    size,
+                    grab_keyboard,
+                } => {
+                    let window = &mut self.windows[window_id];
+                    window.window_geom = WindowGeom {
+                        dpi_factor: direct_app.dpi_factor,
+                        can_fullscreen: false,
+                        xr_is_presenting: false,
+                        is_fullscreen: false,
+                        is_topmost: true,
+                        position,
+                        inner_size: size,
+                        outer_size: size,
+                    };
+                    window.is_popup = true;
+                    window.popup_parent = Some(parent_window_id);
+                    window.popup_position = Some(position);
+                    window.popup_size = Some(size);
+                    window.popup_grab_keyboard = grab_keyboard;
+                    window.is_created = true;
+                }
                 CxOsOp::StartTimer {
                     timer_id,
                     interval,

--- a/platform/src/os/linux/open_harmony/open_harmony.rs
+++ b/platform/src/os/linux/open_harmony/open_harmony.rs
@@ -533,6 +533,25 @@ impl Cx {
                     };
                     window.is_created = true;
                 }
+                CxOsOp::CreatePopupWindow {
+                    window_id,
+                    parent_window_id,
+                    position,
+                    size,
+                    grab_keyboard,
+                } => {
+                    let window = &mut self.windows[window_id];
+                    window.window_geom.position = position;
+                    window.window_geom.inner_size = size;
+                    window.window_geom.outer_size = size;
+                    window.window_geom.dpi_factor = self.os.dpi_factor;
+                    window.is_popup = true;
+                    window.popup_parent = Some(parent_window_id);
+                    window.popup_position = Some(position);
+                    window.popup_size = Some(size);
+                    window.popup_grab_keyboard = grab_keyboard;
+                    window.is_created = true;
+                }
                 CxOsOp::StartTimer {
                     timer_id,
                     interval,

--- a/platform/src/os/linux/wayland/linux_wayland.rs
+++ b/platform/src/os/linux/wayland/linux_wayland.rs
@@ -3,7 +3,7 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
-use super::opengl_wayland::WaylandWindow;
+use super::opengl_wayland::{WaylandPopupWindow, WaylandWindow};
 use super::wayland_state::WaylandState;
 use crate::cx_native::EventFlow;
 use crate::egl_sys::NativeDisplayType;
@@ -20,9 +20,12 @@ use crate::WindowId;
 use crate::{
     cx::{LinuxWindowParams, OsType},
     egl_sys,
-    event::video_playback::{
-        VideoDecodingErrorEvent, VideoPlaybackPreparedEvent,
-        VideoPlaybackResourcesReleasedEvent, VideoTextureUpdatedEvent,
+    event::{
+        video_playback::{
+            VideoDecodingErrorEvent, VideoPlaybackPreparedEvent,
+            VideoPlaybackResourcesReleasedEvent, VideoTextureUpdatedEvent,
+        },
+        PopupDismissReason, PopupDismissedEvent,
     },
     gpu_info::GpuPerformance,
     Area, Cx, CxDrawPassParent, CxOsOp, CxWindowPool, Event, KeyModifiers, MouseButton,
@@ -138,6 +141,11 @@ impl WaylandCx {
                         cx.repaint_pass(main_pass_id);
                     }
                 }
+                for popup in state.popups.iter_mut() {
+                    if let Some(main_pass_id) = cx.windows[popup.window_id].main_pass_id {
+                        cx.repaint_pass(main_pass_id);
+                    }
+                }
                 //paint_dirty = true;
                 cx.call_event_handler(&Event::WindowGotFocus(window_id));
             }
@@ -166,23 +174,50 @@ impl WaylandCx {
                             cx.redraw_pass_and_child_passes(main_pass_id);
                         }
                     }
+                } else if let Some(window) = state
+                    .popups
+                    .iter_mut()
+                    .find(|w| w.window_id == re.window_id)
+                {
+                    window.window_geom = re.new_geom.clone();
+                    cx.windows[re.window_id].window_geom = re.new_geom.clone();
+                    if re.old_geom.inner_size != re.new_geom.inner_size {
+                        if let Some(main_pass_id) = cx.windows[re.window_id].main_pass_id {
+                            cx.redraw_pass_and_child_passes(main_pass_id);
+                        }
+                    }
                 }
                 // ok lets not redraw all, just this window
                 cx.call_event_handler(&Event::WindowGeomChange(re));
             }
             XlibEvent::WindowClosed(wc) => {
-                let mut cx = self.cx.borrow_mut();
                 let window_id = wc.window_id;
+                self.close_popup_children(state, window_id);
+
+                let mut cx = self.cx.borrow_mut();
                 cx.call_event_handler(&Event::WindowClosed(wc));
                 // lets remove the window from the set
                 cx.windows[window_id].is_created = false;
+                if state.pointer_window == Some(window_id) {
+                    state.pointer_window = None;
+                }
+                if state.keyboard_window == Some(window_id) {
+                    state.keyboard_window = None;
+                }
                 if let Some(index) = state.windows.iter().position(|w| w.window_id == window_id) {
                     state.windows.remove(index);
                     if state.windows.len() == 0 {
                         cx.call_event_handler(&Event::Shutdown);
                         return EventFlow::Exit;
                     }
+                } else if let Some(index) = state.popups.iter().position(|w| w.window_id == window_id)
+                {
+                    state.popups.remove(index);
                 }
+            }
+            XlibEvent::PopupDismissed(event) => {
+                let mut cx = self.cx.borrow_mut();
+                cx.call_event_handler(&Event::PopupDismissed(event));
             }
             XlibEvent::Paint => {
                 {
@@ -356,6 +391,52 @@ impl WaylandCx {
         event_flow
     }
 
+    fn close_popup_window(
+        &self,
+        state: &mut WaylandState,
+        window_id: WindowId,
+        reason: Option<PopupDismissReason>,
+    ) {
+        let mut cx = self.cx.borrow_mut();
+        if let Some(reason) = reason {
+            cx.call_event_handler(&Event::PopupDismissed(PopupDismissedEvent {
+                window_id,
+                reason,
+            }));
+        }
+        cx.call_event_handler(&Event::WindowClosed(WindowClosedEvent { window_id }));
+        cx.windows[window_id].is_created = false;
+        if state.pointer_window == Some(window_id) {
+            state.pointer_window = None;
+        }
+        if state.keyboard_window == Some(window_id) {
+            state.keyboard_window = None;
+        }
+        if let Some(index) = state.popups.iter().position(|w| w.window_id == window_id) {
+            state.popups.remove(index);
+        }
+    }
+
+    fn close_popup_children(&self, state: &mut WaylandState, parent_window_id: WindowId) {
+        loop {
+            let child = state
+                .popups
+                .iter()
+                .find(|p| p.parent_window_id == parent_window_id)
+                .map(|p| p.window_id);
+            if let Some(child_window_id) = child {
+                self.close_popup_children(state, child_window_id);
+                self.close_popup_window(
+                    state,
+                    child_window_id,
+                    Some(PopupDismissReason::ParentClosed),
+                );
+            } else {
+                break;
+            }
+        }
+    }
+
     fn handle_platform_ops(&self, state: &mut WaylandState) -> EventFlow {
         let mut ret = EventFlow::Poll;
         let mut cx = self.cx.borrow_mut();
@@ -399,12 +480,59 @@ impl WaylandCx {
                     );
                     state.windows.push(window);
                 }
+                CxOsOp::CreatePopupWindow {
+                    window_id,
+                    parent_window_id,
+                    position,
+                    size,
+                    grab_keyboard,
+                } => {
+                    let gl_cx = cx.os.opengl_cx.as_ref().unwrap();
+                    let compositor = state.compositor.as_ref().unwrap();
+                    let wm_base = state.wm_base.as_ref().unwrap();
+                    if let Some(parent_xdg_surface) = state.xdg_surface_for_window(parent_window_id)
+                    {
+                        let popup = WaylandPopupWindow::new(
+                            window_id,
+                            parent_window_id,
+                            compositor,
+                            wm_base,
+                            &parent_xdg_surface,
+                            state.seat.as_ref(),
+                            state.pointer_serial,
+                            state.keyboard_serial,
+                            state.scale_manager.as_ref(),
+                            state.viewporter.as_ref(),
+                            self.qhandle.as_ref().unwrap(),
+                            gl_cx,
+                            size,
+                            position,
+                            grab_keyboard,
+                        );
+                        cx.windows[window_id].is_popup = true;
+                        cx.windows[window_id].popup_parent = Some(parent_window_id);
+                        cx.windows[window_id].popup_position = Some(position);
+                        cx.windows[window_id].popup_size = Some(size);
+                        cx.windows[window_id].popup_grab_keyboard = grab_keyboard;
+                        state.popups.push(popup);
+                    }
+                }
                 CxOsOp::CloseWindow(window_id) => {
+                    self.close_popup_children(state, window_id);
+                    if state.popups.iter().any(|w| w.window_id == window_id) {
+                        drop(cx);
+                        self.close_popup_window(state, window_id, None);
+                        cx = self.cx.borrow_mut();
+                        if state.windows.is_empty() {
+                            ret = EventFlow::Exit;
+                        }
+                        continue;
+                    }
+
                     cx.call_event_handler(&Event::WindowClosed(WindowClosedEvent { window_id }));
                     let windows = &mut state.windows;
                     if let Some(index) = windows.iter().position(|w| w.window_id == window_id) {
                         cx.windows[window_id].is_created = false;
-                        windows[index].close_window();
                         windows.remove(index);
                         if windows.len() == 0 {
                             ret = EventFlow::Exit
@@ -494,7 +622,7 @@ impl WaylandCx {
                     let _ = cx.net.http_cancel(request_id);
                 }
                 CxOsOp::ShowTextIME(area, pos, _config) => {
-                    if let Some(window) = state.current_window {
+                    if let Some(_window) = state.keyboard_window.or(state.pointer_window) {
                         if let Some(text_input) = state.text_input.as_ref() {
                             text_input.enable();
 
@@ -624,13 +752,13 @@ impl WaylandCx {
         cx.repaint_id += 1;
         for draw_pass_id in &passes_todo {
             let now = state.time_now();
-            let windows = &mut state.windows;
             cx.passes[*draw_pass_id].set_time(now as f32);
             let parent = cx.passes[*draw_pass_id].parent.clone();
             match parent {
                 CxDrawPassParent::Xr => {}
                 CxDrawPassParent::Window(window_id) => {
-                    if let Some(window) = windows.iter_mut().find(|w| w.window_id == window_id) {
+                    if let Some(window) = state.windows.iter_mut().find(|w| w.window_id == window_id)
+                    {
                         if !window.configured {
                             continue;
                         }
@@ -658,6 +786,30 @@ impl WaylandCx {
                         let pix_height =
                             window.window_geom.inner_size.y * window.window_geom.dpi_factor;
 
+                        cx.draw_pass_to_window(
+                            *draw_pass_id,
+                            window.egl_surface,
+                            pix_width,
+                            pix_height,
+                        );
+                    } else if let Some(window) =
+                        state.popups.iter_mut().find(|w| w.window_id == window_id)
+                    {
+                        if !window.configured {
+                            continue;
+                        }
+                        window.resize_buffers();
+                        if let Some(viewport) = window.viewport.as_ref() {
+                            viewport.set_source(-1., -1., -1., -1.);
+                            viewport.set_destination(
+                                window.window_geom.inner_size.x as i32,
+                                window.window_geom.inner_size.y as i32,
+                            );
+                        }
+                        let pix_width =
+                            window.window_geom.inner_size.x * window.window_geom.dpi_factor;
+                        let pix_height =
+                            window.window_geom.inner_size.y * window.window_geom.dpi_factor;
                         cx.draw_pass_to_window(
                             *draw_pass_id,
                             window.egl_surface,

--- a/platform/src/os/linux/wayland/opengl_wayland.rs
+++ b/platform/src/os/linux/wayland/opengl_wayland.rs
@@ -16,7 +16,9 @@ use wayland_protocols::xdg::decoration::zv1::client::{
     zxdg_decoration_manager_v1, zxdg_toplevel_decoration_v1,
 };
 use wayland_protocols::xdg::shell;
-use wayland_protocols::xdg::shell::client::{xdg_surface, xdg_toplevel, xdg_wm_base};
+use wayland_protocols::xdg::shell::client::{
+    xdg_popup, xdg_positioner, xdg_surface, xdg_toplevel, xdg_wm_base,
+};
 use wayland_protocols::xdg::toplevel_icon::v1::client::{
     xdg_toplevel_icon_manager_v1, xdg_toplevel_icon_v1,
 };
@@ -230,22 +232,177 @@ impl WaylandWindow {
         }
     }
     pub fn close_window(&mut self) {
-        self.base_surface.destroy();
+        // Destroy in protocol order: role-specific objects first, base
+        // surface last.
         if let Some(decoration) = self.decoration.take() {
             decoration.destroy();
         }
+        self.toplevel.destroy();
+        self.xdg_surface.destroy();
         if let Some(viewport) = self.viewport.take() {
             viewport.destroy();
         }
         if let Some(fractional_scale) = self.fractional_scale.take() {
             fractional_scale.destroy();
         }
-        self.toplevel.destroy();
+        self.base_surface.destroy();
+    }
+}
+
+pub(crate) struct WaylandPopupWindow {
+    pub window_id: WindowId,
+    pub parent_window_id: WindowId,
+    pub base_surface: wl_surface::WlSurface,
+    pub xdg_surface: xdg_surface::XdgSurface,
+    pub xdg_popup: xdg_popup::XdgPopup,
+    pub viewport: Option<wp_viewport::WpViewport>,
+    pub fractional_scale: Option<wp_fractional_scale_v1::WpFractionalScaleV1>,
+    pub wl_egl_surface: Option<WlEglSurface>,
+    pub egl_surface: EGLSurface,
+    pub egl_display: egl_sys::EGLDisplay,
+    egl_destroy_surface_fn: unsafe extern "C" fn(egl_sys::EGLDisplay, EGLSurface) -> egl_sys::EGLBoolean,
+    pub window_geom: WindowGeom,
+    pub configured: bool,
+    pub cal_size: Vec2d,
+}
+
+impl WaylandPopupWindow {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        window_id: WindowId,
+        parent_window_id: WindowId,
+        compositer: &wl_compositor::WlCompositor,
+        wm_base: &xdg_wm_base::XdgWmBase,
+        parent_xdg_surface: &xdg_surface::XdgSurface,
+        _seat: Option<&wayland_client::protocol::wl_seat::WlSeat>,
+        _pointer_serial: Option<u32>,
+        _keyboard_serial: Option<u32>,
+        scale_manager: Option<&wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1>,
+        viewporter: Option<&wp_viewporter::WpViewporter>,
+        qhandle: &QueueHandle<WaylandState>,
+        opengl_cx: &OpenglCx,
+        size: Vec2d,
+        position: Vec2d,
+        _grab_keyboard: bool,
+    ) -> WaylandPopupWindow {
+        assert_eq!(opengl_cx.egl_platform, egl_sys::EGL_PLATFORM_WAYLAND_KHR);
+
+        let base_surface = compositer.create_surface(qhandle, ());
+        let fractional_scale = scale_manager
+            .map(|manager| manager.get_fractional_scale(&base_surface, qhandle, window_id));
+        let viewport = viewporter.map(|vp| vp.get_viewport(&base_surface, qhandle, ()));
+
+        let xdg_surface = wm_base.get_xdg_surface(&base_surface, qhandle, window_id);
+        let positioner = wm_base.create_positioner(qhandle, ());
+        positioner.set_size(size.x.max(1.0) as i32, size.y.max(1.0) as i32);
+        positioner.set_anchor_rect(position.x as i32, position.y as i32, 1, 1);
+        positioner.set_anchor(xdg_positioner::Anchor::TopLeft);
+        positioner.set_gravity(xdg_positioner::Gravity::BottomRight);
+        positioner.set_constraint_adjustment(
+            xdg_positioner::ConstraintAdjustment::FlipX
+                | xdg_positioner::ConstraintAdjustment::FlipY
+                | xdg_positioner::ConstraintAdjustment::SlideX
+                | xdg_positioner::ConstraintAdjustment::SlideY,
+        );
+
+        let xdg_popup = xdg_surface.get_popup(Some(parent_xdg_surface), &positioner, qhandle, window_id);
+        // Do NOT grab the popup. Without a grab the compositor will not
+        // auto-dismiss the popup on outside clicks, giving the app full
+        // control over popup lifetime via explicit close.
+        base_surface.commit();
+        positioner.destroy();
+
+        let wl_egl_surface =
+            WlEglSurface::new(base_surface.id(), size.x.max(1.0) as i32, size.y.max(1.0) as i32)
+                .unwrap();
+        let egl_surface = unsafe {
+            (opengl_cx.libegl.eglCreateWindowSurface.unwrap())(
+                opengl_cx.egl_display,
+                opengl_cx.egl_config,
+                wl_egl_surface.ptr() as NativeWindowType,
+                std::ptr::null(),
+            )
+        };
+        assert!(!egl_surface.is_null(), "eglCreateWindowSurface failed");
+
+        let geom = WindowGeom {
+            xr_is_presenting: false,
+            can_fullscreen: false,
+            is_topmost: false,
+            is_fullscreen: false,
+            inner_size: size,
+            outer_size: size,
+            dpi_factor: 1.0,
+            position,
+        };
+
+        Self {
+            window_id,
+            parent_window_id,
+            base_surface,
+            xdg_surface,
+            xdg_popup,
+            viewport,
+            fractional_scale,
+            wl_egl_surface: Some(wl_egl_surface),
+            egl_surface,
+            egl_display: opengl_cx.egl_display,
+            egl_destroy_surface_fn: opengl_cx.libegl.eglDestroySurface.unwrap(),
+            window_geom: geom,
+            configured: false,
+            cal_size: Vec2d::default(),
+        }
+    }
+
+    pub fn resize_buffers(&mut self) -> bool {
+        let cal_size = Vec2d {
+            x: self.window_geom.inner_size.x * self.window_geom.dpi_factor,
+            y: self.window_geom.inner_size.y * self.window_geom.dpi_factor,
+        };
+        if self.cal_size != cal_size {
+            self.cal_size = cal_size;
+            if let Some(ref wl_egl_surface) = self.wl_egl_surface {
+                wl_egl_surface
+                    .resize(cal_size.x.max(1.0) as i32, cal_size.y.max(1.0) as i32, 0, 0);
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn close_window(&mut self) {
+        // Destroy EGL surface first — it holds a reference to the wl_egl_surface.
+        if !self.egl_surface.is_null() {
+            unsafe {
+                (self.egl_destroy_surface_fn)(self.egl_display, self.egl_surface);
+            }
+            self.egl_surface = std::ptr::null_mut();
+        }
+        // Drop wl_egl_surface before Wayland objects — wl_egl_window_destroy
+        // accesses the underlying wl_surface.
+        self.wl_egl_surface.take();
+        // Destroy Wayland objects in protocol order: role-specific first,
+        // then the base surface last.
+        self.xdg_popup.destroy();
         self.xdg_surface.destroy();
+        if let Some(viewport) = self.viewport.take() {
+            viewport.destroy();
+        }
+        if let Some(fractional_scale) = self.fractional_scale.take() {
+            fractional_scale.destroy();
+        }
+        self.base_surface.destroy();
     }
 }
 
 impl Drop for WaylandWindow {
+    fn drop(&mut self) {
+        self.close_window();
+    }
+}
+
+impl Drop for WaylandPopupWindow {
     fn drop(&mut self) {
         self.close_window();
     }

--- a/platform/src/os/linux/wayland/wayland_state.rs
+++ b/platform/src/os/linux/wayland/wayland_state.rs
@@ -42,7 +42,7 @@ use wayland_protocols::{
     xdg::{
         self,
         decoration::zv1::client::{zxdg_decoration_manager_v1, zxdg_toplevel_decoration_v1},
-        shell::client::{xdg_positioner, xdg_surface, xdg_toplevel, xdg_wm_base},
+        shell::client::{xdg_popup, xdg_positioner, xdg_surface, xdg_toplevel, xdg_wm_base},
         toplevel_icon::v1::client::{
             xdg_toplevel_icon_manager_v1, xdg_toplevel_icon_v1,
         },
@@ -50,12 +50,15 @@ use wayland_protocols::{
 };
 
 use crate::{
-    cx_native::EventFlow, event::ScrollEvent, event::WindowGeom, select_timer::SelectTimers,
-    wayland::wayland_app::WaylandApp, x11::xlib_event::XlibEvent, KeyCode,
-    WindowCloseRequestedEvent, WindowGeomChangeEvent, WindowId, WindowMovedEvent,
+    cx_native::EventFlow,
+    event::{PopupDismissReason, PopupDismissedEvent, ScrollEvent, WindowGeom},
+    select_timer::SelectTimers,
+    wayland::wayland_app::WaylandApp,
+    x11::xlib_event::XlibEvent,
+    KeyCode, WindowCloseRequestedEvent, WindowGeomChangeEvent, WindowId, WindowMovedEvent,
 };
 
-use super::opengl_wayland::WaylandWindow;
+use super::opengl_wayland::{WaylandPopupWindow, WaylandWindow};
 
 pub(crate) struct ClipboardOffer {
     offer: wl_data_offer::WlDataOffer,
@@ -92,7 +95,9 @@ pub(crate) struct WaylandState {
     pub(crate) decoration_manager: Option<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1>,
     pub(crate) icon_manager: Option<xdg_toplevel_icon_manager_v1::XdgToplevelIconManagerV1>,
     pub(crate) windows: Vec<WaylandWindow>,
-    pub(crate) current_window: Option<WindowId>,
+    pub(crate) popups: Vec<WaylandPopupWindow>,
+    pub(crate) pointer_window: Option<WindowId>,
+    pub(crate) keyboard_window: Option<WindowId>,
     pub(crate) modifiers: KeyModifiers,
     pub(crate) timers: SelectTimers,
     pub(crate) scale_manager: Option<wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1>,
@@ -140,7 +145,9 @@ impl WaylandState {
             scale_manager: None,
             viewporter: None,
             windows: Vec::new(),
-            current_window: None,
+            popups: Vec::new(),
+            pointer_window: None,
+            keyboard_window: None,
             pointer_serial: None,
             keyboard_serial: None,
             modifiers: KeyModifiers::default(),
@@ -162,6 +169,36 @@ impl WaylandState {
             event_flow: EventFlow::Wait,
             event_loop_running: true,
         }
+    }
+
+    fn window_id_for_surface(&self, surface: &wl_surface::WlSurface) -> Option<WindowId> {
+        let surface_id = surface.id();
+        self.windows
+            .iter()
+            .find(|win| win.base_surface.id() == surface_id)
+            .map(|win| win.window_id)
+            .or_else(|| {
+                self.popups
+                    .iter()
+                    .find(|win| win.base_surface.id() == surface_id)
+                    .map(|win| win.window_id)
+            })
+    }
+
+    pub(crate) fn xdg_surface_for_window(
+        &self,
+        window_id: WindowId,
+    ) -> Option<xdg_surface::XdgSurface> {
+        self.windows
+            .iter()
+            .find(|win| win.window_id == window_id)
+            .map(|win| win.xdg_surface.clone())
+            .or_else(|| {
+                self.popups
+                    .iter()
+                    .find(|win| win.window_id == window_id)
+                    .map(|win| win.xdg_surface.clone())
+            })
     }
 }
 
@@ -316,7 +353,19 @@ impl Dispatch<wp_fractional_scale_v1::WpFractionalScaleV1, WindowId> for Wayland
                     .iter_mut()
                     .find(|win| win.window_id == *window_id)
                 {
-                    println!("preffered scale: {}", scale as f64 / 120.);
+                    let old_geom = window.window_geom.clone();
+                    let mut new_geom = window.window_geom.clone();
+                    new_geom.dpi_factor = scale as f64 / 120.;
+                    state.do_callback(XlibEvent::WindowGeomChange(WindowGeomChangeEvent {
+                        window_id: *window_id,
+                        old_geom,
+                        new_geom,
+                    }));
+                } else if let Some(window) = state
+                    .popups
+                    .iter_mut()
+                    .find(|win| win.window_id == *window_id)
+                {
                     let old_geom = window.window_geom.clone();
                     let mut new_geom = window.window_geom.clone();
                     new_geom.dpi_factor = scale as f64 / 120.;
@@ -410,10 +459,79 @@ impl Dispatch<xdg_surface::XdgSurface, WindowId> for WaylandState {
                     });
                 }
                 window.configured = true;
+            } else if let Some(window) = state
+                .popups
+                .iter_mut()
+                .find(|win| win.window_id == *window_id)
+            {
+                if !window.configured {
+                    let mut old_geom = window.window_geom.clone();
+                    old_geom.inner_size = dvec2(0., 0.);
+                    old_geom.outer_size = dvec2(0., 0.);
+                    first_configure_event = Some(WindowGeomChangeEvent {
+                        window_id: *window_id,
+                        old_geom,
+                        new_geom: window.window_geom.clone(),
+                    });
+                }
+                window.configured = true;
             }
             if let Some(event) = first_configure_event {
                 state.do_callback(XlibEvent::WindowGeomChange(event));
             }
+        }
+    }
+}
+
+impl Dispatch<xdg_popup::XdgPopup, WindowId> for WaylandState {
+    fn event(
+        state: &mut Self,
+        _xdg_popup: &xdg_popup::XdgPopup,
+        event: xdg_popup::Event,
+        window_id: &WindowId,
+        _conn: &Connection,
+        _qhandle: &QueueHandle<Self>,
+    ) {
+        match event {
+            xdg_popup::Event::Configure { x, y, width, height } => {
+                let mut geom_change = None;
+                if let Some(popup) = state
+                    .popups
+                    .iter_mut()
+                    .find(|popup| popup.window_id == *window_id)
+                {
+                    let old_geom = popup.window_geom.clone();
+                    popup.window_geom.position = dvec2(x as f64, y as f64);
+                    if width > 0 && height > 0 {
+                        popup.window_geom.inner_size = dvec2(width as f64, height as f64);
+                        popup.window_geom.outer_size = popup.window_geom.inner_size;
+                    }
+                    if popup.window_geom != old_geom {
+                        geom_change = Some(WindowGeomChangeEvent {
+                            window_id: *window_id,
+                            old_geom,
+                            new_geom: popup.window_geom.clone(),
+                        });
+                    }
+                }
+                if let Some(event) = geom_change {
+                    state.do_callback(XlibEvent::WindowGeomChange(event));
+                }
+            }
+            xdg_popup::Event::PopupDone => {
+                // WindowClosed must fire before PopupDismissed so the
+                // platform can access the CxWindow pool entry (valid
+                // generation) before the app drops its WindowHandle
+                // which frees the pool slot.
+                state.do_callback(XlibEvent::WindowClosed(WindowClosedEvent {
+                    window_id: *window_id,
+                }));
+                state.do_callback(XlibEvent::PopupDismissed(PopupDismissedEvent {
+                    window_id: *window_id,
+                    reason: PopupDismissReason::Compositor,
+                }));
+            }
+            _ => {}
         }
     }
 }
@@ -707,16 +825,38 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandState {
             wl_keyboard::Event::Enter {
                 serial,
                 surface,
-                keys,
+                keys: _,
             } => {
                 state.keyboard_serial = Some(serial);
                 state.flush_pending_clipboard_copy(qhandle, serial);
-                // state.do_callback(XlibEvent::AppGotFocus);
+                if let Some(window_id) = state.window_id_for_surface(&surface) {
+                    if state.keyboard_window != Some(window_id) {
+                        if let Some(prev) = state.keyboard_window {
+                            state.do_callback(XlibEvent::WindowLostFocus(prev));
+                        }
+                        state.keyboard_window = Some(window_id);
+                        state.do_callback(XlibEvent::WindowGotFocus(window_id));
+                    }
+                }
             }
             wl_keyboard::Event::Leave { serial, surface } => {
                 state.keyboard_serial = Some(serial);
                 state.flush_pending_clipboard_copy(qhandle, serial);
-                // state.do_callback(XlibEvent::AppLostFocus);
+                if let Some(window_id) = state.window_id_for_surface(&surface) {
+                    if state.keyboard_window == Some(window_id) {
+                        state.keyboard_window = None;
+                        state.do_callback(XlibEvent::WindowLostFocus(window_id));
+                    }
+                }
+                {
+                    let popup_ids: Vec<_> = state.popups.iter().rev().map(|p| p.window_id).collect();
+                    for window_id in popup_ids {
+                        state.do_callback(XlibEvent::PopupDismissed(PopupDismissedEvent {
+                            window_id,
+                            reason: PopupDismissReason::FocusLost,
+                        }));
+                    }
+                }
             }
             wl_keyboard::Event::Key {
                 serial,
@@ -851,28 +991,17 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandState {
             wl_pointer::Event::Enter {
                 serial,
                 surface,
-                surface_x,
-                surface_y,
+                surface_x: _,
+                surface_y: _,
             } => {
                 state.pointer_serial = Some(serial);
                 state.flush_pending_clipboard_copy(qhandle, serial);
-                let mut window_id = None;
-                state.windows.iter().for_each(|win| {
-                    if win.base_surface.id() == surface.id() {
-                        window_id = Some(win.window_id);
-                        state.current_window = window_id;
-                    }
-                });
-                if let Some(window_id) = window_id {
-                    state.do_callback(XlibEvent::WindowGotFocus(window_id));
-                }
+                state.pointer_window = state.window_id_for_surface(&surface);
             }
             wl_pointer::Event::Leave { serial, surface: _ } => {
                 state.pointer_serial = Some(serial);
                 state.flush_pending_clipboard_copy(qhandle, serial);
-                if let Some(window_id) = state.current_window {
-                    state.do_callback(XlibEvent::WindowLostFocus(window_id));
-                }
+                state.pointer_window = None;
                 state.last_resize_edge = None;
             }
             wl_pointer::Event::Motion {
@@ -880,7 +1009,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandState {
                 surface_x,
                 surface_y,
             } => {
-                if let Some(window_id) = state.current_window {
+                if let Some(window_id) = state.pointer_window {
                     let pos = dvec2(surface_x as f64, surface_y as f64);
                     state.last_mouse_pos = pos;
 
@@ -982,44 +1111,66 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandState {
             } => {
                 state.pointer_serial = Some(serial);
                 state.flush_pending_clipboard_copy(qhandle, serial);
+                // Outside-click popup dismissal: if press lands on a
+                // regular window while popups are open, fire dismiss.
+                if let WEnum::Value(ButtonState::Pressed) = key_state {
+                    if let Some(win_id) = state.pointer_window {
+                        if state.windows.iter().any(|w| w.window_id == win_id)
+                            && !state.popups.is_empty()
+                        {
+                            let popup_ids: Vec<_> = state.popups.iter().rev().map(|p| p.window_id).collect();
+                            for popup_wid in popup_ids {
+                                state.do_callback(XlibEvent::PopupDismissed(PopupDismissedEvent {
+                                    window_id: popup_wid,
+                                    reason: PopupDismissReason::OutsideClick,
+                                }));
+                            }
+                        }
+                    }
+                }
                 if let Some(btn) = wayland_type::from_mouse(button) {
-                    if let Some(window_id) = state.current_window {
+                    if let Some(window_id) = state.pointer_window {
                         match key_state {
                             WEnum::Value(ButtonState::Pressed) => {
                                 if btn == MouseButton::PRIMARY {
-                                    // Edge resize takes priority
-                                    if let Some(resize_edge) = state.last_resize_edge.take() {
-                                        if let (Some(seat), Some(window)) = (
-                                            state.seat.as_ref(),
-                                            state
-                                                .windows
-                                                .iter()
-                                                .find(|win| win.window_id == window_id),
-                                        ) {
-                                            window.toplevel.resize(seat, serial, resize_edge);
-                                            return;
+                                    if state.windows.iter().any(|win| win.window_id == window_id) {
+                                        // Edge resize takes priority
+                                        if let Some(resize_edge) = state.last_resize_edge.take() {
+                                            if let (Some(seat), Some(window)) = (
+                                                state.seat.as_ref(),
+                                                state
+                                                    .windows
+                                                    .iter()
+                                                    .find(|win| win.window_id == window_id),
+                                            ) {
+                                                window.toplevel.resize(seat, serial, resize_edge);
+                                                return;
+                                            }
                                         }
-                                    }
 
-                                    let response =
-                                        Rc::new(Cell::new(WindowDragQueryResponse::NoAnswer));
-                                    state.do_callback(XlibEvent::WindowDragQuery(
-                                        WindowDragQueryEvent {
-                                            window_id,
-                                            abs: state.last_mouse_pos,
-                                            response: response.clone(),
-                                        },
-                                    ));
-                                    if matches!(response.get(), WindowDragQueryResponse::Caption) {
-                                        if let (Some(seat), Some(window)) = (
-                                            state.seat.as_ref(),
-                                            state
-                                                .windows
-                                                .iter()
-                                                .find(|win| win.window_id == window_id),
+                                        let response =
+                                            Rc::new(Cell::new(WindowDragQueryResponse::NoAnswer));
+                                        state.do_callback(XlibEvent::WindowDragQuery(
+                                            WindowDragQueryEvent {
+                                                window_id,
+                                                abs: state.last_mouse_pos,
+                                                response: response.clone(),
+                                            },
+                                        ));
+                                        if matches!(
+                                            response.get(),
+                                            WindowDragQueryResponse::Caption
                                         ) {
-                                            window.toplevel._move(seat, serial);
-                                            return;
+                                            if let (Some(seat), Some(window)) = (
+                                                state.seat.as_ref(),
+                                                state
+                                                    .windows
+                                                    .iter()
+                                                    .find(|win| win.window_id == window_id),
+                                            ) {
+                                                window.toplevel._move(seat, serial);
+                                                return;
+                                            }
                                         }
                                     }
                                 }
@@ -1082,7 +1233,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandState {
             wl_pointer::Event::Frame => {
                 let acc = state.scroll_accumulator;
                 if acc.x != 0.0 || acc.y != 0.0 {
-                    if let Some(window_id) = state.current_window {
+                    if let Some(window_id) = state.pointer_window {
                         let time_now = state.time_now();
                         let scroll = if state.scroll_is_wheel {
                             let last = state.last_scroll_time;
@@ -1152,7 +1303,7 @@ delegate_noop!(WaylandState: ignore xdg_toplevel_icon_v1::XdgToplevelIconV1);
 delegate_noop!(WaylandState: ignore wl_shm::WlShm);
 delegate_noop!(WaylandState: ignore wl_shm_pool::WlShmPool);
 delegate_noop!(WaylandState: ignore wl_buffer::WlBuffer);
-// delegate_noop!(WaylandState: ignore xdg_positioner::XdgPositioner);
+delegate_noop!(WaylandState: ignore xdg_positioner::XdgPositioner);
 delegate_noop!(WaylandState: ignore zwp_primary_selection_device_manager_v1::ZwpPrimarySelectionDeviceManagerV1);
 delegate_noop!(WaylandState: ignore zwp_primary_selection_offer_v1::ZwpPrimarySelectionOfferV1);
 

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -138,12 +138,19 @@ impl X11Cx {
                 cx.call_event_handler(&Event::WindowGeomChange(re));
             }
             XlibEvent::WindowClosed(wc) => {
-                let mut cx = self.cx.borrow_mut();
                 let window_id = wc.window_id;
+                self.close_popup_children(opengl_windows, xlib_app, window_id);
+
+                let mut cx = self.cx.borrow_mut();
                 cx.call_event_handler(&Event::WindowClosed(wc));
                 // lets remove the window from the set
                 cx.windows[window_id].is_created = false;
                 if let Some(index) = opengl_windows.iter().position(|w| w.window_id == window_id) {
+                    if let Some(xid) = opengl_windows[index].xlib_window.window {
+                        unsafe {
+                            xlib_app.release_popup_grab(xid);
+                        }
+                    }
                     opengl_windows.remove(index);
                     if opengl_windows.len() == 0 {
                         xlib_app.terminate_event_loop();
@@ -151,6 +158,10 @@ impl X11Cx {
                         return EventFlow::Exit;
                     }
                 }
+            }
+            XlibEvent::PopupDismissed(event) => {
+                let mut cx = self.cx.borrow_mut();
+                cx.call_event_handler(&Event::PopupDismissed(event));
             }
             XlibEvent::Paint => {
                 {
@@ -392,6 +403,58 @@ impl X11Cx {
         }
     }
 
+    fn close_popup_window(
+        &mut self,
+        opengl_windows: &mut Vec<OpenglWindow>,
+        xlib_app: &mut XlibApp,
+        window_id: crate::window::WindowId,
+        reason: Option<PopupDismissReason>,
+    ) {
+        if let Some(index) = opengl_windows.iter().position(|w| w.window_id == window_id) {
+            let mut cx = self.cx.borrow_mut();
+            if let Some(reason) = reason {
+                cx.call_event_handler(&Event::PopupDismissed(PopupDismissedEvent {
+                    window_id,
+                    reason,
+                }));
+            }
+            cx.call_event_handler(&Event::WindowClosed(WindowClosedEvent { window_id }));
+            cx.windows[window_id].is_created = false;
+            if let Some(xid) = opengl_windows[index].xlib_window.window {
+                unsafe {
+                    xlib_app.release_popup_grab(xid);
+                }
+            }
+            opengl_windows[index].xlib_window.close_window();
+            opengl_windows.remove(index);
+        }
+    }
+
+    fn close_popup_children(
+        &mut self,
+        opengl_windows: &mut Vec<OpenglWindow>,
+        xlib_app: &mut XlibApp,
+        parent_window_id: crate::window::WindowId,
+    ) {
+        loop {
+            let child = opengl_windows
+                .iter()
+                .find(|w| w.xlib_window.popup_parent == Some(parent_window_id))
+                .map(|w| w.window_id);
+            if let Some(child_window_id) = child {
+                self.close_popup_children(opengl_windows, xlib_app, child_window_id);
+                self.close_popup_window(
+                    opengl_windows,
+                    xlib_app,
+                    child_window_id,
+                    Some(PopupDismissReason::ParentClosed),
+                );
+            } else {
+                break;
+            }
+        }
+    }
+
     fn handle_platform_ops(
         &mut self,
         opengl_windows: &mut Vec<OpenglWindow>,
@@ -417,14 +480,58 @@ impl X11Cx {
                     opengl_windows.push(opengl_window);
                     window.is_created = true;
                 }
+                CxOsOp::CreatePopupWindow {
+                    window_id,
+                    parent_window_id,
+                    position,
+                    size,
+                    grab_keyboard,
+                } => {
+                    let gl_cx = cx.os.opengl_cx.as_ref().unwrap();
+                    let opengl_window =
+                        OpenglWindow::new_popup(window_id, parent_window_id, gl_cx, size, position);
+                    let window = &mut cx.windows[window_id];
+                    window.window_geom = opengl_window.window_geom.clone();
+                    window.is_created = true;
+                    window.is_popup = true;
+                    window.popup_parent = Some(parent_window_id);
+                    window.popup_position = Some(position);
+                    window.popup_size = Some(size);
+                    window.popup_grab_keyboard = grab_keyboard;
+                    if let Some(xid) = opengl_window.xlib_window.window {
+                        unsafe {
+                            xlib_app.activate_popup_grab(xid, grab_keyboard);
+                        }
+                    }
+                    opengl_windows.push(opengl_window);
+                }
                 CxOsOp::CloseWindow(window_id) => {
-                    cx.call_event_handler(&Event::WindowClosed(WindowClosedEvent { window_id }));
-                    if let Some(index) =
-                        opengl_windows.iter().position(|w| w.window_id == window_id)
+                    drop(cx);
+                    self.close_popup_children(opengl_windows, xlib_app, window_id);
+                    cx = self.cx.borrow_mut();
+
+                    if let Some(index) = opengl_windows.iter().position(|w| w.window_id == window_id)
                     {
-                        cx.windows[window_id].is_created = false;
-                        opengl_windows[index].xlib_window.close_window();
-                        opengl_windows.remove(index);
+                        if opengl_windows[index].xlib_window.is_popup {
+                            drop(cx);
+                            self.close_popup_window(
+                                opengl_windows,
+                                xlib_app,
+                                window_id,
+                                None,
+                            );
+                            cx = self.cx.borrow_mut();
+                        } else {
+                            cx.call_event_handler(&Event::WindowClosed(WindowClosedEvent { window_id }));
+                            cx.windows[window_id].is_created = false;
+                            if let Some(xid) = opengl_windows[index].xlib_window.window {
+                                unsafe {
+                                    xlib_app.release_popup_grab(xid);
+                                }
+                            }
+                            opengl_windows[index].xlib_window.close_window();
+                            opengl_windows.remove(index);
+                        }
                         if opengl_windows.len() == 0 {
                             ret = EventFlow::Exit
                         }

--- a/platform/src/os/linux/x11/linux_x11_stdin.rs
+++ b/platform/src/os/linux/x11/linux_x11_stdin.rs
@@ -482,13 +482,18 @@ impl Cx {
                     while window_id.id() >= stdin_windows.len() {
                         stdin_windows.push(StdinWindow::default());
                     }
-                    //let stdin_window = &mut stdin_windows[window_id.id()];
                     let window = &mut self.windows[window_id];
                     window.is_created = true;
                     Self::stdin_send_to_host(AppToStudio::CreateWindow {
                         window_id: window_id.id(),
                         kind_id: window.kind_id,
                     });
+                }
+                CxOsOp::CreatePopupWindow { window_id, .. } => {
+                    while window_id.id() >= stdin_windows.len() {
+                        stdin_windows.push(StdinWindow::default());
+                    }
+                    self.windows[window_id].is_created = true;
                 }
                 CxOsOp::SetCursor(cursor) => {
                     Self::stdin_send_to_host(AppToStudio::SetCursor(cursor.into()));

--- a/platform/src/os/linux/x11/opengl_x11.rs
+++ b/platform/src/os/linux/x11/opengl_x11.rs
@@ -417,6 +417,73 @@ impl OpenglWindow {
         }
     }
 
+    pub fn new_popup(
+        window_id: WindowId,
+        parent_window_id: WindowId,
+        opengl_cx: &OpenglCx,
+        size: Vec2d,
+        position: Vec2d,
+    ) -> OpenglWindow {
+        assert_eq!(opengl_cx.egl_platform, egl_sys::EGL_PLATFORM_X11_EXT);
+        let display = opengl_cx.egl_platform_display as *mut x11_sys::Display;
+
+        let mut xlib_window = Box::new(XlibWindow::new(window_id));
+
+        let visual_info = unsafe {
+            let mut native_visual_id = 0;
+            assert!(
+                (opengl_cx.libegl.eglGetConfigAttrib.unwrap())(
+                    opengl_cx.egl_display,
+                    opengl_cx.egl_config,
+                    egl_sys::EGL_NATIVE_VISUAL_ID as _,
+                    &mut native_visual_id,
+                ) != 0,
+                "eglGetConfigAttrib(EGL_NATIVE_VISUAL_ID) failed",
+            );
+
+            let mut visual_template = mem::zeroed::<x11_sys::XVisualInfo>();
+            visual_template.visualid = native_visual_id as _;
+
+            let mut count = 0;
+            let visual_info_ptr = x11_sys::XGetVisualInfo(
+                display,
+                x11_sys::VisualIDMask as c_long,
+                &mut visual_template,
+                &mut count,
+            );
+            assert!(
+                !visual_info_ptr.is_null() && count == 1,
+                "can't get visual from EGL configuration with XGetVisualInfo",
+            );
+
+            let visual_info = *visual_info_ptr;
+            x11_sys::XFree(visual_info_ptr as *mut c_void);
+            visual_info
+        };
+
+        xlib_window.init_popup(parent_window_id, size, position, visual_info);
+
+        let egl_surface = unsafe {
+            (opengl_cx.libegl.eglCreateWindowSurface.unwrap())(
+                opengl_cx.egl_display,
+                opengl_cx.egl_config,
+                xlib_window.window.unwrap(),
+                std::ptr::null(),
+            )
+        };
+        assert!(!egl_surface.is_null(), "eglCreateWindowSurface failed");
+
+        OpenglWindow {
+            first_draw: true,
+            window_id,
+            opening_repaint_count: 0,
+            cal_size: Vec2d::default(),
+            window_geom: xlib_window.get_window_geom(),
+            xlib_window,
+            egl_surface,
+        }
+    }
+
     pub fn resize_buffers(&mut self) -> bool {
         let cal_size = Vec2d {
             x: self.window_geom.inner_size.x * self.window_geom.dpi_factor,

--- a/platform/src/os/linux/x11/x11_sys.rs
+++ b/platform/src/os/linux/x11/x11_sys.rs
@@ -40,6 +40,7 @@ pub const DestroyNotify: u32 = 17;
 pub const ConfigureNotify: u32 = 22;
 pub const EnterNotify: u32 = 7;
 pub const LeaveNotify: u32 = 8;
+pub const FocusOut: u32 = 10;
 pub const MotionNotify: u32 = 6;
 pub const AllocNone: u32 = 0;
 pub const InputOutput: u32 = 1;
@@ -53,6 +54,10 @@ pub const Expose: u32 = 12;
 pub const CWBorderPixel: u32 = 8;
 pub const CWColormap: u32 = 8192;
 pub const CWEventMask: u32 = 2048;
+pub const CWOverrideRedirect: u32 = 512;
+
+pub const GrabModeAsync: i32 = 1;
+pub const GrabSuccess: i32 = 0;
 
 pub const SubstructureNotifyMask: u32 = 524288;
 pub const SubstructureRedirectMask: u32 = 1048576;
@@ -78,7 +83,6 @@ pub const XLookupKeySym: i32 = 3;
 pub const XLookupBoth: i32 = 4;
 
 pub const FocusIn: u32 = 9;
-pub const FocusOut: u32 = 10;
 
 pub const QueuedAlready: i32 = 0;
 pub const QueuedAfterReading: i32 = 1;
@@ -353,6 +357,7 @@ extern "C" {
         -> c_int;
 
     pub fn XMapWindow(arg1: *mut Display, arg2: Window) -> c_int;
+    pub fn XMapRaised(arg1: *mut Display, arg2: Window) -> c_int;
 
     pub fn XMoveWindow(display: *mut Display, window: Window, x: c_int, y: c_int);
 
@@ -417,7 +422,30 @@ extern "C" {
 
     pub fn XSetInputFocus(arg1: *mut Display, arg2: Window, arg3: c_int, arg4: Time) -> c_int;
 
+    pub fn XGrabPointer(
+        arg1: *mut Display,
+        arg2: Window,
+        arg3: c_int,
+        arg4: c_uint,
+        arg5: c_int,
+        arg6: c_int,
+        arg7: Window,
+        arg8: Cursor,
+        arg9: Time,
+    ) -> c_int;
+
     pub fn XUngrabPointer(arg1: *mut Display, arg2: Time) -> c_int;
+
+    pub fn XGrabKeyboard(
+        arg1: *mut Display,
+        arg2: Window,
+        arg3: c_int,
+        arg4: c_int,
+        arg5: c_int,
+        arg6: Time,
+    ) -> c_int;
+
+    pub fn XUngrabKeyboard(arg1: *mut Display, arg2: Time) -> c_int;
 
     pub fn XSetSelectionOwner(arg1: *mut Display, arg2: Atom, arg3: Window, arg4: Time) -> c_int;
 

--- a/platform/src/os/linux/x11/xlib_app.rs
+++ b/platform/src/os/linux/x11/xlib_app.rs
@@ -48,6 +48,8 @@ pub struct XlibApp {
     pub atoms: XlibAtoms,
     pub dnd: Dnd,
     pub next_keypress_is_repeat: bool,
+    pub active_popup: Option<c_ulong>,
+    pub active_popup_grabbed_keyboard: bool,
 }
 
 impl XlibApp {
@@ -86,6 +88,8 @@ impl XlibApp {
                 internal_cursor: MouseCursor::Default,
                 dnd: Dnd::new(display),
                 next_keypress_is_repeat: false,
+                active_popup: None,
+                active_popup_grabbed_keyboard: false,
             }
         }
     }
@@ -222,6 +226,9 @@ impl XlibApp {
                     let destroy_window = event.xdestroywindow;
                     if let Some(window_ptr) = self.window_map.get(&destroy_window.window) {
                         let window = &mut (**window_ptr);
+                        if self.active_popup == Some(destroy_window.window) {
+                            self.release_popup_grab(destroy_window.window);
+                        }
                         window.do_callback(XlibEvent::WindowClosed(WindowClosedEvent {
                             window_id: window.window_id,
                         }));
@@ -287,6 +294,12 @@ impl XlibApp {
                             y: y as f64 / window.last_window_geom.dpi_factor,
                         };
 
+                        if window.is_popup {
+                            window.last_nc_mode = None;
+                            window.send_mouse_move(pos, KeyModifiers::default());
+                            continue;
+                        }
+
                         // query window for chrome
                         let response = Rc::new(Cell::new(WindowDragQueryResponse::NoAnswer));
                         window.do_callback(XlibEvent::WindowDragQuery(WindowDragQueryEvent {
@@ -339,6 +352,20 @@ impl XlibApp {
                     // mouse down
                     let button = event.xbutton;
                     let time_now = self.time_now();
+
+                    if let Some(popup_window) = self.active_popup {
+                        if let Some(window_ptr) = self.window_map.get(&popup_window) {
+                            let popup = &mut (**window_ptr);
+                            if !popup.contains_root_pos(button.x_root, button.y_root) {
+                                self.do_callback(XlibEvent::PopupDismissed(PopupDismissedEvent {
+                                    window_id: popup.window_id,
+                                    reason: PopupDismissReason::OutsideClick,
+                                }));
+                                self.release_popup_grab(popup_window);
+                            }
+                        }
+                    }
+
                     if let Some(window_ptr) = self.window_map.get(&button.window) {
                         let window = &mut (**window_ptr);
                         x11_sys::XSetInputFocus(
@@ -382,50 +409,57 @@ impl XlibApp {
                             }))
                         } else {
                             // do all the 'nonclient' area messaging to the window manager
-                            if let Some(last_nc_mode) = window.last_nc_mode {
-                                if (time_now - self.last_click_time) < 0.35
-                                    && (button.x_root - self.last_click_pos.0).abs() < 5
-                                    && (button.y_root - self.last_click_pos.1).abs() < 5
-                                    && last_nc_mode == _NET_WM_MOVERESIZE_MOVE
-                                {
-                                    if window.get_is_maximized() {
-                                        window.restore();
+                            if !window.is_popup {
+                                if let Some(last_nc_mode) = window.last_nc_mode {
+                                    if (time_now - self.last_click_time) < 0.35
+                                        && (button.x_root - self.last_click_pos.0).abs() < 5
+                                        && (button.y_root - self.last_click_pos.1).abs() < 5
+                                        && last_nc_mode == _NET_WM_MOVERESIZE_MOVE
+                                    {
+                                        if window.get_is_maximized() {
+                                            window.restore();
+                                        } else {
+                                            window.maximize();
+                                        }
                                     } else {
-                                        window.maximize();
+                                        let default_screen = x11_sys::XDefaultScreen(self.display);
+                                        let root_window =
+                                            x11_sys::XRootWindow(self.display, default_screen);
+                                        x11_sys::XUngrabPointer(self.display, 0);
+                                        x11_sys::XFlush(self.display);
+                                        let mut xclient = x11_sys::XClientMessageEvent {
+                                            type_: x11_sys::ClientMessage as i32,
+                                            serial: 0,
+                                            send_event: 0,
+                                            display: self.display,
+                                            window: window.window.unwrap(),
+                                            message_type: self.atoms.net_wm_moveresize,
+                                            format: 32,
+                                            data: {
+                                                let mut msg = mem::zeroed::<
+                                                    x11_sys::XClientMessageEvent__bindgen_ty_1,
+                                                >(
+                                                );
+                                                msg.l[0] = button.x_root as c_long;
+                                                msg.l[1] = button.y_root as c_long;
+                                                msg.l[2] = last_nc_mode;
+                                                msg
+                                            },
+                                        };
+                                        x11_sys::XSendEvent(
+                                            self.display,
+                                            root_window,
+                                            0,
+                                            (x11_sys::SubstructureRedirectMask
+                                                | x11_sys::SubstructureNotifyMask)
+                                                as c_long,
+                                            &mut xclient as *mut _ as *mut x11_sys::XEvent,
+                                        );
                                     }
                                 } else {
-                                    let default_screen = x11_sys::XDefaultScreen(self.display);
-                                    let root_window =
-                                        x11_sys::XRootWindow(self.display, default_screen);
-                                    x11_sys::XUngrabPointer(self.display, 0);
-                                    x11_sys::XFlush(self.display);
-                                    let mut xclient = x11_sys::XClientMessageEvent {
-                                        type_: x11_sys::ClientMessage as i32,
-                                        serial: 0,
-                                        send_event: 0,
-                                        display: self.display,
-                                        window: window.window.unwrap(),
-                                        message_type: self.atoms.net_wm_moveresize,
-                                        format: 32,
-                                        data: {
-                                            let mut msg = mem::zeroed::<
-                                                x11_sys::XClientMessageEvent__bindgen_ty_1,
-                                            >(
-                                            );
-                                            msg.l[0] = button.x_root as c_long;
-                                            msg.l[1] = button.y_root as c_long;
-                                            msg.l[2] = last_nc_mode;
-                                            msg
-                                        },
-                                    };
-                                    x11_sys::XSendEvent(
-                                        self.display,
-                                        root_window,
-                                        0,
-                                        (x11_sys::SubstructureRedirectMask
-                                            | x11_sys::SubstructureNotifyMask)
-                                            as c_long,
-                                        &mut xclient as *mut _ as *mut x11_sys::XEvent,
+                                    window.send_mouse_down(
+                                        self.xbutton_to_mouse_button(button.button),
+                                        self.xkeystate_to_modifiers(button.state),
                                     );
                                 }
                             } else {
@@ -451,10 +485,23 @@ impl XlibApp {
                     }
                 }
                 x11_sys::KeyPress => {
+                    let key_code = self.xkeyevent_to_keycode(&mut event.xkey);
+                    if key_code == KeyCode::Escape {
+                        if let Some(popup_window) = self.active_popup {
+                            if let Some(window_ptr) = self.window_map.get(&popup_window) {
+                                let window = &mut (**window_ptr);
+                                self.do_callback(XlibEvent::PopupDismissed(PopupDismissedEvent {
+                                    window_id: window.window_id,
+                                    reason: PopupDismissReason::Escape,
+                                }));
+                                self.release_popup_grab(popup_window);
+                            }
+                        }
+                    }
+
                     if let Some(window_ptr) = self.window_map.get(&event.xkey.window) {
                         let window = &mut (**window_ptr);
                         let block_text = if event.xkey.keycode != 0 {
-                            let key_code = self.xkeyevent_to_keycode(&mut event.xkey);
                             let modifiers = self.xkeystate_to_modifiers(event.xkey.state);
 
                             if modifiers.control || modifiers.logo {
@@ -630,6 +677,16 @@ impl XlibApp {
                     }
                 }
                 x11_sys::FocusOut => {
+                    if let Some(popup_window) = self.active_popup {
+                        if let Some(window_ptr) = self.window_map.get(&popup_window) {
+                            let window = &mut (**window_ptr);
+                            self.do_callback(XlibEvent::PopupDismissed(PopupDismissedEvent {
+                                window_id: window.window_id,
+                                reason: PopupDismissReason::FocusLost,
+                            }));
+                            self.release_popup_grab(popup_window);
+                        }
+                    }
                     let event = event.xfocus;
                     if let Some(window_ptr) = self.window_map.get(&event.window) {
                         let window = &mut (**window_ptr);
@@ -715,6 +772,46 @@ impl XlibApp {
 
     pub fn time_now(&self) -> f64 {
         self.timers.time_now()
+    }
+
+    pub unsafe fn activate_popup_grab(&mut self, popup_window: c_ulong, grab_keyboard: bool) {
+        self.active_popup = Some(popup_window);
+        self.active_popup_grabbed_keyboard = false;
+        x11_sys::XGrabPointer(
+            self.display,
+            popup_window,
+            0,
+            (x11_sys::ButtonPressMask | x11_sys::ButtonReleaseMask | x11_sys::PointerMotionMask)
+                as u32,
+            x11_sys::GrabModeAsync,
+            x11_sys::GrabModeAsync,
+            0,
+            0,
+            x11_sys::CurrentTime.into(),
+        );
+        if grab_keyboard
+            && x11_sys::XGrabKeyboard(
+                self.display,
+                popup_window,
+                0,
+                x11_sys::GrabModeAsync,
+                x11_sys::GrabModeAsync,
+                x11_sys::CurrentTime.into(),
+            ) == x11_sys::GrabSuccess as i32
+        {
+            self.active_popup_grabbed_keyboard = true;
+        }
+    }
+
+    pub unsafe fn release_popup_grab(&mut self, popup_window: c_ulong) {
+        if self.active_popup == Some(popup_window) {
+            x11_sys::XUngrabPointer(self.display, x11_sys::CurrentTime.into());
+            if self.active_popup_grabbed_keyboard {
+                x11_sys::XUngrabKeyboard(self.display, x11_sys::CurrentTime.into());
+            }
+            self.active_popup = None;
+            self.active_popup_grabbed_keyboard = false;
+        }
     }
 
     pub fn load_first_cursor(&self, names: &[&[u8]]) -> Option<c_ulong> {
@@ -981,6 +1078,8 @@ pub struct XlibAtoms {
     pub primary: x11_sys::Atom,
     pub net_wm_moveresize: x11_sys::Atom,
     pub net_wm_icon: x11_sys::Atom,
+    pub net_wm_window_type: x11_sys::Atom,
+    pub net_wm_window_type_popup_menu: x11_sys::Atom,
     pub cardinal: x11_sys::Atom,
     pub wm_delete_window: x11_sys::Atom,
     pub wm_protocols: x11_sys::Atom,
@@ -1012,6 +1111,16 @@ impl XlibAtoms {
                 net_wm_icon: x11_sys::XInternAtom(
                     display,
                     "_NET_WM_ICON\0".as_ptr() as *const _,
+                    0,
+                ),
+                net_wm_window_type: x11_sys::XInternAtom(
+                    display,
+                    "_NET_WM_WINDOW_TYPE\0".as_ptr() as *const _,
+                    0,
+                ),
+                net_wm_window_type_popup_menu: x11_sys::XInternAtom(
+                    display,
+                    "_NET_WM_WINDOW_TYPE_POPUP_MENU\0".as_ptr() as *const _,
                     0,
                 ),
                 cardinal: x11_sys::XInternAtom(

--- a/platform/src/os/linux/x11/xlib_event.rs
+++ b/platform/src/os/linux/x11/xlib_event.rs
@@ -1,7 +1,8 @@
 use crate::{
     event::{
-        DragEvent, DropEvent, KeyEvent, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ScrollEvent,
-        TextClipboardEvent, TextInputEvent, TimerEvent, WindowCloseRequestedEvent,
+        DragEvent, DropEvent, KeyEvent, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
+        PopupDismissedEvent, ScrollEvent, TextClipboardEvent, TextInputEvent, TimerEvent,
+        WindowCloseRequestedEvent,
         WindowClosedEvent, WindowDragQueryEvent, WindowGeomChangeEvent,
     },
     window::WindowId,
@@ -13,6 +14,7 @@ pub enum XlibEvent {
     WindowLostFocus(WindowId),
     WindowGeomChange(WindowGeomChangeEvent),
     WindowClosed(WindowClosedEvent),
+    PopupDismissed(PopupDismissedEvent),
     Paint,
 
     MouseDown(MouseDownEvent),

--- a/platform/src/os/linux/x11/xlib_window.rs
+++ b/platform/src/os/linux/x11/xlib_window.rs
@@ -27,6 +27,8 @@ pub struct XlibWindow {
     pub last_mouse_pos: Vec2d,
     // When ime_active is false, XSetICFocus is not used so the IME candidate window does not show.
     pub ime_active: bool,
+    pub is_popup: bool,
+    pub popup_parent: Option<WindowId>,
 }
 /*
 #[derive(Clone)]
@@ -54,6 +56,8 @@ impl XlibWindow {
             current_cursor: MouseCursor::Default,
             last_mouse_pos: Vec2d::default(),
             ime_active: false,
+            is_popup: false,
+            popup_parent: None,
         }
     }
 
@@ -66,6 +70,8 @@ impl XlibWindow {
         visual_info: x11_sys::XVisualInfo,
         custom_window_chrome: bool,
     ) {
+        self.is_popup = false;
+        self.popup_parent = None;
         unsafe {
             let display = get_xlib_app_global().display;
 
@@ -248,6 +254,104 @@ impl XlibWindow {
             if is_fullscreen {
                 self.maximize();
             }
+        }
+    }
+
+    pub fn init_popup(
+        &mut self,
+        parent_window_id: WindowId,
+        size: Vec2d,
+        position: Vec2d,
+        visual_info: x11_sys::XVisualInfo,
+    ) {
+        self.is_popup = true;
+        self.popup_parent = Some(parent_window_id);
+        unsafe {
+            let display = get_xlib_app_global().display;
+            let default_screen = x11_sys::XDefaultScreen(display);
+            let root_window = x11_sys::XRootWindow(display, default_screen);
+
+            let mut attributes = mem::zeroed::<x11_sys::XSetWindowAttributes>();
+            attributes.border_pixel = 0;
+            attributes.override_redirect = 1;
+            attributes.colormap = x11_sys::XCreateColormap(
+                display,
+                root_window,
+                visual_info.visual,
+                x11_sys::AllocNone as i32,
+            );
+            attributes.event_mask = (x11_sys::ExposureMask
+                | x11_sys::StructureNotifyMask
+                | x11_sys::ButtonMotionMask
+                | x11_sys::PointerMotionMask
+                | x11_sys::ButtonPressMask
+                | x11_sys::ButtonReleaseMask
+                | x11_sys::KeyPressMask
+                | x11_sys::KeyReleaseMask
+                | x11_sys::VisibilityChangeMask
+                | x11_sys::FocusChangeMask
+                | x11_sys::EnterWindowMask
+                | x11_sys::LeaveWindowMask) as c_long;
+
+            let dpi_factor = self.get_dpi_factor();
+            let window = x11_sys::XCreateWindow(
+                display,
+                root_window,
+                position.x as i32,
+                position.y as i32,
+                (size.x * dpi_factor) as u32,
+                (size.y * dpi_factor) as u32,
+                0,
+                visual_info.depth,
+                x11_sys::InputOutput as u32,
+                visual_info.visual,
+                (x11_sys::CWBorderPixel
+                    | x11_sys::CWColormap
+                    | x11_sys::CWEventMask
+                    | x11_sys::CWOverrideRedirect) as c_ulong,
+                &mut attributes,
+            );
+
+            x11_sys::XChangeProperty(
+                display,
+                window,
+                get_xlib_app_global().atoms.net_wm_window_type,
+                get_xlib_app_global().atoms.atom,
+                32,
+                x11_sys::PropModeReplace as i32,
+                &get_xlib_app_global().atoms.net_wm_window_type_popup_menu as *const _
+                    as *const u8,
+                1,
+            );
+
+            x11_sys::XMapRaised(display, window);
+            x11_sys::XFlush(display);
+
+            let xic = x11_sys::XCreateIC(
+                get_xlib_app_global().xim,
+                x11_sys::XNInputStyle.as_ptr(),
+                (x11_sys::XIMPreeditNothing | x11_sys::XIMStatusNothing) as i32,
+                x11_sys::XNClientWindow.as_ptr(),
+                window,
+                x11_sys::XNFocusWindow.as_ptr(),
+                window,
+                ptr::null_mut() as *mut c_void,
+            );
+
+            get_xlib_app_global().window_map.insert(window, self);
+
+            self.attributes = Some(attributes);
+            self.visual_info = Some(visual_info);
+            self.window = Some(window);
+            self.xic = Some(xic);
+            self.last_window_geom = self.get_window_geom();
+
+            let new_geom = self.get_window_geom();
+            self.do_callback(XlibEvent::WindowGeomChange(WindowGeomChangeEvent {
+                window_id: self.window_id,
+                old_geom: new_geom.clone(),
+                new_geom,
+            }));
         }
     }
 
@@ -591,6 +695,22 @@ impl XlibWindow {
 
     pub fn send_focus_lost_event(&mut self) {
         self.do_callback(XlibEvent::WindowLostFocus(self.window_id));
+    }
+
+    pub fn contains_root_pos(&self, root_x: i32, root_y: i32) -> bool {
+        unsafe {
+            let mut xwa = mem::MaybeUninit::uninit();
+            x11_sys::XGetWindowAttributes(
+                get_xlib_app_global().display,
+                self.window.unwrap(),
+                xwa.as_mut_ptr(),
+            );
+            let xwa = xwa.assume_init();
+            root_x >= xwa.x
+                && root_y >= xwa.y
+                && root_x <= xwa.x + xwa.width
+                && root_y <= xwa.y + xwa.height
+        }
     }
 
     pub fn send_mouse_down(&mut self, button: MouseButton, modifiers: KeyModifiers) {

--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -487,6 +487,26 @@ impl Cx {
                     self.windows[window_id].is_created = true;
                     self.redraw_all();
                 }
+                CxOsOp::CreatePopupWindow {
+                    window_id,
+                    parent_window_id,
+                    position,
+                    size,
+                    grab_keyboard,
+                } => {
+                    let mut geom = self.os.window_geom.clone();
+                    geom.position = position;
+                    geom.inner_size = size;
+                    geom.outer_size = size;
+                    let window = &mut self.windows[window_id];
+                    window.window_geom = geom;
+                    window.is_popup = true;
+                    window.popup_parent = Some(parent_window_id);
+                    window.popup_position = Some(position);
+                    window.popup_size = Some(size);
+                    window.popup_grab_keyboard = grab_keyboard;
+                    window.is_created = true;
+                }
                 CxOsOp::FullscreenWindow(_window_id) => {
                     self.os.from_wasm(FromWasmFullScreen {});
                 }

--- a/platform/src/os/windows/d3d11.rs
+++ b/platform/src/os/windows/d3d11.rs
@@ -695,6 +695,61 @@ impl D3d11Window {
         }
     }
 
+    pub fn new_popup(
+        window_id: WindowId,
+        d3d11_cx: &D3d11Cx,
+        size: Vec2d,
+        position: Vec2d,
+    ) -> D3d11Window {
+        let mut win32_window = Box::new(Win32Window::new_popup(window_id, position, size));
+        win32_window.init(size);
+
+        let wg = win32_window.get_window_geom();
+
+        let sc_desc = DXGI_SWAP_CHAIN_DESC1 {
+            AlphaMode: DXGI_ALPHA_MODE_IGNORE,
+            BufferCount: 2,
+            Width: (wg.inner_size.x * wg.dpi_factor) as u32,
+            Height: (wg.inner_size.y * wg.dpi_factor) as u32,
+            Format: DXGI_FORMAT_B8G8R8A8_UNORM,
+            Flags: 0,
+            BufferUsage: DXGI_USAGE_RENDER_TARGET_OUTPUT,
+            SampleDesc: DXGI_SAMPLE_DESC {
+                Count: 1,
+                Quality: 0,
+            },
+            Scaling: DXGI_SCALING_NONE,
+            Stereo: FALSE,
+            SwapEffect: DXGI_SWAP_EFFECT_FLIP_DISCARD,
+        };
+
+        unsafe {
+            let swap_chain = d3d11_cx
+                .factory
+                .CreateSwapChainForHwnd(&d3d11_cx.device, win32_window.hwnd, &sc_desc, None, None)
+                .unwrap();
+
+            let swap_texture = swap_chain.GetBuffer(0).unwrap();
+            let mut render_target_view = None;
+            d3d11_cx
+                .device
+                .CreateRenderTargetView(&swap_texture, None, Some(&mut render_target_view))
+                .unwrap();
+
+            D3d11Window {
+                first_draw: true,
+                is_in_resize: false,
+                window_id,
+                alloc_size: wg.inner_size,
+                window_geom: wg,
+                win32_window,
+                swap_texture: Some(swap_texture),
+                render_target_view,
+                swap_chain,
+            }
+        }
+    }
+
     pub fn start_resize(&mut self) {
         self.is_in_resize = true;
     }

--- a/platform/src/os/windows/win32_event.rs
+++ b/platform/src/os/windows/win32_event.rs
@@ -1,8 +1,9 @@
 use crate::{
     event::{
         DragEvent, DropEvent, KeyEvent, MouseDownEvent, MouseLeaveEvent, MouseMoveEvent,
-        MouseUpEvent, ScrollEvent, TextClipboardEvent, TextInputEvent, TimerEvent,
-        WindowCloseRequestedEvent, WindowClosedEvent, WindowDragQueryEvent, WindowGeomChangeEvent,
+        MouseUpEvent, PopupDismissedEvent, ScrollEvent, TextClipboardEvent, TextInputEvent,
+        TimerEvent, WindowCloseRequestedEvent, WindowClosedEvent, WindowDragQueryEvent,
+        WindowGeomChangeEvent,
     },
     window::WindowId,
 };
@@ -15,6 +16,7 @@ pub enum Win32Event {
     WindowResizeLoopStop(WindowId),
     WindowGeomChange(WindowGeomChangeEvent),
     WindowClosed(WindowClosedEvent),
+    PopupDismissed(PopupDismissedEvent),
     Paint,
 
     MouseDown(MouseDownEvent),

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         area::Area,
         cursor::MouseCursor,
-        event::*,
+        event::{PopupDismissReason, PopupDismissedEvent, *},
         makepad_math::*,
         os::windows::{
             droptarget::*,
@@ -75,8 +75,9 @@ use {
                         WM_MBUTTONUP, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_NCCALCSIZE, WM_NCHITTEST,
                         WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SIZE, WM_SYSKEYDOWN, WM_SYSKEYUP,
                         WM_XBUTTONDOWN, WM_XBUTTONUP, WS_CLIPCHILDREN, WS_CLIPSIBLINGS,
-                        WS_EX_ACCEPTFILES, WS_EX_APPWINDOW, WS_EX_TOPMOST, WS_EX_WINDOWEDGE,
-                        WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_POPUP, WS_SIZEBOX, WS_SYSMENU,
+                        WS_EX_ACCEPTFILES, WS_EX_APPWINDOW, WS_EX_TOOLWINDOW, WS_EX_TOPMOST,
+                        WS_EX_WINDOWEDGE, WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_POPUP, WS_SIZEBOX,
+                        WS_SYSMENU,
                     },
                 },
             },
@@ -118,7 +119,7 @@ pub struct Win32Window {
     pub hwnd: HWND,
     pub track_mouse_event: bool,
     pub is_fullscreen: bool,
-
+    pub is_popup: bool,
     ime_saved_himc: HIMC,
 }
 
@@ -188,6 +189,58 @@ impl Win32Window {
             hwnd,
             track_mouse_event: false,
             is_fullscreen,
+            is_popup: false,
+            ime_saved_himc: HIMC::default(),
+        }
+    }
+
+    pub fn new_popup(
+        window_id: WindowId,
+        position: Vec2d,
+        size: Vec2d,
+    ) -> Win32Window {
+        let title = encode_wide("Makepad Popup");
+
+        let style = WS_POPUP | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
+        let style_ex = WS_EX_TOPMOST | WS_EX_TOOLWINDOW;
+
+        let dpi = with_win32_app(|app| app.dpi_functions.system_dpi_factor() as f64);
+        let x = (position.x * dpi) as i32;
+        let y = (position.y * dpi) as i32;
+        let w = (size.x * dpi) as i32;
+        let h = (size.y * dpi) as i32;
+
+        let hwnd = unsafe {
+            CreateWindowExW(
+                style_ex,
+                PCWSTR(with_win32_app(|app| app.window_class_name.as_ptr())),
+                PCWSTR(title.as_ptr()),
+                style,
+                x,
+                y,
+                w,
+                h,
+                None,
+                None,
+                Some(GetModuleHandleW(None).unwrap().into()),
+                None,
+            )
+            .unwrap()
+        };
+
+        Win32Window {
+            window_id,
+            mouse_buttons_down: 0,
+            last_window_geom: WindowGeom::default(),
+            last_key_mod: KeyModifiers::default(),
+            ime_spot: Vec2d::default(),
+            current_cursor: MouseCursor::Default,
+            last_mouse_pos: Vec2d::default(),
+            ignore_wmsize: 0,
+            hwnd,
+            track_mouse_event: false,
+            is_fullscreen: false,
+            is_popup: true,
             ime_saved_himc: HIMC::default(),
         }
     }
@@ -221,7 +274,14 @@ impl Win32Window {
                 if wparam.0 & 0xffff == WA_ACTIVE as usize {
                     window.do_callback(Win32Event::WindowGotFocus(window.window_id));
                 } else {
-                    window.do_callback(Win32Event::WindowLostFocus(window.window_id));
+                    if window.is_popup {
+                        window.do_callback(Win32Event::PopupDismissed(PopupDismissedEvent {
+                            window_id: window.window_id,
+                            reason: PopupDismissReason::FocusLost,
+                        }));
+                    } else {
+                        window.do_callback(Win32Event::WindowLostFocus(window.window_id));
+                    }
                 }
             }
             WM_NCCALCSIZE => {
@@ -384,6 +444,13 @@ impl Win32Window {
                 // detect control/cmd - c / v / x
                 let modifiers = Self::get_key_modifiers();
                 let key_code = Self::virtual_key_to_key_code(wparam);
+                if window.is_popup && key_code == KeyCode::Escape {
+                    window.do_callback(Win32Event::PopupDismissed(PopupDismissedEvent {
+                        window_id: window.window_id,
+                        reason: PopupDismissReason::Escape,
+                    }));
+                    return LRESULT(0);
+                }
                 if modifiers.alt && key_code == KeyCode::F4 {
                     PostMessageW(Some(hwnd), WM_CLOSE, WPARAM(0), LPARAM(0)).unwrap();
                 }

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -103,6 +103,9 @@ impl Cx {
             Win32Event::WindowLostFocus(window_id) => {
                 self.call_event_handler(&Event::WindowLostFocus(window_id));
             }
+            Win32Event::PopupDismissed(event) => {
+                self.call_event_handler(&Event::PopupDismissed(event));
+            }
             Win32Event::WindowResizeLoopStart(window_id) => {
                 if let Some(window) = d3d11_windows.iter_mut().find(|w| w.window_id == window_id) {
                     window.start_resize();
@@ -140,6 +143,30 @@ impl Cx {
             }
             Win32Event::WindowClosed(wc) => {
                 let window_id = wc.window_id;
+                // Cascade-close any popup windows parented to this window
+                let popup_ids: Vec<WindowId> = d3d11_windows
+                    .iter()
+                    .filter(|w| self.windows[w.window_id].popup_parent == Some(window_id))
+                    .map(|w| w.window_id)
+                    .collect();
+                for popup_id in popup_ids {
+                    self.call_event_handler(&Event::PopupDismissed(
+                        crate::event::PopupDismissedEvent {
+                            window_id: popup_id,
+                            reason: crate::event::PopupDismissReason::ParentClosed,
+                        },
+                    ));
+                    self.call_event_handler(&Event::WindowClosed(WindowClosedEvent {
+                        window_id: popup_id,
+                    }));
+                    self.windows[popup_id].is_created = false;
+                    if let Some(idx) =
+                        d3d11_windows.iter().position(|w| w.window_id == popup_id)
+                    {
+                        d3d11_windows[idx].win32_window.close_window();
+                        d3d11_windows.remove(idx);
+                    }
+                }
                 self.call_event_handler(&Event::WindowClosed(wc));
                 // lets remove the window from the set
                 self.windows[window_id].is_created = false;
@@ -377,6 +404,50 @@ impl Cx {
                         window.is_fullscreen,
                     );
 
+                    window.window_geom = d3d11_window.window_geom.clone();
+                    d3d11_windows.push(d3d11_window);
+                    window.is_created = true;
+                    geom_changes.push(WindowGeomChangeEvent {
+                        window_id,
+                        old_geom: window.window_geom.clone(),
+                        new_geom: window.window_geom.clone(),
+                    });
+                }
+                CxOsOp::CreatePopupWindow {
+                    window_id,
+                    parent_window_id,
+                    position,
+                    size,
+                    grab_keyboard,
+                } => {
+                    let window = &mut self.windows[window_id];
+                    window.is_popup = true;
+                    window.popup_parent = Some(parent_window_id);
+                    window.popup_position = Some(position);
+                    window.popup_size = Some(size);
+                    window.popup_grab_keyboard = grab_keyboard;
+
+                    // Convert parent-relative position to screen coordinates
+                    let screen_position = if let Some(parent_d3d11) =
+                        d3d11_windows.iter().find(|w| w.window_id == parent_window_id)
+                    {
+                        let parent_pos = parent_d3d11.win32_window.get_position();
+                        let parent_dpi = parent_d3d11.win32_window.get_dpi_factor();
+                        // parent_pos is already in screen pixels / dpi, position is in logical coords
+                        dvec2(
+                            parent_pos.x + position.x * parent_dpi,
+                            parent_pos.y + position.y * parent_dpi,
+                        )
+                    } else {
+                        position
+                    };
+
+                    let d3d11_window = D3d11Window::new_popup(
+                        window_id,
+                        &d3d11_cx,
+                        size,
+                        screen_position,
+                    );
                     window.window_geom = d3d11_window.window_geom.clone();
                     d3d11_windows.push(d3d11_window);
                     window.is_created = true;

--- a/platform/src/os/windows/windows_stdin.rs
+++ b/platform/src/os/windows/windows_stdin.rs
@@ -348,6 +348,12 @@ impl Cx {
                         }];
                     }*/
                 }
+                CxOsOp::CreatePopupWindow { window_id, .. } => {
+                    while window_id.id() >= stdin_windows.len() {
+                        stdin_windows.push(StdinWindow::default());
+                    }
+                    self.windows[window_id].is_created = true;
+                }
                 CxOsOp::SetCursor(cursor) => {
                     Self::stdin_send_to_host(AppToStudio::SetCursor(cursor.into()));
                 }

--- a/platform/src/window.rs
+++ b/platform/src/window.rs
@@ -35,6 +35,10 @@ impl CxWindowPool {
         WindowHandle(self.0.alloc())
     }
 
+    pub fn len(&self) -> usize {
+        self.0.pool.len()
+    }
+
     pub fn window_id_contains(&self, pos: Vec2d) -> (WindowId, Vec2d) {
         for (index, item) in self.0.pool.iter().enumerate() {
             let window = &item.item;
@@ -146,8 +150,46 @@ impl WindowHandle {
         cxwindow.create_inner_size = None;
         cxwindow.create_position = None;
         cxwindow.create_app_id = "Makepad".to_string();
+        cxwindow.is_popup = false;
+        cxwindow.popup_parent = None;
+        cxwindow.popup_position = None;
+        cxwindow.popup_size = None;
+        cxwindow.popup_grab_keyboard = true;
         cx.platform_ops
             .push(CxOsOp::CreateWindow(window.window_id()));
+        window
+    }
+
+    /// Creates a popup window that must be explicitly closed by the app.
+    ///
+    /// The framework sends `Event::PopupDismissed` when the popup should be
+    /// dismissed (outside click, focus loss, Escape). The app must handle that
+    /// event and call `close()` on the window handle. The popup is **not**
+    /// auto-closed by the framework.
+    pub fn new_popup(cx: &mut Cx, parent: WindowId, position: Vec2d, size: Vec2d) -> Self {
+        let window = cx.windows.alloc();
+        let window_id = window.window_id();
+        let grab_keyboard = {
+            let cxwindow = &mut cx.windows[window_id];
+            cxwindow.is_created = false;
+            cxwindow.create_title = "Makepad Popup".to_string();
+            cxwindow.create_inner_size = Some(size);
+            cxwindow.create_position = Some(position);
+            cxwindow.create_app_id = "Makepad".to_string();
+            cxwindow.is_popup = true;
+            cxwindow.popup_parent = Some(parent);
+            cxwindow.popup_position = Some(position);
+            cxwindow.popup_size = Some(size);
+            cxwindow.popup_grab_keyboard = true;
+            cxwindow.popup_grab_keyboard
+        };
+        cx.platform_ops.push(CxOsOp::CreatePopupWindow {
+            window_id,
+            parent_window_id: parent,
+            position,
+            size,
+            grab_keyboard,
+        });
         window
     }
 }
@@ -233,6 +275,10 @@ impl WindowHandle {
         cx.windows[self.window_id()].get_position()
     }
 
+    pub fn is_popup(&self, cx: &Cx) -> bool {
+        cx.windows[self.window_id()].is_popup
+    }
+
     pub fn set_kind_id(&mut self, cx: &mut Cx, kind_id: usize) {
         cx.windows[self.window_id()].kind_id = kind_id;
     }
@@ -309,7 +355,7 @@ pub struct WindowIcon {
     pub buffers: Vec<WindowIconBuffer>,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct CxWindow {
     pub create_title: String,
     pub create_position: Option<Vec2d>,
@@ -323,6 +369,35 @@ pub struct CxWindow {
     pub window_geom: WindowGeom,
     pub main_pass_id: Option<DrawPassId>,
     pub is_fullscreen: bool,
+    pub is_popup: bool,
+    pub popup_parent: Option<WindowId>,
+    pub popup_position: Option<Vec2d>,
+    pub popup_size: Option<Vec2d>,
+    pub popup_grab_keyboard: bool,
+}
+
+impl Default for CxWindow {
+    fn default() -> Self {
+        Self {
+            create_title: String::default(),
+            create_position: None,
+            create_inner_size: None,
+            create_icon: None,
+            create_app_id: String::default(),
+            kind_id: 0,
+            dpi_override: None,
+            os_dpi_factor: None,
+            is_created: false,
+            window_geom: WindowGeom::default(),
+            main_pass_id: None,
+            is_fullscreen: false,
+            is_popup: false,
+            popup_parent: None,
+            popup_position: None,
+            popup_size: None,
+            popup_grab_keyboard: true,
+        }
+    }
 }
 
 impl CxWindow {


### PR DESCRIPTION
Add cross-platform popup window operations to the platform API. Popup windows support parent-child relationships, positioning, and automatic dismissal on focus loss, outside click, or escape.

Platforms wired: X11, Wayland, macOS, Windows, iOS, Android. Stub-only on web, tvOS, OpenHarmony.

Validated with cargo check -p makepad-platform.