### PR TITLE
platform: cycle tap count after triple-click so fast double-clicks keep working

### DIFF
--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -428,6 +428,11 @@ impl CxFingers {
             && pos.distance(&self.tap.last_pos) < TAP_COUNT_DISTANCE
         {
             self.tap.count += 1;
+            // Cycle back after triple-click so fast repeated
+            // double-clicks keep working (1→2→3→1→2→3…).
+            if self.tap.count > 3 {
+                self.tap.count = 1;
+            }
         } else {
             self.tap.count = 1;
         }


### PR DESCRIPTION
\`process_tap_count\` incremented without bound. \`TextInput\` handles \`tap_count\` 2 (select word) and 3 (select all) but ignored counts >= 4. Rapid repeated double-clicks produced tap counts of 4, 5, 6... hitting the \`_ => {}\` fallthrough and doing nothing.

Cycles the counter back to 1 after reaching 3 (1→2→3→1→2→3).