### PR TITLE
CodeEditor Fix for Wasm: Use fallback cell size when glyphs missing

### DIFF
--- a/code_editor/src/code_editor.rs
+++ b/code_editor/src/code_editor.rs
@@ -321,10 +321,21 @@ impl CodeEditor {
         let text = self
             .draw_text
             .layout(cx, 0.0, 0.0, None, false, Align::default(), "!");
-        let first_row = text.rows.first().unwrap();
-        let first_glyph = first_row.glyphs.first().unwrap();
-        let width_in_lpxs = first_glyph.advance_in_lpxs();
-        let height_in_lpxs = first_glyph.ascender_in_lpxs() - first_glyph.descender_in_lpxs();
+        let (width_in_lpxs, height_in_lpxs) = if let Some(first_glyph) = text
+            .rows
+            .first()
+            .and_then(|first_row| first_row.glyphs.first())
+        {
+            (
+                first_glyph.advance_in_lpxs(),
+                first_glyph.ascender_in_lpxs() - first_glyph.descender_in_lpxs(),
+            )
+        } else {
+            // On wasm the code font can still be loading on the first draw.
+            // Fall back to a reasonable monospace cell size instead of aborting.
+            let font_size = self.draw_text.text_style.font_size.max(1.0);
+            (font_size * 0.6, font_size)
+        };
         let line_spacing_in_lpxs = height_in_lpxs * self.draw_text.text_style.line_spacing;
         self.cell_size = dvec2(width_in_lpxs as f64, line_spacing_in_lpxs as f64);
         self.cell_offset_y = ((line_spacing_in_lpxs - height_in_lpxs) / 2.0) as f64;


### PR DESCRIPTION
Replace unwraps when querying the first glyph with safe handling and provide a fallback monospace cell size if no glyph is available (e.g. on wasm while fonts are still loading). Computes a reasonable width/height from the current font_size (width = 0.6 * font_size, height = font_size) so the editor can render on first draw instead of aborting. Keeps existing cell_size and cell_offset_y calculations based on the chosen dimensions.

Needed for:
<img width="917" height="942" alt="image" src="https://github.com/user-attachments/assets/5a6124eb-48e4-400e-8556-fffc29677a29" />
