### PR TITLE
fix: iOS app crashes on device rotation

### DIFF
--- a/platform/src/os/apple/ios/ios_app.rs
+++ b/platform/src/os/apple/ios/ios_app.rs
@@ -316,19 +316,19 @@ impl IosApp {
     }
 
     pub fn draw_size_will_change() {
-        // Avoid re-entrant calls by checking if we're already in a with_ios_app call
-        if IOS_APP
+        // Avoid re-entrant calls by checking if we're already in a with_ios_app call.
+        // We must drop the borrow *before* calling check_window_geom, because
+        // check_window_geom calls with_ios_app which tries to borrow_mut again.
+        let should_call = IOS_APP
             .try_with(|app| {
-                if let Ok(app_ref) = app.try_borrow_mut() {
-                    if app_ref.is_some() {
-                        Self::check_window_geom();
-                    }
-                    // Otherwise we skip the call, should be safe since draw_size_will_change is called again afterwards
+                match app.try_borrow_mut() {
+                    Ok(app_ref) => app_ref.is_some(),
+                    Err(_) => false, // already borrowed (re-entrant call), skip
                 }
             })
-            .is_err()
-        {
-            // IOS_APP is not accessible on this thread, ignore the call (this shouldn't happen)
+            .unwrap_or(false);
+        if should_call {
+            Self::check_window_geom();
         }
     }
 


### PR DESCRIPTION
# iOS app crashes on device rotation (SIGABRT in `draw_size_will_change`)

**Component:** `platform/src/os/apple/ios/ios_app.rs`

## Summary

Any iOS Makepad app crashes with `SIGABRT` (`abort() called`) whenever the device is rotated.
The crash is a Rust `RefCell` double-borrow panic originating in `IosApp::draw_size_will_change`.

## Steps to reproduce

1. Build and deploy any Makepad app to a physical iOS device.
2. Launch the app.
3. Rotate the device — the app crashes immediately.

## Crash report excerpt

```
exception: EXC_CRASH (SIGABRT)
termination: abort() called

Faulting thread stack:
  abort
  _RNvNtCsem2mLT9En9Y_3std7process5abort
  _RNvNtCsem2mLT9En9Y_3std9panicking15panic_with_hook
  _RNvNtCslRlVelvjuA1_4core9panicking19panic_cannot_unwind
  _RNvNvNtNtNtNtCsbH4DR0quZTl_16makepad_platform2os5apple3ios13ios_delegates
        24define_mtk_view_delegate21draw_size_will_change   <- Makepad entry point
  -[MTKView _resizeDrawable]
  -[MTKView setFrame:]
  ... UIKit rotation animation chain ...
```

## Root cause

In `IosApp::draw_size_will_change` (`ios_app.rs:318`), a `try_borrow_mut()` guard is acquired
on `IOS_APP`'s `RefCell` and held alive while `check_window_geom()` is called:

```rust
// BEFORE (buggy)
pub fn draw_size_will_change() {
    IOS_APP.try_with(|app| {
        if let Ok(app_ref) = app.try_borrow_mut() {  // borrow acquired
            if app_ref.is_some() {
                Self::check_window_geom();            // borrow still held here!
            }
        }
    }).is_err();
}
```

`check_window_geom` calls `with_ios_app` → `IOS_APP.with_borrow_mut()`, which attempts a second
mutable borrow of the same `RefCell`. Since `app_ref` is still in scope, the `RefCell` is already
mutably borrowed and Rust panics with `panic_cannot_unwind`. Because this happens inside an
ObjC/C callback that cannot unwind, the runtime calls `abort()`.

## Fix

Drop the borrow before calling `check_window_geom` by resolving to a plain `bool` first:

```rust
// AFTER (fixed)
pub fn draw_size_will_change() {
    // Must drop the borrow *before* calling check_window_geom, because
    // check_window_geom -> with_ios_app -> with_borrow_mut would double-borrow.
    let should_call = IOS_APP
        .try_with(|app| match app.try_borrow_mut() {
            Ok(app_ref) => app_ref.is_some(),
            Err(_) => false, // already borrowed (re-entrant), skip
        })
        .unwrap_or(false);
    if should_call {
        Self::check_window_geom();
    }
}
```

## Affected file

`platform/src/os/apple/ios/ios_app.rs`, function `draw_size_will_change` (~line 318)

## Environment

- iOS 26.3.1 (iPhone 12)
- macOS 24.6.0
- Makepad built from current `dev` branch