### PR TITLE
Avoid double refcell borrow in `Widget::area()` fn

### DIFF
--- a/widgets/src/widget.rs
+++ b/widgets/src/widget.rs
@@ -731,8 +731,10 @@ impl WidgetRef {
     }
 
     pub fn area(&self) -> Area {
-        if let Some(inner) = self.0.borrow().as_ref() {
-            return inner.widget.area();
+        if let Ok(inner) = self.0.try_borrow() {
+            if let Some(inner) = inner.as_ref() {
+                return inner.widget.area();
+            }
         }
         Area::Empty
     }


### PR DESCRIPTION
This was causing loads of random runtime panics in Robrix. I'm not sure if this is the root cause but it is a fix at least.