### PR TITLE
TextInput: actually use `color_empty_hover`/`focus` in draw_text shader

### DIFF
--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -197,8 +197,13 @@ script_mod! {
             get_color: fn() {
                 return self.color
                     .mix(self.color_hover.mix(self.color_down, self.down), self.hover)
-                    .mix(self.color_empty, self.empty)
-                    .mix(self.color_focus, self.focus)
+                    .mix(
+                        self.color_empty
+                            .mix(self.color_empty_hover, self.hover)
+                            .mix(self.color_empty_focus, self.focus),
+                        self.empty
+                    )
+                    .mix(self.color_focus, self.focus * (1.0 - self.empty))
                     .mix(self.color_disabled, self.disabled)
             }
         }


### PR DESCRIPTION
I noticed that `color_empty_hover` and `color_empty_focus` were defined but not used in the shader. Now they're used in the proper priority order.