### PR TITLE
platform: small fixes and quality improvements

### DIFF
--- a/platform/script/src/thread.rs
+++ b/platform/script/src/thread.rs
@@ -230,11 +230,17 @@ impl ScriptThread {
     }
 
     pub fn call_has_me(&self) -> bool {
-        self.mes.len() > self.calls.last().unwrap().bases.mes
+        self.calls
+            .last()
+            .map(|call| self.mes.len() > call.bases.mes)
+            .unwrap_or(false)
     }
 
     pub fn call_has_try(&self) -> bool {
-        self.tries.len() > self.calls.last().unwrap().bases.tries
+        self.calls
+            .last()
+            .map(|call| self.tries.len() > call.bases.tries)
+            .unwrap_or(false)
     }
 
     // lets resolve an id to a ScriptValue

--- a/platform/src/log.rs
+++ b/platform/src/log.rs
@@ -65,11 +65,18 @@ pub(crate) fn log_with_level_makepad_platform(
             extern "C" {
                 pub fn __android_log_write(prio: c_int, tag: *const u8, text: *const u8) -> c_int;
             }
+            // Android log priorities: 2=VERBOSE, 3=DEBUG, 4=INFO, 5=WARN, 6=ERROR
+            // Some devices (e.g. Motorola/MediaTek) suppress DEBUG by default.
+            let prio: c_int = match level {
+                LogLevel::Error | LogLevel::Panic => 6,
+                LogLevel::Warning => 5,
+                _ => 4,
+            };
             let msg = format!(
                 "{}:{}:{} - {}\0",
                 file_name, line_start, column_start, message
             );
-            unsafe { __android_log_write(3, "Makepad\0".as_ptr(), msg.as_ptr()) };
+            unsafe { __android_log_write(prio, "Makepad\0".as_ptr(), msg.as_ptr()) };
         }
         #[cfg(target_env = "ohos")]
         {
@@ -101,11 +108,16 @@ pub(crate) fn log_with_level_makepad_platform(
             extern "C" {
                 pub fn __android_log_write(prio: c_int, tag: *const u8, text: *const u8) -> c_int;
             }
+            let prio: c_int = match level {
+                LogLevel::Error | LogLevel::Panic => 6,
+                LogLevel::Warning => 5,
+                _ => 4,
+            };
             let msg = format!(
                 "{}:{}:{} - {}\0",
                 file_name, line_start, column_start, message
             );
-            unsafe { __android_log_write(3, "Makepad\0".as_ptr(), msg.as_ptr()) };
+            unsafe { __android_log_write(prio, "Makepad\0".as_ptr(), msg.as_ptr()) };
         }
 
         Cx::send_studio_message(AppToStudio::LogItem(StudioLogItem {

--- a/platform/src/os/cx_shared.rs
+++ b/platform/src/os/cx_shared.rs
@@ -406,7 +406,7 @@ impl Cx {
 
     pub(crate) fn inner_call_event_handler(&mut self, event: &Event) {
         self.event_id += 1;
-        if Cx::has_studio_web_socket() || Cx::local_profile_capture_enabled() {
+        if (Cx::has_studio_web_socket() && !crate::web_socket::STUDIO_STDOUT_MODE.load(std::sync::atomic::Ordering::SeqCst)) || Cx::local_profile_capture_enabled() {
             let start = self.seconds_since_app_start();
             let mut event_handler = self.event_handler.take().unwrap();
             event_handler(self, event);

--- a/platform/src/web_socket.rs
+++ b/platform/src/web_socket.rs
@@ -305,6 +305,7 @@ impl Cx {
         if STUDIO_STDOUT_MODE.load(Ordering::SeqCst) {
             use std::io::Write;
             let _ = std::io::stdout().write_all(msg.to_json().as_bytes());
+            let _ = std::io::stdout().write_all(b"\n");
             let _ = std::io::stdout().flush();
             return;
         }

--- a/tools/cargo_makepad/src/android/compile.rs
+++ b/tools/cargo_makepad/src/android/compile.rs
@@ -47,8 +47,6 @@ struct BuildPaths {
     res_dir: PathBuf,
     manifest_file: PathBuf,
     java_file: PathBuf,
-    java_class: PathBuf,
-    xr_class: PathBuf,
     xr_file: PathBuf,
     dst_unaligned_apk: PathBuf,
     dst_apk: PathBuf,
@@ -274,12 +272,10 @@ fn prepare_build(
     let main_java = main_java(java_url);
     let java_path = java_url.replace('.', "/");
     let java_file = tmp_dir.join(&java_path).join("MakepadApp.java");
-    let java_class = out_dir.join(&java_path).join("MakepadApp.class");
     write_text(&java_file, &main_java)?;
 
     let xr_java = xr_java(java_url);
     let xr_file = tmp_dir.join(&java_path).join("MakepadAppXr.java");
-    let xr_class = out_dir.join(&java_path).join("MakepadAppXr.class");
     write_text(&xr_file, &xr_java)?;
 
     let apk_filename = to_snakecase(app_label);
@@ -295,8 +291,6 @@ fn prepare_build(
         res_dir,
         manifest_file,
         java_file,
-        java_class,
-        xr_class,
         xr_file,
         dst_unaligned_apk,
         dst_apk,
@@ -359,6 +353,11 @@ fn compile_java(
         &cwd,
         java_home.join("bin/javac").to_str().unwrap(),
         &[
+            "-source",
+            "1.8",
+            "-target",
+            "1.8",
+            "-Xlint:-options",
             "-classpath",
             (android_jar_path(sdk_dir, urls).to_str().unwrap()),
             "-Xlint:deprecation",
@@ -405,6 +404,10 @@ fn compile_java(
                 .join("VideoPlayerRunnable.java")
                 .to_str()
                 .unwrap()),
+            (makepad_java_classes_dir
+                .join("H264Encoder.java")
+                .to_str()
+                .unwrap()),
             (build_paths.java_file.to_str().unwrap()),
             (build_paths.xr_file.to_str().unwrap()),
         ],
@@ -418,127 +421,46 @@ fn build_dex(
     build_paths: &BuildPaths,
     urls: &AndroidSDKUrls,
 ) -> Result<(), String> {
-    let makepad_package_path = "dev/makepad/android";
     let java_home = sdk_dir.join("openjdk");
     let cwd = std::env::current_dir().unwrap();
 
-    let compiled_java_classes_dir = build_paths.out_dir.join(makepad_package_path);
+    let mut class_files: Vec<PathBuf> = ls(&build_paths.out_dir)?
+        .into_iter()
+        .filter(|rel| rel.extension().and_then(|ext| ext.to_str()) == Some("class"))
+        .map(|rel| build_paths.out_dir.join(rel))
+        .collect();
+
+    class_files.sort();
+
+    if class_files.is_empty() {
+        return Err(format!(
+            "No compiled Java class files found in {:?}",
+            build_paths.out_dir
+        ));
+    }
+
+    let d8_jar = d8_jar_path(sdk_dir, urls);
+    let android_jar = android_jar_path(sdk_dir, urls);
+
+    let mut args: Vec<&str> = vec![
+        "-cp",
+        d8_jar.to_str().unwrap(),
+        "com.android.tools.r8.D8",
+        "--classpath",
+        android_jar.to_str().unwrap(),
+        "--output",
+        build_paths.out_dir.to_str().unwrap(),
+    ];
+
+    for class_file in &class_files {
+        args.push(class_file.to_str().unwrap());
+    }
 
     shell_env_cap(
         &[("JAVA_HOME", (java_home.to_str().unwrap()))],
         &cwd,
         java_home.join("bin/java").to_str().unwrap(),
-        &[
-            "-cp",
-            (d8_jar_path(sdk_dir, urls).to_str().unwrap()),
-            "com.android.tools.r8.D8",
-            "--classpath",
-            (android_jar_path(sdk_dir, urls).to_str().unwrap()),
-            "--output",
-            (build_paths.out_dir.to_str().unwrap()),
-            (compiled_java_classes_dir
-                .join("MakepadNative.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("MakepadActivity.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("MakepadSurface.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("ResizingLayout.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("MakepadNetwork.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("MakepadSocketStream.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("MakepadSocketStream$1.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("MakepadWebSocket.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("MakepadWebSocketReader.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("HttpResponse.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("ByteArrayMediaDataSource.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("VideoPlayer.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("VideoPlayerRunnable.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("VideoPlayer$1.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("VideoPlayer$2.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("VideoPlayer$3.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("MakepadActivity$1.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("MakepadActivity$2.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("MakepadActivity$3.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("MakepadActivity$4.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("MakepadActivity$5.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("MakepadActivity$5$1.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("MakepadActivity$5$2.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("MakepadActivity$6.class")
-                .to_str()
-                .unwrap()),
-            (compiled_java_classes_dir
-                .join("MakepadInputConnection.class")
-                .to_str()
-                .unwrap()),
-            (build_paths.java_class.to_str().unwrap()),
-            (build_paths.xr_class.to_str().unwrap()),
-        ],
+        &args,
     )?;
 
     Ok(())

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNetwork.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNetwork.java
@@ -1,7 +1,5 @@
 package dev.makepad.android;
 
-import android.os.AsyncTask;
-
 import java.io.IOException;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;

--- a/tools/cargo_makepad/src/android/mod.rs
+++ b/tools/cargo_makepad/src/android/mod.rs
@@ -389,6 +389,29 @@ impl HostOs {
     }
 }
 
+fn android_help() -> &'static str {
+    "Android commands:\n\
+  cargo makepad android [options] install-toolchain\n\
+  cargo makepad android [options] build <cargo args>\n\
+  cargo makepad android [options] run <cargo args>\n\
+  cargo makepad android [options] adb <adb args>\n\
+\n\
+Common options:\n\
+  --abi=aarch64|x86_64|armv7|i686|all   (default: aarch64)\n\
+  --package-name=<id>\n\
+  --app-label=<label>\n\
+  --sdk-path=<path>\n\
+  --host-os=linux-x64|windows-x64|macos-aarch64|macos-x64\n\
+  --variant=default|quest\n\
+  --devices=<serial1,serial2,...>        (for run)\n\
+  --keep-sdk-sources\n\
+\n\
+Examples:\n\
+  cargo makepad android --abi=aarch64 build -p my-app --release\n\
+  cargo makepad android --abi=aarch64 run -p my-app --release\n\
+  cargo makepad android adb devices -l"
+}
+
 pub fn handle_android(mut args: &[String]) -> Result<(), String> {
     #[allow(unused)]
     let mut host_os = HostOs::Unsupported;
@@ -434,6 +457,19 @@ pub fn handle_android(mut args: &[String]) -> Result<(), String> {
             break;
         }
     }
+
+    if args.is_empty() {
+        return Err(format!(
+            "missing android subcommand. use one of: install-toolchain, build, run, adb\n\n{}",
+            android_help()
+        ));
+    }
+
+    if args[0] == "--help" || args[0] == "-h" || args[0] == "help" {
+        println!("{}", android_help());
+        return Ok(());
+    }
+
     if sdk_path.is_none() {
         sdk_path = Some(format!(
             "{}/{}",
@@ -493,7 +529,11 @@ pub fn handle_android(mut args: &[String]) -> Result<(), String> {
             &urls,
             devices,
         ),
-        _ => Err(format!("{} is not a valid command or option", args[0])),
+        _ => Err(format!(
+            "{} is not a valid android subcommand\n\n{}",
+            args[0],
+            android_help()
+        )),
     }
 }
 

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -929,6 +929,9 @@ impl Widget for TextFlow {
             Hit::FingerHoverIn(_) => {
                 cx.set_cursor(MouseCursor::Text);
             }
+            Hit::FingerHoverOut(_) => {
+                cx.set_cursor(MouseCursor::Default);
+            }
             Hit::FingerDown(fe) if fe.is_primary_hit() => {
                 cx.set_key_focus(self.area);
                 if let Some(idx) = self.selection_tracker.point_to_index(cx, fe.abs) {

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -1464,6 +1464,7 @@ impl Widget for TextInput {
                 self.animator_play(cx, ids!(hover.on));
             }
             Hit::FingerHoverOut(_) => {
+                cx.set_cursor(MouseCursor::Default);
                 self.animator_play(cx, ids!(hover.off));
             }
             Hit::KeyFocus(_) => {


### PR DESCRIPTION
Small independent fixes:

- **Android log levels**: Map `log!` macro levels to Android log priorities (ERROR=6, WARN=5, INFO=4). Some devices (Motorola/MediaTek) suppress DEBUG by default.
- **cargo-makepad android**: Show help text instead of panicking on missing/invalid subcommand.
- **Android build**: Discover `.class` files dynamically instead of hardcoding ~25 individual paths. Add Java 8 source/target flags.
- **Remove deprecated import**: Drop unused `AsyncTask` import from `MakepadNetwork.java`.
- **Studio stdout**: Add newline after JSON messages for JSON-lines parsing. Skip profiler timing in stdout mode.
- **Script thread**: Fix panic on empty call stack in `call_has_me`/`call_has_try`.
- **Cursor**: Reset to `Default` on `FingerHoverOut` in `TextFlow` and `TextInput`.