### PR TITLE
fix(draw): prevent panics when font data unavailable on WASM

### DIFF
--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -390,6 +390,10 @@ impl DrawText {
         use crate::text::geom::{Point, Size};
         use crate::turtle;
 
+        if laidout_text.rows.is_empty() {
+            return Rect::default();
+        }
+
         let size_in_lpxs = laidout_text.size_in_lpxs * self.font_scale;
         let max_size_in_lpxs = Size::new(
             cx.turtle()
@@ -460,6 +464,9 @@ impl DrawText {
             Align::default(),
             text_str,
         );
+        if text.rows.is_empty() {
+            return;
+        }
         self.draw_text(cx, origin_in_lpxs, &text);
 
         let last_row = text.rows.last().unwrap();

--- a/draw/src/text/fonts.rs
+++ b/draw/src/text/fonts.rs
@@ -137,7 +137,7 @@ impl Fonts {
         self.layouter.define_font(id, definition);
     }
 
-    pub fn get_or_load_font_family(&mut self, id: FontFamilyId) -> Rc<FontFamily> {
+    pub fn get_or_load_font_family(&mut self, id: FontFamilyId) -> Option<Rc<FontFamily>> {
         self.layouter.get_or_load_font_family(id)
     }
 

--- a/draw/src/text/layouter.rs
+++ b/draw/src/text/layouter.rs
@@ -75,7 +75,7 @@ impl Layouter {
         self.loader.define_font(id, definition);
     }
 
-    pub fn get_or_load_font_family(&mut self, id: FontFamilyId) -> Rc<FontFamily> {
+    pub fn get_or_load_font_family(&mut self, id: FontFamilyId) -> Option<Rc<FontFamily>> {
         self.loader.get_or_load_font_family_rc(id)
     }
 
@@ -95,10 +95,19 @@ impl Layouter {
     }
 
     fn layout(&mut self, params: OwnedLayoutParams) -> LaidoutText {
-        let font_family = self
+        let font_family = match self
             .loader
             .get_or_load_font_family(params.style.font_family_id)
-            .clone();
+        {
+            Some(family) => family.clone(),
+            None => {
+                return LaidoutText {
+                    text: params.text,
+                    size_in_lpxs: Size::ZERO,
+                    rows: Vec::new(),
+                };
+            }
+        };
         LayoutContext::new(font_family, params.text, params.style, params.options)
             .layout_multiline()
     }

--- a/draw/src/text/loader.rs
+++ b/draw/src/text/loader.rs
@@ -94,60 +94,57 @@ impl Loader {
         self.font_definitions.insert(id, definition);
     }
 
-    pub fn get_or_load_font_family(&mut self, id: FontFamilyId) -> &Rc<FontFamily> {
+    pub fn get_or_load_font_family(&mut self, id: FontFamilyId) -> Option<&Rc<FontFamily>> {
         if !self.font_family_cache.contains_key(&id) {
-            let font_family = self.load_font_family(id);
+            let font_family = self.load_font_family(id)?;
             self.font_family_cache.insert(id, Rc::new(font_family));
         }
-        self.font_family_cache.get(&id).unwrap()
+        self.font_family_cache.get(&id)
     }
 
-    pub fn get_or_load_font_family_rc(&mut self, id: FontFamilyId) -> Rc<FontFamily> {
-        self.get_or_load_font_family(id).clone()
+    pub fn get_or_load_font_family_rc(&mut self, id: FontFamilyId) -> Option<Rc<FontFamily>> {
+        self.get_or_load_font_family(id).cloned()
     }
 
-    fn load_font_family(&mut self, id: FontFamilyId) -> FontFamily {
-        let definition = self
-            .font_family_definitions
-            .get(&id)
-            .cloned()
-            .unwrap_or_else(|| panic!("font family {:?} is not defined", id));
-        FontFamily::new(
+    fn load_font_family(&mut self, id: FontFamilyId) -> Option<FontFamily> {
+        let definition = self.font_family_definitions.get(&id).cloned()?;
+        let fonts: Vec<Rc<Font>> = definition
+            .font_ids
+            .into_iter()
+            .filter_map(|font_id| self.get_or_load_font(font_id).cloned())
+            .collect();
+        if fonts.is_empty() {
+            return None;
+        }
+        Some(FontFamily::new(
             id,
             self.shaper.clone(),
-            definition
-                .font_ids
-                .into_iter()
-                .map(|font_id| self.get_or_load_font(font_id).clone())
-                .collect(),
-        )
+            fonts.into(),
+        ))
     }
 
-    pub fn get_or_load_font(&mut self, id: FontId) -> &Rc<Font> {
+    pub fn get_or_load_font(&mut self, id: FontId) -> Option<&Rc<Font>> {
         if !self.font_cache.contains_key(&id) {
-            let font = self.load_font(id);
-            self.font_cache.insert(id, Rc::new(font));
+            if let Some(font) = self.load_font(id) {
+                self.font_cache.insert(id, Rc::new(font));
+            }
         }
-        self.font_cache.get(&id).unwrap()
+        self.font_cache.get(&id)
     }
 
-    fn load_font(&mut self, id: FontId) -> Font {
-        let definition = self
-            .font_definitions
-            .remove(&id)
-            .expect("font is not defined");
-        let mut face = FontFace::from_data_and_index(definition.data, definition.index)
-            .expect("failed to load font from definition");
+    fn load_font(&mut self, id: FontId) -> Option<Font> {
+        let definition = self.font_definitions.remove(&id)?;
+        let mut face = FontFace::from_data_and_index(definition.data, definition.index)?;
         if !definition.variations.is_empty() {
             face.set_variations(&definition.variations);
         }
-        Font::new(
+        Some(Font::new(
             id.clone(),
             self.rasterizer.clone(),
             face,
             definition.ascender_fudge_in_ems,
             definition.descender_fudge_in_ems,
-        )
+        ))
     }
 }
 

--- a/widgets/src/math_view.rs
+++ b/widgets/src/math_view.rs
@@ -165,7 +165,7 @@ impl MathView {
         let layout_font = {
             let mut fonts = cx.fonts.borrow_mut();
             let family = fonts.get_or_load_font_family(font_family_id);
-            family.fonts().first().cloned()
+            family.and_then(|f| f.fonts().first().cloned())
         };
 
         let Some(layout_font) = layout_font else {


### PR DESCRIPTION
## Summary

Fixes `RuntimeError: unreachable` panics on WASM when font binary data is not yet available via the JS dependency table during early frames.

### Root cause
On WASM, font resources arrive asynchronously via `ToWasmInit`. If `cx.get_resource(handle)` returns `None` for a font, `update_font_definitions()` in `draw_text.rs` silently skips it but still registers the font family. When the text system later attempts to load the family, the loader panics on `.expect()` / `.unwrap()`. This corrupts Makepad's event handler state, causing every subsequent frame to also panic.

### Changes

**`draw/src/text/loader.rs`** — 5 methods return `Option` instead of panicking:
- `load_font()` → `Option<Font>` (font definition or face parse failure returns `None`)
- `get_or_load_font()` → `Option<&Rc<Font>>`
- `load_font_family()` → `Option<FontFamily>` (skips failed fonts, returns `None` if all fail)
- `get_or_load_font_family()` → `Option<&Rc<FontFamily>>`
- `get_or_load_font_family_rc()` → `Option<Rc<FontFamily>>`

**`draw/src/text/layouter.rs`** — 2 methods:
- `get_or_load_font_family()` → `Option<Rc<FontFamily>>`
- `layout()` → returns empty `LaidoutText` when font family unavailable

**`draw/src/text/fonts.rs`** — 1 method:
- `get_or_load_font_family()` → `Option<Rc<FontFamily>>`

**`draw/src/shader/draw_text.rs`** — 2 methods:
- `draw_walk_laidout()` → early return with `Rect::default()` when rows are empty
- `draw_walk_resumable_with()` → early return when rows are empty

**`widgets/src/math_view.rs`** — 1 caller adapted to use `and_then`

### Testing
- Desktop build compiles and passes tests
- WASM build loads with **zero** `RuntimeError` panics (previously ~70 per-frame panics)
- Fonts render correctly once data becomes available