### PR TITLE
Fix: IME Popup Window Appears Without TextInput Focus

### DIFF
--- a/libs/windows/windows-rs/src/Windows/mod.rs
+++ b/libs/windows/windows-rs/src/Windows/mod.rs
@@ -43863,12 +43863,6 @@ impl IRecordInfo_Vtbl {
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
 impl windows_core::RuntimeName for IRecordInfo {}
-#[repr(C)]
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
-pub struct PARAMDESCEX {
-    pub cBytes: u32,
-    pub varDefaultValue: super::Variant::VARIANT,
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PARAMFLAGS(pub u16);
@@ -43879,11 +43873,11 @@ pub struct PARAMDESC {
     pub pparamdescex: *mut PARAMDESCEX,
     pub wParamFlags: PARAMFLAGS,
 }
+#[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
-impl Clone for PARAMDESCEX {
-    fn clone(&self) -> Self {
-        unsafe { core::mem::transmute_copy(self) }
-    }
+pub struct PARAMDESCEX {
+    pub cBytes: u32,
+    pub varDefaultValue: super::Variant::VARIANT,
 }
 impl PARAMFLAGS {
     pub const fn contains(&self, other: Self) -> bool {
@@ -43897,15 +43891,21 @@ impl Default for PARAMDESC {
     }
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
-impl Default for PARAMDESCEX {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
+impl Clone for PARAMDESCEX {
+    fn clone(&self) -> Self {
+        unsafe { core::mem::transmute_copy(self) }
     }
 }
 impl core::ops::BitOr for PARAMFLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
         Self(self.0 | other.0)
+    }
+}
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
+impl Default for PARAMDESCEX {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
     }
 }
 impl core::ops::BitAnd for PARAMFLAGS {
@@ -44445,6 +44445,11 @@ pub const PROCESS_PER_MONITOR_DPI_AWARE: PROCESS_DPI_AWARENESS = PROCESS_DPI_AWA
 }
 pub mod Input{
 pub mod Ime{
+#[inline]
+pub unsafe fn ImmAssociateContext(param0: super::super::super::Foundation::HWND, param1: HIMC) -> HIMC {
+    windows_core::link!("imm32.dll" "system" fn ImmAssociateContext(param0 : super::super::super::Foundation:: HWND, param1 : HIMC) -> HIMC);
+    unsafe { ImmAssociateContext(param0, param1) }
+}
 #[inline]
 pub unsafe fn ImmDestroyContext(param0: HIMC) -> windows_core::BOOL {
     windows_core::link!("imm32.dll" "system" fn ImmDestroyContext(param0 : HIMC) -> windows_core::BOOL);

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -674,11 +674,13 @@ impl Cx {
                 CxOsOp::ShowTextIME(area, pos, _config) => {
                     let pos = area.clipped_rect(self).pos + pos;
                     metal_windows.iter_mut().for_each(|w| {
+                        w.cocoa_window.set_ime_active(true);
                         w.cocoa_window.set_ime_spot(pos);
                     });
                 }
                 CxOsOp::HideTextIME => {
                     metal_windows.iter_mut().for_each(|w| {
+                        w.cocoa_window.set_ime_active(false);
                         w.cocoa_window.set_ime_spot(dvec2(0.0, 0.0));
                     });
                 }

--- a/platform/src/os/apple/macos/macos_delegates.rs
+++ b/platform/src/os/apple/macos/macos_delegates.rs
@@ -654,10 +654,14 @@ pub fn define_cocoa_view_class() -> *const Class {
     }
 
     extern "C" fn key_down(this: &Object, _sel: Sel, event: ObjcId) {
-        let _cw = get_cocoa_window(this);
-        unsafe {
-            let input_context: ObjcId = msg_send![this, inputContext];
-            let () = msg_send![input_context, handleEvent: event];
+        let cw = get_cocoa_window(this);
+        // Only forward to NSTextInputContext when IME is active (a text field has focus).
+        // Otherwise, typing outside the TextInput still trigger the system IME.
+        if (cw.ime_active) {
+            unsafe {
+                let input_context: ObjcId = msg_send![this, inputContext];
+                let () = msg_send![input_context, handleEvent: event];
+            }
         }
     }
 

--- a/platform/src/os/apple/macos/macos_window.rs
+++ b/platform/src/os/apple/macos/macos_window.rs
@@ -27,6 +27,8 @@ pub struct MacosWindow {
     pub(crate) view: ObjcId,
     pub(crate) window: ObjcId,
     pub(crate) ime_spot: Vec2d,
+    // When ime_active is false, key events are not forward to NSTextInputContext so IME dose not active.
+    pub(crate) ime_active: bool,
     pub(crate) is_fullscreen: bool,
     pub(crate) last_mouse_pos: Vec2d,
     window_delegate: ObjcId,
@@ -55,6 +57,7 @@ impl MacosWindow {
                 last_window_geom: None,
                 ime_spot: Vec2d::default(),
                 last_mouse_pos: Vec2d::default(),
+                ime_active: false,
             }
         }
     }
@@ -483,6 +486,10 @@ impl MacosWindow {
             replace_last: replace_last,
             ..Default::default()
         }))
+    }
+
+    pub fn set_ime_active(&mut self, active: bool) {
+        self.ime_active = active;
     }
 
     #[cfg(target_os = "macos")]

--- a/platform/src/os/windows/d3d11.rs
+++ b/platform/src/os/windows/d3d11.rs
@@ -627,7 +627,7 @@ impl D3d11Window {
         let mut win32_window =
             Box::new(Win32Window::new(window_id, title, position, is_fullscreen));
         win32_window.init(inner_size);
-
+        win32_window.set_ime_active(false);
         let wg = win32_window.get_window_geom();
 
         let sc_desc = DXGI_SWAP_CHAIN_DESC1 {

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -40,8 +40,8 @@ use {
                     Controls::{MARGINS, WM_MOUSELEAVE},
                     Input::{
                         Ime::{
-                            ImmGetContext, ImmReleaseContext, ImmSetCompositionWindow, CFS_POINT,
-                            COMPOSITIONFORM,
+                            ImmGetContext, ImmReleaseContext, ImmSetCompositionWindow, ImmAssociateContext,
+                            CFS_POINT, COMPOSITIONFORM, HIMC,
                         },
                         KeyboardAndMouse::{
                             GetKeyState, ReleaseCapture, SetCapture, TrackMouseEvent, TME_LEAVE,
@@ -118,6 +118,8 @@ pub struct Win32Window {
     pub hwnd: HWND,
     pub track_mouse_event: bool,
     pub is_fullscreen: bool,
+
+    ime_saved_himc: HIMC,
 }
 
 impl Win32Window {
@@ -186,6 +188,7 @@ impl Win32Window {
             hwnd,
             track_mouse_event: false,
             is_fullscreen,
+            ime_saved_himc: HIMC::default(),
         }
     }
 
@@ -1025,6 +1028,16 @@ impl Win32Window {
             replace_last: replace_last,
             ..Default::default()
         }))
+    }
+
+    pub fn set_ime_active(&mut self, active: bool) {
+        if active {
+            if !self.ime_saved_himc.is_invalid() {
+                unsafe { ImmAssociateContext(self.hwnd, self.ime_saved_himc) };
+            }
+        } else {
+            self.ime_saved_himc = unsafe { ImmAssociateContext(self.hwnd, HIMC::default()) };
+        }
     }
 
     pub fn virtual_key_to_key_code(wparam: WPARAM) -> KeyCode {

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -484,11 +484,13 @@ impl Cx {
                 CxOsOp::ShowTextIME(area, pos, _config) => {
                     let pos = area.clipped_rect(self).pos + pos;
                     d3d11_windows.iter_mut().for_each(|w| {
+                        w.win32_window.set_ime_active(true);
                         w.win32_window.set_ime_spot(pos);
                     });
                 }
                 CxOsOp::HideTextIME => {
                     d3d11_windows.iter_mut().for_each(|w| {
+                        w.win32_window.set_ime_active(false);
                         w.win32_window.set_ime_spot(Vec2d::default());
                     });
                 }


### PR DESCRIPTION
## Summary

This PR fixes an issue where the IME popup window would appear even when no `TextInput` widget had focus on Windows and macOS.

## Problem

When using Makepad applications:
- Pressing keyboard keys triggered IME popup even without text input focus
- Typing in non-text-input areas activated the system IME unexpectedly
- General application usage was interrupted by unwanted IME windows

## Solution

Implemented cross-platform fix to gate IME functionality behind actual text input focus states:
- **Windows**: Uses `ImmAssociateContext` API to dynamically associate/dissociate IME context
- **macOS**: Controls key event forwarding to `NSTextInputContext` based on focus state

## Changes

### Windows
- Regenerate windows-rs to export `ImmAssociateContext`
- Add `set_ime_active()` method to manage IME context
- Initialize windows with IME inactive by default

### macOS  
- Add `ime_active` flag to track IME state
- Only forward key events to `NSTextInputContext` when IME is active
- Initialize windows with IME inactive by default