### PR TITLE
Fixed several issue in text drawing, layout, and text flow.

### DIFF
--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -469,12 +469,23 @@ impl DrawText {
                 last_row.origin_in_lpxs.y - last_row.ascender_in_lpxs,
             ) * self.font_scale;
         let used_size_in_lpxs = text.size_in_lpxs * self.font_scale;
+        // Account for temp_y_shift in the allocated height so that shifted
+        // glyphs (e.g., from top_drop) don't get clipped by their container.
+        let shift_extra_height = if self.temp_y_shift != 0.0 {
+            let fs = text.rows.first()
+                .and_then(|r| r.glyphs.first())
+                .map(|g| g.font_size_in_lpxs)
+                .unwrap_or(0.0);
+            (self.temp_y_shift * fs * self.font_scale).abs() as f64
+        } else {
+            0.0
+        };
         let new_turtle_pos = dvec2(new_turtle_pos.x as f64, new_turtle_pos.y as f64);
         let turtle = cx.turtle_mut();
 
         turtle.move_to(dvec2(origin_in_lpxs.x as f64, origin_in_lpxs.y as f64));
         turtle.allocate_width(used_size_in_lpxs.width as f64);
-        turtle.allocate_height(used_size_in_lpxs.height as f64);
+        turtle.allocate_height(used_size_in_lpxs.height as f64 + shift_extra_height);
         turtle.move_to(new_turtle_pos);
 
         turtle.set_wrap_spacing(
@@ -486,7 +497,7 @@ impl DrawText {
             pos: new_turtle_pos,
             size: dvec2(
                 used_size_in_lpxs.width as f64,
-                used_size_in_lpxs.height as f64,
+                used_size_in_lpxs.height as f64 + shift_extra_height,
             ),
         });
 
@@ -793,6 +804,11 @@ pub struct TextStyle {
     pub font_size: f32,
     #[live(1.0)]
     pub line_spacing: f32,
+    /// A vertical offset applied when drawing text, as a fraction of the font size.
+    /// Positive values shift text downward, useful for aligning baselines when
+    /// mixing fonts with different vertical metrics (e.g., code font with regular text).
+    #[live(0.0)]
+    pub top_drop: f32,
 }
 
 #[derive(Debug, Clone, Script, ScriptHook)]

--- a/draw/src/turtle.rs
+++ b/draw/src/turtle.rs
@@ -620,6 +620,14 @@ impl Turtle {
         self.layout.padding
     }
 
+    /// Sets the left padding of this turtle's layout.
+    ///
+    /// This is useful for adjusting the hanging indent of list items
+    /// after measuring the actual width of the bullet/marker text.
+    pub fn set_padding_left(&mut self, left: f64) {
+        self.layout.padding.left = left;
+    }
+
     /// Returns the alignment of each walk of this turtle with respect to it's rectangle.
     pub fn align(&self) -> Align {
         self.layout.align

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -634,6 +634,9 @@ pub struct TextFlow {
     list_item_layout: Layout,
     #[live]
     list_item_walk: Walk,
+    /// The spacing (in pixels) between the list item marker and the content text.
+    #[live(5.0)]
+    list_item_marker_pad: f64,
     #[live]
     pub inline_code_padding: Inset,
     #[live]
@@ -1290,7 +1293,13 @@ impl TextFlow {
             .move_right_down(dvec2(-font_based_padding, 0.0));
 
         self.draw_text(cx, dot);
-        self.draw_text(cx, " ");
+        TextFlow::walk_margin(cx, self.list_item_marker_pad);
+
+        // Adjust the left padding to match the actual cursor position after the
+        // bullet marker and its trailing pad, so that wrapped lines align with
+        // the text after the marker rather than being over-indented.
+        let actual_indent = cx.turtle().pos().x - cx.turtle().origin().x;
+        cx.turtle_mut().set_padding_left(actual_indent);
 
         self.area_stack.push(self.draw_block.draw_vars.area);
     }
@@ -1554,11 +1563,13 @@ impl TextFlow {
             };
 
             // Apply the text style to the single draw_text instance
+            let top_drop = text_style.top_drop;
             self.draw_text.text_style = text_style;
             let font_size = self.font_sizes.last().unwrap_or(&self.font_size);
             let font_color = self.font_colors.last().unwrap_or(&self.font_color);
             self.draw_text.text_style.font_size = *font_size as _;
             self.draw_text.color = *font_color;
+            self.draw_text.temp_y_shift = top_drop;
 
             let dt = &mut self.draw_text;
 


### PR DESCRIPTION
These are needed to support better formatting of Html code that mixes multiple different styles together, e.g., inline code next to normal code, or inline code within a blockquote or a heading.

---------

Full summary of changes:

* **File:** `draw/src/shader/draw_text.rs`
  * Added `#[live(0.0)] pub top_drop: f32` to `TextStyle`. This is a vertical offset expressed as a fraction of font size — positive values shift text downward. It's useful for aligning baselines when mixing fonts with different vertical metrics (e.g., a code font rendered inline with regular text).
* **File:** `draw/src/shader/draw_text.rs`
  * When `temp_y_shift != 0`, the extra shift pixels are now added to `allocate_height()` and the emitted walk rect. This prevents containers (blockquotes, etc.) from clipping the descenders (g, p, q, y) of vertically-shifted text.
* **File:** `widgets/src/text_flow.rs`
  * After selecting the appropriate text style (normal/bold/italic/fixed), `draw_text.temp_y_shift` is now set from that style's `top_drop` value. This allows each style variant to specify its own vertical offset, since `TextFlow` uses a single shared `DrawText` instance for all text rendering.
* **File:** `draw/src/turtle.rs`
  *New public method to mutate `layout.padding.left` after a turtle has been created.
* **File:** `widgets/src/text_flow.rs`
  * After drawing the bullet/number marker, the actual cursor position is now measured and `set_padding_left()` is called so that wrapped continuation lines align with the text after the marker, rather than being over-indented by the estimated `font_based_padding` (which was `2.5 * font_size`).
  * Additionally, the hardcoded `draw_text(cx, " ")` spacer after the marker was replaced with `walk_margin(cx, self.list_item_marker_pad)` for precise pixel-based control.
* **File:** `widgets/src/text_flow.rs`
  *Added `#[live(5.0)] list_item_marker_pad: f64` — a configurable spacing (in pixels) between the list item marker (bullet/number) and the content text that follows it.