### PR TITLE
Fix windows build error

### DIFF
--- a/libs/windows/windows-rs/src/Windows/mod.rs
+++ b/libs/windows/windows-rs/src/Windows/mod.rs
@@ -43881,13 +43881,6 @@ impl IRecordInfo_Vtbl {
 impl windows_core::RuntimeName for IRecordInfo {}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct PARAMDESC {
-    pub pparamdescex: *mut PARAMDESCEX,
-    pub wParamFlags: PARAMFLAGS,
-}
-#[repr(C)]
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
 pub struct PARAMDESCEX {
     pub cBytes: u32,
     pub varDefaultValue: super::Variant::VARIANT,
@@ -43895,11 +43888,12 @@ pub struct PARAMDESCEX {
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PARAMFLAGS(pub u16);
+#[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
-impl Default for PARAMDESC {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PARAMDESC {
+    pub pparamdescex: *mut PARAMDESCEX,
+    pub wParamFlags: PARAMFLAGS,
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
 impl Clone for PARAMDESCEX {
@@ -43910,6 +43904,12 @@ impl Clone for PARAMDESCEX {
 impl PARAMFLAGS {
     pub const fn contains(&self, other: Self) -> bool {
         self.0 & other.0 == other.0
+    }
+}
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
+impl Default for PARAMDESC {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
     }
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
@@ -45614,6 +45614,7 @@ pub const WS_CLIPSIBLINGS: WINDOW_STYLE = WINDOW_STYLE(67108864u32);
 pub const WS_EX_ACCEPTFILES: WINDOW_EX_STYLE = WINDOW_EX_STYLE(16u32);
 pub const WS_EX_APPWINDOW: WINDOW_EX_STYLE = WINDOW_EX_STYLE(262144u32);
 pub const WS_EX_LAYERED: WINDOW_EX_STYLE = WINDOW_EX_STYLE(524288u32);
+pub const WS_EX_TOOLWINDOW: WINDOW_EX_STYLE = WINDOW_EX_STYLE(128u32);
 pub const WS_EX_TOPMOST: WINDOW_EX_STYLE = WINDOW_EX_STYLE(8u32);
 pub const WS_EX_WINDOWEDGE: WINDOW_EX_STYLE = WINDOW_EX_STYLE(256u32);
 pub const WS_MAXIMIZEBOX: WINDOW_STYLE = WINDOW_STYLE(65536u32);

--- a/libs/windows/windows-rs/src/Windows/mod.rs
+++ b/libs/windows/windows-rs/src/Windows/mod.rs
@@ -29378,6 +29378,22 @@ pub unsafe fn DwmExtendFrameIntoClientArea(hwnd: super::super::Foundation::HWND,
     windows_core::link!("dwmapi.dll" "system" fn DwmExtendFrameIntoClientArea(hwnd : super::super::Foundation:: HWND, pmarinset : *const super::super::UI::Controls:: MARGINS) -> windows_core::HRESULT);
     unsafe { DwmExtendFrameIntoClientArea(hwnd, pmarinset).ok() }
 }
+#[inline]
+pub unsafe fn DwmSetWindowAttribute(hwnd: super::super::Foundation::HWND, dwattribute: DWMWINDOWATTRIBUTE, pvattribute: *const core::ffi::c_void, cbattribute: u32) -> windows_core::Result<()> {
+    windows_core::link!("dwmapi.dll" "system" fn DwmSetWindowAttribute(hwnd : super::super::Foundation:: HWND, dwattribute : u32, pvattribute : *const core::ffi::c_void, cbattribute : u32) -> windows_core::HRESULT);
+    unsafe { DwmSetWindowAttribute(hwnd, dwattribute.0 as _, pvattribute, cbattribute).ok() }
+}
+pub const DWMSBT_MAINWINDOW: DWM_SYSTEMBACKDROP_TYPE = DWM_SYSTEMBACKDROP_TYPE(2i32);
+pub const DWMSBT_NONE: DWM_SYSTEMBACKDROP_TYPE = DWM_SYSTEMBACKDROP_TYPE(1i32);
+pub const DWMSBT_TABBEDWINDOW: DWM_SYSTEMBACKDROP_TYPE = DWM_SYSTEMBACKDROP_TYPE(4i32);
+pub const DWMSBT_TRANSIENTWINDOW: DWM_SYSTEMBACKDROP_TYPE = DWM_SYSTEMBACKDROP_TYPE(3i32);
+pub const DWMWA_SYSTEMBACKDROP_TYPE: DWMWINDOWATTRIBUTE = DWMWINDOWATTRIBUTE(38i32);
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct DWMWINDOWATTRIBUTE(pub i32);
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct DWM_SYSTEMBACKDROP_TYPE(pub i32);
 }
 pub mod Dxgi{
 #[inline]
@@ -43863,9 +43879,6 @@ impl IRecordInfo_Vtbl {
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
 impl windows_core::RuntimeName for IRecordInfo {}
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct PARAMFLAGS(pub u16);
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -43879,11 +43892,9 @@ pub struct PARAMDESCEX {
     pub cBytes: u32,
     pub varDefaultValue: super::Variant::VARIANT,
 }
-impl PARAMFLAGS {
-    pub const fn contains(&self, other: Self) -> bool {
-        self.0 & other.0 == other.0
-    }
-}
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PARAMFLAGS(pub u16);
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
 impl Default for PARAMDESC {
     fn default() -> Self {
@@ -43896,16 +43907,21 @@ impl Clone for PARAMDESCEX {
         unsafe { core::mem::transmute_copy(self) }
     }
 }
-impl core::ops::BitOr for PARAMFLAGS {
-    type Output = Self;
-    fn bitor(self, other: Self) -> Self {
-        Self(self.0 | other.0)
+impl PARAMFLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
 impl Default for PARAMDESCEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
+    }
+}
+impl core::ops::BitOr for PARAMFLAGS {
+    type Output = Self;
+    fn bitor(self, other: Self) -> Self {
+        Self(self.0 | other.0)
     }
 }
 impl core::ops::BitAnd for PARAMFLAGS {
@@ -45108,6 +45124,11 @@ pub unsafe fn SetCursor(hcursor: Option<HCURSOR>) -> HCURSOR {
     unsafe { SetCursor(hcursor.unwrap_or(core::mem::zeroed()) as _) }
 }
 #[inline]
+pub unsafe fn SetLayeredWindowAttributes(hwnd: super::super::Foundation::HWND, crkey: super::super::Foundation::COLORREF, balpha: u8, dwflags: LAYERED_WINDOW_ATTRIBUTES_FLAGS) -> windows_core::Result<()> {
+    windows_core::link!("user32.dll" "system" fn SetLayeredWindowAttributes(hwnd : super::super::Foundation:: HWND, crkey : super::super::Foundation:: COLORREF, balpha : u8, dwflags : LAYERED_WINDOW_ATTRIBUTES_FLAGS) -> windows_core::BOOL);
+    unsafe { SetLayeredWindowAttributes(hwnd, crkey, balpha, dwflags).ok() }
+}
+#[inline]
 pub unsafe fn SetTimer(hwnd: Option<super::super::Foundation::HWND>, nidevent: usize, uelapse: u32, lptimerfunc: TIMERPROC) -> usize {
     windows_core::link!("user32.dll" "system" fn SetTimer(hwnd : super::super::Foundation:: HWND, nidevent : usize, uelapse : u32, lptimerfunc : TIMERPROC) -> usize);
     unsafe { SetTimer(hwnd.unwrap_or(core::mem::zeroed()) as _, nidevent, uelapse, lptimerfunc) }
@@ -45254,6 +45275,43 @@ pub const IDC_SIZENS: windows_core::PCWSTR = windows_core::PCWSTR(32645u16 as _)
 pub const IDC_SIZENWSE: windows_core::PCWSTR = windows_core::PCWSTR(32642u16 as _);
 pub const IDC_SIZEWE: windows_core::PCWSTR = windows_core::PCWSTR(32644u16 as _);
 pub const IDI_WINLOGO: windows_core::PCWSTR = windows_core::PCWSTR(32517u32 as _);
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct LAYERED_WINDOW_ATTRIBUTES_FLAGS(pub u32);
+impl LAYERED_WINDOW_ATTRIBUTES_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
+impl core::ops::BitOr for LAYERED_WINDOW_ATTRIBUTES_FLAGS {
+    type Output = Self;
+    fn bitor(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+}
+impl core::ops::BitAnd for LAYERED_WINDOW_ATTRIBUTES_FLAGS {
+    type Output = Self;
+    fn bitand(self, other: Self) -> Self {
+        Self(self.0 & other.0)
+    }
+}
+impl core::ops::BitOrAssign for LAYERED_WINDOW_ATTRIBUTES_FLAGS {
+    fn bitor_assign(&mut self, other: Self) {
+        self.0.bitor_assign(other.0)
+    }
+}
+impl core::ops::BitAndAssign for LAYERED_WINDOW_ATTRIBUTES_FLAGS {
+    fn bitand_assign(&mut self, other: Self) {
+        self.0.bitand_assign(other.0)
+    }
+}
+impl core::ops::Not for LAYERED_WINDOW_ATTRIBUTES_FLAGS {
+    type Output = Self;
+    fn not(self) -> Self {
+        Self(self.0.not())
+    }
+}
+pub const LWA_ALPHA: LAYERED_WINDOW_ATTRIBUTES_FLAGS = LAYERED_WINDOW_ATTRIBUTES_FLAGS(2u32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct MSG {
@@ -45555,6 +45613,7 @@ pub const WS_CLIPCHILDREN: WINDOW_STYLE = WINDOW_STYLE(33554432u32);
 pub const WS_CLIPSIBLINGS: WINDOW_STYLE = WINDOW_STYLE(67108864u32);
 pub const WS_EX_ACCEPTFILES: WINDOW_EX_STYLE = WINDOW_EX_STYLE(16u32);
 pub const WS_EX_APPWINDOW: WINDOW_EX_STYLE = WINDOW_EX_STYLE(262144u32);
+pub const WS_EX_LAYERED: WINDOW_EX_STYLE = WINDOW_EX_STYLE(524288u32);
 pub const WS_EX_TOPMOST: WINDOW_EX_STYLE = WINDOW_EX_STYLE(8u32);
 pub const WS_EX_WINDOWEDGE: WINDOW_EX_STYLE = WINDOW_EX_STYLE(256u32);
 pub const WS_MAXIMIZEBOX: WINDOW_STYLE = WINDOW_STYLE(65536u32);

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -76,15 +76,14 @@ use {
                         HTRIGHT, HTSYSMENU, HTTOP, HTTOPLEFT, HTTOPRIGHT, HWND_NOTOPMOST,
                         HWND_TOPMOST, LWA_ALPHA, SWP_NOMOVE, SWP_NOSIZE, SW_MAXIMIZE,
                         SW_MINIMIZE, SW_RESTORE, SW_SHOW, WA_ACTIVE, WINDOWPLACEMENT,
-                        WINDOW_EX_STYLE, WM_ACTIVATE, WM_CHAR, WM_CLOSE, WM_DESTROY,
-                        WM_DPICHANGED,
+                        WM_ACTIVATE, WM_CHAR, WM_CLOSE, WM_DESTROY, WM_DPICHANGED,
                         WM_ENTERSIZEMOVE, WM_ERASEBKGND, WM_EXITSIZEMOVE, WM_IME_STARTCOMPOSITION,
                         WM_KEYDOWN, WM_KEYUP, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN,
                         WM_MBUTTONUP, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_NCCALCSIZE, WM_NCHITTEST,
                         WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SIZE, WM_SYSKEYDOWN, WM_SYSKEYUP,
                         WM_XBUTTONDOWN, WM_XBUTTONUP, WS_CLIPCHILDREN, WS_CLIPSIBLINGS,
                         WS_EX_ACCEPTFILES, WS_EX_APPWINDOW, WS_EX_LAYERED, WS_EX_TOPMOST,
-                        WS_EX_WINDOWEDGE, WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_POPUP, WS_SIZEBOX,
+                        WS_EX_WINDOWEDGE, WS_EX_TOOLWINDOW, WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_POPUP, WS_SIZEBOX,
                         WS_SYSMENU,
                     },
                 },
@@ -123,7 +122,6 @@ unsafe fn SetWindowCompositionAttribute(hwnd: HWND, data: *mut WindowComposition
     unsafe { SetWindowCompositionAttribute(hwnd, data) }
 }
 
-const WS_EX_TOOLWINDOW_FALLBACK: WINDOW_EX_STYLE = WINDOW_EX_STYLE(0x0000_0080);
 /*
 // Copied from Microsoft so it refers to the right IDropTarget
 #[allow(non_snake_case)]
@@ -229,7 +227,7 @@ impl Win32Window {
         let title = encode_wide("Makepad Popup");
 
         let style = WS_POPUP | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
-        let style_ex = WS_EX_TOPMOST | WS_EX_TOOLWINDOW_FALLBACK;
+        let style_ex = WS_EX_TOPMOST | WS_EX_TOOLWINDOW;
 
         let dpi = with_win32_app(|app| app.dpi_functions.system_dpi_factor() as f64);
         let x = (position.x * dpi) as i32;

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -18,8 +18,14 @@ use {
             //core::Result as coreResult,
             //core::HRESULT,
             Win32::{
-                Foundation::{HANDLE, HGLOBAL, HWND, LPARAM, LRESULT, POINT, POINTL, RECT, WPARAM},
-                Graphics::{Dwm::DwmExtendFrameIntoClientArea, Gdi::ScreenToClient},
+                Foundation::{HANDLE, HGLOBAL, HWND, LPARAM, LRESULT, POINT, POINTL, RECT, WPARAM, COLORREF},
+                Graphics::{
+                    Dwm::{
+                        DwmExtendFrameIntoClientArea, DwmSetWindowAttribute, DWMWA_SYSTEMBACKDROP_TYPE,
+                        DWMSBT_NONE, DWMSBT_MAINWINDOW, DWMSBT_TRANSIENTWINDOW, DWMSBT_TABBEDWINDOW,
+                    }, 
+                    Gdi::ScreenToClient
+                },
                 System::{
                     DataExchange::{
                         CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard,
@@ -111,19 +117,10 @@ struct WindowCompositionAttribData {
     cb_data: usize,
 }
 
-#[link(name = "user32")]
-unsafe extern "system" {
-    fn SetWindowCompositionAttribute(hwnd: HWND, data: *mut WindowCompositionAttribData) -> i32;
-}
-
-#[link(name = "dwmapi")]
-unsafe extern "system" {
-    fn DwmSetWindowAttribute(
-        hwnd: HWND,
-        dw_attribute: u32,
-        pv_attribute: *const c_void,
-        cb_attribute: u32,
-    ) -> i32;
+#[inline]
+unsafe fn SetWindowCompositionAttribute(hwnd: HWND, data: *mut WindowCompositionAttribData) -> windows_core::BOOL {
+    windows_core::link!("user32.dll" "system" fn SetWindowCompositionAttribute(hwnd : HWND, data : *mut WindowCompositionAttribData) -> windows_core::BOOL);
+    unsafe { SetWindowCompositionAttribute(hwnd, data) }
 }
 
 const WS_EX_TOOLWINDOW_FALLBACK: WINDOW_EX_STYLE = WINDOW_EX_STYLE(0x0000_0080);
@@ -973,13 +970,6 @@ impl Win32Window {
     }
 
     pub fn apply_window_visuals(&mut self, visuals: WindowVisuals) {
-        const DWM_ATTRIBUTE_SYSTEM_BACKDROP_TYPE: u32 = 38;
-        const S_OK: i32 = 0;
-        const DWMSBT_NONE: i32 = 1;
-        const DWMSBT_MAINWINDOW: i32 = 2;
-        const DWMSBT_TRANSIENTWINDOW: i32 = 3;
-        const DWMSBT_TABBEDWINDOW: i32 = 4;
-
         const WCA_ACCENT_POLICY: u32 = 19;
         const ACCENT_DISABLED: u32 = 0;
         const ACCENT_ENABLE_BLURBEHIND: u32 = 3;
@@ -1003,7 +993,7 @@ impl Win32Window {
                 ex_style &= !WS_EX_LAYERED.0;
             }
             SetWindowLongPtrW(self.hwnd, GWL_EXSTYLE, ex_style as isize);
-            SetLayeredWindowAttributes(self.hwnd, 0, 255, LWA_ALPHA).unwrap();
+            let _ = SetLayeredWindowAttributes(self.hwnd, COLORREF(0), 255, LWA_ALPHA);
 
             let margins = if visuals.transparent {
                 MARGINS {
@@ -1026,8 +1016,8 @@ impl Win32Window {
         let hr = unsafe {
             DwmSetWindowAttribute(
                 self.hwnd,
-                DWM_ATTRIBUTE_SYSTEM_BACKDROP_TYPE,
-                &backdrop as *const _ as *const c_void,
+                DWMWA_SYSTEMBACKDROP_TYPE,
+                &(backdrop.0) as *const _ as *const c_void,
                 std::mem::size_of::<i32>() as u32,
             )
         };
@@ -1044,7 +1034,7 @@ impl Win32Window {
         };
         let mut accent = AccentPolicy {
             accent_state,
-            accent_flags: if hr == S_OK { 0x20 } else { 0 },
+            accent_flags: if hr.is_ok() { 0x20 } else { 0 },
             gradient_color,
             animation_id: 0,
         };
@@ -1054,7 +1044,7 @@ impl Win32Window {
             cb_data: std::mem::size_of::<AccentPolicy>(),
         };
         unsafe {
-            SetWindowCompositionAttribute(self.hwnd, &mut data);
+            let _ = SetWindowCompositionAttribute(self.hwnd, &mut data);
         }
     }
 


### PR DESCRIPTION
## Overview
This PR fixes build errors for windows:
<img width="2096" height="808" alt="image" src="https://github.com/user-attachments/assets/0bae0324-af4b-49e8-8e2f-b591beead0b6" />

---

## Modification
1. **Fix compilation/runtime issues in `platform/src/os/windows/win32_window.rs`**
2. **Regenerate `windows-rs` to expose required Win32 APIs and constants**

---

The local `windows-rs` bindings were regenerated so that the following Win32 symbols are available for use in the project:

- `DwmSetWindowAttribute` (DWM API function)
- `DWMWA_SYSTEMBACKDROP_TYPE` (DWM attribute constant)
- `DWMSBT_NONE`
- `DWMSBT_MAINWINDOW`
- `DWMSBT_TRANSIENTWINDOW`
- `DWMSBT_TABBEDWINDOW`
- `SetLayeredWindowAttributes`
- `COLORREF` (GDI color type used by `SetLayeredWindowAttributes`)
- `LWA_ALPHA`
- `LAYERED_WINDOW_ATTRIBUTES_FLAGS`
- `WS_EX_LAYERED`

These exports are required for the Windows visual/backdrop code paths used by the platform layer.
