### PR TITLE
Add --no-threads option and runtime thread checks

### DIFF
--- a/platform/src/os/web/web.js
+++ b/platform/src/os/web/web.js
@@ -59,7 +59,7 @@ export class WasmWebBrowser extends WasmBridge {
                 pathname: location.pathname + "",
                 search: location.search + "",
                 hash: location.hash + "",
-                has_thread_support: this.wasm._has_threading_support
+                has_thread_support: this.wasm._has_thread_support
             },
             window_info: this.window_info,
         });
@@ -278,6 +278,15 @@ export class WasmWebBrowser extends WasmBridge {
         if (this.audio_context) {
             return
         }
+        if (!this.wasm._has_thread_support) {
+            console.warn("FromWasmStartAudioOutput skipped: wasm threading support is unavailable");
+            return
+        }
+        const thread_info = this.alloc_thread_stack(args.context_ptr);
+        if (!thread_info) {
+            console.warn("FromWasmStartAudioOutput skipped: thread stack allocation prerequisites are unavailable");
+            return
+        }
         const start_worklet = async () => {
 
             await this.audio_context.audioWorklet.addModule("./makepad_platform/audio_worklet.js", {credentials: 'omit'});
@@ -286,7 +295,7 @@ export class WasmWebBrowser extends WasmBridge {
                 numberOfInputs: 0,
                 numberOfOutputs: 1,
                 outputChannelCount: [2],
-                processorOptions: {thread_info: this.alloc_thread_stack(args.context_ptr)}
+                processorOptions: {thread_info}
             });
             
             audio_worklet.port.onmessage = (e) => {
@@ -425,7 +434,15 @@ export class WasmWebBrowser extends WasmBridge {
         
     }
     
-    alloc_thread_stack(context_ptr, timer) {
+    alloc_thread_stack(context_ptr, timer = 0) {
+        if (!this.wasm._has_thread_support) {
+            console.warn("alloc_thread_stack unavailable: wasm threading support is disabled");
+            return null;
+        }
+        if (this.exports.__stack_pointer === undefined) {
+            console.warn("alloc_thread_stack unavailable: missing __stack_pointer export");
+            return null;
+        }
         var ret = {
             timer,
             module: this.wasm._module,
@@ -435,10 +452,21 @@ export class WasmWebBrowser extends WasmBridge {
         if (typeof this.exports.__wbindgen_start !== 'undefined') {
             ret.wasm_bindgen = true;
         } else {
+            if (this.exports.__tls_size === undefined) {
+                console.warn("alloc_thread_stack unavailable: missing __tls_size export");
+                return null;
+            }
+            if (typeof this.exports.wasm_thread_alloc_tls_and_stack !== "function") {
+                console.warn("alloc_thread_stack unavailable: missing wasm_thread_alloc_tls_and_stack export");
+                return null;
+            }
             let tls_size = this.exports.__tls_size.value;
             tls_size += 8 - (tls_size & 7); // align it to 8 bytes
             let stack_size = this.thread_stack_size; // 8mb
-            if ((tls_size + stack_size) & 7 != 0) throw new Error("stack size not 8 byte aligned");
+            if ((tls_size + stack_size) & 7 != 0) {
+                console.warn("alloc_thread_stack unavailable: stack size is not 8-byte aligned");
+                return null;
+            }
             ret.tls_ptr = this.exports.wasm_thread_alloc_tls_and_stack((tls_size + stack_size) >> 3);
             this.update_array_buffer_refs();
             ret.stack_ptr = ret.tls_ptr + tls_size + stack_size - 8;
@@ -454,21 +482,20 @@ export class WasmWebBrowser extends WasmBridge {
     // example build command:
     // RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--export=__stack_pointer" cargo build -p thing_to_compile --target=wasm32-unknown-unknown -Z build-std=panic_abort,std
     FromWasmCreateThread(args) {
-        
-        let worker = new Worker(
-            './makepad_platform/web_worker.js',
-            {type: 'module'}
-        );
-        
         if (!this.wasm._has_thread_support) {
             console.error("FromWasmCreateThread not available, wasm file not compiled with threading support");
             return
         }
-        if (this.exports.__stack_pointer === undefined) {
-            console.error("FromWasmCreateThread not available, wasm file not compiled with -C link-arg=--export=__stack_pointer");
+        let thread_info = this.alloc_thread_stack(args.context_ptr, args.timer);
+        if (!thread_info) {
+            console.error("FromWasmCreateThread not available, thread stack allocation prerequisites are missing");
             return
         }
-        worker.postMessage(this.alloc_thread_stack(args.context_ptr, args.timer));
+        let worker = new Worker(
+            './makepad_platform/web_worker.js',
+            {type: 'module'}
+        );
+        worker.postMessage(thread_info);
         
         this.workers.push(worker);
     }

--- a/tools/cargo_makepad/src/main.rs
+++ b/tools/cargo_makepad/src/main.rs
@@ -45,6 +45,7 @@ fn show_help() {
         "       --brotli                                  Use brotli to compress the wasm file"
     );
     println!("       --bindgen                                 Enable wasm-bindgen compatibility");
+    println!("       --no-threads                              Build single-threaded wasm (no COOP/COEP needed)");
     println!();
     println!("Apple iOS/TVOs Commands:");
     println!();

--- a/tools/cargo_makepad/src/wasm/compile.rs
+++ b/tools/cargo_makepad/src/wasm/compile.rs
@@ -19,6 +19,7 @@ pub struct WasmConfig {
     pub small_fonts: bool,
     pub brotli: bool,
     pub bindgen: bool,
+    pub threads: bool,
 }
 
 pub fn generate_html(wasm: &str, config: &WasmConfig) -> String {
@@ -171,8 +172,11 @@ pub fn cp_brotli(
 
 const WASM_TARGET_TRIPLE: &str = "wasm32-unknown-unknown";
 const WASM_TARGET_SPEC_FEATURES: &str = "+atomics,+bulk-memory,+mutable-globals";
+const WASM_RUSTFLAGS_THREADED: &str = "-C codegen-units=1 -C link-arg=--export=__stack_pointer -C link-arg=--shared-memory -C link-arg=--max-memory=2147483648 -C link-arg=--import-memory -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base -C opt-level=z";
+const WASM_RUSTFLAGS_SINGLE_THREADED: &str =
+    "-C codegen-units=1 -C link-arg=--export=__stack_pointer -C opt-level=z";
 
-fn build_wasm_target_spec(cwd: &PathBuf) -> Result<PathBuf, String> {
+fn build_wasm_target_spec(cwd: &PathBuf, threaded: bool) -> Result<PathBuf, String> {
     let target_spec_dir = cwd.join("target/makepad-wasm-target");
     mkdir(&target_spec_dir)?;
     let target_spec_path = target_spec_dir.join(format!("{WASM_TARGET_TRIPLE}.json"));
@@ -201,13 +205,15 @@ fn build_wasm_target_spec(cwd: &PathBuf) -> Result<PathBuf, String> {
         );
     }
 
-    let insert_at = target_spec
-        .rfind('}')
-        .ok_or_else(|| "Unable to parse wasm target spec JSON from rustc".to_string())?;
-    target_spec.insert_str(
-        insert_at,
-        &format!(",\n  \"features\": \"{WASM_TARGET_SPEC_FEATURES}\"\n"),
-    );
+    if threaded {
+        let insert_at = target_spec
+            .rfind('}')
+            .ok_or_else(|| "Unable to parse wasm target spec JSON from rustc".to_string())?;
+        target_spec.insert_str(
+            insert_at,
+            &format!(",\n  \"features\": \"{WASM_TARGET_SPEC_FEATURES}\"\n"),
+        );
+    }
 
     fs::write(&target_spec_path, target_spec)
         .map_err(|e| format!("Can't write wasm target spec {:?}: {:?}", target_spec_path, e))?;
@@ -217,7 +223,7 @@ fn build_wasm_target_spec(cwd: &PathBuf) -> Result<PathBuf, String> {
 pub fn build(config: WasmConfig, args: &[String]) -> Result<WasmBuildResult, String> {
     let build_crate = get_build_crate_from_args(args)?;
     let cwd = std::env::current_dir().unwrap();
-    let wasm_target_spec = build_wasm_target_spec(&cwd)?;
+    let wasm_target_spec = build_wasm_target_spec(&cwd, config.threads)?;
     let target_arg = format!("--target={}", wasm_target_spec.display());
 
     let base_args = vec![
@@ -241,10 +247,17 @@ pub fn build(config: WasmConfig, args: &[String]) -> Result<WasmBuildResult, Str
     }
     let args_out_refs: Vec<&str> = args_out.iter().map(|arg| arg.as_str()).collect();
 
-    shell_env(&[
-        ("RUSTFLAGS", "-C codegen-units=1 -C link-arg=--export=__stack_pointer -C link-arg=--shared-memory -C link-arg=--max-memory=2147483648 -C link-arg=--import-memory -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base -C opt-level=z"),
-        ("MAKEPAD", "lines"),
-    ], &cwd, "rustup", &args_out_refs) ?;
+    let rustflags = if config.threads {
+        WASM_RUSTFLAGS_THREADED
+    } else {
+        WASM_RUSTFLAGS_SINGLE_THREADED
+    };
+    shell_env(
+        &[("RUSTFLAGS", rustflags), ("MAKEPAD", "lines")],
+        &cwd,
+        "rustup",
+        &args_out_refs,
+    )?;
 
     let app_dir = cwd.join(format!("target/makepad-wasm-app/{profile}/{}", build_crate));
     let build_dir = cwd.join(format!("target/{WASM_TARGET_TRIPLE}/{profile}"));
@@ -472,9 +485,14 @@ pub fn build(config: WasmConfig, args: &[String]) -> Result<WasmBuildResult, Str
         brotli_compress(&index_path);
     }
     println!("Created wasm package: {:?}", app_dir);
-    println!("Copy this directory to any webserver, and serve with atleast these headers:");
-    println!("Cross-Origin-Embedder-Policy: require-corp");
-    println!("Cross-Origin-Opener-Policy: same-origin");
+    if config.threads {
+        println!("Copy this directory to any webserver, and serve with atleast these headers:");
+        println!("Cross-Origin-Embedder-Policy: require-corp");
+        println!("Cross-Origin-Opener-Policy: same-origin");
+    } else {
+        println!("Copy this directory to any webserver.");
+        println!("This single-threaded wasm build does not require COOP/COEP headers.");
+    }
     println!("Files need to be served with these mime types: ");
     println!("*.html => text/html");
     println!("*.wasm => application/wasm");
@@ -492,7 +510,12 @@ pub fn build(config: WasmConfig, args: &[String]) -> Result<WasmBuildResult, Str
 pub fn run(config: WasmConfig, args: &[String]) -> Result<(), String> {
     // we should run the compiled folder root as webserver
     let result = build(config, args)?;
-    start_wasm_server(result.app_dir, config.lan, config.port.unwrap_or(8010));
+    start_wasm_server(
+        result.app_dir,
+        config.lan,
+        config.port.unwrap_or(8010),
+        config.threads,
+    );
     Ok(())
 }
 
@@ -535,7 +558,7 @@ fn decode_query_component(input: &str) -> String {
     String::from_utf8_lossy(&out).to_string()
 }
 
-pub fn start_wasm_server(root: PathBuf, lan: bool, port: u16) {
+pub fn start_wasm_server(root: PathBuf, lan: bool, port: u16, threaded: bool) {
     let net = NetworkRuntime::new(NetworkConfig::default());
     let addr = if lan {
         SocketAddr::new("0.0.0.0".parse().unwrap(), port)
@@ -659,16 +682,22 @@ pub fn start_wasm_server(root: PathBuf, lan: bool, port: u16) {
                     if let Ok(mut file_handle) = File::open(&path) {
                         let mut body = Vec::<u8>::new();
                         if file_handle.read_to_end(&mut body).is_ok() {
+                            let coop_coep_headers = if threaded {
+                                "Cross-Origin-Embedder-Policy: require-corp\r\n\
+                                Cross-Origin-Opener-Policy: same-origin\r\n"
+                            } else {
+                                ""
+                            };
                             let header = format!(
                                 "HTTP/1.1 200 OK\r\n\
                                 Content-Type: {}\r\n\
-                                Cross-Origin-Embedder-Policy: require-corp\r\n\
-                                Cross-Origin-Opener-Policy: same-origin\r\n\
+                                {}\
                                 Content-encoding: none\r\n\
                                 Cache-Control: max-age:0\r\n\
                                 Content-Length: {}\r\n\
                                 Connection: close\r\n\r\n",
                                 mime_type,
+                                coop_coep_headers,
                                 body.len()
                             );
                             let _ = response_sender.send(HttpServerResponse { header, body });

--- a/tools/cargo_makepad/src/wasm/mod.rs
+++ b/tools/cargo_makepad/src/wasm/mod.rs
@@ -2,6 +2,43 @@ mod compile;
 mod sdk;
 use compile::WasmConfig;
 
+fn parse_wasm_option(config: &mut WasmConfig, v: &str) -> bool {
+    if let Some(opt) = v.strip_prefix("--port=") {
+        config.port = Some(opt.parse::<u16>().unwrap_or(8010));
+        true
+    } else if v == "--strip" {
+        config.strip = true;
+        true
+    } else if v == "--small-fonts" {
+        config.small_fonts = true;
+        true
+    } else if v == "--brotli" {
+        config.brotli = true;
+        true
+    } else if v == "--lan" {
+        config.lan = true;
+        true
+    } else if v == "--bindgen" {
+        config.bindgen = true;
+        true
+    } else if v == "--no-threads" {
+        config.threads = false;
+        true
+    } else {
+        false
+    }
+}
+
+fn strip_wasm_options(config: &mut WasmConfig, args: &[String]) -> Vec<String> {
+    let mut out = Vec::new();
+    for v in args {
+        if !parse_wasm_option(config, v) {
+            out.push(v.clone());
+        }
+    }
+    out
+}
+
 pub fn handle_wasm(mut args: &[String]) -> Result<(), String> {
     let mut config = WasmConfig {
         strip: false,
@@ -10,24 +47,13 @@ pub fn handle_wasm(mut args: &[String]) -> Result<(), String> {
         port: None,
         small_fonts: false,
         bindgen: false,
+        threads: true,
     };
 
     // pull out options
     for i in 0..args.len() {
         let v = &args[i];
-        if let Some(opt) = v.strip_prefix("--port=") {
-            config.port = Some(opt.parse::<u16>().unwrap_or(8010));
-        } else if let Some(_) = v.strip_prefix("--strip") {
-            config.strip = true;
-        } else if let Some(_) = v.strip_prefix("--small-fonts") {
-            config.small_fonts = true;
-        } else if let Some(_) = v.strip_prefix("--brotli") {
-            config.brotli = true;
-        } else if let Some(_) = v.strip_prefix("--lan") {
-            config.lan = true;
-        } else if let Some(_) = v.strip_prefix("--bindgen") {
-            config.bindgen = true;
-        } else {
+        if !parse_wasm_option(&mut config, v) {
             args = &args[i..];
             break;
         }
@@ -37,11 +63,13 @@ pub fn handle_wasm(mut args: &[String]) -> Result<(), String> {
         "rustup-install-toolchain" => sdk::rustup_toolchain_install(),
         "install-toolchain" => sdk::rustup_toolchain_install(),
         "build" => {
-            compile::build(config, &args[1..])?;
+            let build_args = strip_wasm_options(&mut config, &args[1..]);
+            compile::build(config, &build_args)?;
             Ok(())
         }
         "run" => {
-            compile::run(config, &args[1..])?;
+            let run_args = strip_wasm_options(&mut config, &args[1..]);
+            compile::run(config, &run_args)?;
             Ok(())
         }
         _ => Err(format!("{} is not a valid command or option", args[0])),


### PR DESCRIPTION
Introduce a single-threaded wasm build mode and add defensive runtime handling for missing wasm threading support.

- CLI: add --no-threads flag and WasmConfig.threads to control threaded vs single-threaded builds. Parse and strip wasm-specific options before forwarding build/run args.
- Build: select target features and RUSTFLAGS based on threading; omit atomics/bulk-memory features for single-threaded builds. Adjust generated server instructions to require COOP/COEP only for threaded builds.
- Dev server: conditionally include COOP/COEP headers when serving threaded wasm artifacts.
- JS runtime (platform/src/os/web/web.js): guard audio worklet startup and thread creation on wasm._has_thread_support; make alloc_thread_stack return null with clear console warnings when required exports or alignment are missing; pass allocated thread_info to workers.

These changes enable building and running a single-threaded wasm variant without COOP/COEP server requirements and improve runtime resilience when threading features are unavailable.