### PR TITLE
Remove debug title update in redraw handler

### DIFF
--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -184,9 +184,6 @@ impl Cx {
 
                 live_id!(ToWasmRedrawAll) => {
                     self.redraw_all();
-                    self.os.from_wasm(FromWasmSetDocumentTitle {
-                        title: "debug got ToWasmRedrawAll".to_string(),
-                    });
                 }
 
                 live_id!(ToWasmPaintDirty) => {


### PR DESCRIPTION
Remove a leftover debug call that set the document title when handling ToWasmRedrawAll in platform/src/os/web/web.rs. This avoids an unnecessary DOM update used only for debugging and cleans up the redraw handler.