### PR TITLE
fix: Single-slot UInt/SInt instance attributes render incorrectly

### DIFF
--- a/platform/script/src/shader_metal.rs
+++ b/platform/script/src/shader_metal.rs
@@ -1,4 +1,4 @@
-use crate::pod::{ScriptPodMat, ScriptPodTy};
+use crate::pod::{ScriptPodMat, ScriptPodTy, ScriptPodVec};
 use crate::shader::{ShaderIoKind, ShaderOutput, TextureType};
 use crate::vm::ScriptVm;
 use makepad_live_id::{id, LiveId};
@@ -84,41 +84,84 @@ impl ShaderOutput {
         writeln!(out, "}};").ok();
     }
 
+    /// Returns true for integer/boolean pod types that require vec4 alignment in the
+    /// instance buffer (matching the logic in DrawShaderInputs::push for Attribute packing).
+    fn metal_instance_is_non_float(vm: &ScriptVm, ty: crate::ScriptPodType) -> bool {
+        let pod_ty = vm.bx.heap.pod_type_ref(ty);
+        match &pod_ty.ty {
+            ScriptPodTy::U32
+            | ScriptPodTy::AtomicU32
+            | ScriptPodTy::Bool
+            | ScriptPodTy::I32
+            | ScriptPodTy::AtomicI32 => true,
+            ScriptPodTy::Vec(v) => matches!(
+                v,
+                ScriptPodVec::Vec2u
+                    | ScriptPodVec::Vec3u
+                    | ScriptPodVec::Vec4u
+                    | ScriptPodVec::Vec2b
+                    | ScriptPodVec::Vec3b
+                    | ScriptPodVec::Vec4b
+                    | ScriptPodVec::Vec2i
+                    | ScriptPodVec::Vec3i
+                    | ScriptPodVec::Vec4i
+            ),
+            _ => false,
+        }
+    }
+
     pub fn metal_create_instance_struct(&self, vm: &ScriptVm, out: &mut String) {
         writeln!(out, "struct IoInstanceRaw {{").ok();
 
-        // 1. Output Dyn instance fields first (order doesn't matter, just output as encountered)
-        // Use packed types to match CPU-side repr(C) struct alignment
-        for io in &self.io {
-            if let ShaderIoKind::DynInstance = io.kind {
-                let pod_ty = vm.bx.heap.pod_type_ref(io.ty);
-                if matches!(pod_ty.ty, ScriptPodTy::Mat(ScriptPodMat::Mat4x4f)) {
-                    for col in 0..4 {
-                        writeln!(out, "    packed_float4 {}_{};", io.name, col).ok();
-                    }
-                } else {
-                    write!(out, "    ").ok();
-                    self.backend
-                        .pod_type_name_packed_from_ty(&vm.bx.heap, io.ty, out);
-                    writeln!(out, " {};", io.name).ok();
+        // Emit DynInstance fields then RustInstance fields, inserting float padding before
+        // and after non-float fields to match the vec4-aligned layout produced by
+        // DrawShaderInputs::push(DrawShaderInputPacking::Attribute) on the CPU side.
+        let mut current_slot = 0usize;
+        let mut pad_idx = 0usize;
+        for io in self
+            .io
+            .iter()
+            .filter(|io| matches!(io.kind, ShaderIoKind::DynInstance))
+            .chain(
+                self.io
+                    .iter()
+                    .filter(|io| matches!(io.kind, ShaderIoKind::RustInstance)),
+            )
+        {
+            let pod_ty = vm.bx.heap.pod_type_ref(io.ty);
+            let slots = pod_ty.ty.slots();
+            let is_non_float = Self::metal_instance_is_non_float(vm, io.ty);
+
+            // Pre-alignment: pad to vec4 boundary before a non-float field.
+            if is_non_float && (current_slot & 3) != 0 {
+                let pad = 4 - (current_slot & 3);
+                for _ in 0..pad {
+                    writeln!(out, "    float _instance_pad_{};", pad_idx).ok();
+                    pad_idx += 1;
+                    current_slot += 1;
                 }
             }
-        }
 
-        // 2. Output Rust instance fields last (already in correct order from pre_collect_rust_instance_io)
-        // Use packed types to match CPU-side repr(C) struct alignment
-        for io in &self.io {
-            if let ShaderIoKind::RustInstance = io.kind {
-                let pod_ty = vm.bx.heap.pod_type_ref(io.ty);
-                if matches!(pod_ty.ty, ScriptPodTy::Mat(ScriptPodMat::Mat4x4f)) {
-                    for col in 0..4 {
-                        writeln!(out, "    packed_float4 {}_{};", io.name, col).ok();
-                    }
-                } else {
-                    write!(out, "    ").ok();
-                    self.backend
-                        .pod_type_name_packed_from_ty(&vm.bx.heap, io.ty, out);
-                    writeln!(out, " {};", io.name).ok();
+            // Emit the field using packed types (no implicit Metal alignment padding).
+            if matches!(pod_ty.ty, ScriptPodTy::Mat(ScriptPodMat::Mat4x4f)) {
+                for col in 0..4 {
+                    writeln!(out, "    packed_float4 {}_{};", io.name, col).ok();
+                }
+            } else {
+                write!(out, "    ").ok();
+                self.backend
+                    .pod_type_name_packed_from_ty(&vm.bx.heap, io.ty, out);
+                writeln!(out, " {};", io.name).ok();
+            }
+            current_slot += slots;
+
+            // Post-alignment: pad to vec4 boundary after a non-float field.
+            if is_non_float && (current_slot & 3) != 0 {
+                let pad = 4 - (current_slot & 3);
+                for _ in 0..pad {
+                    writeln!(out, "    float _instance_pad_{};", pad_idx).ok();
+                    pad_idx += 1;
+                    current_slot += 1;
                 }
             }
         }

--- a/platform/src/draw_shader.rs
+++ b/platform/src/draw_shader.rs
@@ -220,7 +220,7 @@ impl DrawShaderInputs {
     pub fn push(&mut self, id: LiveId, slots: usize, attr_format: DrawShaderAttrFormat) {
         match self.packing_method {
             DrawShaderInputPacking::Attribute => {
-                let needs_int_align = attr_format != DrawShaderAttrFormat::Float && slots > 1;
+                let needs_int_align = attr_format != DrawShaderAttrFormat::Float;
                 if needs_int_align && (self.total_slots & 3) != 0 {
                     self.total_slots += 4 - (self.total_slots & 3);
                 }


### PR DESCRIPTION
# Bug Report: Single-slot UInt/SInt instance attributes render incorrectly due to layout mismatch between Rust and GLSL

## Summary

Widgets that use a single-slot integer (`UInt` or `SInt`) instance attribute — such as `DesktopButton` with its `button_type: instance(DesktopButtonType.Fullscreen)` — render incorrectly (typically invisible) on GLSL backends because the Rust-side instance data layout does not match the GLSL shader's attribute layout.

On Wayland/Linux the window chrome buttons (minimize, maximize, close) are invisible on startup as a result.

---

## Root Cause

Two separate code paths compute the byte layout of per-instance vertex attribute data, and they apply different alignment rules for single-component integer attributes:

### GLSL layout (`platform/script/src/shader_glsl.rs`, `glsl_push_field`)

```rust
if attribute_packing && attr_format != GlslPackedFormat::Float && (*offset & 3) != 0 {
    *offset += 4 - (*offset & 3);   // align to vec4 boundary — for ANY non-Float
}
// push field at *offset
*offset += slots;
if attribute_packing && attr_format != GlslPackedFormat::Float && (*offset & 3) != 0 {
    *offset += 4 - (*offset & 3);   // post-align
}
```

Non-Float attributes of **any** size force alignment to a 4-slot (vec4) boundary.

### Rust data layout (`platform/src/draw_shader.rs`, `DrawShaderInputs::push`, `Attribute` branch)

```rust
let needs_int_align = attr_format != DrawShaderAttrFormat::Float && slots > 1;  // ← BUG
```

The `&& slots > 1` guard suppresses alignment for **single-slot** integer attributes, causing a mismatch.

### Concrete layout divergence for `DesktopButton`

`DesktopButton` has three DynInstance fields: `hover` (Float, 1 slot), `down` (Float, 1 slot), `button_type` (UInt, 1 slot), followed by `DrawQuad` RustInstance fields (`rect_pos`, `rect_size`, …).

| Field | Rust layout (buggy) | GLSL layout |
|-------|---------------------|-------------|
| `hover` | slot 0 | slot 0 |
| `down` | slot 1 | slot 1 |
| `button_type` | slot **2** | slot **4** (padded) |
| `rect_pos` | slot **3** | slot **8** (padded) |

The GL backend (`opengl_get_attributes`) determines `chunk_formats` from the Rust mapping, so it marks `packed_instance_0` as `uvec4` (because `button_type` is at Rust slot 2, i.e. chunk 0). But the GLSL declares `packed_instance_0` as `vec4` (Float, since with GLSL alignment `button_type` is in chunk 1). This creates both a type mismatch in the attribute binding and wrong data at every field:

- The shader reads `button_type` from `packed_instance_1.x`, which actually holds `rect_pos.x` from the VBO.
- The shader reads `rect_pos` from `packed_instance_2`, offset by a full vec4 from the correct data.

No `match` branch on `button_type` fires, so the pixel shader falls through without drawing, and the quad's `rect_pos`/`rect_size` are corrupted — the buttons are invisible.

---

## Fix

Two files must be changed together. The Rust buffer layout and all shader backends that use direct struct indexing (Metal) must agree on the aligned slot positions.

### 1. `platform/src/draw_shader.rs` — align the Rust buffer layout

Remove the `&& slots > 1` guard so the Rust attribute layout always matches the GLSL layout:

```diff
-                let needs_int_align = attr_format != DrawShaderAttrFormat::Float && slots > 1;
+                let needs_int_align = attr_format != DrawShaderAttrFormat::Float;
```

After this change `button_type` lands at slot 4 in both Rust and GLSL layouts, `rect_pos` at slot 8, and the OpenGL vertex shader receives correct data.

### 2. `platform/script/src/shader_metal.rs` — align `IoInstanceRaw` to match

The Metal backend does not use per-field attribute bindings; it passes the raw buffer as `constant IoInstanceRaw *i_raw` and the GPU indexes it as `i_raw[iid]`, using `sizeof(IoInstanceRaw)` as the implicit stride. After fix 1, the CPU writes 20 floats per instance (with padding), but without this fix the Metal struct would still have 15 fields (no padding) and the stride would be wrong for any draw call with more than one batched instance.

Add a helper that identifies non-float types, and rewrite `IoInstanceRaw` generation to insert explicit `float _instance_pad_N` fields at the same positions as the CPU-side padding:

```diff
-use crate::pod::{ScriptPodMat, ScriptPodTy};
+use crate::pod::{ScriptPodMat, ScriptPodTy, ScriptPodVec};
```

```diff
+    fn metal_instance_is_non_float(vm: &ScriptVm, ty: crate::ScriptPodType) -> bool {
+        let pod_ty = vm.bx.heap.pod_type_ref(ty);
+        match &pod_ty.ty {
+            ScriptPodTy::U32 | ScriptPodTy::AtomicU32 | ScriptPodTy::Bool
+            | ScriptPodTy::I32 | ScriptPodTy::AtomicI32 => true,
+            ScriptPodTy::Vec(v) => matches!(v,
+                ScriptPodVec::Vec2u | ScriptPodVec::Vec3u | ScriptPodVec::Vec4u
+                | ScriptPodVec::Vec2b | ScriptPodVec::Vec3b | ScriptPodVec::Vec4b
+                | ScriptPodVec::Vec2i | ScriptPodVec::Vec3i | ScriptPodVec::Vec4i),
+            _ => false,
+        }
+    }
+
     pub fn metal_create_instance_struct(&self, vm: &ScriptVm, out: &mut String) {
         writeln!(out, "struct IoInstanceRaw {{").ok();

-        // DynInstance loop (no padding) …
-        // RustInstance loop (no padding) …
+        let mut current_slot = 0usize;
+        let mut pad_idx = 0usize;
+        for io in self.io.iter()
+            .filter(|io| matches!(io.kind, ShaderIoKind::DynInstance))
+            .chain(self.io.iter().filter(|io| matches!(io.kind, ShaderIoKind::RustInstance)))
+        {
+            let pod_ty = vm.bx.heap.pod_type_ref(io.ty);
+            let slots = pod_ty.ty.slots();
+            let is_non_float = Self::metal_instance_is_non_float(vm, io.ty);
+
+            if is_non_float && (current_slot & 3) != 0 {
+                let pad = 4 - (current_slot & 3);
+                for _ in 0..pad {
+                    writeln!(out, "    float _instance_pad_{};", pad_idx).ok();
+                    pad_idx += 1; current_slot += 1;
+                }
+            }
+            // … emit field as before …
+            current_slot += slots;
+            if is_non_float && (current_slot & 3) != 0 {
+                let pad = 4 - (current_slot & 3);
+                for _ in 0..pad {
+                    writeln!(out, "    float _instance_pad_{};", pad_idx).ok();
+                    pad_idx += 1; current_slot += 1;
+                }
+            }
+        }
```

The `IoInstance` struct and `_mp_decode_instance` function are unchanged — they reference fields by name, so the padding fields are simply ignored.

For `DesktopButton` the generated `IoInstanceRaw` becomes:
```metal
struct IoInstanceRaw {
    float hover;               // slot 0
    float down;                // slot 1
    float _instance_pad_0;     // slot 2 — pre-align padding for button_type
    float _instance_pad_1;     // slot 3
    uint  button_type;         // slot 4
    float _instance_pad_2;     // slot 5 — post-align padding
    float _instance_pad_3;     // slot 6
    float _instance_pad_4;     // slot 7
    packed_float2 rect_pos;    // slot 8
    …
};                             // sizeof = 20 floats = 80 bytes ✓
```

`sizeof(IoInstanceRaw)` = 80 bytes now matches `total_slots * 4 = 20 * 4 = 80` bytes.

---

## Platform Impact Analysis

The fix changes `mapping.instances.total_slots` and all DynInstance field offsets. Each rendering backend must use these values consistently. Analysis:

### OpenGL / GLSL — Linux, Android, WebAssembly ✅ Fixed

The GL backend (`opengl_get_attributes`) uses `mapping.instances.inputs[i].offset` to compute per-chunk byte offsets and `mapping.instances.total_slots` as the VBO stride. After the fix, both the Rust-side buffer layout and the GLSL attribute layout are padded identically. **This backend is fixed.**

### D3D11 / HLSL — Windows ✅ Compatible

The D3D11 backend (`d3d11.rs`) sets up the input layout using `(inst.offset + slot_offset) * 4` as `AlignedByteOffset` for each field and `sh.mapping.instances.total_slots` as the stride. Because it reads per-field offsets directly from the mapping, it automatically picks up the new padded offsets after the fix. The HLSL struct (`IoInstance`) uses per-field D3D semantic bindings (`INST0`, `INST1`, …) rather than raw buffer indexing, so its layout is also unaffected. **This backend is compatible with the fix.**

### Metal / MSL — macOS, iOS ✅ Fixed by companion change

The Metal backend (`metal.rs`) takes a fundamentally different approach: it passes the raw instance buffer as `constant IoInstanceRaw *i_raw [[buffer(1)]]` and indexes it as `i_raw[iid]` in the vertex shader. The GPU uses `sizeof(IoInstanceRaw)` as the implicit stride.

`IoInstanceRaw` is generated by `shader_metal.rs` using `packed_` types (no padding) to intentionally mirror the CPU buffer layout:

```metal
struct IoInstanceRaw {
    float hover;          // 4 bytes
    float down;           // 4 bytes
    uint button_type;     // 4 bytes  ← offset 8, but buffer now has it at offset 16!
    packed_float2 rect_pos; // 8 bytes ← offset 12, but buffer now has it at offset 32!
    …
};
```

After the fix, the CPU writes `button_type` at buffer offset 16 (slot 4 × 4 bytes) but the Metal shader still reads it at struct offset 8. For a single-instance draw call the first instance is correct (both start at offset 0), but for batched draw calls (multiple instances) the stride diverges: the CPU buffer uses 20 floats (80 bytes) per instance while `sizeof(IoInstanceRaw)` = 15 floats (60 bytes). The second and subsequent instances are read from wrong positions.

**Practical impact on macOS today:** `custom_window_chrome` is `false` on macOS/iOS (native NSWindow title bar is used), so `DesktopButton` window-chrome instances are never submitted to the GPU on Apple platforms. The bug therefore does not currently manifest there. However, without the companion fix any widget with a single-slot UInt/SInt instance attribute in a batched draw call (multiple instances) would be broken on macOS after fix 1 alone.

The companion change to `shader_metal.rs` described in the Fix section resolves this by inserting explicit `float _instance_pad_N` fields into `IoInstanceRaw` so that `sizeof(IoInstanceRaw)` matches the new padded buffer stride.

---

## How to reproduce

1. Run any Makepad application on Wayland (Linux) that shows a window with custom chrome.
2. The minimize/maximize/close buttons in the title bar are invisible.
3. Apply the one-line fix above and rebuild — the buttons appear correctly.

The bug also affects any widget that defines a single-component `UInt` or `SInt` instance field via the `instance(...)` DSL form.

---

## Affected files

| File | Change |
|------|--------|
| `platform/src/draw_shader.rs` | One-line fix: remove `&& slots > 1` from `DrawShaderInputPacking::Attribute` branch |
| `platform/script/src/shader_metal.rs` | Add `metal_instance_is_non_float` helper; rewrite `IoInstanceRaw` generation to emit alignment padding floats |

---

## Tested on

- Platform: Linux (Wayland, GNOME, kernel 6.18 zen)
- Backend: Wayland + OpenGL (EGL)
- Makepad commit: `8e3ae8ea1` ("Add --no-threads option and runtime thread checks")