### PR TITLE
Consider Logo or Control primary on wasm32

### DIFF
--- a/platform/studio/src/mouse.rs
+++ b/platform/studio/src/mouse.rs
@@ -14,11 +14,15 @@ impl KeyModifiers {
     /// The primary modifier is Logo key (Command ⌘) on macOS
     /// and the Control key on all other platforms.
     pub fn is_primary(&self) -> bool {
+        #[cfg(target_arch = "wasm32")]
+        {
+            self.logo || self.control
+        }
         #[cfg(target_vendor = "apple")]
         {
             self.logo
         }
-        #[cfg(not(target_vendor = "apple"))]
+        #[cfg(all(not(target_arch = "wasm32"), not(target_vendor = "apple")))]
         {
             self.control
         }


### PR DESCRIPTION
Add a wasm32-specific branch in KeyModifiers::is_primary so the primary modifier is treated as true when either `logo` or `control` is set on WebAssembly targets. This preserves expected web behavior where Meta/Command or Control can act as the primary key. Also tighten the non-Apple cfg to exclude wasm32 explicitly to avoid overlapping cfg matches.