### PR TITLE
fix: find_within returns shallowest match instead of deepest

### DIFF
--- a/widgets/src/widget_tree.rs
+++ b/widgets/src/widget_tree.rs
@@ -878,7 +878,6 @@ impl WidgetTree {
         }
 
         let target = path[path.len() - 1];
-        let mut result = WidgetRef::empty();
         let mut visited = HashSet::new();
         let mut stack = vec![Frame {
             uid: root_uid,
@@ -914,7 +913,7 @@ impl WidgetTree {
                         .get(&frame.uid)
                         .and_then(|node| node.widget.upgrade());
                     if let Some(widget) = upgraded {
-                        result = widget;
+                        return widget;
                     } else {
                         Self::discard_stale_cache_item(inner, frame.uid);
                         continue;
@@ -947,7 +946,7 @@ impl WidgetTree {
             });
         }
 
-        result
+        WidgetRef::empty()
     }
 
     fn collect_within_graph(
@@ -1544,10 +1543,11 @@ impl WidgetTree {
     }
 
     /// Find a widget within the subtree of `root_uid` by matching a path of LiveIds.
+    /// Returns the shallowest (first) match in the tree.
     pub fn find_within(&self, root_uid: WidgetUid, path: &[LiveId]) -> WidgetRef {
         let mut inner = self.inner.borrow_mut();
-        let mut results = Self::find_all_within_cached_graph(&mut inner, root_uid, path);
-        results.pop().unwrap_or_else(WidgetRef::empty)
+        let results = Self::find_all_within_cached_graph(&mut inner, root_uid, path);
+        results.into_iter().next().unwrap_or_else(WidgetRef::empty)
     }
 
     /// Find all widgets matching path within the subtree of `root_uid`.


### PR DESCRIPTION
## Problem

`find_within` traverses the entire subtree and returns the **deepest** match. This means that even when a direct child has the queried name, `find_within` skips it in favor of an identically-named widget buried inside a descendant's internal tree — silently returning the wrong widget.

This breaks any composite widget that uses common names like `content`, `header`, or `body` when another composite in its subtree happens to use the same name internally.

## Fix

- `find_within`: `results.pop()` → `results.into_iter().next()` (return first/shallowest match instead of last/deepest)
- `find_within_graph`: `result = widget` → `return widget` (same fix for the uncached variant used by `find_flood`, also avoids traversing the full subtree)

Shallowest-first is correct because callers expect the nearest match — renaming children or using multi-segment queries doesn't scale, since widget authors would need to anticipate the internal naming of every composite they contain.

## Reproduction

```rust
script_mod! {
    use mod.prelude.widgets.*

    mod.widgets.Inner = View {
        content := View { Label { text: "inner" } }
    }

    load_all_resources() do #(App::script_component(vm)) {
        ui: Root {
            main_window := Window {
                body +: {
                    outer := View {
                        content := View { Label { text: "expected" } }
                        inner := Inner {}
                    }
                }
            }
        }
    }
}

// self.view(cx, ids!(content)) returns Inner's content, not outer's
```