### PR TITLE
platform: rework custom MSE playback sessions

### DIFF
--- a/platform/src/event/video_playback.rs
+++ b/platform/src/event/video_playback.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use crate::makepad_live_id::LiveId;
 use crate::texture::Texture;
 use crate::video::{VideoFormatId, VideoInputId};
-use crate::TextureId;
+use crate::{MediaPlaybackSessionId, TextureId, VideoFrameSessionId};
 
 #[derive(Clone, Debug)]
 pub struct VideoPlaybackPreparedEvent {
@@ -73,6 +73,14 @@ pub enum VideoSource {
     Network(String),
     Filesystem(String),
     Camera(VideoInputId, VideoFormatId),
+    PlaybackSession(MediaPlaybackSessionId),
+    Session(VideoFrameSessionId),
+}
+
+impl VideoSource {
+    pub fn is_session(&self) -> bool {
+        matches!(self, Self::PlaybackSession(..) | Self::Session(..))
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -61,6 +61,8 @@ pub mod file_dialogs;
 mod media_api;
 mod media_host;
 mod media_plugin;
+mod playback_session;
+mod video_session;
 
 pub mod ui_runner;
 
@@ -181,9 +183,21 @@ pub use {
         media_host::{MediaControlBridge, MediaEventBridge, MediaTextureBridge, MediaTextureInfo},
         media_plugin::{
             media_plugin, media_video_capabilities, merge_video_capabilities,
-            register_media_plugin, FrameDecoderCodec, FrameDecoderConfig, MediaPlugin,
-            MediaSoftwareVideoPlayer, MediaVideoEncoder, MseAppendResult, MseDecodedFrame,
-            MsePlayer, VideoFrameDecoder,
+            register_media_plugin, FrameDecoderCodec, FrameDecoderConfig,
+            MediaPlaybackSession, MediaPlugin, MediaVideoEncoder, MseAudioTrackInfo,
+            MseDecodedAudioFrame, MseDecodedFrame, MseEngineOutput, MseInitMetadata,
+            MsePlaybackEngine, MseVideoTrackInfo, PlaybackPrepared, VideoFrameDecoder,
+        },
+        playback_session::{
+            mix_active_media_audio, register_active_media_audio,
+            register_media_playback_session, take_registered_media_playback_session,
+            unregister_active_media_audio, unregister_media_playback_session,
+            MediaPlaybackSessionId,
+        },
+        video_session::{
+            register_video_frame_session, take_registered_video_frame_session,
+            unregister_video_frame_session, VideoFrameSession, VideoFrameSessionId,
+            VideoSessionState,
         },
         midi::*,
         os::*,

--- a/platform/src/media_plugin.rs
+++ b/platform/src/media_plugin.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        AudioBuffer, AudioInfo,
         event::video_playback::VideoSource,
         makepad_live_id::LiveId,
         texture::TextureId,
@@ -17,45 +18,83 @@ use crate::video_decode::yuv::YuvPlaneData;
 pub struct YuvPlaneData;
 
 // ---------------------------------------------------------------------------
-// MSE (Media Source Extensions) player trait
+// Custom MSE (Media Source Extensions) playback engine
 // ---------------------------------------------------------------------------
 
-/// Result of an `MsePlayer::append_data()` call.
-pub struct MseAppendResult {
-    /// True when an init segment (ftyp+moov) was successfully parsed.
-    pub init_segment_parsed: bool,
-    /// Video width from init segment (0 until parsed).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MseAudioTrackInfo {
+    pub track_id: u32,
+    pub codec: String,
+    pub sample_rate: u32,
+    pub channels: u16,
+    pub config: Vec<u8>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MseVideoTrackInfo {
+    pub track_id: u32,
+    pub codec: String,
     pub width: u32,
-    /// Video height from init segment (0 until parsed).
     pub height: u32,
-    /// Duration in milliseconds from the init segment (0 if unknown/live).
+    pub config: Vec<u8>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MseInitMetadata {
     pub duration_ms: u128,
-    /// Newly decoded frames ready for display.
-    pub new_frames: Vec<MseDecodedFrame>,
-    /// Updated buffered time ranges (seconds).
-    pub buffered_ranges: Vec<(f64, f64)>,
+    pub audio_tracks: Vec<MseAudioTrackInfo>,
+    pub video_tracks: Vec<MseVideoTrackInfo>,
+}
+
+/// A single decoded audio frame from the MSE pipeline.
+#[derive(Clone, Debug, PartialEq)]
+pub struct MseDecodedAudioFrame {
+    pub track_id: u32,
+    pub pts_ms: u64,
+    pub sample_rate: u32,
+    pub channels: u16,
+    /// Interleaved PCM samples in channel order.
+    pub samples: Vec<f32>,
 }
 
 /// A single decoded video frame from the MSE pipeline.
+#[derive(Clone, Debug, PartialEq)]
 pub struct MseDecodedFrame {
+    /// Track identifier from the init segment.
+    pub track_id: u32,
     /// Presentation timestamp in milliseconds.
     pub pts_ms: u64,
     /// YUV plane data for texture upload.
     pub yuv: YuvPlaneData,
 }
 
-/// Push-based video player for MSE (Media Source Extensions).
+/// Batch output from the append/decode engine.
+#[derive(Default)]
+pub struct MseEngineOutput {
+    /// Init metadata produced by this append, if any.
+    pub init: Option<MseInitMetadata>,
+    /// Newly decoded audio frames ready for session-side queueing.
+    pub audio_frames: Vec<MseDecodedAudioFrame>,
+    /// Newly decoded video frames ready for session-side scheduling.
+    pub video_frames: Vec<MseDecodedFrame>,
+    /// Updated buffered time ranges (seconds).
+    pub buffered_ranges: Vec<(f64, f64)>,
+    /// True once end-of-stream has been reached for the engine.
+    pub reached_eos: bool,
+}
+
+/// Push-based custom playback engine for MSE (Media Source Extensions).
 ///
-/// Accepts incremental fMP4 data (init segments + media segments) and
-/// produces decoded YUV frames. Codec selection is handled internally
-/// based on the init segment: dav1d for AV1, platform decoders for H.264.
-pub trait MsePlayer: Send {
+/// This is the append-buffer/custom-transport path. It owns demux, decode
+/// orchestration, and timing policy for media that is not delegated to native
+/// platform players.
+pub trait MsePlaybackEngine: Send {
     /// Push fMP4 data (init segment or media segment bytes).
-    /// Returns decoded frames and metadata updates.
-    fn append_data(&mut self, data: &[u8]) -> Result<MseAppendResult, String>;
+    /// Returns decoded output and metadata updates.
+    fn append_data(&mut self, data: &[u8]) -> Result<MseEngineOutput, String>;
 
     /// Signal end of stream. Flushes any buffered decoder output.
-    fn end_of_stream(&mut self) -> Result<Vec<MseDecodedFrame>, String>;
+    fn end_of_stream(&mut self) -> Result<MseEngineOutput, String>;
 
     /// Remove buffered data in a time range (seconds).
     fn remove(&mut self, start: f64, end: f64);
@@ -69,6 +108,7 @@ pub trait MsePlayer: Send {
     /// Clean up resources.
     fn cleanup(&mut self);
 }
+
 
 // ---------------------------------------------------------------------------
 // Platform video frame decoder (H.264 etc.)
@@ -122,10 +162,43 @@ pub trait MediaVideoEncoder: Send + Sync {
     fn stop(&self);
 }
 
-pub trait MediaSoftwareVideoPlayer {
-    fn check_prepared(
-        &mut self,
-    ) -> Option<Result<(u32, u32, u128, bool, Vec<String>, Vec<String>), String>>;
+/// Metadata reported when a playback session becomes ready.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PlaybackPrepared {
+    pub width: u32,
+    pub height: u32,
+    pub duration_ms: u128,
+    pub is_seekable: bool,
+    pub video_tracks: Vec<String>,
+    pub audio_tracks: Vec<String>,
+}
+
+impl PlaybackPrepared {
+    pub fn new(
+        width: u32,
+        height: u32,
+        duration_ms: u128,
+        is_seekable: bool,
+        video_tracks: Vec<String>,
+        audio_tracks: Vec<String>,
+    ) -> Self {
+        Self {
+            width,
+            height,
+            duration_ms,
+            is_seekable,
+            video_tracks,
+            audio_tracks,
+        }
+    }
+}
+
+/// High-level playback session abstraction.
+///
+/// This is the shared control surface above two distinct playback paths:
+/// native delegated playback and custom MSE-backed playback.
+pub trait MediaPlaybackSession {
+    fn check_prepared(&mut self) -> Option<Result<PlaybackPrepared, String>>;
     fn poll_frame(&mut self) -> bool;
     fn take_yuv_frame(&mut self) -> Option<YuvPlaneData>;
     fn check_eos(&mut self) -> bool;
@@ -141,9 +214,11 @@ pub trait MediaSoftwareVideoPlayer {
     fn set_playback_rate(&self, rate: f64);
     fn seekable_ranges(&self) -> Vec<(f64, f64)>;
     fn buffered_ranges(&self) -> Vec<(f64, f64)>;
+    fn fill_audio_output(&mut self, _info: AudioInfo, _output: &mut AudioBuffer) {}
     fn is_active(&self) -> bool;
     fn cleanup(&mut self);
 }
+
 
 pub trait MediaPlugin: Send + Sync {
     fn create_video_encoder(
@@ -154,16 +229,17 @@ pub trait MediaPlugin: Send + Sync {
         None
     }
 
-    fn create_software_video_player(
+    fn create_playback_session(
         &self,
         _video_id: LiveId,
         _texture_id: TextureId,
         _source: VideoSource,
         _autoplay: bool,
         _is_looping: bool,
-    ) -> Result<Box<dyn MediaSoftwareVideoPlayer>, VideoDecodeError> {
+    ) -> Result<Box<dyn MediaPlaybackSession>, VideoDecodeError> {
         Err(VideoDecodeError::UnsupportedCodec)
     }
+
 
     fn video_capabilities(&self) -> crate::video::VideoCapabilities {
         crate::video::VideoCapabilities::default()
@@ -173,11 +249,16 @@ pub trait MediaPlugin: Send + Sync {
 
     fn on_android_h264_error(&self, _encoder_id: u64, _message: String) {}
 
-    /// Create an MSE player for the given MIME type (e.g. `video/mp4; codecs="av01.0.04M.08"`).
+    /// Create a custom MSE playback engine for the given MIME type
+    /// (e.g. `video/mp4; codecs="av01.0.04M.08"`).
     /// Returns `Err` if the MIME type is unsupported.
-    fn create_mse_player(&self, _mime: &str) -> Result<Box<dyn MsePlayer>, String> {
+    fn create_mse_playback_engine(
+        &self,
+        _mime: &str,
+    ) -> Result<Box<dyn MsePlaybackEngine>, String> {
         Err("MSE not supported by this media plugin".into())
     }
+
 
     /// Create a platform video frame decoder for the given codec.
     /// Used by MSE player to decode H.264 via GStreamer/VideoToolbox/MediaCodec.

--- a/platform/src/os/apple/apple_video_playback.rs
+++ b/platform/src/os/apple/apple_video_playback.rs
@@ -161,6 +161,13 @@ impl AppleVideoPlayer {
                 let _: () = msg_send![ns_string, release];
                 (url, None)
             }
+            VideoSource::PlaybackSession(..) | VideoSource::Session(..) => {
+                error!("VIDEO: session sources are handled by the software video player");
+                let ns_string = Self::to_nsstring("about:blank");
+                let url: ObjcId = msg_send![class!(NSURL), URLWithString: ns_string];
+                let _: () = msg_send![ns_string, release];
+                (url, None)
+            }
         }
     }
 
@@ -201,7 +208,7 @@ impl AppleVideoPlayer {
     /// Returns `Ok(...)` with metadata when ready, `Err(msg)` on failure, `None` if still loading.
     pub fn check_prepared(
         &mut self,
-    ) -> Option<Result<(u32, u32, u128, bool, Vec<String>, Vec<String>), String>> {
+    ) -> Option<Result<PlaybackPrepared, String>> {
         if self.prepare_notified {
             return None;
         }
@@ -266,7 +273,7 @@ impl AppleVideoPlayer {
                     vec![]
                 };
 
-                return Some(Ok((
+                return Some(Ok(PlaybackPrepared::new(
                     width,
                     height,
                     duration_ms,

--- a/platform/src/os/apple/apple_video_player.rs
+++ b/platform/src/os/apple/apple_video_player.rs
@@ -6,7 +6,7 @@ use {
         event::video_playback::VideoSource,
         makepad_live_id::LiveId,
         texture::{CxTexturePool, TextureId},
-        video_decode::software_video::SoftwareVideoPlayer,
+        video_decode::software_video::PlaybackSessionHandle,
         video_decode::yuv::{YuvColorMatrix, YuvPlaneData},
     },
 };
@@ -28,7 +28,7 @@ pub struct AppleUnifiedVideoPlayer {
 
 enum ApplePlayerMode {
     Native(AppleVideoPlayer),
-    Software(SoftwareVideoPlayer),
+    Software(PlaybackSessionHandle),
 }
 
 impl AppleUnifiedVideoPlayer {
@@ -45,10 +45,15 @@ impl AppleUnifiedVideoPlayer {
     ) -> Self {
         let yuv_metal = AppleYuvMetal::new(metal_device, "apple unified player");
 
-        let force_software = std::env::var_os("MAKEPAD_FORCE_SOFTWARE_VIDEO").is_some();
+        let force_software_env = std::env::var_os("MAKEPAD_FORCE_SOFTWARE_VIDEO").is_some();
+        let force_software = force_software_env || source.is_session();
         let mode = if force_software {
-            crate::log!("VIDEO: MAKEPAD_FORCE_SOFTWARE_VIDEO set, using software video decoder");
-            ApplePlayerMode::Software(SoftwareVideoPlayer::new(
+            if force_software_env {
+                crate::log!("VIDEO: MAKEPAD_FORCE_SOFTWARE_VIDEO set, using software video decoder");
+            } else if source.is_session() {
+                crate::log!("VIDEO: session source uses software video decoder");
+            }
+            ApplePlayerMode::Software(PlaybackSessionHandle::new(
                 video_id,
                 texture_id,
                 source.clone(),
@@ -87,7 +92,7 @@ impl AppleUnifiedVideoPlayer {
             "VIDEO: Apple native playback failed, falling back to software video decoder: {}",
             reason
         );
-        self.mode = ApplePlayerMode::Software(SoftwareVideoPlayer::new(
+        self.mode = ApplePlayerMode::Software(PlaybackSessionHandle::new(
             self.video_id,
             self.texture_id,
             self.source.clone(),
@@ -98,7 +103,7 @@ impl AppleUnifiedVideoPlayer {
 
     pub fn check_prepared(
         &mut self,
-    ) -> Option<Result<(u32, u32, u128, bool, Vec<String>, Vec<String>), String>> {
+    ) -> Option<Result<PlaybackPrepared, String>> {
         match &mut self.mode {
             ApplePlayerMode::Native(player) => match player.check_prepared() {
                 Some(Err(err)) => {

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -157,7 +157,7 @@ impl IosCameraPlayer {
 
     fn check_prepared(
         &mut self,
-    ) -> Option<Result<(u32, u32, u128, bool, Vec<String>, Vec<String>), String>> {
+    ) -> Option<Result<PlaybackPrepared, String>> {
         if self.prepare_notified {
             return None;
         }
@@ -167,7 +167,7 @@ impl IosCameraPlayer {
             self.height = frame.height as u32;
             self.prepared = true;
             self.prepare_notified = true;
-            return Some(Ok((
+            return Some(Ok(PlaybackPrepared::new(
                 self.width,
                 self.height,
                 0,
@@ -190,7 +190,7 @@ impl IosCameraPlayer {
         self.prepared = true;
         self.prepare_notified = true;
 
-        Some(Ok((
+        Some(Ok(PlaybackPrepared::new(
             self.width,
             self.height,
             0,
@@ -324,12 +324,12 @@ impl IosNativeCameraPreview {
 
     fn check_prepared(
         &mut self,
-    ) -> Option<Result<(u32, u32, u128, bool, Vec<String>, Vec<String>), String>> {
+    ) -> Option<Result<PlaybackPrepared, String>> {
         if self.prepare_notified {
             return None;
         }
         self.prepare_notified = true;
-        Some(Ok((
+        Some(Ok(PlaybackPrepared::new(
             self.width,
             self.height,
             0,
@@ -582,7 +582,7 @@ impl Cx {
                     let mut video_events = Vec::new();
                     for (_video_id, player) in self.os.video_players.iter_mut() {
                         match player.check_prepared() {
-                            Some(Ok((
+                            Some(Ok(PlaybackPrepared::new(
                                 width,
                                 height,
                                 duration,
@@ -654,7 +654,7 @@ impl Cx {
                     let mut camera_events = Vec::new();
                     for (_video_id, player) in self.os.camera_players.iter_mut() {
                         match player.check_prepared() {
-                            Some(Ok((
+                            Some(Ok(PlaybackPrepared::new(
                                 width,
                                 height,
                                 duration,
@@ -970,7 +970,7 @@ impl Cx {
                                 format_id,
                                 camera_access,
                             );
-                            if let Some(Ok((
+                            if let Some(Ok(PlaybackPrepared::new(
                                 width,
                                 height,
                                 duration,

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -212,12 +212,12 @@ impl MacosNativeCameraPreview {
 
     fn check_prepared(
         &mut self,
-    ) -> Option<Result<(u32, u32, u128, bool, Vec<String>, Vec<String>), String>> {
+    ) -> Option<Result<PlaybackPrepared, String>> {
         if self.prepare_notified {
             return None;
         }
         self.prepare_notified = true;
-        Some(Ok((
+        Some(Ok(PlaybackPrepared::new(
             self.width,
             self.height,
             0,
@@ -635,7 +635,7 @@ impl Cx {
                     let mut video_events = Vec::new();
                     for (_video_id, player) in self.os.video_players.iter_mut() {
                         match player.check_prepared() {
-                            Some(Ok((
+                            Some(Ok(PlaybackPrepared::new(
                                 width,
                                 height,
                                 duration,
@@ -1149,7 +1149,7 @@ impl Cx {
                         let camera_access = self.os.media.av_capture();
                         let mut preview =
                             MacosNativeCameraPreview::new(input_id, format_id, camera_access);
-                        if let Some(Ok((
+                        if let Some(Ok(PlaybackPrepared::new(
                             width,
                             height,
                             duration,

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -67,7 +67,7 @@ use {
         //makepad_live_compiler::LiveFileChange,
         thread::SignalToUI,
         video::{VideoEncodeError, MAX_VIDEO_DEVICE_INDEX},
-        video_decode::software_video::SoftwareVideoPlayer,
+        video_decode::software_video::PlaybackSessionHandle,
         web_socket::WebSocketMessage,
         //web_socket::WebSocket,
         window::CxWindowPool,
@@ -642,7 +642,7 @@ impl Cx {
                             error
                         );
                         let asp = AndroidSoftwarePlayer {
-                            player: SoftwareVideoPlayer::new(
+                            player: PlaybackSessionHandle::new(
                                 live_id,
                                 config.texture_id,
                                 config.source,
@@ -1013,7 +1013,14 @@ impl Cx {
 
         for (_video_id, player) in players.iter_mut() {
             match player.check_prepared() {
-                Some(Ok((width, height, duration, is_seekable, video_tracks, audio_tracks))) => {
+                Some(Ok(crate::media_plugin::PlaybackPrepared {
+                    width,
+                    height,
+                    duration_ms: duration,
+                    is_seekable,
+                    video_tracks,
+                    audio_tracks,
+                })) => {
                     events.push(Event::VideoPlaybackPrepared(VideoPlaybackPreparedEvent {
                         video_id: player.video_id,
                         video_width: width,
@@ -1066,7 +1073,14 @@ impl Cx {
 
         for (_video_id, asp) in players.iter_mut() {
             match asp.player.check_prepared() {
-                Some(Ok((width, height, duration, is_seekable, video_tracks, audio_tracks))) => {
+                Some(Ok(crate::media_plugin::PlaybackPrepared {
+                    width,
+                    height,
+                    duration_ms: duration,
+                    is_seekable,
+                    video_tracks,
+                    audio_tracks,
+                })) => {
                     events.push(Event::VideoPlaybackPrepared(VideoPlaybackPreparedEvent {
                         video_id: asp.player.video_id,
                         video_width: width,
@@ -1802,15 +1816,20 @@ impl Cx {
                         },
                     );
 
-                    let force_software = force_software_video();
+                    let force_software_env = force_software_video();
+                    let force_software = force_software_env || source.is_session();
                     if force_software {
-                        crate::log!(
-                            "VIDEO: MAKEPAD_FORCE_SOFTWARE_VIDEO set, using software video decoder"
-                        );
+                        if force_software_env {
+                            crate::log!(
+                                "VIDEO: MAKEPAD_FORCE_SOFTWARE_VIDEO set, using software video decoder"
+                            );
+                        } else if source.is_session() {
+                            crate::log!("VIDEO: session source uses software video decoder");
+                        }
                         self.os.software_video_players.insert(
                             video_id,
                             AndroidSoftwarePlayer {
-                                player: SoftwareVideoPlayer::new(
+                                player: PlaybackSessionHandle::new(
                                     video_id,
                                     texture_id,
                                     source,
@@ -2271,7 +2290,7 @@ pub struct CxAndroidDisplay {
 }
 
 pub(crate) struct AndroidSoftwarePlayer {
-    pub player: SoftwareVideoPlayer,
+    pub player: PlaybackSessionHandle,
     pub tex_y_id: TextureId,
     pub tex_u_id: TextureId,
     pub tex_v_id: TextureId,

--- a/platform/src/os/linux/android/android_camera_player.rs
+++ b/platform/src/os/linux/android/android_camera_player.rs
@@ -91,14 +91,14 @@ impl AndroidCameraPlayer {
 
     pub fn check_prepared(
         &mut self,
-    ) -> Option<Result<(u32, u32, u128, bool, Vec<String>, Vec<String>), String>> {
+    ) -> Option<Result<PlaybackPrepared, String>> {
         if self.prepare_notified {
             return None;
         }
 
         if self.native_preview && self.prepared {
             self.prepare_notified = true;
-            return Some(Ok((
+            return Some(Ok(PlaybackPrepared::new(
                 self.width,
                 self.height,
                 0,
@@ -121,7 +121,7 @@ impl AndroidCameraPlayer {
         self.height = height;
         self.prepared = true;
         self.prepare_notified = true;
-        Some(Ok((
+        Some(Ok(PlaybackPrepared::new(
             self.width,
             self.height,
             0,

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -1509,6 +1509,10 @@ pub unsafe fn to_java_prepare_video_playback(
             crate::error!("VIDEO: Camera source not supported on Android");
             return;
         }
+        VideoSource::PlaybackSession(..) | VideoSource::Session(..) => {
+            crate::error!("VIDEO: session sources are handled by the software video player");
+            return;
+        }
     };
 
     ndk_utils::call_void_method!(

--- a/platform/src/os/linux/linux_media.rs
+++ b/platform/src/os/linux/linux_media.rs
@@ -10,9 +10,16 @@ use {
     std::sync::{Arc, Mutex},
 };
 
+fn pulse_audio_enabled() -> bool {
+    std::env::var_os("MAKEPAD_DISABLE_PULSE_AUDIO").is_none()
+}
+
 impl Cx {
     pub(crate) fn handle_media_signals(&mut self) {
-        if self.os.media.audio_change.check_and_clear() {
+        let pulse_enabled = pulse_audio_enabled();
+        let audio_first = self.os.media.alsa_audio.is_none()
+            || (pulse_enabled && self.os.media.pulse_audio.is_none());
+        if audio_first || self.os.media.audio_change.check_and_clear() {
             // alright so. if we 'failed' opening a device here
             // what do we do. we could flag our device as 'failed' on the desc
             let mut descs = self
@@ -22,14 +29,16 @@ impl Cx {
                 .lock()
                 .unwrap()
                 .get_updated_descs();
-            let descs2 = self
-                .os
-                .media
-                .pulse_audio()
-                .lock()
-                .unwrap()
-                .get_updated_descs();
-            descs.extend(descs2);
+            if pulse_enabled {
+                let descs2 = self
+                    .os
+                    .media
+                    .pulse_audio()
+                    .lock()
+                    .unwrap()
+                    .get_updated_descs();
+                descs.extend(descs2);
+            }
             self.call_event_handler(&Event::AudioDevices(AudioDevicesEvent { descs }));
         }
         if self.os.media.alsa_midi_change.check_and_clear() {
@@ -143,12 +152,14 @@ impl CxMediaApi for Cx {
             .lock()
             .unwrap()
             .use_audio_inputs(devices);
-        self.os
-            .media
-            .pulse_audio()
-            .lock()
-            .unwrap()
-            .use_audio_inputs(devices);
+        if pulse_audio_enabled() {
+            self.os
+                .media
+                .pulse_audio()
+                .lock()
+                .unwrap()
+                .use_audio_inputs(devices);
+        }
     }
 
     fn use_audio_outputs(&mut self, devices: &[AudioDeviceId]) {
@@ -158,12 +169,14 @@ impl CxMediaApi for Cx {
             .lock()
             .unwrap()
             .use_audio_outputs(devices);
-        self.os
-            .media
-            .pulse_audio()
-            .lock()
-            .unwrap()
-            .use_audio_outputs(devices);
+        if pulse_audio_enabled() {
+            self.os
+                .media
+                .pulse_audio()
+                .lock()
+                .unwrap()
+                .use_audio_outputs(devices);
+        }
     }
 
     fn audio_output_box(&mut self, index: usize, f: AudioOutputFn) {
@@ -202,10 +215,6 @@ impl CxMediaApi for Cx {
         config: VideoEncoderConfig,
         f: VideoOutputFn,
     ) -> Result<(), VideoEncodeError> {
-        if config.codec != VideoCodec::Av1 {
-            return Err(VideoEncodeError::UnsupportedCodec);
-        }
-
         match config.source {
             VideoEncodeSource::Camera { .. } => {
                 let camera = self.os.media.v4l2_camera();

--- a/platform/src/os/linux/linux_video_playback.rs
+++ b/platform/src/os/linux/linux_video_playback.rs
@@ -13,6 +13,7 @@ use {
         event::video_playback::VideoSource,
         makepad_error_log::*,
         makepad_live_id::LiveId,
+        media_plugin::PlaybackPrepared,
         texture::{CxTexturePool, TextureAlloc, TextureCategory, TextureId, TexturePixel},
     },
     std::{
@@ -385,6 +386,10 @@ impl GStreamerVideoPlayer {
                 // Camera sources are handled by V4l2CameraPlayer, not GStreamer.
                 ("".to_string(), None)
             }
+            VideoSource::PlaybackSession(..) | VideoSource::Session(..) => {
+                crate::error!("VIDEO: session sources are handled by the software video player");
+                ("".to_string(), None)
+            }
         }
     }
 
@@ -414,9 +419,7 @@ impl GStreamerVideoPlayer {
 
     /// Check if the player has finished prerolling and is ready to play.
     /// Returns `Ok(...)` with metadata when ready, `Err(msg)` on failure, `None` if still loading.
-    pub fn check_prepared(
-        &mut self,
-    ) -> Option<Result<(u32, u32, u128, bool, Vec<String>, Vec<String>), String>> {
+    pub fn check_prepared(&mut self) -> Option<Result<PlaybackPrepared, String>> {
         if self.prepare_notified || self.pipeline.is_null() {
             return None;
         }
@@ -544,7 +547,7 @@ impl GStreamerVideoPlayer {
                 };
             let audio_tracks = vec!["audio".to_string()];
 
-            Some(Ok((
+            Some(Ok(PlaybackPrepared::new(
                 self.video_width,
                 self.video_height,
                 duration_ms,

--- a/platform/src/os/linux/linux_video_player.rs
+++ b/platform/src/os/linux/linux_video_player.rs
@@ -8,8 +8,9 @@ use {
     super::v4l2_camera_player::V4l2CameraPlayer,
     crate::{
         makepad_live_id::LiveId,
+        media_plugin::PlaybackPrepared,
         texture::{CxTexturePool, Texture},
-        video_decode::software_video::SoftwareVideoPlayer,
+        video_decode::software_video::PlaybackSessionHandle,
     },
 };
 
@@ -42,7 +43,7 @@ pub enum LinuxVideoPlayer {
         yuv: Option<YuvTextureSet>,
     },
     Software {
-        player: SoftwareVideoPlayer,
+        player: PlaybackSessionHandle,
         yuv: YuvTextureSet,
         yuv_matrix: f32,
     },
@@ -60,7 +61,7 @@ impl LinuxVideoPlayer {
 
     pub fn check_prepared(
         &mut self,
-    ) -> Option<Result<(u32, u32, u128, bool, Vec<String>, Vec<String>), String>> {
+    ) -> Option<Result<PlaybackPrepared, String>> {
         match self {
             LinuxVideoPlayer::GStreamer { player: p, .. } => p.check_prepared(),
             LinuxVideoPlayer::Software { player: p, .. } => p.check_prepared(),

--- a/platform/src/os/linux/v4l2_camera.rs
+++ b/platform/src/os/linux/v4l2_camera.rs
@@ -50,11 +50,21 @@ impl V4l2CaptureSession {
             let path_cstr = std::ffi::CString::new(device_path).ok()?;
             let fd = libc_sys::open(path_cstr.as_ptr() as *const _, libc_sys::O_RDWR);
             if fd < 0 {
-                crate::log!("V4L2: failed to open {}", device_path);
+                crate::log!("V4L2: failed to open {}: {}", device_path, std::io::Error::last_os_error());
                 return None;
             }
 
-            // Set format
+            // Negotiate format: query device capabilities and find a compatible setting
+            let format = match Self::negotiate_format(fd, &format) {
+                Some(f) => f,
+                None => {
+                    crate::log!("V4L2: no compatible format for {} (requested {}x{} {:?})", device_path, format.width, format.height, format.pixel_format);
+                    libc_sys::close(fd);
+                    return None;
+                }
+            };
+
+            // Set the negotiated format
             let mut fmt: v4l2_format = std::mem::zeroed();
             fmt.type_ = V4L2_BUF_TYPE_VIDEO_CAPTURE;
             fmt.fmt.pix.width = format.width as u32;
@@ -62,10 +72,19 @@ impl V4l2CaptureSession {
             fmt.fmt.pix.pixelformat = video_pixel_format_to_fourcc(format.pixel_format);
             fmt.fmt.pix.field = V4L2_FIELD_ANY;
             if ioctl(fd, VIDIOC_S_FMT, &mut fmt as *mut _ as *mut c_void) < 0 {
-                crate::log!("V4L2: VIDIOC_S_FMT failed for {}", device_path);
+                crate::log!("V4L2: VIDIOC_S_FMT failed for {} ({}x{} {:?}): {}", device_path, format.width, format.height, format.pixel_format, std::io::Error::last_os_error());
                 libc_sys::close(fd);
                 return None;
             }
+
+            // Read back what the driver actually accepted
+            let format = VideoFormat {
+                format_id: format.format_id,
+                width: fmt.fmt.pix.width as usize,
+                height: fmt.fmt.pix.height as usize,
+                pixel_format: fourcc_to_video_pixel_format(fmt.fmt.pix.pixelformat),
+                frame_rate: format.frame_rate,
+            };
 
             // Set frame rate if specified
             if let Some(fps) = format.frame_rate {
@@ -86,7 +105,7 @@ impl V4l2CaptureSession {
             req.type_ = V4L2_BUF_TYPE_VIDEO_CAPTURE;
             req.memory = V4L2_MEMORY_MMAP;
             if ioctl(fd, VIDIOC_REQBUFS, &mut req as *mut _ as *mut c_void) < 0 {
-                crate::log!("V4L2: VIDIOC_REQBUFS failed for {}", device_path);
+                crate::log!("V4L2: VIDIOC_REQBUFS failed for {}: {}", device_path, std::io::Error::last_os_error());
                 libc_sys::close(fd);
                 return None;
             }
@@ -101,7 +120,7 @@ impl V4l2CaptureSession {
                 buf.memory = V4L2_MEMORY_MMAP;
                 buf.index = i as u32;
                 if ioctl(fd, VIDIOC_QUERYBUF, &mut buf as *mut _ as *mut c_void) < 0 {
-                    crate::log!("V4L2: VIDIOC_QUERYBUF failed for buffer {}", i);
+                    crate::log!("V4L2: VIDIOC_QUERYBUF failed for buffer {}: {}", i, std::io::Error::last_os_error());
                     for b in &buffers {
                         libc_sys::munmap(b.ptr as *mut c_void, b.length);
                     }
@@ -118,7 +137,7 @@ impl V4l2CaptureSession {
                     buf.m.offset as libc_sys::off_t,
                 );
                 if ptr == libc_sys::MAP_FAILED {
-                    crate::log!("V4L2: mmap failed for buffer {}", i);
+                    crate::log!("V4L2: mmap failed for buffer {}: {}", i, std::io::Error::last_os_error());
                     for b in &buffers {
                         libc_sys::munmap(b.ptr as *mut c_void, b.length);
                     }
@@ -146,7 +165,7 @@ impl V4l2CaptureSession {
             // Stream on
             let mut buf_type: c_int = V4L2_BUF_TYPE_VIDEO_CAPTURE as c_int;
             if ioctl(fd, VIDIOC_STREAMON, &mut buf_type as *mut _ as *mut c_void) < 0 {
-                crate::log!("V4L2: VIDIOC_STREAMON failed for {}", device_path);
+                crate::log!("V4L2: VIDIOC_STREAMON failed for {}: {}", device_path, std::io::Error::last_os_error());
                 for b in &buffers {
                     libc_sys::munmap(b.ptr as *mut c_void, b.length);
                 }
@@ -180,6 +199,133 @@ impl V4l2CaptureSession {
                 buffers,
             })
         }
+    }
+
+    /// Query device for supported formats/resolutions and pick the best match.
+    /// Tries the requested format first, then falls back to device-supported alternatives.
+    unsafe fn negotiate_format(fd: c_int, requested: &VideoFormat) -> Option<VideoFormat> {
+        // Enumerate all supported (pixelformat, width, height) tuples
+        let mut supported: Vec<(u32, u32, u32)> = Vec::new();
+        let mut fmt_index = 0u32;
+        loop {
+            let mut fmtdesc: v4l2_fmtdesc = std::mem::zeroed();
+            fmtdesc.index = fmt_index;
+            fmtdesc.type_ = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+            if ioctl(fd, VIDIOC_ENUM_FMT, &mut fmtdesc as *mut _ as *mut c_void) < 0 {
+                break;
+            }
+            let pixfmt = fmtdesc.pixelformat;
+
+            let mut size_index = 0u32;
+            loop {
+                let mut frmsize: v4l2_frmsizeenum = std::mem::zeroed();
+                frmsize.index = size_index;
+                frmsize.pixel_format = pixfmt;
+                if ioctl(fd, VIDIOC_ENUM_FRAMESIZES, &mut frmsize as *mut _ as *mut c_void) < 0 {
+                    break;
+                }
+                if frmsize.type_ == V4L2_FRMSIZE_TYPE_DISCRETE {
+                    let w = frmsize.u.discrete.width;
+                    let h = frmsize.u.discrete.height;
+                    supported.push((pixfmt, w, h));
+                }
+                size_index += 1;
+            }
+
+            // Device reports format but no discrete sizes: accept any resolution
+            if size_index == 0 {
+                supported.push((pixfmt, 0, 0));
+            }
+
+            fmt_index += 1;
+        }
+
+        // If enumeration returned nothing, let the driver decide via G_FMT
+        if supported.is_empty() {
+            crate::log!("V4L2: no formats enumerated, trying G_FMT fallback");
+            let mut fmt: v4l2_format = std::mem::zeroed();
+            fmt.type_ = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+            if ioctl(fd, VIDIOC_G_FMT, &mut fmt as *mut _ as *mut c_void) >= 0 {
+                let pf = fourcc_to_video_pixel_format(fmt.fmt.pix.pixelformat);
+                if !matches!(pf, VideoPixelFormat::Unsupported(_)) {
+                    return Some(VideoFormat {
+                        format_id: requested.format_id,
+                        width: fmt.fmt.pix.width as usize,
+                        height: fmt.fmt.pix.height as usize,
+                        pixel_format: pf,
+                        frame_rate: requested.frame_rate,
+                    });
+                }
+            }
+            return None;
+        }
+
+        let req_fourcc = video_pixel_format_to_fourcc(requested.pixel_format);
+        let req_w = requested.width as u32;
+        let req_h = requested.height as u32;
+
+        // 1. Exact match (format + resolution)
+        if supported.iter().any(|&(f, w, h)| f == req_fourcc && (w == req_w && h == req_h || w == 0)) {
+            return Some(*requested);
+        }
+
+        // 2. Same pixel format, different resolution — pick closest
+        if let Some(fmt) = Self::pick_closest_resolution(&supported, req_fourcc, req_w, req_h) {
+            return Some(VideoFormat {
+                format_id: requested.format_id,
+                width: fmt.1 as usize,
+                height: fmt.2 as usize,
+                pixel_format: requested.pixel_format,
+                frame_rate: requested.frame_rate,
+            });
+        }
+
+        // 3. Different pixel format — prefer YUYV, MJPEG, NV12, YUV420 in order
+        let preferred = [V4L2_PIX_FMT_YUYV, V4L2_PIX_FMT_MJPEG, V4L2_PIX_FMT_NV12, V4L2_PIX_FMT_YUV420];
+        for &pf in &preferred {
+            if let Some(fmt) = Self::pick_closest_resolution(&supported, pf, req_w, req_h) {
+                return Some(VideoFormat {
+                    format_id: requested.format_id,
+                    width: fmt.1 as usize,
+                    height: fmt.2 as usize,
+                    pixel_format: fourcc_to_video_pixel_format(pf),
+                    frame_rate: requested.frame_rate,
+                });
+            }
+        }
+
+        // 4. Take whatever the device offers first
+        let (pf, w, h) = supported[0];
+        let pixel_format = fourcc_to_video_pixel_format(pf);
+        let (w, h) = if w == 0 { (req_w, req_h) } else { (w, h) };
+        Some(VideoFormat {
+            format_id: requested.format_id,
+            width: w as usize,
+            height: h as usize,
+            pixel_format,
+            frame_rate: requested.frame_rate,
+        })
+    }
+
+    /// From entries matching `pixfmt`, return the one closest to (target_w, target_h).
+    fn pick_closest_resolution(
+        supported: &[(u32, u32, u32)],
+        pixfmt: u32,
+        target_w: u32,
+        target_h: u32,
+    ) -> Option<(u32, u32, u32)> {
+        supported
+            .iter()
+            .filter(|&&(f, _, _)| f == pixfmt)
+            .min_by_key(|&&(_, w, h)| {
+                if w == 0 { return 0i64; } // wildcard size — perfect match
+                let dw = w as i64 - target_w as i64;
+                let dh = h as i64 - target_h as i64;
+                dw * dw + dh * dh
+            })
+            .map(|&entry| {
+                if entry.1 == 0 { (entry.0, target_w, target_h) } else { entry }
+            })
     }
 
     fn capture_loop(
@@ -445,7 +591,7 @@ impl V4l2CameraAccess {
                             format_id: *format_id,
                         };
                         let output_cb = self.video_output_cb[index].clone();
-                        *self.video_encoder[index].lock().unwrap() = VideoEncoder::start(
+                        let encoder = VideoEncoder::start(
                             config,
                             Box::new(move |packet| {
                                 if let Some(cb) = &mut *output_cb.lock().unwrap() {
@@ -453,6 +599,10 @@ impl V4l2CameraAccess {
                                 }
                             }),
                         );
+                        if encoder.is_none() {
+                            crate::error!("linux camera video encoder unavailable for slot {}", index);
+                        }
+                        *self.video_encoder[index].lock().unwrap() = encoder;
                     }
 
                     if let Some(session) = V4l2CaptureSession::start(

--- a/platform/src/os/linux/v4l2_camera_player.rs
+++ b/platform/src/os/linux/v4l2_camera_player.rs
@@ -6,6 +6,7 @@ use {
     super::v4l2_camera::V4l2CameraAccess,
     crate::{
         makepad_live_id::LiveId,
+        media_plugin::PlaybackPrepared,
         texture::{CxTexturePool, TextureId},
         video::*,
     },
@@ -84,7 +85,7 @@ impl V4l2CameraPlayer {
 
     pub fn check_prepared(
         &mut self,
-    ) -> Option<Result<(u32, u32, u128, bool, Vec<String>, Vec<String>), String>> {
+    ) -> Option<Result<PlaybackPrepared, String>> {
         if self.prepare_notified {
             return None;
         }
@@ -95,7 +96,7 @@ impl V4l2CameraPlayer {
         self.prepared = true;
         self.prepare_notified = true;
         pool.publish_latest(frame);
-        Some(Ok((
+        Some(Ok(PlaybackPrepared::new(
             self.width,
             self.height,
             0,

--- a/platform/src/os/linux/wayland/linux_wayland.rs
+++ b/platform/src/os/linux/wayland/linux_wayland.rs
@@ -356,14 +356,14 @@ impl WaylandCx {
                         let mut video_events = Vec::new();
                         for (_video_id, player) in players.iter_mut() {
                             match player.check_prepared() {
-                                Some(Ok((
+                                Some(Ok(crate::media_plugin::PlaybackPrepared {
                                     width,
                                     height,
-                                    duration,
+                                    duration_ms: duration,
                                     is_seekable,
                                     video_tracks,
                                     audio_tracks,
-                                ))) => {
+                                })) => {
                                     video_events.push(Event::VideoPlaybackPrepared(
                                         VideoPlaybackPreparedEvent {
                                             video_id: player.video_id(),
@@ -764,12 +764,15 @@ impl WaylandCx {
                         continue;
                     }
                     // Try GStreamer first, fall back to software rav1d
-                    let mut use_software =
+                    let force_software_env =
                         std::env::var_os("MAKEPAD_FORCE_SOFTWARE_VIDEO").is_some();
-                    if use_software {
+                    let mut use_software = force_software_env || source.is_session();
+                    if force_software_env {
                         crate::log!(
                             "VIDEO: MAKEPAD_FORCE_SOFTWARE_VIDEO set, using software video decoder"
                         );
+                    } else if source.is_session() {
+                        crate::log!("VIDEO: session source uses software video decoder");
                     }
                     if cx.os.gstreamer.is_none() {
                         match LibGStreamer::try_load() {
@@ -832,7 +835,7 @@ impl WaylandCx {
                             cx.textures.alloc(TextureFormat::VideoYuvPlane),
                             cx.textures.alloc(TextureFormat::VideoYuvPlane),
                         );
-                        let player = crate::video_decode::software_video::SoftwareVideoPlayer::new(
+                        let player = crate::video_decode::software_video::PlaybackSessionHandle::new(
                             video_id,
                             texture_id,
                             source,

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -324,14 +324,14 @@ impl X11Cx {
                         let mut video_events = Vec::new();
                         for (_video_id, player) in players.iter_mut() {
                             match player.check_prepared() {
-                                Some(Ok((
+                                Some(Ok(crate::media_plugin::PlaybackPrepared {
                                     width,
                                     height,
-                                    duration,
+                                    duration_ms: duration,
                                     is_seekable,
                                     video_tracks,
                                     audio_tracks,
-                                ))) => {
+                                })) => {
                                     video_events.push(Event::VideoPlaybackPrepared(
                                         VideoPlaybackPreparedEvent {
                                             video_id: player.video_id(),
@@ -788,12 +788,15 @@ impl X11Cx {
                         continue;
                     }
                     // Try GStreamer first, fall back to software rav1d
-                    let mut use_software =
+                    let force_software_env =
                         std::env::var_os("MAKEPAD_FORCE_SOFTWARE_VIDEO").is_some();
-                    if use_software {
+                    let mut use_software = force_software_env || source.is_session();
+                    if force_software_env {
                         crate::log!(
                             "VIDEO: MAKEPAD_FORCE_SOFTWARE_VIDEO set, using software video decoder"
                         );
+                    } else if source.is_session() {
+                        crate::log!("VIDEO: session source uses software video decoder");
                     }
                     if cx.os.gstreamer.is_none() {
                         match LibGStreamer::try_load() {
@@ -856,7 +859,7 @@ impl X11Cx {
                             cx.textures.alloc(TextureFormat::VideoYuvPlane),
                             cx.textures.alloc(TextureFormat::VideoYuvPlane),
                         );
-                        let player = crate::video_decode::software_video::SoftwareVideoPlayer::new(
+                        let player = crate::video_decode::software_video::PlaybackSessionHandle::new(
                             video_id,
                             texture_id,
                             source,

--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -635,37 +635,46 @@ impl Cx {
                     texture_id,
                     autoplay,
                     should_loop,
-                ) => match source {
-                    VideoSource::Network(url) => {
-                        self.os.from_wasm(FromWasmPrepareVideoPlayback {
-                            video_id_lo: video_id.lo(),
-                            video_id_hi: video_id.hi(),
-                            texture_id: texture_id.0,
-                            source_url: url,
-                            autoplay,
-                            should_loop,
-                        });
-                    }
-                    VideoSource::InMemory(_) => {
-                        let error = "VideoSource::InMemory is not supported on web".to_string();
-                        crate::error!("{}", error);
-                        self.call_event_handler(&Event::VideoDecodingError(
-                            VideoDecodingErrorEvent { video_id, error },
-                        ));
-                    }
-                    VideoSource::Filesystem(_) => {
-                        let error = "VideoSource::Filesystem is not supported on web".to_string();
-                        crate::error!("{}", error);
-                        self.call_event_handler(&Event::VideoDecodingError(
-                            VideoDecodingErrorEvent { video_id, error },
-                        ));
-                    }
-                    VideoSource::Camera(..) => {
-                        let error = "VideoSource::Camera is not supported on web".to_string();
-                        crate::error!("{}", error);
-                        self.call_event_handler(&Event::VideoDecodingError(
-                            VideoDecodingErrorEvent { video_id, error },
-                        ));
+                ) => {
+                    match source {
+                        VideoSource::Network(url) => {
+                            self.os.from_wasm(FromWasmPrepareVideoPlayback {
+                                video_id_lo: video_id.lo(),
+                                video_id_hi: video_id.hi(),
+                                texture_id: texture_id.0,
+                                source_url: url,
+                                autoplay,
+                                should_loop,
+                            });
+                        }
+                        VideoSource::InMemory(_) => {
+                            let error = "VideoSource::InMemory is not supported on web".to_string();
+                            crate::error!("{}", error);
+                            self.call_event_handler(&Event::VideoDecodingError(
+                                VideoDecodingErrorEvent { video_id, error },
+                            ));
+                        }
+                        VideoSource::Filesystem(_) => {
+                            let error = "VideoSource::Filesystem is not supported on web".to_string();
+                            crate::error!("{}", error);
+                            self.call_event_handler(&Event::VideoDecodingError(
+                                VideoDecodingErrorEvent { video_id, error },
+                            ));
+                        }
+                        VideoSource::Camera(..) => {
+                            let error = "VideoSource::Camera is not supported on web".to_string();
+                            crate::error!("{}", error);
+                            self.call_event_handler(&Event::VideoDecodingError(
+                                VideoDecodingErrorEvent { video_id, error },
+                            ));
+                        }
+                        VideoSource::PlaybackSession(..) | VideoSource::Session(..) => {
+                            let error = "VideoSource::Session is not supported on web".to_string();
+                            crate::error!("{}", error);
+                            self.call_event_handler(&Event::VideoDecodingError(
+                                VideoDecodingErrorEvent { video_id, error },
+                            ));
+                        }
                     }
                 },
                 CxOsOp::BeginVideoPlayback(video_id) => {

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -185,14 +185,14 @@ impl Cx {
                     let mut video_events = Vec::new();
                     for (_id, player) in players.iter_mut() {
                         match player.check_prepared() {
-                            Some(Ok((
+                            Some(Ok(crate::media_plugin::PlaybackPrepared {
                                 width,
                                 height,
-                                duration,
+                                duration_ms: duration,
                                 is_seekable,
                                 video_tracks,
                                 audio_tracks,
-                            ))) => {
+                            })) => {
                                 video_events.push(Event::VideoPlaybackPrepared(
                                     VideoPlaybackPreparedEvent {
                                         video_id: player.video_id,

--- a/platform/src/os/windows/windows_video_playback.rs
+++ b/platform/src/os/windows/windows_video_playback.rs
@@ -595,6 +595,10 @@ impl WindowsVideoPlayer {
                 error!("VIDEO: Camera source not supported on Windows");
                 (vec![0], None)
             }
+            VideoSource::PlaybackSession(..) | VideoSource::Session(..) => {
+                error!("VIDEO: session sources are handled by the software video player");
+                (vec![0], None)
+            }
         }
     }
 
@@ -688,7 +692,7 @@ impl WindowsVideoPlayer {
 
     pub fn check_prepared(
         &mut self,
-    ) -> Option<Result<(u32, u32, u128, bool, Vec<String>, Vec<String>), String>> {
+    ) -> Option<Result<PlaybackPrepared, String>> {
         if self.prepare_notified {
             return None;
         }
@@ -728,7 +732,7 @@ impl WindowsVideoPlayer {
                 vec![]
             };
             let audio_tracks = vec!["audio".to_string()];
-            Some(Ok((
+            Some(Ok(PlaybackPrepared::new(
                 w,
                 h,
                 duration_ms,

--- a/platform/src/os/windows/windows_video_player.rs
+++ b/platform/src/os/windows/windows_video_player.rs
@@ -6,7 +6,7 @@ use {
         texture::{
             CxTexturePool, TextureAlloc, TextureCategory, TextureFormat, TextureId, TexturePixel,
         },
-        video_decode::software_video::SoftwareVideoPlayer,
+        video_decode::software_video::PlaybackSessionHandle,
         video_decode::yuv::YuvPlaneData,
         windows::{
             core::Interface,
@@ -38,7 +38,7 @@ pub struct WindowsUnifiedVideoPlayer {
 
 enum WindowsPlayerMode {
     Native(WindowsVideoPlayer),
-    Software(SoftwareVideoPlayer),
+    Software(PlaybackSessionHandle),
 }
 
 impl WindowsUnifiedVideoPlayer {
@@ -56,7 +56,7 @@ impl WindowsUnifiedVideoPlayer {
         let force_software = std::env::var_os("MAKEPAD_FORCE_SOFTWARE_VIDEO").is_some();
         let mode = if force_software {
             crate::log!("VIDEO: MAKEPAD_FORCE_SOFTWARE_VIDEO set, using software video decoder");
-            WindowsPlayerMode::Software(SoftwareVideoPlayer::new(
+            WindowsPlayerMode::Software(PlaybackSessionHandle::new(
                 video_id,
                 texture_id,
                 source.clone(),
@@ -74,7 +74,7 @@ impl WindowsUnifiedVideoPlayer {
             WindowsPlayerMode::Native(native)
         } else {
             crate::log!("VIDEO: Windows native playback unavailable, using software video decoder");
-            WindowsPlayerMode::Software(SoftwareVideoPlayer::new(
+            WindowsPlayerMode::Software(PlaybackSessionHandle::new(
                 video_id,
                 texture_id,
                 source.clone(),
@@ -103,7 +103,7 @@ impl WindowsUnifiedVideoPlayer {
             "VIDEO: Windows native playback failed, falling back to software video decoder: {}",
             reason
         );
-        self.mode = WindowsPlayerMode::Software(SoftwareVideoPlayer::new(
+        self.mode = WindowsPlayerMode::Software(PlaybackSessionHandle::new(
             self.video_id,
             self.texture_id,
             self.source.clone(),
@@ -114,7 +114,7 @@ impl WindowsUnifiedVideoPlayer {
 
     pub fn check_prepared(
         &mut self,
-    ) -> Option<Result<(u32, u32, u128, bool, Vec<String>, Vec<String>), String>> {
+    ) -> Option<Result<PlaybackPrepared, String>> {
         match &mut self.mode {
             WindowsPlayerMode::Native(player) => match player.check_prepared() {
                 Some(Err(err)) => {

--- a/platform/src/playback_session.rs
+++ b/platform/src/playback_session.rs
@@ -1,0 +1,149 @@
+use crate::media_plugin::MediaPlaybackSession;
+use crate::{AudioBuffer, AudioInfo};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock, atomic::{AtomicU64, Ordering}};
+
+/// Opaque handle for a registered custom playback session.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct MediaPlaybackSessionId(pub u64);
+
+type SendPlaybackSession = Box<dyn MediaPlaybackSession + Send>;
+type SharedPlaybackSession = Arc<Mutex<SendPlaybackSession>>;
+
+static MEDIA_PLAYBACK_SESSION_IDS: AtomicU64 = AtomicU64::new(1);
+static MEDIA_PLAYBACK_SESSIONS: OnceLock<Mutex<HashMap<MediaPlaybackSessionId, SendPlaybackSession>>> =
+    OnceLock::new();
+static ACTIVE_MEDIA_AUDIO: OnceLock<Mutex<HashMap<MediaPlaybackSessionId, SharedPlaybackSession>>> =
+    OnceLock::new();
+
+fn media_playback_sessions(
+) -> &'static Mutex<HashMap<MediaPlaybackSessionId, SendPlaybackSession>> {
+    MEDIA_PLAYBACK_SESSIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn active_media_audio(
+) -> &'static Mutex<HashMap<MediaPlaybackSessionId, SharedPlaybackSession>> {
+    ACTIVE_MEDIA_AUDIO.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Register a custom playback session for later handoff into Makepad playback.
+pub fn register_media_playback_session(
+    session: SendPlaybackSession,
+) -> MediaPlaybackSessionId {
+    let id = MediaPlaybackSessionId(MEDIA_PLAYBACK_SESSION_IDS.fetch_add(1, Ordering::Relaxed));
+    media_playback_sessions().lock().unwrap().insert(id, session);
+    id
+}
+
+/// Remove a registered playback session that has not yet been consumed.
+pub fn unregister_media_playback_session(
+    id: MediaPlaybackSessionId,
+) -> Option<SendPlaybackSession> {
+    media_playback_sessions().lock().unwrap().remove(&id)
+}
+
+/// Take ownership of a registered playback session.
+#[doc(hidden)]
+pub fn take_registered_media_playback_session(
+    id: MediaPlaybackSessionId,
+) -> Option<SendPlaybackSession> {
+    unregister_media_playback_session(id)
+}
+
+/// Register an active custom session for Makepad audio output mixing.
+pub fn register_active_media_audio(
+    id: MediaPlaybackSessionId,
+    session: SharedPlaybackSession,
+) {
+    active_media_audio().lock().unwrap().insert(id, session);
+}
+
+/// Remove an active custom session from Makepad audio output mixing.
+pub fn unregister_active_media_audio(id: MediaPlaybackSessionId) {
+    active_media_audio().lock().unwrap().remove(&id);
+}
+
+/// Mix active custom-session audio into one output buffer.
+pub fn mix_active_media_audio(info: AudioInfo, output: &mut AudioBuffer) {
+    output.zero();
+    let sessions: Vec<SharedPlaybackSession> = active_media_audio()
+        .lock()
+        .unwrap()
+        .values()
+        .cloned()
+        .collect();
+    for session in sessions {
+        if let Ok(mut session) = session.lock() {
+            session.fill_audio_output(info, output);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::media_plugin::PlaybackPrepared;
+    use crate::video_decode::yuv::YuvPlaneData;
+
+    struct StubSession {
+        audio_calls: usize,
+    }
+
+    impl MediaPlaybackSession for StubSession {
+        fn check_prepared(&mut self) -> Option<Result<PlaybackPrepared, String>> {
+            Some(Ok(PlaybackPrepared::new(1, 1, 0, false, vec![], vec![])))
+        }
+
+        fn poll_frame(&mut self) -> bool { false }
+        fn take_yuv_frame(&mut self) -> Option<YuvPlaneData> { None }
+        fn check_eos(&mut self) -> bool { false }
+        fn play(&mut self) {}
+        fn pause(&mut self) {}
+        fn resume(&mut self) {}
+        fn is_playing(&self) -> bool { true }
+        fn seek_to(&mut self, _position_ms: u64) {}
+        fn set_volume(&self, _volume: f64) {}
+        fn current_position_ms(&self) -> u128 { 0 }
+        fn mute(&self) {}
+        fn unmute(&self) {}
+        fn set_playback_rate(&self, _rate: f64) {}
+        fn seekable_ranges(&self) -> Vec<(f64, f64)> { Vec::new() }
+        fn buffered_ranges(&self) -> Vec<(f64, f64)> { Vec::new() }
+        fn fill_audio_output(&mut self, _info: AudioInfo, output: &mut AudioBuffer) {
+            self.audio_calls += 1;
+            if let Some(sample) = output.data.first_mut() {
+                *sample += 0.5;
+            }
+        }
+        fn is_active(&self) -> bool { true }
+        fn cleanup(&mut self) {}
+    }
+
+    #[test]
+    fn registry_roundtrip() {
+        let id = register_media_playback_session(Box::new(StubSession { audio_calls: 0 }));
+        let mut session = take_registered_media_playback_session(id).expect("session missing");
+        assert!(session.check_prepared().is_some());
+        assert!(take_registered_media_playback_session(id).is_none());
+    }
+
+    #[test]
+    fn active_audio_mix_calls_registered_sessions() {
+        let id = MediaPlaybackSessionId(999_001);
+        let session: SharedPlaybackSession = Arc::new(Mutex::new(Box::new(StubSession { audio_calls: 0 })));
+        register_active_media_audio(id, session.clone());
+
+        let mut output = AudioBuffer::new_with_size(16, 2);
+        mix_active_media_audio(
+            AudioInfo {
+                device_id: Default::default(),
+                time: None,
+                sample_rate: 48_000.0,
+            },
+            &mut output,
+        );
+
+        assert!(output.data[0] > 0.0);
+        unregister_active_media_audio(id);
+    }
+}

--- a/platform/src/video_decode/software_video.rs
+++ b/platform/src/video_decode/software_video.rs
@@ -1,20 +1,20 @@
 use crate::{
     event::video_playback::VideoSource,
     makepad_live_id::LiveId,
-    media_plugin::{media_plugin, MediaSoftwareVideoPlayer},
+    media_plugin::{media_plugin, MediaPlaybackSession, PlaybackPrepared},
     texture::TextureId,
     video::VideoDecodeError,
     video_decode::yuv::YuvPlaneData,
 };
 
-pub struct SoftwareVideoPlayer {
+pub struct PlaybackSessionHandle {
     pub video_id: LiveId,
     pub texture_id: TextureId,
-    inner: Option<Box<dyn MediaSoftwareVideoPlayer>>,
+    inner: Option<Box<dyn MediaPlaybackSession>>,
     failed: Option<String>,
 }
 
-impl SoftwareVideoPlayer {
+impl PlaybackSessionHandle {
     pub fn new(
         video_id: LiveId,
         texture_id: TextureId,
@@ -23,15 +23,19 @@ impl SoftwareVideoPlayer {
         is_looping: bool,
     ) -> Self {
         let (inner, failed) = match media_plugin() {
-            Some(plugin) => match plugin
-                .create_software_video_player(video_id, texture_id, source, autoplay, is_looping)
-            {
+            Some(plugin) => match plugin.create_playback_session(
+                video_id,
+                texture_id,
+                source,
+                autoplay,
+                is_looping,
+            ) {
                 Ok(player) => (Some(player), None),
-                Err(err) => (None, Some(format!("software video unavailable: {:?}", err))),
+                Err(err) => (None, Some(format!("playback session unavailable: {:?}", err))),
             },
             None => (
                 None,
-                Some("software video unavailable: no media plugin installed".to_string()),
+                Some("playback session unavailable: no media plugin installed".to_string()),
             ),
         };
 
@@ -45,7 +49,7 @@ impl SoftwareVideoPlayer {
 
     pub fn check_prepared(
         &mut self,
-    ) -> Option<Result<(u32, u32, u128, bool, Vec<String>, Vec<String>), String>> {
+    ) -> Option<Result<PlaybackPrepared, String>> {
         if let Some(inner) = &mut self.inner {
             return inner.check_prepared();
         }

--- a/platform/src/video_decode/yuv.rs
+++ b/platform/src/video_decode/yuv.rs
@@ -31,6 +31,7 @@ impl YuvLayout {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
 pub struct YuvPlaneData {
     pub y: Vec<u8>,
     pub u: Vec<u8>,

--- a/platform/src/video_session.rs
+++ b/platform/src/video_session.rs
@@ -1,0 +1,123 @@
+use crate::media_plugin::MseDecodedFrame;
+use std::{
+    collections::HashMap,
+    sync::{
+        Mutex, OnceLock,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+/// State of an app-owned video frame session.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VideoSessionState {
+    /// Session is initializing and has not produced displayable output yet.
+    Connecting,
+    /// Session is active and may produce frames.
+    Active,
+    /// Session ended cleanly.
+    Ended,
+    /// Session failed.
+    Error(String),
+}
+
+/// App-owned decoded-frame session for the generic Makepad video path.
+///
+/// Implementations own transport, decode, buffering, and lifetime. The
+/// Makepad `Video` widget drains decoded frames through this trait and reuses
+/// the normal YUV upload path.
+pub trait VideoFrameSession: Send {
+    /// Drain newly available decoded frames.
+    fn take_frames(&mut self) -> Vec<MseDecodedFrame>;
+
+    /// Current video dimensions, if known.
+    fn dimensions(&self) -> Option<(u32, u32)>;
+
+    /// Current session lifecycle state.
+    fn state(&self) -> VideoSessionState;
+}
+
+/// Opaque handle for a registered video frame session source.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct VideoFrameSessionId(pub u64);
+
+static VIDEO_FRAME_SESSION_IDS: AtomicU64 = AtomicU64::new(1);
+static VIDEO_FRAME_SESSIONS: OnceLock<Mutex<HashMap<VideoFrameSessionId, Box<dyn VideoFrameSession>>>> =
+    OnceLock::new();
+
+fn video_frame_sessions(
+) -> &'static Mutex<HashMap<VideoFrameSessionId, Box<dyn VideoFrameSession>>> {
+    VIDEO_FRAME_SESSIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Register an app-owned video frame session for later playback binding.
+pub fn register_video_frame_session(session: Box<dyn VideoFrameSession>) -> VideoFrameSessionId {
+    let id = VideoFrameSessionId(VIDEO_FRAME_SESSION_IDS.fetch_add(1, Ordering::Relaxed));
+    video_frame_sessions().lock().unwrap().insert(id, session);
+    id
+}
+
+/// Remove a registered video frame session that has not yet been consumed.
+pub fn unregister_video_frame_session(id: VideoFrameSessionId) -> Option<Box<dyn VideoFrameSession>> {
+    video_frame_sessions().lock().unwrap().remove(&id)
+}
+
+/// Take ownership of a registered video frame session.
+///
+/// This is the handoff from widget/platform plumbing into the software player.
+#[doc(hidden)]
+pub fn take_registered_video_frame_session(
+    id: VideoFrameSessionId,
+) -> Option<Box<dyn VideoFrameSession>> {
+    unregister_video_frame_session(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::video_decode::yuv::{YuvColorMatrix, YuvLayout, YuvPlaneData};
+
+    struct StubSession;
+
+    impl VideoFrameSession for StubSession {
+        fn take_frames(&mut self) -> Vec<MseDecodedFrame> {
+            vec![MseDecodedFrame {
+                track_id: 0,
+                pts_ms: 123,
+                yuv: YuvPlaneData {
+                    y: vec![16; 4],
+                    u: vec![128; 1],
+                    v: vec![128; 1],
+                    width: 2,
+                    height: 2,
+                    layout: YuvLayout::I420,
+                    matrix: YuvColorMatrix::BT709,
+                },
+            }]
+        }
+
+        fn dimensions(&self) -> Option<(u32, u32)> {
+            Some((2, 2))
+        }
+
+        fn state(&self) -> VideoSessionState {
+            VideoSessionState::Active
+        }
+    }
+
+    #[test]
+    fn registry_roundtrip() {
+        let id = register_video_frame_session(Box::new(StubSession));
+        let mut session = take_registered_video_frame_session(id).expect("session missing");
+        assert_eq!(session.dimensions(), Some((2, 2)));
+        assert_eq!(session.state(), VideoSessionState::Active);
+        assert_eq!(session.take_frames().len(), 1);
+        assert!(take_registered_video_frame_session(id).is_none());
+    }
+
+    #[test]
+    fn unregister_drops_pending_session() {
+        let id = register_video_frame_session(Box::new(StubSession));
+        assert!(unregister_video_frame_session(id).is_some());
+        assert!(take_registered_video_frame_session(id).is_none());
+    }
+}

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -5,6 +5,10 @@ use crate::{
     makepad_draw::*,
     makepad_platform::event::video_playback::*,
     makepad_platform::video::{VideoFormatId, VideoInputId},
+    makepad_platform::{
+        VideoFrameSession, VideoFrameSessionId, register_video_frame_session,
+        unregister_video_frame_session,
+    },
     widget::*,
 };
 use std::rc::Rc;
@@ -400,6 +404,10 @@ pub struct Video {
     #[rust]
     in_memory_source: Option<Rc<Vec<u8>>>,
     #[rust]
+    session_source_id: Option<VideoFrameSessionId>,
+    #[rust]
+    has_session_source: bool,
+    #[rust]
     video_texture: Option<Texture>,
     #[rust]
     video_texture_handle: Option<u32>,
@@ -589,6 +597,7 @@ impl VideoRef {
     ) {
         if let Some(mut inner) = self.borrow_mut() {
             if inner.playback_state == PlaybackState::Unprepared {
+                inner.clear_session_source_registration();
                 inner.source = VideoDataSource::Camera {
                     input_id: input_id.0,
                     format_id: format_id.0,
@@ -604,6 +613,26 @@ impl VideoRef {
     pub fn set_source_in_memory(&self, data: Rc<Vec<u8>>) {
         if let Some(mut inner) = self.borrow_mut() {
             inner.set_source_in_memory(data);
+        }
+    }
+
+    /// Sets an app-owned decoded-frame session as the source for this video.
+    ///
+    /// The session is consumed by the next playback preparation and is rendered
+    /// through the normal widget YUV path.
+    pub fn set_source_session<S>(&self, session: S)
+    where
+        S: VideoFrameSession + 'static,
+    {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_source_session(Box::new(session));
+        }
+    }
+
+    /// Sets an app-owned decoded-frame session as the source for this video.
+    pub fn set_boxed_source_session(&self, session: Box<dyn VideoFrameSession>) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_source_session(session);
         }
     }
 
@@ -852,6 +881,12 @@ impl Widget for Video {
     }
 }
 
+impl Drop for Video {
+    fn drop(&mut self) {
+        self.clear_session_source_registration();
+    }
+}
+
 impl ImageCacheImpl for Video {
     fn get_texture(&self, _id: usize) -> &Option<Texture> {
         &self.thumbnail_texture
@@ -919,7 +954,17 @@ impl Video {
         cx.update_camera_native_preview(self.id, area, visible);
     }
 
+    fn clear_session_source_registration(&mut self) {
+        if let Some(session_id) = self.session_source_id.take() {
+            let _ = unregister_video_frame_session(session_id);
+        }
+        self.has_session_source = false;
+    }
+
     fn infer_source_mode(&self) -> VideoSourceMode {
+        if self.has_session_source {
+            return VideoSourceMode::YuvPlanes;
+        }
         if self.in_memory_source.is_some() {
             return VideoSourceMode::ExternalTexture;
         }
@@ -1001,7 +1046,15 @@ impl Video {
                 return;
             }
 
-            let source = if let Some(data) = self.in_memory_source.clone() {
+            let source = if self.has_session_source {
+                match self.session_source_id.take() {
+                    Some(session_id) => VideoSource::Session(session_id),
+                    None => {
+                        error!("Attempted to prepare playback: session source already consumed");
+                        return;
+                    }
+                }
+            } else if let Some(data) = self.in_memory_source.clone() {
                 VideoSource::InMemory(data)
             } else {
                 match &self.source {
@@ -1347,6 +1400,7 @@ impl Video {
 
     fn set_source(&mut self, source: VideoDataSource) {
         if self.playback_state == PlaybackState::Unprepared {
+            self.clear_session_source_registration();
             self.in_memory_source = None;
             self.source_mode = match source {
                 VideoDataSource::Camera { .. } => VideoSourceMode::YuvPlanes,
@@ -1375,8 +1429,24 @@ impl Video {
 
     fn set_source_in_memory(&mut self, data: Rc<Vec<u8>>) {
         if self.playback_state == PlaybackState::Unprepared {
+            self.clear_session_source_registration();
             self.source_mode = VideoSourceMode::ExternalTexture;
             self.in_memory_source = Some(data);
+        } else {
+            error!(
+                "Attempted to set source while player {} state is: {:?}",
+                self.id.0, self.playback_state
+            );
+        }
+    }
+
+    fn set_source_session(&mut self, session: Box<dyn VideoFrameSession>) {
+        if self.playback_state == PlaybackState::Unprepared {
+            self.clear_session_source_registration();
+            self.in_memory_source = None;
+            self.session_source_id = Some(register_video_frame_session(session));
+            self.has_session_source = true;
+            self.source_mode = VideoSourceMode::YuvPlanes;
         } else {
             error!(
                 "Attempted to set source while player {} state is: {:?}",
@@ -1798,7 +1868,9 @@ impl Video {
     }
 }
 
-/// The source of the video data.
+/// The script-facing source of the video data.
+///
+/// For app-owned live sessions, use [`VideoRef::set_source_session`].
 ///
 /// [`Dependency`]: A resource handle (loaded with `crate_resource("self:path/to/video.mp4")`).
 ///


### PR DESCRIPTION
## Summary
- split custom MSE playback into explicit engine, playback-session, and video-session abstractions
- add registries for app-owned playback, audio, and video session handoff into the widget/platform path
- update the video widget and platform backends to use the new custom session model
- trigger Linux audio device enumeration on startup and make PulseAudio optional via `MAKEPAD_DISABLE_PULSE_AUDIO`

## Validation
- cargo check -p makepad-platform -p makepad-widgets
