### PR TITLE
fix(draw): return Option from font loader instead of panicking

### DIFF
--- a/draw/src/text/fonts.rs
+++ b/draw/src/text/fonts.rs
@@ -128,7 +128,7 @@ impl Fonts {
         self.layouter.define_font(id, definition);
     }
 
-    pub fn get_or_load_font_family(&mut self, id: FontFamilyId) -> Rc<FontFamily> {
+    pub fn get_or_load_font_family(&mut self, id: FontFamilyId) -> Option<Rc<FontFamily>> {
         self.layouter.get_or_load_font_family(id)
     }
 

--- a/draw/src/text/layouter.rs
+++ b/draw/src/text/layouter.rs
@@ -75,7 +75,7 @@ impl Layouter {
         self.loader.define_font(id, definition);
     }
 
-    pub fn get_or_load_font_family(&mut self, id: FontFamilyId) -> Rc<FontFamily> {
+    pub fn get_or_load_font_family(&mut self, id: FontFamilyId) -> Option<Rc<FontFamily>> {
         self.loader.get_or_load_font_family_rc(id)
     }
 
@@ -95,10 +95,19 @@ impl Layouter {
     }
 
     fn layout(&mut self, params: OwnedLayoutParams) -> LaidoutText {
-        let font_family = self
+        let font_family = match self
             .loader
             .get_or_load_font_family(params.style.font_family_id)
-            .clone();
+        {
+            Some(family) => family.clone(),
+            None => {
+                return LaidoutText {
+                    text: params.text,
+                    size_in_lpxs: Size::ZERO,
+                    rows: Vec::new(),
+                };
+            }
+        };
         LayoutContext::new(font_family, params.text, params.style, params.options)
             .layout_multiline()
     }

--- a/draw/src/text/loader.rs
+++ b/draw/src/text/loader.rs
@@ -85,55 +85,54 @@ impl Loader {
         self.font_definitions.insert(id, definition);
     }
 
-    pub fn get_or_load_font_family(&mut self, id: FontFamilyId) -> &Rc<FontFamily> {
+    pub fn get_or_load_font_family(&mut self, id: FontFamilyId) -> Option<&Rc<FontFamily>> {
         if !self.font_family_cache.contains_key(&id) {
-            let font_family = self.load_font_family(id);
+            let font_family = self.load_font_family(id)?;
             self.font_family_cache.insert(id, Rc::new(font_family));
         }
-        self.font_family_cache.get(&id).unwrap()
+        self.font_family_cache.get(&id)
     }
 
-    pub fn get_or_load_font_family_rc(&mut self, id: FontFamilyId) -> Rc<FontFamily> {
-        self.get_or_load_font_family(id).clone()
+    pub fn get_or_load_font_family_rc(&mut self, id: FontFamilyId) -> Option<Rc<FontFamily>> {
+        self.get_or_load_font_family(id).cloned()
     }
 
-    fn load_font_family(&mut self, id: FontFamilyId) -> FontFamily {
-        let definition = self
-            .font_family_definitions
-            .remove(&id)
-            .unwrap_or_else(|| panic!("font family {:?} is not defined", id));
-        FontFamily::new(
+    fn load_font_family(&mut self, id: FontFamilyId) -> Option<FontFamily> {
+        let definition = self.font_family_definitions.remove(&id)?;
+        let fonts: Vec<Rc<Font>> = definition
+            .font_ids
+            .into_iter()
+            .filter_map(|font_id| self.get_or_load_font(font_id).cloned())
+            .collect();
+        if fonts.is_empty() {
+            return None;
+        }
+        Some(FontFamily::new(
             id,
             self.shaper.clone(),
-            definition
-                .font_ids
-                .into_iter()
-                .map(|font_id| self.get_or_load_font(font_id).clone())
-                .collect(),
-        )
+            fonts.into(),
+        ))
     }
 
-    pub fn get_or_load_font(&mut self, id: FontId) -> &Rc<Font> {
+    pub fn get_or_load_font(&mut self, id: FontId) -> Option<&Rc<Font>> {
         if !self.font_cache.contains_key(&id) {
-            let font = self.load_font(id);
-            self.font_cache.insert(id, Rc::new(font));
+            if let Some(font) = self.load_font(id) {
+                self.font_cache.insert(id, Rc::new(font));
+            }
         }
-        self.font_cache.get(&id).unwrap()
+        self.font_cache.get(&id)
     }
 
-    fn load_font(&mut self, id: FontId) -> Font {
-        let definition = self
-            .font_definitions
-            .remove(&id)
-            .expect("font is not defined");
-        Font::new(
+    fn load_font(&mut self, id: FontId) -> Option<Font> {
+        let definition = self.font_definitions.remove(&id)?;
+        let face = FontFace::from_data_and_index(definition.data, definition.index)?;
+        Some(Font::new(
             id.clone(),
             self.rasterizer.clone(),
-            FontFace::from_data_and_index(definition.data, definition.index)
-                .expect("failed to load font from definition"),
+            face,
             definition.ascender_fudge_in_ems,
             definition.descender_fudge_in_ems,
-        )
+        ))
     }
 }
 

--- a/widgets/src/math_view.rs
+++ b/widgets/src/math_view.rs
@@ -165,7 +165,7 @@ impl MathView {
         let layout_font = {
             let mut fonts = cx.fonts.borrow_mut();
             let family = fonts.get_or_load_font_family(font_family_id);
-            family.fonts().first().cloned()
+            family.and_then(|f| f.fonts().first().cloned())
         };
 
         let Some(layout_font) = layout_font else {


### PR DESCRIPTION
The font loader methods (load_font, get_or_load_font, load_font_family, get_or_load_font_family) used .expect() / .unwrap() which caused RuntimeError::unreachable panics on WASM when font data was not yet available via the JS dependency table.

Changed 7 method signatures in draw/src/text/ to return Option, propagating None gracefully. When a font family cannot be loaded, layout() returns an empty LaidoutText instead of panicking.