### PR TITLE
widgets: add external control tools and control DSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,6 @@ experiments/websocket-windows/nodejs-websocketserver
 experiments/svgloader
 CLAUDE.md
 
+/.makepad/
 /tools/__pycache__/
 **/*.obsidian

--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -144,8 +144,9 @@ pub struct Cx {
     pub widget_query_invalidation_event: Option<u64>,
 
     pub widget_tree_ptr: *mut (),
-    pub widget_tree_dump_callback: Option<fn(&Cx) -> String>,
+    pub widget_tree_dump_callback: Option<fn(&mut Cx) -> String>,
     pub widget_query_callback: Option<fn(&Cx, &str) -> Vec<String>>,
+    pub widget_control_callback: Option<fn(&mut Cx, &str, &str, &str) -> Option<String>>,
 
     pub net: Arc<NetworkRuntime>,
 }
@@ -421,6 +422,7 @@ impl Cx {
             widget_tree_ptr: std::ptr::null_mut(),
             widget_tree_dump_callback: None,
             widget_query_callback: None,
+            widget_control_callback: None,
             net,
 
             script_data: CxScriptData {

--- a/platform/src/os/cx_shared.rs
+++ b/platform/src/os/cx_shared.rs
@@ -13,7 +13,7 @@ use {
     },
     makepad_studio_protocol::{
         AppToStudio, EventSample, ScreenshotResponse, StudioToApp, WidgetQueryResponse,
-        WidgetTreeDumpResponse,
+        WidgetResponse, WidgetTreeDumpResponse,
     },
     std::cell::{Cell, RefCell},
     std::collections::{HashMap, HashSet},
@@ -335,6 +335,29 @@ impl Cx {
             }
             StudioToApp::WidgetQuery(request) => {
                 self.send_studio_widget_query_response(request.request_id, request.query);
+            }
+            StudioToApp::WidgetControl(req) => {
+                let result = if let Some(callback) = self.widget_control_callback {
+                    callback(self, &req.id, &req.op, &req.arg)
+                } else {
+                    None
+                };
+                match result {
+                    Some(out) => {
+                        Cx::send_studio_message(AppToStudio::WidgetResponse(WidgetResponse {
+                            request_id: req.request_id,
+                            ok: true,
+                            out,
+                        }));
+                    }
+                    None => {
+                        Cx::send_studio_message(AppToStudio::WidgetResponse(WidgetResponse {
+                            request_id: req.request_id,
+                            ok: false,
+                            out: String::new(),
+                        }));
+                    }
+                }
             }
             StudioToApp::Kill => {
                 self.call_event_handler(&Event::Shutdown);

--- a/platform/studio/src/studio.rs
+++ b/platform/studio/src/studio.rs
@@ -198,6 +198,7 @@ pub enum AppToStudio {
     Screenshot(ScreenshotResponse),
     WidgetTreeDump(WidgetTreeDumpResponse),
     WidgetQuery(WidgetQueryResponse),
+    WidgetResponse(WidgetResponse),
     TweakHits(TweakHitsResponse),
     BeforeStartup,
     CreateWindow {
@@ -247,6 +248,21 @@ pub struct WidgetQueryResponse {
 }
 
 #[derive(Debug, Default, SerBin, DeBin, SerJson, DeJson, Clone)]
+pub struct WidgetControl {
+    pub request_id: u64,
+    pub id: String,
+    pub op: String,
+    pub arg: String,
+}
+
+#[derive(Debug, Default, SerBin, DeBin, SerJson, DeJson, Clone)]
+pub struct WidgetResponse {
+    pub request_id: u64,
+    pub ok: bool,
+    pub out: String,
+}
+
+#[derive(Debug, Default, SerBin, DeBin, SerJson, DeJson, Clone)]
 pub struct TweakHitsResponse {
     pub window_id: usize,
     pub dpi_factor: f64,
@@ -273,6 +289,7 @@ pub enum StudioToApp {
     Screenshot(ScreenshotRequest),
     WidgetTreeDump(WidgetTreeDumpRequest),
     WidgetQuery(WidgetQueryRequest),
+    WidgetControl(WidgetControl),
     KeepAlive,
     LiveChange {
         file_name: String,

--- a/studio/hub/src/dispatch.rs
+++ b/studio/hub/src/dispatch.rs
@@ -2682,7 +2682,8 @@ impl HubCore {
             | AppToStudio::TweakHits(_)
             | AppToStudio::BeforeStartup
             | AppToStudio::RequestAnimationFrame
-            | AppToStudio::SetClipboard(_) => {}
+            | AppToStudio::SetClipboard(_)
+            | AppToStudio::WidgetResponse(_) => {}
         }
     }
 

--- a/tools/makepad-control-socket
+++ b/tools/makepad-control-socket
@@ -1,0 +1,59 @@
+#!/usr/bin/env -S uv --quiet run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Launch a Makepad app with stdin/stdout control, relay via Unix socket.
+
+Creates a Unix domain socket so makepad-ui-cli (or any JSON-line client)
+can connect. JSON lines from socket clients are forwarded to the app's
+stdin; JSON lines from the app's stdout are broadcast to all connected
+clients.
+
+Usage:
+    makepad-control-socket --socket /tmp/app.sock -- cargo run -p my-app
+
+The app must support Makepad's stdin/stdout control mode.
+"""
+
+import argparse
+import os
+import shlex
+import sys
+import tempfile
+
+# Add tools directory to path for makepad_control import.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import makepad_control as mc
+
+
+def main():
+    p = argparse.ArgumentParser(
+        prog="makepad-control-socket",
+        description="Launch a Makepad app and relay control over a Unix socket.")
+    p.add_argument("--socket", "-s", default=None,
+                   help="Unix socket path (default: auto-generated in /tmp)")
+    p.add_argument("--env", "-e", action="append", default=[],
+                   help="Extra env var as KEY=VALUE (repeatable)")
+    p.add_argument("cmd", nargs="+",
+                   help="Command to launch (the Makepad app)")
+    args = p.parse_args()
+
+    socket_path = args.socket or os.path.join(
+        tempfile.gettempdir(), f"makepad-control-{os.getpid()}.sock")
+
+    env = {}
+    for item in args.env:
+        if "=" in item:
+            k, v = item.split("=", 1)
+            env[k] = v
+
+    print(f"MAKEPAD_SOCKET={socket_path}")
+    sys.stdout.flush()
+
+    rc = mc.run_relay(args.cmd, socket_path, env=env)
+    raise SystemExit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/makepad-ui-cli
+++ b/tools/makepad-ui-cli
@@ -1,0 +1,381 @@
+#!/usr/bin/env -S uv --quiet run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Drive any Makepad app via the control socket.
+
+Connects to a Unix domain socket created by makepad-control-socket.
+Sends StudioToApp JSON lines, reads AppToStudio JSON lines.
+
+All coordinates are in Makepad window space (0,0 = top-left of window).
+"""
+
+import argparse, json, os, subprocess, sys, time
+
+# Add tools directory to path for makepad_control import.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import makepad_control as mc
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+last_pos = [0.0, 0.0]
+dump_origin = None  # (ox, oy, dpi)
+latest_dump = None
+
+
+def translate_coords(x, y):
+    if dump_origin is None:
+        return (float(x), float(y))
+    ox, oy, dpi = dump_origin
+    dpi = max(dpi, 1.0)
+    return ((x + ox) / dpi, (y + oy) / dpi)
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+def cmd_click(args, conn):
+    x, y = float(args.x), float(args.y)
+    tx, ty = translate_coords(x, y)
+    last_pos[0], last_pos[1] = x, y
+    bits = mc.BUTTON_BITS.get(getattr(args, "button", "left") or "left", 1)
+    now = time.time()
+    conn.send(mc.mkv("MouseMove", {"time": now, "x": tx, "y": ty, "modifiers": mc.MODS}))
+    mc.tick(conn)
+    conn.send(mc.mkv("MouseDown", {"button_raw_bits": bits, "x": tx, "y": ty,
+                                    "time": now, "modifiers": mc.MODS}))
+    mc.tick(conn)
+    conn.send(mc.mkv("MouseUp", {"time": now + 0.01, "button_raw_bits": bits,
+                                   "x": tx, "y": ty, "modifiers": mc.MODS}))
+    mc.tick(conn)
+
+
+def cmd_type(args, conn):
+    text = " ".join(args.text)
+    conn.send(mc.mkv("TextInput", {"input": text, "replace_last": False, "was_paste": False}))
+    mc.tick(conn)
+
+
+def cmd_key(args, conn):
+    name = args.name
+    code = mc.keycode_index(name)
+    now = time.time()
+    kd = {"key_code": code, "is_repeat": False, "modifiers": mc.MODS, "time": now}
+    conn.send(mc.mkv("KeyDown", kd))
+    mc.tick(conn)
+    char = name if len(name) == 1 else {"space": " "}.get(name.lower())
+    if char:
+        conn.send(mc.mkv("TextInput", {"input": char, "replace_last": False, "was_paste": False}))
+        mc.tick(conn)
+    conn.send(mc.mkv("KeyUp", kd))
+    mc.tick(conn)
+
+
+def cmd_mousedown(args, conn):
+    x, y = float(args.x), float(args.y)
+    tx, ty = translate_coords(x, y)
+    last_pos[0], last_pos[1] = x, y
+    bits = mc.BUTTON_BITS.get(getattr(args, "button", "left") or "left", 1)
+    conn.send(mc.mkv("MouseDown", {"button_raw_bits": bits, "x": tx, "y": ty,
+                                    "time": 0.0, "modifiers": mc.MODS}))
+    mc.tick(conn)
+
+
+def cmd_mouseup(args, conn):
+    x = float(args.x) if args.x is not None else last_pos[0]
+    y = float(args.y) if args.y is not None else last_pos[1]
+    tx, ty = translate_coords(x, y)
+    last_pos[0], last_pos[1] = x, y
+    bits = mc.BUTTON_BITS.get(getattr(args, "button", "left") or "left", 1)
+    conn.send(mc.mkv("MouseUp", {"time": 0.0, "button_raw_bits": bits,
+                                   "x": tx, "y": ty, "modifiers": mc.MODS}))
+    mc.tick(conn)
+
+
+def cmd_mousemove(args, conn):
+    x, y = float(args.x), float(args.y)
+    tx, ty = translate_coords(x, y)
+    last_pos[0], last_pos[1] = x, y
+    conn.send(mc.mkv("MouseMove", {"time": 0.0, "x": tx, "y": ty, "modifiers": mc.MODS}))
+    mc.tick(conn)
+
+
+def cmd_touch(args, conn):
+    state_map = {"start": "Start", "down": "Start", "stop": "Stop",
+                 "up": "Stop", "move": "Move", "stable": "Stable"}
+    state_name = state_map.get(args.phase.lower())
+    if not state_name:
+        sys.exit(f"error: unknown touch phase: {args.phase}")
+    conn.send(mc.mkv("TouchUpdate", {"touches": [
+        {"uid": args.id, "state": state_name,
+         "x": float(args.x), "y": float(args.y), "time": time.time(),
+         "rotation_angle": 0.0, "force": 1.0,
+         "radius_x": 0.0, "radius_y": 0.0}],
+        "modifiers": mc.MODS}))
+    mc.tick(conn)
+
+
+def cmd_screenshot(args, conn):
+    req_id = int(time.monotonic() * 1000) & 0xFFFFFFFF
+    conn.send(mc.mkv("Screenshot", {"request_id": req_id, "kind_id": 0}))
+    mc.tick(conn)
+
+    resp = conn.recv(match_fn=lambda m: isinstance(m, dict) and "Screenshot" in m,
+                     timeout=30)
+    if not resp or "Screenshot" not in resp:
+        print(json.dumps(resp or {"error": "timeout"}))
+        sys.exit(1)
+
+    sdata = resp["Screenshot"]
+    if isinstance(sdata, list):
+        sdata = sdata[0]
+    png_bytes = bytes(sdata["png"])
+    with open(args.path, "wb") as f:
+        f.write(png_bytes)
+
+    try:
+        subprocess.run(["magick", args.path, args.path], check=True,
+                       capture_output=True, timeout=10)
+    except (FileNotFoundError, subprocess.SubprocessError):
+        pass
+
+    info = {k: v for k, v in sdata.items() if k != "png"}
+    info["path"] = args.path
+    print(json.dumps({"Screenshot": info}))
+
+
+def cmd_sleep(args, conn):
+    time.sleep(args.ms / 1000.0)
+
+
+def cmd_builds(args, conn):
+    print("connected [active]")
+
+
+def cmd_dump(args, conn):
+    global latest_dump, dump_origin
+    req_id = int(time.monotonic() * 1000) & 0xFFFFFFFF
+    conn.send(mc.mkv("WidgetTreeDump", {"request_id": req_id}))
+    mc.tick(conn)
+
+    resp = conn.recv(
+        match_fn=lambda m: isinstance(m, dict) and "WidgetTreeDump" in m,
+        timeout=30)
+    if not resp or "WidgetTreeDump" not in resp:
+        print(json.dumps(resp or {"error": "timeout"}))
+        sys.exit(1)
+
+    dump = resp["WidgetTreeDump"][0]["dump"] if isinstance(resp["WidgetTreeDump"], list) else resp["WidgetTreeDump"]["dump"]
+    latest_dump = dump
+    origin = mc.parse_dump_origin(dump)
+    if origin:
+        dump_origin = origin
+    print(dump)
+
+
+def cmd_query(args, conn):
+    global latest_dump, dump_origin
+    req_id = int(time.monotonic() * 1000) & 0xFFFFFFFF
+    conn.send(mc.mkv("WidgetTreeDump", {"request_id": req_id}))
+    mc.tick(conn)
+
+    resp = conn.recv(
+        match_fn=lambda m: isinstance(m, dict) and "WidgetTreeDump" in m,
+        timeout=30)
+    if not resp or "WidgetTreeDump" not in resp:
+        print(json.dumps(resp or {"error": "timeout"}))
+        sys.exit(1)
+
+    dump = resp["WidgetTreeDump"][0]["dump"] if isinstance(resp["WidgetTreeDump"], list) else resp["WidgetTreeDump"]["dump"]
+    latest_dump = dump
+    origin = mc.parse_dump_origin(dump)
+    if origin:
+        dump_origin = origin
+
+    for line in mc.query_widget_dump(dump, args.query):
+        print(line)
+
+
+def cmd_control(args, conn):
+    req_id = int(time.monotonic() * 1000) & 0xFFFFFFFF
+    op = args.op if args.op else ""
+    arg = " ".join(args.arg) if args.arg else ""
+    conn.send(mc.mkv("WidgetControl", {"request_id": req_id, "id": args.id,
+                                        "op": op, "arg": arg}))
+    mc.tick(conn)
+    resp = conn.recv(
+        match_fn=lambda m: isinstance(m, dict) and "WidgetResponse" in m,
+        timeout=10)
+    if not resp or "WidgetResponse" not in resp:
+        print(json.dumps(resp or {"error": "timeout"}))
+        sys.exit(1)
+    data = resp["WidgetResponse"]
+    if isinstance(data, list):
+        data = data[0]
+    print(json.dumps(data))
+
+
+def cmd_send(args, conn):
+    msg = json.loads(args.json)
+    conn.send(msg)
+    mc.tick(conn)
+    resp = conn.recv(timeout=5)
+    if resp:
+        print(json.dumps(resp))
+
+
+def cmd_pipe(args, conn):
+    """Read commands from stdin, one per line. Space-separated."""
+    dispatch = {
+        "click": lambda parts: cmd_click(
+            argparse.Namespace(x=parts[0], y=parts[1],
+                               button=parts[2] if len(parts) > 2 else "left"), conn),
+        "type": lambda parts: cmd_type(
+            argparse.Namespace(text=parts), conn),
+        "key": lambda parts: cmd_key(
+            argparse.Namespace(name=parts[0]), conn),
+        "mousedown": lambda parts: cmd_mousedown(
+            argparse.Namespace(x=parts[0], y=parts[1],
+                               button=parts[2] if len(parts) > 2 else "left"), conn),
+        "mouseup": lambda parts: cmd_mouseup(
+            argparse.Namespace(x=parts[0] if parts else None,
+                               y=parts[1] if len(parts) > 1 else None,
+                               button=parts[2] if len(parts) > 2 else "left"), conn),
+        "mousemove": lambda parts: cmd_mousemove(
+            argparse.Namespace(x=parts[0], y=parts[1]), conn),
+        "touch": lambda parts: cmd_touch(
+            argparse.Namespace(id=int(parts[0]), phase=parts[1],
+                               x=parts[2], y=parts[3]), conn),
+        "screenshot": lambda parts: cmd_screenshot(
+            argparse.Namespace(path=parts[0]), conn),
+        "sleep": lambda parts: cmd_sleep(
+            argparse.Namespace(ms=int(parts[0])), conn),
+        "dump": lambda parts: cmd_dump(
+            argparse.Namespace(), conn),
+        "query": lambda parts: cmd_query(
+            argparse.Namespace(query=" ".join(parts)), conn),
+        "control": lambda parts: cmd_control(
+            argparse.Namespace(id=parts[0], op=parts[1] if len(parts) > 1 else "",
+                               arg=parts[2:] if len(parts) > 2 else []), conn),
+        "send": lambda parts: cmd_send(
+            argparse.Namespace(json=" ".join(parts)), conn),
+    }
+    try:
+        for line in sys.stdin:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            cmd_name, cmd_args = parts[0], parts[1:]
+            fn = dispatch.get(cmd_name)
+            if fn:
+                fn(cmd_args)
+                time.sleep(0.02)
+            else:
+                print(f"error: unknown command: {cmd_name}", file=sys.stderr)
+    except (EOFError, KeyboardInterrupt):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def build_parser():
+    p = argparse.ArgumentParser(
+        prog="makepad-ui-cli",
+        description="Drive a Makepad app via the control socket. "
+        "All coordinates are in Makepad window space.")
+    p.add_argument("--socket", "-s", default=None,
+                   help="Path to Unix control socket (or set MAKEPAD_SOCKET)")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    s = sub.add_parser("click", help="Click at window coordinates")
+    s.add_argument("x", type=float)
+    s.add_argument("y", type=float)
+    s.add_argument("--button", "-b", default="left", choices=["left", "right", "middle"])
+    s.set_defaults(func=cmd_click)
+
+    s = sub.add_parser("type", help="Type text")
+    s.add_argument("text", nargs="+")
+    s.set_defaults(func=cmd_type)
+
+    s = sub.add_parser("key", help="Press key (enter, tab, escape, a-z, ...)")
+    s.add_argument("name")
+    s.set_defaults(func=cmd_key)
+
+    s = sub.add_parser("mousedown", help="Mouse button down at window coordinates")
+    s.add_argument("x", type=float)
+    s.add_argument("y", type=float)
+    s.add_argument("--button", "-b", default="left", choices=["left", "right", "middle"])
+    s.set_defaults(func=cmd_mousedown)
+
+    s = sub.add_parser("mouseup", help="Mouse button up")
+    s.add_argument("x", type=float, nargs="?", default=None)
+    s.add_argument("y", type=float, nargs="?", default=None)
+    s.add_argument("--button", "-b", default="left", choices=["left", "right", "middle"])
+    s.set_defaults(func=cmd_mouseup)
+
+    s = sub.add_parser("mousemove", help="Move mouse to window coordinates")
+    s.add_argument("x", type=float)
+    s.add_argument("y", type=float)
+    s.set_defaults(func=cmd_mousemove)
+
+    s = sub.add_parser("touch", help="Touch event at window coordinates")
+    s.add_argument("id", type=int)
+    s.add_argument("phase", choices=["start", "down", "stop", "up", "move", "stable"])
+    s.add_argument("x", type=float)
+    s.add_argument("y", type=float)
+    s.set_defaults(func=cmd_touch)
+
+    s = sub.add_parser("screenshot", help="Take screenshot of full window")
+    s.add_argument("path")
+    s.set_defaults(func=cmd_screenshot)
+
+    s = sub.add_parser("sleep", help="Wait milliseconds")
+    s.add_argument("ms", type=int)
+    s.set_defaults(func=cmd_sleep)
+
+    s = sub.add_parser("builds", help="Show connection status")
+    s.set_defaults(func=cmd_builds)
+
+    s = sub.add_parser("dump", help="Widget tree dump")
+    s.set_defaults(func=cmd_dump)
+
+    s = sub.add_parser("query", help="Query widget tree (id:name, type:name, or substring)")
+    s.add_argument("query")
+    s.set_defaults(func=cmd_query)
+
+    s = sub.add_parser("control", help="Control a widget by id")
+    s.add_argument("id", help="Widget id from dump")
+    s.add_argument("op", nargs="?", default="", help="Control operation (empty = list ops)")
+    s.add_argument("arg", nargs="*", help="Operation argument")
+    s.set_defaults(func=cmd_control)
+
+    s = sub.add_parser("send", help="Send raw JSON")
+    s.add_argument("json")
+    s.set_defaults(func=cmd_send)
+
+    s = sub.add_parser("pipe", help="Read commands from stdin")
+    s.set_defaults(func=cmd_pipe)
+
+    return p
+
+
+def main():
+    p = build_parser()
+    args = p.parse_args()
+    path = getattr(args, "socket", None) or os.environ.get("MAKEPAD_SOCKET")
+    if not path:
+        sys.exit("error: no socket path. Use --socket or set MAKEPAD_SOCKET.")
+    conn = mc.connect(path)
+    args.func(args, conn)
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/makepad_control.py
+++ b/tools/makepad_control.py
@@ -1,0 +1,380 @@
+"""Makepad UI control library.
+
+Reusable client and relay for any Makepad app using stdin/stdout control mode.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import select
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from typing import Any, Callable
+
+# ---------------------------------------------------------------------------
+# Makepad KeyCode integer encoding
+# ---------------------------------------------------------------------------
+# Makepad serializes KeyCode as an integer index via manual SerJson/DeJson.
+# The order must match KEYCODE_VARIANTS in makepad/platform/src/event/keyboard.rs.
+
+KEYCODE_VARIANTS = [
+    "Escape", "Back", "Backtick",
+    "Key0", "Key1", "Key2", "Key3", "Key4", "Key5", "Key6", "Key7", "Key8", "Key9",
+    "Minus", "Equals", "Backspace", "Tab",
+    "KeyQ", "KeyW", "KeyE", "KeyR", "KeyT", "KeyY", "KeyU", "KeyI", "KeyO", "KeyP",
+    "LBracket", "RBracket", "ReturnKey",
+    "KeyA", "KeyS", "KeyD", "KeyF", "KeyG", "KeyH", "KeyJ", "KeyK", "KeyL",
+    "Semicolon", "Quote", "Backslash",
+    "KeyZ", "KeyX", "KeyC", "KeyV", "KeyB", "KeyN", "KeyM",
+    "Comma", "Period", "Slash",
+    "Control", "Alt", "Shift", "Logo",
+    "Space", "Capslock",
+    "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12",
+    "PrintScreen", "ScrollLock", "Pause",
+    "Insert", "Delete", "Home", "End", "PageUp", "PageDown",
+    "Numpad0", "Numpad1", "Numpad2", "Numpad3", "Numpad4",
+    "Numpad5", "Numpad6", "Numpad7", "Numpad8", "Numpad9",
+    "NumpadEquals", "NumpadSubtract", "NumpadAdd", "NumpadDecimal",
+    "NumpadMultiply", "NumpadDivide", "Numlock", "NumpadEnter",
+    "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight",
+    "Unknown",
+]
+
+_KEYCODE_INDEX = {name.lower(): idx for idx, name in enumerate(KEYCODE_VARIANTS)}
+
+KEY_MAP = {
+    "enter": "ReturnKey", "return": "ReturnKey", "tab": "Tab", "escape": "Escape", "esc": "Escape",
+    "backspace": "Backspace", "delete": "Delete",
+    "up": "ArrowUp", "down": "ArrowDown", "left": "ArrowLeft", "right": "ArrowRight",
+    "home": "Home", "end": "End", "pageup": "PageUp", "pagedown": "PageDown",
+    "space": "Space", "capslock": "Capslock",
+    "printscreen": "PrintScreen", "scrolllock": "ScrollLock", "pause": "Pause",
+    "insert": "Insert", "numlock": "Numlock",
+    **{c: f"Key{c.upper()}" for c in "abcdefghijklmnopqrstuvwxyz"},
+    **{d: f"Key{d}" for d in "0123456789"},
+    **{f"f{n}": f"F{n}" for n in range(1, 13)},
+}
+
+MODS = {"shift": False, "control": False, "alt": False, "logo": False}
+
+BUTTON_BITS = {"left": 1, "right": 2, "middle": 4}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def keycode_index(name: str) -> int:
+    """Map key name to Makepad KeyCode integer index."""
+    canonical = KEY_MAP.get(name.lower(), name)
+    idx = _KEYCODE_INDEX.get(canonical.lower())
+    return idx if idx is not None else _KEYCODE_INDEX["unknown"]
+
+
+def tick(conn: Connection) -> None:
+    """Send Tick to trigger event processing."""
+    conn.send({"Tick": []})
+
+
+def mkv(name: str, data: Any) -> dict:
+    """Wrap a value as a Makepad SerJson tuple variant: {"Name":[data]}"""
+    return {name: [data]}
+
+
+def parse_dump_origin(dump: str) -> tuple[float, float, float] | None:
+    """Extract origin (ox, oy, dpi) from widget dump's first O line."""
+    for line in dump.split("\n"):
+        parts = line.split()
+        if parts and parts[0] == "O":
+            try:
+                return (float(parts[1]), float(parts[2]), float(parts[3]))
+            except (IndexError, ValueError):
+                pass
+    return None
+
+
+def query_widget_dump(dump: str, query: str) -> list[str]:
+    """Query widget dump for matching widgets. Returns list of line strings."""
+    results = []
+    query_lower = query.lower()
+    is_id = query.startswith("id:")
+    is_type = query.startswith("type:")
+    term = query[3:] if is_id else query[5:] if is_type else query_lower
+
+    for line in dump.split("\n"):
+        parts = line.split()
+        if len(parts) < 4 or parts[0] in ("O", "W"):
+            continue
+        # Format: index parent name type x y w h [ops]
+        name = parts[2]
+        wtype = parts[3] if len(parts) > 3 else ""
+        if is_id:
+            match = name == term
+        elif is_type:
+            match = wtype.lower() == term.lower()
+        else:
+            match = term in name.lower() or term in wtype.lower()
+        if match:
+            results.append(line)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Connection: Unix domain socket, JSON lines
+# ---------------------------------------------------------------------------
+
+class Connection:
+    """Bidirectional JSON-line connection over a Unix domain socket."""
+
+    def __init__(self, sock_path: str):
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.connect(sock_path)
+        self.rfile = self.sock.makefile("r", encoding="utf-8")
+        self.wfile = self.sock.makefile("w", encoding="utf-8")
+        self.rx: queue.Queue[dict] = queue.Queue()
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+
+    def _read_loop(self) -> None:
+        try:
+            for line in self.rfile:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    self.rx.put(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+        except (OSError, ValueError):
+            pass
+
+    def send(self, msg: Any) -> None:
+        """Send a JSON message as one line."""
+        self.wfile.write(json.dumps(msg) + "\n")
+        self.wfile.flush()
+
+    def recv(self, match_fn: Callable | None = None, timeout: float = 30) -> dict | None:
+        """Wait for a matching response."""
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            try:
+                msg = self.rx.get(timeout=min(remaining, 0.5))
+            except queue.Empty:
+                continue
+            if match_fn is None or match_fn(msg):
+                return msg
+
+    def send_recv(self, msg: Any, match_fn: Callable | None = None, timeout: float = 30) -> dict | None:
+        """Send and wait for matching response."""
+        self.send(msg)
+        return self.recv(match_fn, timeout)
+
+    def close(self) -> None:
+        try:
+            self.sock.close()
+        except OSError:
+            pass
+
+
+def connect(sock_path: str) -> Connection:
+    """Open connection to a Makepad control socket."""
+    return Connection(sock_path)
+
+
+# ---------------------------------------------------------------------------
+# Socket relay
+# ---------------------------------------------------------------------------
+
+def run_relay(
+    cmd: list[str],
+    socket_path: str,
+    *,
+    env: dict[str, str] | None = None,
+    on_json_line: Callable[[dict], None] | None = None,
+    on_nonjson_line: Callable[[str], None] | None = None,
+    ready_event: threading.Event | None = None,
+    ready_timeout: float = 30.0,
+) -> int:
+    """Launch subprocess, relay JSON lines over Unix socket.
+
+    cmd: subprocess command
+    socket_path: path for Unix domain socket
+    env: environment for subprocess (merged with os.environ)
+    on_json_line: called for each parsed JSON line from subprocess stdout
+    on_nonjson_line: called for each non-JSON line from subprocess stdout
+    ready_event: if set, will be signaled when ReadyToStart is received
+    ready_timeout: seconds to wait for ReadyToStart before continuing
+
+    Blocks until subprocess exits. Returns exit code.
+    """
+    # Clean up stale socket.
+    sock_parent = os.path.dirname(socket_path)
+    if sock_parent:
+        os.makedirs(sock_parent, exist_ok=True)
+    try:
+        os.unlink(socket_path)
+    except FileNotFoundError:
+        pass
+
+    # Create Unix domain socket.
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(socket_path)
+    server.listen(8)
+    server.setblocking(False)
+
+    # Build subprocess environment.
+    proc_env = os.environ.copy()
+    # Enable Makepad app-level control mode (stdin/stdout JSON protocol).
+    proc_env["MAKEPAD_EVENTS"] = "1"
+    if env:
+        proc_env.update(env)
+
+    proc = subprocess.Popen(
+        cmd,
+        env=proc_env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=None,
+    )
+    assert proc.stdin is not None
+    assert proc.stdout is not None
+
+    clients: list[socket.socket] = []
+    client_bufs: dict[int, str] = {}
+    stdout_lock = threading.Lock()
+    stdin_lock = threading.Lock()
+    got_ready = threading.Event()
+
+    def _read_stdout() -> None:
+        assert proc.stdout is not None
+        for raw in proc.stdout:
+            line = raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else raw
+            line = line.rstrip("\n")
+            if not line:
+                continue
+
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                if on_nonjson_line:
+                    on_nonjson_line(line)
+                else:
+                    print(line, file=sys.stderr)
+                continue
+
+            if on_json_line:
+                on_json_line(msg)
+
+            if isinstance(msg, dict) and "ReadyToStart" in msg:
+                got_ready.set()
+                if ready_event:
+                    ready_event.set()
+
+            # Broadcast to all connected clients.
+            encoded = (line + "\n").encode("utf-8")
+            with stdout_lock:
+                dead = []
+                for c in clients:
+                    try:
+                        c.sendall(encoded)
+                    except (OSError, BrokenPipeError):
+                        dead.append(c)
+                for c in dead:
+                    clients.remove(c)
+                    client_bufs.pop(id(c), None)
+                    c.close()
+
+        # stdout EOF
+        got_ready.set()
+        if ready_event:
+            ready_event.set()
+
+    reader = threading.Thread(target=_read_stdout, daemon=True)
+    reader.start()
+
+    # Wait for ReadyToStart.
+    got_ready.wait(timeout=ready_timeout)
+
+    rc = proc.poll()
+    if rc is not None and not got_ready.is_set():
+        server.close()
+        try:
+            os.unlink(socket_path)
+        except FileNotFoundError:
+            pass
+        return rc
+
+    def _write_to_proc(data: bytes) -> None:
+        assert proc.stdin is not None
+        with stdin_lock:
+            try:
+                proc.stdin.write(data)
+                proc.stdin.flush()
+            except (OSError, BrokenPipeError):
+                pass
+
+    try:
+        while proc.poll() is None:
+            rlist = [server] + clients
+            try:
+                readable, _, _ = select.select(rlist, [], [], 0.5)
+            except (ValueError, OSError):
+                with stdout_lock:
+                    alive = []
+                    for c in clients:
+                        try:
+                            c.fileno()
+                            alive.append(c)
+                        except Exception:
+                            client_bufs.pop(id(c), None)
+                    clients[:] = alive
+                continue
+
+            for s in readable:
+                if s is server:
+                    conn, _ = server.accept()
+                    conn.setblocking(True)
+                    with stdout_lock:
+                        clients.append(conn)
+                        client_bufs[id(conn)] = ""
+                else:
+                    try:
+                        data = s.recv(65536)
+                    except (OSError, ConnectionResetError):
+                        data = b""
+                    if not data:
+                        with stdout_lock:
+                            if s in clients:
+                                clients.remove(s)
+                            client_bufs.pop(id(s), None)
+                        s.close()
+                        continue
+                    buf = client_bufs.get(id(s), "") + data.decode("utf-8", errors="replace")
+                    while "\n" in buf:
+                        line, buf = buf.split("\n", 1)
+                        line = line.strip()
+                        if line:
+                            _write_to_proc((line + "\n").encode("utf-8"))
+                    client_bufs[id(s)] = buf
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.close()
+        try:
+            os.unlink(socket_path)
+        except FileNotFoundError:
+            pass
+        if proc.poll() is None:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+    return proc.returncode or 0

--- a/widgets/src/button.rs
+++ b/widgets/src/button.rs
@@ -582,6 +582,26 @@ impl Widget for Button {
         self.text.as_mut_empty().push_str(v);
         self.redraw(cx);
     }
+
+    fn controls(&self) -> (String, bool) {
+        ("press".into(), true)
+    }
+
+    fn control(&mut self, cx: &mut Cx, op: &str, _arg: &str) -> String {
+        match op {
+            "press" => {
+                let uid = self.widget_uid();
+                cx.widget_action_with_data(
+                    &self.action_data,
+                    uid,
+                    ButtonAction::Clicked(KeyModifiers::default()),
+                );
+                self.redraw(cx);
+                String::new()
+            }
+            _ => String::new(),
+        }
+    }
 }
 
 impl Button {

--- a/widgets/src/check_box.rs
+++ b/widgets/src/check_box.rs
@@ -559,6 +559,34 @@ impl Widget for CheckBox {
         self.text.as_mut_empty().push_str(v);
         self.redraw(cx);
     }
+
+    fn controls(&self) -> (String, bool) {
+        ("get,set,toggle".into(), true)
+    }
+
+    fn control(&mut self, cx: &mut Cx, op: &str, _arg: &str) -> String {
+        match op {
+            "get" => if self.animator_in_state(cx, ids!(active.on)) { "true".into() } else { "false".into() },
+            "set" => {
+                let target = _arg.trim() == "true";
+                let current = self.animator_in_state(cx, ids!(active.on));
+                if target != current {
+                    self.set_active(cx, target);
+                    let uid = self.widget_uid();
+                    cx.widget_action_with_data(&self.action_data, uid, CheckBoxAction::Change(target));
+                }
+                String::new()
+            }
+            "toggle" => {
+                let current = self.animator_in_state(cx, ids!(active.on));
+                self.set_active(cx, !current);
+                let uid = self.widget_uid();
+                cx.widget_action_with_data(&self.action_data, uid, CheckBoxAction::Change(!current));
+                String::new()
+            }
+            _ => String::new(),
+        }
+    }
 }
 
 impl CheckBoxRef {

--- a/widgets/src/label.rs
+++ b/widgets/src/label.rs
@@ -307,6 +307,17 @@ impl Widget for Label {
         self.text.as_ref().to_string()
     }
 
+    fn controls(&self) -> (String, bool) {
+        ("get".into(), true)
+    }
+
+    fn control(&mut self, _cx: &mut Cx, op: &str, _arg: &str) -> String {
+        match op {
+            "get" => self.text.as_ref().to_string(),
+            _ => String::new(),
+        }
+    }
+
     fn set_text(&mut self, cx: &mut Cx, v: &str) {
         self.text.as_mut_empty().push_str(v);
         self.redraw(cx);

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -1357,6 +1357,25 @@ impl Widget for TextInput {
         self.text.clone()
     }
 
+    fn controls(&self) -> (String, bool) {
+        ("get,set,focus".into(), true)
+    }
+
+    fn control(&mut self, cx: &mut Cx, op: &str, arg: &str) -> String {
+        match op {
+            "get" => self.text.clone(),
+            "set" => {
+                self.set_text(cx, arg);
+                String::new()
+            }
+            "focus" => {
+                cx.set_key_focus(self.draw_bg.area());
+                String::new()
+            }
+            _ => String::new(),
+        }
+    }
+
     fn set_text(&mut self, cx: &mut Cx, text: &str) {
         self.text = self.filter_input(text, true);
         self.set_selection(

--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -4,7 +4,7 @@ use {
         animator::*,
         makepad_derive_widget::*,
         makepad_draw::*,
-        makepad_script::ScriptFnRef,
+        makepad_script::{ScriptFnRef, ScriptObjectRef},
         scroll_bars::ScrollBars,
         widget::*,
         widget_async::{
@@ -123,6 +123,15 @@ pub struct View {
 
     #[live]
     on_render: ScriptFnRef,
+
+    #[live(true)]
+    show_child_controls: bool,
+
+    #[live]
+    on_control: ScriptObjectRef,
+
+    #[rust]
+    control_names: String,
 
     #[rust]
     script_async: ScriptAsyncCalls,
@@ -252,6 +261,27 @@ impl ScriptHook for View {
                     vm,
                     self.scroll_bars.as_object().into(),
                 )));
+            }
+        }
+
+        // Cache on_control handler names for controls() advertisement
+        self.control_names.clear();
+        if !self.on_control.is_zero() {
+            let obj = self.on_control.as_object();
+            let map = vm.bx.heap.map_ref(obj);
+            let mut first = true;
+            for (key, map_val) in map.iter() {
+                if map_val.value.as_object().is_some() {
+                    if let Some(id) = key.as_id() {
+                        if !first { self.control_names.push(','); }
+                        first = false;
+                        id.as_string(|s| {
+                            if let Some(s) = s {
+                                self.control_names.push_str(s);
+                            }
+                        });
+                    }
+                }
             }
         }
 
@@ -813,6 +843,36 @@ impl Widget for View {
         if let Some(scroll_bars) = &mut self.scroll_bars_obj {
             scroll_bars.handle_scroll_event(cx, event, scope, &mut Vec::new());
         }
+    }
+
+    fn controls(&self) -> (String, bool) {
+        (self.control_names.clone(), self.show_child_controls)
+    }
+
+    fn control(&mut self, cx: &mut Cx, op: &str, arg: &str) -> String {
+        if self.on_control.is_zero() {
+            return String::new();
+        }
+        let on_control_obj = self.on_control.as_object();
+        let op_key = ScriptValue::from_id(LiveId::from_str_with_lut(op).unwrap_or(LiveId(0)));
+        cx.with_vm(|vm| {
+            let map = vm.bx.heap.map_ref(on_control_obj);
+            let handler = map.get(&op_key).map(|v| v.value);
+            if let Some(handler) = handler {
+                if handler.as_object().is_some() {
+                    let arg_val = vm.bx.heap.new_string_from_str(arg);
+                    let result = vm.call(handler, &[ScriptValue::from(arg_val)]);
+                    vm.bx.heap.temp_string_with(|heap, out| {
+                        heap.cast_to_string(result, out);
+                        out.to_string()
+                    })
+                } else {
+                    String::new()
+                }
+            } else {
+                String::new()
+            }
+        })
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {

--- a/widgets/src/widget.rs
+++ b/widgets/src/widget.rs
@@ -314,6 +314,13 @@ pub trait Widget: WidgetNode {
         cx.has_key_focus(self.area())
     }
 
+    fn controls(&self) -> (String, bool) { (String::new(), true) }
+
+    fn control(&mut self, cx: &mut Cx, op: &str, arg: &str) -> String {
+        let _ = (cx, op, arg);
+        String::new()
+    }
+
     fn set_disabled(&mut self, _cx: &mut Cx, _disabled: bool) {}
 
     fn disabled(&self, _cx: &Cx) -> bool {
@@ -1094,6 +1101,22 @@ impl WidgetRef {
     pub fn set_key_focus(&self, cx: &mut Cx) {
         if let Some(inner) = self.0.borrow_mut().as_mut() {
             inner.widget.set_key_focus(cx)
+        }
+    }
+
+    pub fn controls(&self) -> (String, bool) {
+        if let Some(inner) = self.0.borrow().as_ref() {
+            inner.widget.controls()
+        } else {
+            (String::new(), true)
+        }
+    }
+
+    pub fn control(&self, cx: &mut Cx, op: &str, arg: &str) -> String {
+        if let Some(inner) = self.0.borrow_mut().as_mut() {
+            inner.widget.control(cx, op, arg)
+        } else {
+            String::new()
         }
     }
 

--- a/widgets/src/widget_tree.rs
+++ b/widgets/src/widget_tree.rs
@@ -1834,7 +1834,7 @@ impl WidgetTree {
         rects
     }
 
-    pub fn compact_dump(&self, cx: &Cx) -> String {
+    pub fn compact_dump(&self, cx: &mut Cx) -> String {
         self.sync_dirty();
         let inner = self.inner.borrow();
 
@@ -1892,6 +1892,7 @@ impl WidgetTree {
             y: i64,
             w: i64,
             h: i64,
+            ctl: String,
         }
 
         #[derive(Clone)]
@@ -1922,6 +1923,7 @@ impl WidgetTree {
         let mut dump_nodes = Vec::new();
         let mut dock_tabs_rows = Vec::<DockTabsRow>::new();
         let mut dock_tab_rows = Vec::<DockTabRow>::new();
+        let mut suppress_set = HashSet::new();
         for (index, node) in inner.nodes.iter().enumerate() {
             let Some(widget) = node.widget.upgrade() else {
                 continue;
@@ -1941,6 +1943,10 @@ impl WidgetTree {
                 if w > 0 && h > 0 {
                     let id_token = live_id_token(id);
                     let ty_token = live_id_token(ty);
+                    let (ctl, show_children) = widget.controls();
+                    if !show_children {
+                        suppress_set.insert(index);
+                    }
                     dump_nodes.push(DumpNode {
                         index,
                         parent: node.parent,
@@ -1950,6 +1956,7 @@ impl WidgetTree {
                         y,
                         w,
                         h,
+                        ctl,
                     });
                 }
             }
@@ -2002,6 +2009,20 @@ impl WidgetTree {
             }
         }
 
+        for node in &mut dump_nodes {
+            if node.ctl.is_empty() {
+                continue;
+            }
+            let mut parent = node.parent;
+            while parent != NONE {
+                if suppress_set.contains(&(parent as usize)) {
+                    node.ctl.clear();
+                    break;
+                }
+                parent = inner.nodes[parent as usize].parent;
+            }
+        }
+
         let mut old_to_new = HashMap::<usize, usize>::new();
         for (new_index, node) in dump_nodes.iter().enumerate() {
             old_to_new.insert(node.index, new_index);
@@ -2019,11 +2040,19 @@ impl WidgetTree {
                 }
                 parent = inner.nodes[parent as usize].parent;
             }
-            let _ = writeln!(
-                &mut out,
-                "{} {} {} {} {} {} {} {}",
-                new_index, parent_index, node.id, node.ty, node.x, node.y, node.w, node.h
-            );
+            if node.ctl.is_empty() {
+                let _ = writeln!(
+                    &mut out,
+                    "{} {} {} {} {} {} {} {}",
+                    new_index, parent_index, node.id, node.ty, node.x, node.y, node.w, node.h
+                );
+            } else {
+                let _ = writeln!(
+                    &mut out,
+                    "{} {} {} {} {} {} {} {} {}",
+                    new_index, parent_index, node.id, node.ty, node.x, node.y, node.w, node.h, node.ctl
+                );
+            }
         }
         if !dock_tabs_rows.is_empty() || !dock_tab_rows.is_empty() {
             let _ = writeln!(
@@ -2105,12 +2134,30 @@ fn get_or_init_state(cx: &mut Cx) -> &mut WidgetTreeState {
     WidgetTreeState::get_or_init(cx)
 }
 
-fn compact_widget_tree_dump_callback(cx: &Cx) -> String {
-    cx.widget_tree().compact_dump(cx)
+fn compact_widget_tree_dump_callback(cx: &mut Cx) -> String {
+    let tree_ptr = cx.widget_tree() as *const WidgetTree;
+    let tree = unsafe { &*tree_ptr };
+    tree.compact_dump(cx)
 }
 
 fn widget_query_callback(cx: &Cx, query: &str) -> Vec<String> {
     cx.widget_tree().query_rects(cx, query)
+}
+
+fn widget_control_callback(cx: &mut Cx, id: &str, op: &str, arg: &str) -> Option<String> {
+    use makepad_live_id::LiveId;
+    let live_id = LiveId::from_str_with_lut(id).unwrap_or(LiveId(0));
+    if live_id == LiveId(0) {
+        return None;
+    }
+    let tree_ptr = cx.widget_tree() as *const WidgetTree;
+    let tree = unsafe { &*tree_ptr };
+    let root_uid = tree.root_uid();
+    let widget = tree.find_within(root_uid, &[live_id]);
+    if widget.is_empty() {
+        return None;
+    }
+    Some(widget.control(cx, op, arg))
 }
 
 pub fn set_ui_root(cx: &mut Cx, ui: &WidgetRef) {
@@ -2118,6 +2165,7 @@ pub fn set_ui_root(cx: &mut Cx, ui: &WidgetRef) {
     state.tree.set_root_widget(ui.clone());
     cx.widget_tree_dump_callback = Some(compact_widget_tree_dump_callback);
     cx.widget_query_callback = Some(widget_query_callback);
+    cx.widget_control_callback = Some(widget_control_callback);
     let root_uid = ui.widget_uid();
     update_global_ui_handle(cx, root_uid);
 }


### PR DESCRIPTION
## Summary
- add widget tree/control APIs for external automation
- add `tools/makepad-control-socket`, `tools/makepad-ui-cli`, and the Python helper
- wire the studio hub and widgets to expose the new control path

## Validation
- cargo check -p makepad-platform -p makepad-widgets -p makepad-studio-hub
