### PR TITLE
Load script resources per-handle (avoid global loads)

### DIFF
--- a/draw/src/shader/draw_svg.rs
+++ b/draw/src/shader/draw_svg.rs
@@ -344,7 +344,7 @@ impl DrawSvg {
         let data = if let Some(data) = cx.get_resource(handle) {
             data
         } else {
-            cx.load_all_script_resources();
+            cx.load_script_resource(handle);
             match cx.get_resource(handle) {
                 Some(data) => data,
                 // Resource not yet available (may be loading via HTTP) - don't

--- a/draw/src/shader/draw_svg_glyph.rs
+++ b/draw/src/shader/draw_svg_glyph.rs
@@ -225,7 +225,7 @@ impl DrawSvgGlyph {
         let data = if let Some(data) = cx.get_resource(handle) {
             data
         } else {
-            cx.load_all_script_resources();
+            cx.load_script_resource(handle);
             match cx.get_resource(handle) {
                 Some(data) => data,
                 None => return,

--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -870,8 +870,10 @@ impl FontFamily {
             }
         }
 
-        // Slow path: attempt to progress pending resource loads, then re-check.
-        cx.load_all_script_resources();
+        // Slow path: request only the resources needed by this family, then re-check.
+        for member in &self.members {
+            cx.load_script_resource(member.handle);
+        }
         {
             let fonts_ref = fonts.borrow();
             if fonts_ref.is_font_family_complete(family_id) {

--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -49,8 +49,6 @@ impl Cx {
                     self.os.window_geom = tw.window_info.into();
                     //self.default_inner_window_size = self.os.window_geom.inner_size;
 
-                    // Ensure script resources deferred during pre-init are queued now.
-                    self.load_all_script_resources();
                     self.call_event_handler(&Event::Startup);
                     self.redraw_all();
                     //self.platform.from_wasm(FromWasmCreateThread{thread_id:1});

--- a/platform/src/script/res.rs
+++ b/platform/src/script/res.rs
@@ -181,6 +181,115 @@ fn load_file_direct(abs_path: &str) -> Option<Result<Rc<Vec<u8>>, String>> {
 }
 
 impl Cx {
+    fn load_script_resource_impl(
+        &mut self,
+        handle: ScriptHandle,
+        #[cfg(target_arch = "wasm32")] crate_manifests: &HashMap<String, String>,
+    ) {
+        // On wasm, skip loading if we haven't received ToWasmInit yet (os_type is Unknown).
+        #[cfg(target_arch = "wasm32")]
+        if matches!(self.os_type(), crate::cx::OsType::Unknown) {
+            return;
+        }
+
+        let is_packaged = self.package_root.is_some();
+
+        #[cfg(target_arch = "wasm32")]
+        let mut pending_http = None::<(LiveId, ScriptHandle, String)>;
+
+        {
+            let mut resources = self.script_data.resources.resources.borrow_mut();
+            let Some(res) = resources.iter_mut().find(|res| res.handle == handle) else {
+                return;
+            };
+
+            if !matches!(res.data, CxScriptResourceData::NotLoaded) {
+                return;
+            }
+
+            #[cfg(target_arch = "wasm32")]
+            if res.web_url.is_none() {
+                if let Some(dep_path) = resolve_dependency_path_from_manifests(
+                    &res.abs_path,
+                    None,
+                    None,
+                    crate_manifests,
+                ) {
+                    res.dependency_path = Some(dep_path.clone());
+                    res.web_url = Some(format!("/{}", dep_path));
+                }
+            }
+
+            if let Some(dep_path) = res.dependency_path.as_deref() {
+                if let Ok(data) = self.get_dependency(dep_path) {
+                    res.data = CxScriptResourceData::Loaded(data);
+                    return;
+                }
+            }
+
+            #[cfg(target_arch = "wasm32")]
+            {
+                if let Some(url) = res.web_url.clone() {
+                    let request_id = LiveId::unique();
+                    res.data = CxScriptResourceData::Loading;
+                    pending_http = Some((request_id, res.handle, url));
+                } else {
+                    res.data = CxScriptResourceData::Error(format!(
+                        "Failed to load resource: {} (dep: {:?}, packaged: {})",
+                        res.abs_path, res.dependency_path, is_packaged,
+                    ));
+                }
+            }
+
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                if is_packaged {
+                    #[cfg(not(target_os = "android"))]
+                    if let Some(dep_path) = res.dependency_path.as_deref() {
+                        if let Some(data) = load_packaged_resource(self, dep_path) {
+                            res.data = CxScriptResourceData::Loaded(data);
+                            return;
+                        }
+                    }
+                } else if let Some(result) = load_file_direct(&res.abs_path) {
+                    res.data = match result {
+                        Ok(data) => CxScriptResourceData::Loaded(data),
+                        Err(e) => CxScriptResourceData::Error(e),
+                    };
+                    return;
+                }
+            }
+
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                res.data = CxScriptResourceData::Error(format!(
+                    "Failed to load resource: {} (dep: {:?}, packaged: {})",
+                    res.abs_path, res.dependency_path, is_packaged,
+                ));
+            }
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        if let Some((request_id, handle, url)) = pending_http {
+            self.script_data
+                .resources
+                .http_resources
+                .push(CxScriptHttpResource { request_id, handle });
+            self.http_request(request_id, HttpRequest::new(url, Default::default()));
+        }
+    }
+
+    pub fn load_script_resource(&mut self, handle: ScriptHandle) {
+        #[cfg(target_arch = "wasm32")]
+        let crate_manifests = self.script_data.crate_manifests.borrow().clone();
+
+        self.load_script_resource_impl(
+            handle,
+            #[cfg(target_arch = "wasm32")]
+            &crate_manifests,
+        );
+    }
+
     /// Load all script resources that are still pending.
     ///
     /// Each platform uses a different loading strategy:
@@ -200,96 +309,17 @@ impl Cx {
         #[cfg(target_arch = "wasm32")]
         let crate_manifests = self.script_data.crate_manifests.borrow().clone();
 
-        let is_packaged = self.package_root.is_some();
+        let handles = {
+            let resources = self.script_data.resources.resources.borrow();
+            resources.iter().map(|res| res.handle).collect::<Vec<_>>()
+        };
 
-        // Collect HTTP requests to issue after releasing the borrow (wasm only).
-        #[cfg(target_arch = "wasm32")]
-        let mut pending_http = Vec::<(LiveId, ScriptHandle, String)>::new();
-
-        {
-            let mut resources = self.script_data.resources.resources.borrow_mut();
-            for res in resources.iter_mut() {
-                if !matches!(res.data, CxScriptResourceData::NotLoaded) {
-                    continue;
-                }
-
-                // --- Wasm: resolve web_url from crate manifests if missing ---
+        for handle in handles {
+            self.load_script_resource_impl(
+                handle,
                 #[cfg(target_arch = "wasm32")]
-                if res.web_url.is_none() {
-                    if let Some(dep_path) = resolve_dependency_path_from_manifests(
-                        &res.abs_path,
-                        None,
-                        None,
-                        &crate_manifests,
-                    ) {
-                        res.dependency_path = Some(dep_path.clone());
-                        res.web_url = Some(format!("/{}", dep_path));
-                    }
-                }
-
-                // --- Step 1: Try the dependency table ---
-                // On android this calls through to the JNI asset manager.
-                if let Some(dep_path) = res.dependency_path.as_deref() {
-                    if let Ok(data) = self.get_dependency(dep_path) {
-                        res.data = CxScriptResourceData::Loaded(data);
-                        continue;
-                    }
-                }
-
-                // --- Step 2: Platform-specific loading ---
-
-                // Wasm: issue an async HTTP request for the web_url.
-                #[cfg(target_arch = "wasm32")]
-                {
-                    if let Some(url) = res.web_url.clone() {
-                        let request_id = LiveId::unique();
-                        res.data = CxScriptResourceData::Loading;
-                        pending_http.push((request_id, res.handle, url));
-                        continue;
-                    }
-                }
-
-                // Native platforms: try packaged or direct file depending on mode.
-                #[cfg(not(target_arch = "wasm32"))]
-                {
-                    if is_packaged {
-                        // Packaged mode: only load from the packaged location.
-                        // Android: get_dependency above already tried JNI — nothing more to do.
-                        #[cfg(not(target_os = "android"))]
-                        if let Some(dep_path) = res.dependency_path.as_deref() {
-                            if let Some(data) = load_packaged_resource(self, dep_path) {
-                                res.data = CxScriptResourceData::Loaded(data);
-                                continue;
-                            }
-                        }
-                    } else {
-                        // Unpackaged (dev) mode: load directly from the filesystem.
-                        if let Some(result) = load_file_direct(&res.abs_path) {
-                            res.data = match result {
-                                Ok(data) => CxScriptResourceData::Loaded(data),
-                                Err(e) => CxScriptResourceData::Error(e),
-                            };
-                            continue;
-                        }
-                    }
-                }
-
-                // --- Step 3: Error ---
-                res.data = CxScriptResourceData::Error(format!(
-                    "Failed to load resource: {} (dep: {:?}, packaged: {})",
-                    res.abs_path, res.dependency_path, is_packaged,
-                ));
-            }
-        }
-
-        // Wasm: fire HTTP requests outside the borrow.
-        #[cfg(target_arch = "wasm32")]
-        for (request_id, handle, url) in pending_http {
-            self.script_data
-                .resources
-                .http_resources
-                .push(CxScriptHttpResource { request_id, handle });
-            self.http_request(request_id, HttpRequest::new(url, Default::default()));
+                &crate_manifests,
+            );
         }
     }
 }

--- a/tools/cargo_makepad/src/wasm/compile.rs
+++ b/tools/cargo_makepad/src/wasm/compile.rs
@@ -678,7 +678,38 @@ pub fn start_wasm_server(root: PathBuf, lan: bool, port: u16, threaded: bool) {
                     let path = path.strip_prefix("/").unwrap();
 
                     let path = root.join(&path);
+                    let compressed_path = path.parent().and_then(|parent| {
+                        path.file_name()
+                            .map(|name| parent.join(format!("{}.br", name.to_string_lossy())))
+                    });
                     //println!("OPENING {:?}", path);
+                    if let Some(compressed_path) = compressed_path.as_ref() {
+                        if let Ok(mut file_handle) = File::open(compressed_path) {
+                            let mut body = Vec::<u8>::new();
+                            if file_handle.read_to_end(&mut body).is_ok() {
+                                let coop_coep_headers = if threaded {
+                                    "Cross-Origin-Embedder-Policy: require-corp\r\n\
+                                    Cross-Origin-Opener-Policy: same-origin\r\n"
+                                } else {
+                                    ""
+                                };
+                                let header = format!(
+                                    "HTTP/1.1 200 OK\r\n\
+                                    Content-Type: {}\r\n\
+                                    {}\
+                                    Content-encoding: br\r\n\
+                                    Cache-Control: max-age:0\r\n\
+                                    Content-Length: {}\r\n\
+                                    Connection: close\r\n\r\n",
+                                    mime_type,
+                                    coop_coep_headers,
+                                    body.len()
+                                );
+                                let _ = response_sender.send(HttpServerResponse { header, body });
+                                continue;
+                            }
+                        }
+                    }
                     if let Ok(mut file_handle) = File::open(&path) {
                         let mut body = Vec::<u8>::new();
                         if file_handle.read_to_end(&mut body).is_ok() {

--- a/widgets/src/3d/gltf_3d.rs
+++ b/widgets/src/3d/gltf_3d.rs
@@ -93,7 +93,7 @@ impl Gltf3D {
             };
         }
 
-        cx.load_all_script_resources();
+        cx.load_script_resource(handle);
 
         if let Some(data) = cx.get_resource(handle) {
             let abs_path = Self::resource_metadata_by_handle(cx, handle)

--- a/widgets/src/3d/view_splat.rs
+++ b/widgets/src/3d/view_splat.rs
@@ -627,7 +627,7 @@ impl ViewSplat {
             };
         }
 
-        cx.load_all_script_resources();
+        cx.load_script_resource(handle);
 
         if let Some(data) = cx.get_resource(handle) {
             let abs_path = Self::resource_metadata_by_handle(cx, handle)

--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -147,7 +147,7 @@ impl Image {
         let data = if let Some(data) = cx.get_resource(handle) {
             data
         } else {
-            cx.load_all_script_resources();
+            cx.load_script_resource(handle);
             match cx.get_resource(handle) {
                 Some(data) => data,
                 None => {

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -245,6 +245,7 @@ pub fn theme_mod(vm: &mut ScriptVm) {
     crate::theme_desktop_dark::script_mod(vm);
     crate::theme_desktop_light::script_mod(vm);
     crate::theme_desktop_skeleton::script_mod(vm);
+    #[cfg(not(target_arch = "wasm32"))]
     script_eval!(vm, {
         mod.helper = {
             startup: |v|{
@@ -255,7 +256,216 @@ pub fn theme_mod(vm: &mut ScriptVm) {
                 v
             }
         }
-        
+    });
+    #[cfg(target_arch = "wasm32")]
+    script_eval!(vm, {
+        mod.helper = {
+            startup: |v|{
+                v
+            }
+        }
+    });
+    #[cfg(target_arch = "wasm32")]
+    script_eval!(vm, {
+        use mod.text.*
+        use mod.res.*
+
+        mod.themes.dark = mod.themes.dark{
+            font_label: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-Text.ttf") asc: -0.1 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_regular: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-Text.ttf") asc: -0.1 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_bold: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-SemiBold.ttf") asc: -0.1 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_italic: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-Italic.ttf") asc: -0.1 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_bold_italic: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-BoldItalic.ttf") asc: -0.1 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_regular_i18n: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-Text.ttf") asc: -0.1 desc: 0.0}
+                    chinese := FontMember{res: crate_resource("self:resources/LXGWWenKaiRegular.ttf") asc: 0.0 desc: 0.0}
+                    emoji := FontMember{res: crate_resource("self:resources/NotoColorEmoji.ttf") asc: 0.0 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_bold_i18n: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-SemiBold.ttf") asc: -0.1 desc: 0.0}
+                    chinese := FontMember{res: crate_resource("self:resources/LXGWWenKaiBold.ttf") asc: 0.0 desc: 0.0}
+                    emoji := FontMember{res: crate_resource("self:resources/NotoColorEmoji.ttf") asc: 0.0 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_italic_i18n: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-Italic.ttf") asc: -0.1 desc: 0.0}
+                    chinese := FontMember{res: crate_resource("self:resources/LXGWWenKaiRegular.ttf") asc: 0.0 desc: 0.0}
+                    emoji := FontMember{res: crate_resource("self:resources/NotoColorEmoji.ttf") asc: 0.0 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_bold_italic_i18n: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-BoldItalic.ttf") asc: -0.1 desc: 0.0}
+                    chinese := FontMember{res: crate_resource("self:resources/LXGWWenKaiBold.ttf") asc: 0.0 desc: 0.0}
+                    emoji := FontMember{res: crate_resource("self:resources/NotoColorEmoji.ttf") asc: 0.0 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+        }
+
+        mod.themes.light = mod.themes.light{
+            font_label: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-Text.ttf") asc: -0.1 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_regular: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-Text.ttf") asc: -0.1 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_bold: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-SemiBold.ttf") asc: -0.1 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_italic: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-Italic.ttf") asc: -0.1 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_bold_italic: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-BoldItalic.ttf") asc: -0.1 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_regular_i18n: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-Text.ttf") asc: -0.1 desc: 0.0}
+                    chinese := FontMember{res: crate_resource("self:resources/LXGWWenKaiRegular.ttf") asc: 0.0 desc: 0.0}
+                    emoji := FontMember{res: crate_resource("self:resources/NotoColorEmoji.ttf") asc: 0.0 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_bold_i18n: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-SemiBold.ttf") asc: -0.1 desc: 0.0}
+                    chinese := FontMember{res: crate_resource("self:resources/LXGWWenKaiBold.ttf") asc: 0.0 desc: 0.0}
+                    emoji := FontMember{res: crate_resource("self:resources/NotoColorEmoji.ttf") asc: 0.0 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_italic_i18n: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-Italic.ttf") asc: -0.1 desc: 0.0}
+                    chinese := FontMember{res: crate_resource("self:resources/LXGWWenKaiRegular.ttf") asc: 0.0 desc: 0.0}
+                    emoji := FontMember{res: crate_resource("self:resources/NotoColorEmoji.ttf") asc: 0.0 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_bold_italic_i18n: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-BoldItalic.ttf") asc: -0.1 desc: 0.0}
+                    chinese := FontMember{res: crate_resource("self:resources/LXGWWenKaiBold.ttf") asc: 0.0 desc: 0.0}
+                    emoji := FontMember{res: crate_resource("self:resources/NotoColorEmoji.ttf") asc: 0.0 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+        }
+
+        mod.themes.skeleton = mod.themes.skeleton{
+            font_label: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-Text.ttf") asc: -0.1 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_regular: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-Text.ttf") asc: -0.1 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_bold: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-SemiBold.ttf") asc: -0.1 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_italic: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-Italic.ttf") asc: -0.1 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_bold_italic: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-BoldItalic.ttf") asc: -0.1 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_regular_i18n: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-Text.ttf") asc: -0.1 desc: 0.0}
+                    chinese := FontMember{res: crate_resource("self:resources/LXGWWenKaiRegular.ttf") asc: 0.0 desc: 0.0}
+                    emoji := FontMember{res: crate_resource("self:resources/NotoColorEmoji.ttf") asc: 0.0 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_bold_i18n: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-SemiBold.ttf") asc: -0.1 desc: 0.0}
+                    chinese := FontMember{res: crate_resource("self:resources/LXGWWenKaiBold.ttf") asc: 0.0 desc: 0.0}
+                    emoji := FontMember{res: crate_resource("self:resources/NotoColorEmoji.ttf") asc: 0.0 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_italic_i18n: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-Italic.ttf") asc: -0.1 desc: 0.0}
+                    chinese := FontMember{res: crate_resource("self:resources/LXGWWenKaiRegular.ttf") asc: 0.0 desc: 0.0}
+                    emoji := FontMember{res: crate_resource("self:resources/NotoColorEmoji.ttf") asc: 0.0 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+            font_bold_italic_i18n: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{res: crate_resource("self:resources/IBMPlexSans-BoldItalic.ttf") asc: -0.1 desc: 0.0}
+                    chinese := FontMember{res: crate_resource("self:resources/LXGWWenKaiBold.ttf") asc: 0.0 desc: 0.0}
+                    emoji := FontMember{res: crate_resource("self:resources/NotoColorEmoji.ttf") asc: 0.0 desc: 0.0}
+                }
+                line_spacing: 1.2
+            }
+        }
+    });
+    script_eval!(vm, {
         mod.prelude.widgets_header = {
             ..mod.res,
             ..mod.helper,

--- a/widgets/src/math_view.rs
+++ b/widgets/src/math_view.rs
@@ -137,9 +137,6 @@ impl Widget for MathView {
 
 impl MathView {
     fn compile_math(&mut self, cx: &mut Cx2d) {
-        // Match DrawText behavior so crate/http resources start loading
-        // before we attempt to resolve the math font family.
-        cx.cx.cx.load_all_script_resources();
         let font_family_id = self.draw_text.text_style.font_family_id();
         self.draw_text.text_style.ensure_fonts_loaded(cx.cx.cx);
         if self.text == self.old_text


### PR DESCRIPTION
Replace broad cx.load_all_script_resources() calls with a targeted cx.load_script_resource(handle) to only request the specific resource needed. Refactor script resource loading (platform/src/script/res.rs) by extracting load_script_resource_impl(handle, crate_manifests) and exposing load_script_resource(handle); keep load_all_script_resources() by iterating per-handle. Improve wasm handling: resolve web_url per-resource, set explicit error states when missing, and fire async HTTP requests safely. Remove an early call to load_all_script_resources() from web startup. Additional changes: serve precompressed .br files in the local wasm dev server (with COOP/COEP headers when threaded), add wasm-specific font/theme script entries for widgets, and update various callers (draw shaders, widgets, math_view, gltf/view_splat, image) to use the per-handle loader. These changes reduce unnecessary global loads and limit network/file operations to only required resources.