### PR TITLE
Ensure that the Html `<br>` tag obeys current line spacing settings

### DIFF
--- a/draw/src/turtle.rs
+++ b/draw/src/turtle.rs
@@ -2250,6 +2250,13 @@ impl Turtle {
         self.used_height = height_used;
     }
 
+    /// Returns the current wrap spacing, which is the extra vertical space
+    /// added between rows when text wraps (based on the line spacing of the
+    /// most recently drawn text).
+    pub fn wrap_spacing(&self) -> f64 {
+        self.wrap_spacing
+    }
+
     pub fn set_wrap_spacing(&mut self, value: f64) {
         self.wrap_spacing = self.wrap_spacing.max(value);
     }

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -317,7 +317,7 @@ impl Html {
                 trim_whitespace_in_text = TrimWhitespaceInText::Trim;
             }
             some_id!(br) => {
-                tf.new_line_collapsed(cx);
+                tf.new_line_with_wrap_spacing(cx);
                 trim_whitespace_in_text = TrimWhitespaceInText::Trim;
             }
             some_id!(hr) | some_id!(sep) => {

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -1311,6 +1311,18 @@ impl TextFlow {
         }
     }
 
+    /// Starts a new line using the current wrap spacing, so that the vertical
+    /// gap matches the line spacing of the most recently drawn text.
+    /// This is intended for `<br>` tags in HTML rendering.
+    pub fn new_line_with_wrap_spacing(&mut self, cx: &mut Cx2d) {
+        let spacing = cx.turtle().wrap_spacing();
+        cx.turtle_new_line_with_spacing(spacing);
+        self.first_thing_on_a_line = true;
+        if self.selectable {
+            self.selection_tracker.push_newline();
+        }
+    }
+
     pub fn new_line_collapsed_with_spacing(&mut self, cx: &mut Cx2d, spacing: f64) {
         cx.turtle_new_line_with_spacing(spacing);
         self.first_thing_on_a_line = true;


### PR DESCRIPTION
Without this, Html blocks that have both `<br>` and `\n` newlines (or even just soft line wraps) look quite janky, with poor vertical spacing.