### PR TITLE
Support hiding a dock tabs bar

### DIFF
--- a/widgets/src/dock.rs
+++ b/widgets/src/dock.rs
@@ -458,6 +458,8 @@ pub struct DockItemTabs {
     pub selected: usize,
     #[live(true)]
     pub closable: bool,
+    #[live]
+    pub hide_tab_bar: bool,
 }
 
 impl DockItemTabs {
@@ -466,6 +468,7 @@ impl DockItemTabs {
             tabs: self.tabs.clone(),
             selected: self.selected,
             closable: self.closable,
+            hide_tab_bar: self.hide_tab_bar,
         }
     }
 }
@@ -506,6 +509,8 @@ pub enum DockItem {
         tabs: Vec<LiveId>,
         selected: usize,
         closable: bool,
+        #[cfg_attr(feature = "serde", serde(default))]
+        hide_tab_bar: bool,
     },
     Tab {
         name: String,
@@ -534,6 +539,7 @@ impl DockItem {
             tabs,
             selected,
             closable,
+            hide_tab_bar: false,
         }
     }
 
@@ -969,6 +975,7 @@ impl Dock {
                     tabs,
                     selected,
                     closable,
+                    ..
                 } => {
                     if let Some(pos) = tabs.iter().position(|v| *v == tab_id) {
                         let tabs_id = *tabs_id;
@@ -1038,6 +1045,7 @@ impl Dock {
                         DockItem::Tabs {
                             tabs: vec![item],
                             closable: true,
+                            hide_tab_bar: false,
                             selected: 0,
                         },
                     );
@@ -1455,7 +1463,7 @@ impl Widget for Dock {
                     splitter.end(cx);
                 }
                 Some(DrawStackItem::Tabs { id }) => {
-                    if let Some(DockItem::Tabs { selected, .. }) = self.dock_items.get(&id) {
+                    if let Some(DockItem::Tabs { selected, hide_tab_bar, .. }) = self.dock_items.get(&id) {
                         let tab_bar_template = self.tab_bar.clone();
                         let tab_bar = self.tab_bars.get_or_insert(cx, id, |cx| {
                             cx.with_vm(|vm| TabBarWrap {
@@ -1467,9 +1475,14 @@ impl Widget for Dock {
                                 contents_rect: Rect::default(),
                             })
                         });
-                        let walk = tab_bar.tab_bar.walk(cx);
-                        tab_bar.tab_bar.begin(cx, Some(*selected), walk);
-                        stack.push(DrawStackItem::TabLabel { id, index: 0 });
+                        if !*hide_tab_bar {
+                            let walk = tab_bar.tab_bar.walk(cx);
+                            tab_bar.tab_bar.begin(cx, Some(*selected), walk);
+                            stack.push(DrawStackItem::TabLabel { id, index: 0 });
+                        } else {
+                            // Skip the tab bar entirely, go straight to content.
+                            stack.push(DrawStackItem::TabLabel { id, index: usize::MAX });
+                        }
                     } else {
                         panic!()
                     }
@@ -1490,7 +1503,9 @@ impl Widget for Dock {
                                 index: index + 1,
                             });
                         } else {
-                            tab_bar.tab_bar.end(cx);
+                            if index != usize::MAX {
+                                tab_bar.tab_bar.end(cx);
+                            }
                             tab_bar.contents_rect = cx.turtle().rect();
                             if !tabs.is_empty()
                                 && tab_bar


### PR DESCRIPTION
Previously in Makepad 1.0, you were able to implicitly hide a bar of dock tabs by giving the tab(s) an empty name string. That no longer works (which is good), but we still need that functionality, so I made it explicit now via a new `hide_tab_bar` which is false by default.