### PR TITLE
studio/runview: wait for app-ready before Wayland swapchain bootstrap

### DIFF
--- a/platform/src/os/shared_framebuf.rs
+++ b/platform/src/os/shared_framebuf.rs
@@ -602,16 +602,25 @@ pub mod aux_chan {
         client_endpoint: &ClientEndpoint,
     ) -> io::Result<LinuxOwnedImage> {
         let makepad_studio_protocol::LinuxSharedImage { drm_format, plane } = image;
-        let dma_buf_fd = client_endpoint.recv().and_then(|(recv_id, recv_fd)| {
-            if recv_id != id {
-                Err(io_error_other(format!(
-                    "recv_fds_from_aux_chan: ID mismatch \
-                     (expected {id:?}, got {recv_id:?}",
-                )))
-            } else {
-                Ok(recv_fd)
+        let mut mismatches = 0usize;
+        let dma_buf_fd = loop {
+            let (recv_id, recv_fd) = client_endpoint.recv()?;
+            if recv_id == id {
+                break recv_fd;
             }
-        })?;
+            mismatches += 1;
+            if mismatches >= 64 {
+                return Err(io_error_other(format!(
+                    "recv_fds_from_aux_chan: ID mismatch \
+                     (expected {id:?}, last got {recv_id:?}, dropped {mismatches} stale images)",
+                )));
+            }
+        };
+        if mismatches != 0 {
+            crate::warning!(
+                "recv_fds_from_aux_chan: dropped {mismatches} stale swapchain images before {id:?}"
+            );
+        }
         Ok(LinuxOwnedImage {
             drm_format: crate::os::linux::dma_buf::DrmFormat {
                 fourcc: drm_format.fourcc,

--- a/studio/desktop/src/desktop_run_view.rs
+++ b/studio/desktop/src/desktop_run_view.rs
@@ -167,6 +167,8 @@ pub struct DesktopRunView {
     #[rust]
     debug_present_ok_count: usize,
     #[rust]
+    app_ready_for_swapchain: bool,
+    #[rust]
     remote_cursor: MouseCursor,
     #[rust]
     is_hovered: bool,
@@ -221,6 +223,7 @@ impl DesktopRunView {
         self.last_swapchain_with_completed_draws = None;
         self.pending_draw = None;
         self.debug_present_ok_count = 0;
+        self.app_ready_for_swapchain = false;
         self.ai_viz_kind = None;
         self.ai_viz_frames_left = 0;
         self.ai_viz_total_frames = 0;
@@ -471,6 +474,9 @@ impl DesktopRunView {
 
         #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
         {
+            if !self.app_ready_for_swapchain {
+                return outbound;
+            }
             let Some(endpoint_slot) = self.aux_chan_host_endpoint.as_ref() else {
                 return outbound;
             };
@@ -543,6 +549,7 @@ impl DesktopRunView {
         // Re-send bootstrap against the current swapchain instead of reallocating.
         // This keeps shared-memory resources stable while still re-triggering
         // WindowGeomChange/Swapchain after app-side readiness.
+        self.app_ready_for_swapchain = true;
         self.debug_present_ok_count = 0;
         self.bootstrap_pending = true;
         self.bootstrap_tick_count = 0;


### PR DESCRIPTION
Summary:
- wait until the app signals readiness before re-sending the Wayland swapchain bootstrap
- drop stale swapchain images from the aux channel until the expected image id arrives

Why:
- PR #934 fixed the initial Wayland bootstrap and control-text input path
- this follow-up keeps the swapchain bootstrap aligned with app readiness and avoids aux-channel image mismatches during rebootstrap

Files:
- platform/src/os/shared_framebuf.rs
- studio/desktop/src/desktop_run_view.rs