### PR TITLE
Optimize font loading and add SharedBytes

### DIFF
--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -540,7 +540,9 @@ impl DrawText {
         align: Align,
         text: &str,
     ) -> Rc<LaidoutText> {
-        self.text_style.font_family.ensure_fonts_loaded(cx);
+        self.text_style
+            .font_family
+            .ensure_fonts_loaded_for_text(cx, Some(text));
         let fonts = cx.get_global::<Rc<RefCell<Fonts>>>().clone();
         let mut fonts = fonts.borrow_mut();
 
@@ -822,14 +824,19 @@ impl FontFamily {
         (self.id.0).into()
     }
 
-    fn update_font_definitions(&self, cx: &mut Cx, fonts: &mut Fonts) {
+    fn update_font_definitions(&self, cx: &mut Cx, fonts: &mut Fonts, text: Option<&str>) {
         let mut font_ids = Vec::new();
 
         for member in &self.members {
+            if !font_member_is_needed_for_text(cx, member.handle, text) {
+                continue;
+            }
             let font_id: FontId = (member.handle.index() as u64).into();
 
             if !fonts.is_font_known(font_id) {
-                if let Some(data) = cx.get_resource(member.handle) {
+                let font_data = cx.get_resource_font_bytes(member.handle);
+
+                if let Some(data) = font_data {
                     fonts.define_font(
                         font_id,
                         FontDefinition {
@@ -857,7 +864,7 @@ impl FontFamily {
         );
     }
 
-    fn ensure_fonts_loaded(&self, cx: &mut Cx) {
+    fn ensure_fonts_loaded_for_text(&self, cx: &mut Cx, text: Option<&str>) {
         CxDraw::lazy_construct_fonts(cx);
 
         let family_id = self.to_font_family_id();
@@ -872,6 +879,9 @@ impl FontFamily {
 
         // Slow path: request only the resources needed by this family, then re-check.
         for member in &self.members {
+            if !font_member_is_needed_for_text(cx, member.handle, text) {
+                continue;
+            }
             cx.load_script_resource(member.handle);
         }
         {
@@ -882,8 +892,85 @@ impl FontFamily {
         }
 
         let mut fonts_ref = fonts.borrow_mut();
-        self.update_font_definitions(cx, &mut fonts_ref);
+        self.update_font_definitions(cx, &mut fonts_ref, text);
     }
+
+    fn ensure_fonts_loaded(&self, cx: &mut Cx) {
+        self.ensure_fonts_loaded_for_text(cx, None);
+    }
+}
+
+fn font_member_is_needed_for_text(cx: &Cx, handle: ScriptHandle, text: Option<&str>) -> bool {
+    let Some(text) = text else {
+        return true;
+    };
+    let Some(path) = cx.get_resource_abs_path(handle) else {
+        return true;
+    };
+
+    if is_cjk_fallback_font_path(&path) {
+        return text_has_cjk(text);
+    }
+    if is_emoji_fallback_font_path(&path) {
+        return text_has_emoji(text);
+    }
+    true
+}
+
+fn is_cjk_fallback_font_path(path: &str) -> bool {
+    matches!(
+        resource_basename(path),
+        Some(name)
+            if name.eq_ignore_ascii_case("LXGWWenKaiRegular.ttf")
+                || name.eq_ignore_ascii_case("LXGWWenKaiBold.ttf")
+    )
+}
+
+fn is_emoji_fallback_font_path(path: &str) -> bool {
+    matches!(
+        resource_basename(path),
+        Some(name) if name.eq_ignore_ascii_case("NotoColorEmoji.ttf")
+    )
+}
+
+fn resource_basename(path: &str) -> Option<&str> {
+    path.rsplit(['/', '\\']).next()
+}
+
+fn text_has_cjk(text: &str) -> bool {
+    text.chars().any(is_cjk_char)
+}
+
+fn is_cjk_char(ch: char) -> bool {
+    matches!(
+        ch as u32,
+        0x2E80..=0x2FFF
+            | 0x3000..=0x303F
+            | 0x3040..=0x30FF
+            | 0x3100..=0x312F
+            | 0x31A0..=0x31EF
+            | 0x1100..=0x11FF
+            | 0x3130..=0x318F
+            | 0xAC00..=0xD7AF
+            | 0x3400..=0x4DBF
+            | 0x4E00..=0x9FFF
+            | 0xF900..=0xFAFF
+            | 0xFE30..=0xFE4F
+            | 0xFF00..=0xFFEF
+            | 0x20000..=0x2EE5F
+            | 0x2F800..=0x2FA1F
+    )
+}
+
+fn text_has_emoji(text: &str) -> bool {
+    text.chars().any(is_emoji_char)
+}
+
+fn is_emoji_char(ch: char) -> bool {
+    matches!(
+        ch as u32,
+        0x2600..=0x27BF | 0x200D | 0xFE0F | 0x1F000..=0x1FAFF | 0x1FB00..=0x1FBFF
+    )
 }
 
 impl TextStyle {
@@ -893,6 +980,10 @@ impl TextStyle {
 
     pub fn ensure_fonts_loaded(&self, cx: &mut Cx) {
         self.font_family.ensure_fonts_loaded(cx);
+    }
+
+    pub fn ensure_fonts_loaded_for_text(&self, cx: &mut Cx, text: &str) {
+        self.font_family.ensure_fonts_loaded_for_text(cx, Some(text));
     }
 }
 

--- a/draw/src/text/font_face.rs
+++ b/draw/src/text/font_face.rs
@@ -17,7 +17,7 @@ impl FontFace {
             _pinned: PhantomPinned,
         });
         unsafe {
-            let data: &'static [u8] = mem::transmute(&**inner.data);
+            let data: &'static [u8] = mem::transmute(inner.data.as_slice());
             let ttf_parser_face = ttf_parser::Face::parse(data, index).ok()?;
             let rustybuzz_face = rustybuzz::Face::from_face(ttf_parser_face.clone());
             let inner_ref = Pin::as_mut(&mut inner).get_unchecked_mut();

--- a/draw/src/text/layouter.rs
+++ b/draw/src/text/layouter.rs
@@ -17,6 +17,7 @@ use {
         borrow::Borrow,
         cell::RefCell,
         collections::{HashMap, VecDeque},
+        env,
         hash::{Hash, Hasher},
         mem,
         rc::Rc,
@@ -112,6 +113,7 @@ pub struct Settings {
 
 impl Default for Settings {
     fn default() -> Self {
+        let atlas_size = default_text_atlas_size();
         Self {
             loader: loader::Settings {
                 shaper: shaper::Settings { cache_size: 4096 },
@@ -141,12 +143,43 @@ impl Default for Settings {
                         max_estimated_segments: 1000,
                     },
                     outline_rasterization_mode: rasterizer::OutlineRasterizationMode::Msdf,
-                    atlas_size: Size::new(4096, 4096),
+                    atlas_size,
                 },
             },
             cache_size: 4096,
         }
     }
+}
+
+fn default_text_atlas_size() -> Size<usize> {
+    atlas_size_override_from_env().unwrap_or_else(|| Size::new(2048, 2048))
+}
+
+fn atlas_size_override_from_env() -> Option<Size<usize>> {
+    let raw = env::var("MAKEPAD_TEXT_ATLAS_SIZE").ok()?;
+    parse_text_atlas_size_value(raw.trim())
+}
+
+fn parse_text_atlas_size_value(value: &str) -> Option<Size<usize>> {
+    if value.is_empty() {
+        return None;
+    }
+
+    fn parse_dim(dim: &str) -> Option<usize> {
+        let parsed = dim.trim().parse::<usize>().ok()?;
+        if (256..=8192).contains(&parsed) {
+            Some(parsed)
+        } else {
+            None
+        }
+    }
+
+    if let Some((w, h)) = value.split_once('x').or_else(|| value.split_once('X')) {
+        return Some(Size::new(parse_dim(w)?, parse_dim(h)?));
+    }
+
+    let dim = parse_dim(value)?;
+    Some(Size::new(dim, dim))
 }
 
 #[derive(Debug)]
@@ -939,5 +972,20 @@ impl LaidoutGlyph {
 
     pub fn rasterize(&self, dpx_per_em: f32) -> Option<RasterizedGlyph> {
         self.font.rasterize_glyph(self.id, dpx_per_em)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_text_atlas_size_value, Size};
+
+    #[test]
+    fn parses_text_atlas_size_from_env_value() {
+        assert_eq!(parse_text_atlas_size_value("1024"), Some(Size::new(1024, 1024)));
+        assert_eq!(parse_text_atlas_size_value("1024x2048"), Some(Size::new(1024, 2048)));
+        assert_eq!(parse_text_atlas_size_value("1024X2048"), Some(Size::new(1024, 2048)));
+        assert_eq!(parse_text_atlas_size_value(""), None);
+        assert_eq!(parse_text_atlas_size_value("64"), None);
+        assert_eq!(parse_text_atlas_size_value("bogus"), None);
     }
 }

--- a/draw/src/text/loader.rs
+++ b/draw/src/text/loader.rs
@@ -8,10 +8,11 @@ use {
         shaper,
         shaper::Shaper,
     },
+    crate::makepad_platform::SharedBytes,
     std::{cell::RefCell, collections::HashMap, rc::Rc},
 };
 
-pub type FontData = Rc<Vec<u8>>;
+pub type FontData = SharedBytes;
 
 #[derive(Clone, Debug)]
 pub struct Loader {
@@ -171,4 +172,41 @@ pub struct FontDefinition {
     pub descender_fudge_in_ems: f32,
     /// Font variation axis settings as (tag_u32, value) pairs.
     pub variations: Vec<(u32, f32)>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FontDefinition, Loader};
+    use crate::{
+        makepad_platform::SharedBytes,
+        text::{font::FontId, layouter},
+    };
+    use std::path::PathBuf;
+
+    fn bundled_font_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../widgets/resources/IBMPlexSans-Text.ttf")
+    }
+
+    #[test]
+    fn get_or_load_font_reuses_cached_instance() {
+        let mut loader = Loader::new(layouter::Settings::default().loader);
+        let font_id: FontId = 0xCAFE_BABE_u64.into();
+        let font_data = SharedBytes::from_file_mmap_or_read(bundled_font_path())
+            .expect("font bytes should load");
+
+        loader.define_font(
+            font_id,
+            FontDefinition {
+                data: font_data,
+                index: 0,
+                ascender_fudge_in_ems: -0.1,
+                descender_fudge_in_ems: 0.0,
+                variations: Vec::new(),
+            },
+        );
+
+        let first = loader.get_or_load_font(font_id).clone();
+        let second = loader.get_or_load_font(font_id).clone();
+        assert!(std::rc::Rc::ptr_eq(&first, &second));
+    }
 }

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -20,6 +20,9 @@ makepad-zune-png = { path = "../libs/zune/zune-png", version = "0.5.1" }
 smallvec = { version = "1.15", path = "../libs/smallvec" }
 bitflags = { version = "2.10", path = "../libs/bitflags" }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+memmap2 = "0.9"
+
 [target.wasm32-unknown-unknown.dependencies]
 makepad-wasm-bridge = { path = "../libs/wasm_bridge", version = "1.0.0" }
 

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -21,6 +21,7 @@ use {
         makepad_math::{Rect, Vec2d},
         makepad_network::HttpRequest,
         makepad_script::value::ScriptHandle,
+        shared_bytes::SharedBytes,
         texture::{Texture, TextureId},
         window::WindowId,
     },
@@ -400,6 +401,37 @@ impl Cx {
         }
 
         None
+    }
+
+    /// Get the absolute path registered for a script resource handle.
+    pub fn get_resource_abs_path(&self, handle: ScriptHandle) -> Option<String> {
+        let resources = self.script_data.resources.resources.borrow();
+        resources
+            .iter()
+            .find(|res| res.handle == handle)
+            .map(|res| res.abs_path.clone())
+    }
+
+    /// Get resource data intended for font parsing.
+    ///
+    /// This tries mmap for local file-backed resources, then falls back to
+    /// already-loaded resource bytes (required for wasm/network-backed assets).
+    pub fn get_resource_font_bytes(&mut self, handle: ScriptHandle) -> Option<SharedBytes> {
+        let resource_path = {
+            let resources = self.script_data.resources.resources.borrow();
+            resources
+                .iter()
+                .find(|res| res.handle == handle)
+                .map(|res| res.abs_path.clone())
+        };
+
+        if let Some(path) = resource_path {
+            if let Ok(bytes) = SharedBytes::from_file_mmap_or_read(&path) {
+                return Some(bytes);
+            }
+        }
+
+        self.get_resource(handle).map(SharedBytes::from_owned)
     }
 
     pub fn null_texture(&self) -> Texture {

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -9,6 +9,7 @@ pub mod log;
 mod cx;
 mod arc_string_mut;
 mod cx_api;
+mod shared_bytes;
 
 pub mod action;
 pub mod game_input;
@@ -186,6 +187,7 @@ pub use {
         },
         midi::*,
         os::*,
+        shared_bytes::{MappedBytes, SharedBytes, SharedBytesStats},
         script::vm::*,
         texture::{
             Texture, TextureAnimation, TextureFormat, TextureId, TextureSize, TextureUpdated,

--- a/platform/src/script/res.rs
+++ b/platform/src/script/res.rs
@@ -180,6 +180,39 @@ fn load_file_direct(abs_path: &str) -> Option<Result<Rc<Vec<u8>>, String>> {
     }
 }
 
+fn should_skip_eager_resource_load(abs_path: &str) -> bool {
+    is_heavy_bundled_fallback_font_path(abs_path)
+}
+
+fn is_heavy_bundled_fallback_font_path(path: &str) -> bool {
+    if !is_widgets_resources_path(path) {
+        return false;
+    }
+    matches!(
+        resource_basename(path),
+        Some(name)
+            if name.eq_ignore_ascii_case("LXGWWenKaiRegular.ttf")
+                || name.eq_ignore_ascii_case("LXGWWenKaiBold.ttf")
+                || name.eq_ignore_ascii_case("NotoColorEmoji.ttf")
+    )
+}
+
+fn is_widgets_resources_path(path: &str) -> bool {
+    let mut prev_is_widgets = false;
+    for component in path.split(['/', '\\']) {
+        let is_resources = component.eq_ignore_ascii_case("resources");
+        if prev_is_widgets && is_resources {
+            return true;
+        }
+        prev_is_widgets = component.eq_ignore_ascii_case("widgets");
+    }
+    false
+}
+
+fn resource_basename(path: &str) -> Option<&str> {
+    path.rsplit(['/', '\\']).next()
+}
+
 impl Cx {
     fn load_script_resource_impl(
         &mut self,
@@ -311,7 +344,11 @@ impl Cx {
 
         let handles = {
             let resources = self.script_data.resources.resources.borrow();
-            resources.iter().map(|res| res.handle).collect::<Vec<_>>()
+            resources
+                .iter()
+                .filter(|res| !should_skip_eager_resource_load(&res.abs_path))
+                .map(|res| res.handle)
+                .collect::<Vec<_>>()
         };
 
         for handle in handles {
@@ -321,6 +358,30 @@ impl Cx {
                 &crate_manifests,
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_skip_eager_resource_load;
+
+    #[test]
+    fn skips_only_heavy_widgets_fallback_fonts() {
+        assert!(should_skip_eager_resource_load(
+            "/tmp/widgets/resources/LXGWWenKaiRegular.ttf"
+        ));
+        assert!(should_skip_eager_resource_load(
+            "/tmp/widgets/resources/LXGWWenKaiBold.ttf"
+        ));
+        assert!(should_skip_eager_resource_load(
+            "/tmp/widgets/resources/NotoColorEmoji.ttf"
+        ));
+        assert!(!should_skip_eager_resource_load(
+            "/tmp/widgets/resources/IBMPlexSans-Text.ttf"
+        ));
+        assert!(!should_skip_eager_resource_load(
+            "/tmp/app/resources/LXGWWenKaiRegular.ttf"
+        ));
     }
 }
 

--- a/platform/src/shared_bytes.rs
+++ b/platform/src/shared_bytes.rs
@@ -1,0 +1,184 @@
+use std::{
+    fmt, io,
+    path::Path,
+    rc::Rc,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::fs::File;
+
+#[cfg(not(target_arch = "wasm32"))]
+use memmap2::MmapOptions;
+
+#[derive(Clone)]
+pub enum SharedBytes {
+    Owned(Rc<Vec<u8>>),
+    Mapped(Rc<MappedBytes>),
+}
+
+impl SharedBytes {
+    pub fn from_owned(data: Rc<Vec<u8>>) -> Self {
+        OWNED_LOADS.fetch_add(1, Ordering::Relaxed);
+        Self::Owned(data)
+    }
+
+    pub fn from_vec(data: Vec<u8>) -> Self {
+        Self::from_owned(Rc::new(data))
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        match self {
+            SharedBytes::Owned(data) => data.as_slice(),
+            SharedBytes::Mapped(data) => data.as_slice(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.as_slice().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn from_file_mmap_or_read(path: impl AsRef<Path>) -> io::Result<Self> {
+        let path = path.as_ref();
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            match MappedBytes::map_file(path) {
+                Ok(Some(mapped)) => {
+                    MMAP_HITS.fetch_add(1, Ordering::Relaxed);
+                    return Ok(Self::Mapped(Rc::new(mapped)));
+                }
+                Ok(None) => {
+                    MMAP_FALLBACKS.fetch_add(1, Ordering::Relaxed);
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("cannot mmap empty file: {}", path.display()),
+                    ));
+                }
+                Err(err) => {
+                    MMAP_FALLBACKS.fetch_add(1, Ordering::Relaxed);
+                    return Err(err);
+                }
+            }
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            MMAP_FALLBACKS.fetch_add(1, Ordering::Relaxed);
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "mmap font loading is unsupported on wasm32",
+            ))
+        }
+    }
+
+    pub fn stats() -> SharedBytesStats {
+        SharedBytesStats {
+            mmap_hits: MMAP_HITS.load(Ordering::Relaxed),
+            mmap_fallbacks: MMAP_FALLBACKS.load(Ordering::Relaxed),
+            owned_loads: OWNED_LOADS.load(Ordering::Relaxed),
+        }
+    }
+
+    pub fn reset_stats() {
+        MMAP_HITS.store(0, Ordering::Relaxed);
+        MMAP_FALLBACKS.store(0, Ordering::Relaxed);
+        OWNED_LOADS.store(0, Ordering::Relaxed);
+    }
+}
+
+impl fmt::Debug for SharedBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SharedBytes::Owned(data) => f
+                .debug_struct("SharedBytes::Owned")
+                .field("len", &data.len())
+                .finish(),
+            SharedBytes::Mapped(data) => f
+                .debug_struct("SharedBytes::Mapped")
+                .field("len", &data.len())
+                .finish(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SharedBytesStats {
+    pub mmap_hits: u64,
+    pub mmap_fallbacks: u64,
+    pub owned_loads: u64,
+}
+
+#[derive(Debug)]
+pub struct MappedBytes {
+    #[cfg(not(target_arch = "wasm32"))]
+    mmap: memmap2::Mmap,
+    #[cfg(target_arch = "wasm32")]
+    _unused: (),
+}
+
+impl MappedBytes {
+    #[cfg(not(target_arch = "wasm32"))]
+    fn map_file(path: &Path) -> io::Result<Option<Self>> {
+        let file = File::open(path)?;
+        if file.metadata()?.len() == 0 {
+            return Ok(None);
+        }
+        let mmap = unsafe { MmapOptions::new().map(&file)? };
+        Ok(Some(Self { mmap }))
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.mmap.as_ref()
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            &[]
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.as_slice().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+static MMAP_HITS: AtomicU64 = AtomicU64::new(0);
+static MMAP_FALLBACKS: AtomicU64 = AtomicU64::new(0);
+static OWNED_LOADS: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(test)]
+mod tests {
+    use super::SharedBytes;
+    use std::path::PathBuf;
+
+    fn bundled_font_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../widgets/resources/IBMPlexSans-Text.ttf")
+    }
+
+    #[test]
+    fn from_file_mmap_or_read_matches_fs_read() {
+        let path = bundled_font_path();
+        let expected = std::fs::read(&path).expect("font file should be readable");
+        let bytes = SharedBytes::from_file_mmap_or_read(&path).expect("font bytes should load");
+        assert_eq!(bytes.as_slice(), expected.as_slice());
+        assert!(matches!(bytes, SharedBytes::Mapped(_)));
+        assert!(!bytes.is_empty());
+    }
+
+    #[test]
+    fn from_file_mmap_or_read_errors_for_missing_file() {
+        let path = bundled_font_path().with_extension("missing");
+        let err = SharedBytes::from_file_mmap_or_read(&path).expect_err("missing file should fail");
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
+}


### PR DESCRIPTION
Introduce selective font loading and a SharedBytes abstraction with mmap support to reduce memory and IO overhead when handling fonts.

Key changes:
- Add SharedBytes (with MappedBytes using memmap2) and stats; switch FontData to SharedBytes and update loader/loader tests.
- Platform: add memmap2 dependency (non-wasm), new platform API helpers get_resource_abs_path and get_resource_font_bytes to prefer mmap'ed files and fall back to owned bytes.
- Font family/load changes: ensure_fonts_loaded_for_text and update_font_definitions now accept optional text to load only needed fallback fonts (CJK/emoji) based on text content and resource basename heuristics.
- Avoid eager loading of heavy bundled fallback fonts (LXGWWenKai*, NotoColorEmoji.ttf) when loading all script resources.
- Add env override MAKEPAD_TEXT_ATLAS_SIZE for text atlas size parsing and tests; add related parsing helpers and tests.
- Minor fixes: safer transmute for font_face data slice and several unit tests to validate behavior.

Overall this reduces unnecessary font resource reads/mmap usage and allows tuning text atlas size via environment.