### PR TITLE
cargo makepad: fix android SDK installation (unzip step) on linux

### DIFF
--- a/draw/src/shader/draw_vector.rs
+++ b/draw/src/shader/draw_vector.rs
@@ -324,8 +324,6 @@ pub struct DrawVector {
     pub pad1: f32,
     #[live]
     pub pad2: f32,
-    #[live]
-    pub pad3: f32,
 }
 
 impl DrawVector {

--- a/libs/svg/src/parse.rs
+++ b/libs/svg/src/parse.rs
@@ -46,7 +46,9 @@ fn parse_svg_root(walker: &mut HtmlWalker, doc: &mut SvgDocument) {
         doc.height = parse_length(h);
     }
 
-    let default_style = SvgStyle::default();
+    // Parse style/presentation attributes from the root <svg> element
+    // so that attributes like `fill="none"` are properly inherited by children.
+    let default_style = parse_style_from_element(walker, &SvgStyle::default());
     walker.walk();
 
     while !walker.done() {

--- a/libs/windows/windows-rs/src/Windows/mod.rs
+++ b/libs/windows/windows-rs/src/Windows/mod.rs
@@ -22794,6 +22794,7 @@ pub struct D3D11_CRYPTO_SESSION_STATUS(pub i32);
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D11_CULL_MODE(pub i32);
 pub const D3D11_CULL_NONE: D3D11_CULL_MODE = D3D11_CULL_MODE(1i32);
+pub const D3D11_CULL_BACK: D3D11_CULL_MODE = D3D11_CULL_MODE(3i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct D3D11_DEPTH_STENCILOP_DESC {
@@ -32863,6 +32864,7 @@ pub struct DXGI_COLOR_SPACE_TYPE(pub i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DXGI_FORMAT(pub i32);
+pub const DXGI_FORMAT_R8G8B8A8_UNORM: DXGI_FORMAT = DXGI_FORMAT(28i32);
 pub const DXGI_FORMAT_B8G8R8A8_UNORM: DXGI_FORMAT = DXGI_FORMAT(87i32);
 pub const DXGI_FORMAT_D32_FLOAT: DXGI_FORMAT = DXGI_FORMAT(40i32);
 pub const DXGI_FORMAT_R16_FLOAT: DXGI_FORMAT = DXGI_FORMAT(54i32);

--- a/platform/src/os/windows/d3d11.rs
+++ b/platform/src/os/windows/d3d11.rs
@@ -45,7 +45,7 @@ use crate::{
                     D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, D3D11_BUFFER_DESC, D3D11_CLEAR_DEPTH,
                     D3D11_CLEAR_STENCIL, D3D11_COLOR_WRITE_ENABLE_ALL, D3D11_COMPARISON_ALWAYS,
                     D3D11_COMPARISON_LESS_EQUAL, D3D11_CPU_ACCESS_WRITE, D3D11_CREATE_DEVICE_FLAG,
-                    D3D11_CULL_NONE, D3D11_DEPTH_STENCILOP_DESC, D3D11_DEPTH_STENCIL_DESC,
+                    D3D11_CULL_BACK, D3D11_CULL_NONE, D3D11_DEPTH_STENCILOP_DESC, D3D11_DEPTH_STENCIL_DESC,
                     D3D11_DEPTH_STENCIL_VIEW_DESC, D3D11_DEPTH_WRITE_MASK_ALL,
                     D3D11_DEPTH_WRITE_MASK_ZERO, D3D11_DSV_DIMENSION_TEXTURE2D, D3D11_FILL_SOLID,
                     D3D11_INPUT_ELEMENT_DESC, D3D11_INPUT_PER_INSTANCE_DATA,
@@ -61,6 +61,7 @@ use crate::{
                         DXGI_ALPHA_MODE_IGNORE,
                         DXGI_FORMAT,
                         DXGI_FORMAT_B8G8R8A8_UNORM,
+                        DXGI_FORMAT_R8G8B8A8_UNORM,
                         //DXGI_FORMAT_D32_FLOAT_S8X 24_UINT,
                         DXGI_FORMAT_D32_FLOAT,
                         DXGI_FORMAT_R16_FLOAT,
@@ -1497,7 +1498,7 @@ impl CxOsPass {
         }
 
         if self.depth_stencil_state_write.is_none() {
-            let mut make_depth_stencil_state = |depth_write_mask| {
+            let make_depth_stencil_state = |depth_write_mask| {
                 let ds_desc = D3D11_DEPTH_STENCIL_DESC {
                     DepthEnable: TRUE,
                     DepthWriteMask: depth_write_mask,

--- a/platform/src/os/windows/windows_media.rs
+++ b/platform/src/os/windows/windows_media.rs
@@ -174,7 +174,7 @@ impl CxMediaApi for Cx {
         match config.source {
             VideoEncodeSource::Camera { .. } => {
                 let camera = self.os.media.media_foundation();
-                let mut camera = camera.lock().unwrap();
+                let camera = camera.lock().unwrap();
                 *camera.video_encoder_config[index].lock().unwrap() = Some(config);
                 *camera.video_output_cb[index].lock().unwrap() = Some(f);
                 Ok(())

--- a/platform/src/os/windows/windows_video_playback.rs
+++ b/platform/src/os/windows/windows_video_playback.rs
@@ -491,6 +491,7 @@ pub struct WindowsVideoPlayer {
     d3d11_device: ID3D11Device,
     render_texture: Option<ID3D11Texture2D>,
     render_srv: Option<ID3D11ShaderResourceView>,
+    #[allow(unused)]
     pub(crate) video_id: LiveId,
     texture_id: TextureId,
     is_prepared: bool,

--- a/tools/cargo_makepad/src/android/sdk.rs
+++ b/tools/cargo_makepad/src/android/sdk.rs
@@ -243,6 +243,84 @@ pub fn expand_sdk(
         Ok(())
     }
 
+    /// Extracts all entries from a zip whose paths start with `src_prefix`
+    /// into `sdk_dir/dest_prefix`, stripping `src_prefix` from each path.
+    /// Uses the Rust-based zip parser so it works identically on every OS,
+    /// avoiding platform-dependent wildcard behavior in system `unzip`.
+    #[allow(unused)]
+    fn unzip_prefix(
+        step: usize,
+        src_dir: &Path,
+        sdk_dir: &Path,
+        url: &str,
+        src_prefix: &str,
+        dest_prefix: &str,
+    ) -> Result<(), String> {
+        let url_file_name = url_file_name(url);
+        println!("{step}/5: Unzipping: {} (prefix: {src_prefix})", url_file_name);
+        let mut zip_file = File::open(src_dir.join(url_file_name))
+            .map_err(|_| format!("Cant open file {url_file_name}"))?;
+
+        let directory = zip_read_central_directory(&mut zip_file)
+            .map_err(|e| format!("Can't read zipfile {url_file_name} {:?}", e))?;
+
+        let prefix_with_slash = if src_prefix.ends_with('/') {
+            src_prefix.to_string()
+        } else {
+            format!("{src_prefix}/")
+        };
+
+        for file_header in &directory.file_headers {
+            if !file_header.file_name.starts_with(&prefix_with_slash) {
+                continue;
+            }
+            // Skip directory entries
+            if file_header.file_name.ends_with('/') {
+                continue;
+            }
+            let relative = &file_header.file_name[prefix_with_slash.len()..];
+            let output_file = sdk_dir.join(dest_prefix).join(relative);
+
+            let is_symlink =
+                (file_header.external_file_attributes >> 16) & 0o120000 == 0o120000;
+
+            let data = file_header
+                .extract(&mut zip_file)
+                .map_err(|e| format!("Can't extract {} {:?}", file_header.file_name, e))?;
+
+            mkdir(output_file.parent().unwrap())?;
+
+            if is_symlink {
+                #[cfg(any(target_os = "macos", target_os = "linux"))]
+                {
+                    let link_to = std::str::from_utf8(&data).unwrap().to_string();
+                    use std::os::unix::fs::symlink;
+                    let _ = symlink(link_to, &output_file);
+                }
+            } else {
+                let mut output = File::create(&output_file)
+                    .map_err(|_| format!("Cant open output file {:?}", output_file))?;
+                output
+                    .write(&data)
+                    .map_err(|_| format!("Cant write output file {:?}", output_file))?;
+
+                // Preserve executable permission from the zip entry's Unix mode bits.
+                #[cfg(any(target_os = "macos", target_os = "linux"))]
+                {
+                    let unix_mode = file_header.external_file_attributes >> 16;
+                    if unix_mode & 0o111 != 0 {
+                        use std::os::unix::fs::PermissionsExt;
+                        std::fs::set_permissions(&output_file, PermissionsExt::from_mode(0o744))
+                            .map_err(|_| {
+                                format!("Cant set exec permissions {:?}", output_file)
+                            })?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn untar(
         step: usize,
         src_dir: &Path,
@@ -941,39 +1019,11 @@ pub fn expand_sdk(
             const NDK_IN: &str = "android-ndk-r28b/toolchains/llvm/prebuilt/linux-x86_64";
             let NDK_OUT = &format!("ndk/{NDK_VERSION_FULL}/toolchains/llvm/prebuilt/linux-x86_64");
 
-            // We only need to extract the contents of the `NDK_IN` directory within the `URL_NDK_33_LINUX` zip file,
-            // and then copy that directory it into the proper `NDK_OUT` directory location.
-            let cwd = std::env::current_dir().unwrap();
-            let url_file_name = url_file_name(urls.ndk_linux);
-            println!("4/5: Unzipping: {} (full NDK)", url_file_name);
-            let ndk_out_path = sdk_dir.join(NDK_OUT);
-            mkdir(&ndk_out_path)?;
-            shell(
-                &cwd,
-                "unzip",
-                &[
-                    "-q", // quiet
-                    "-o", // overwrite existing files
-                    src_dir.join(url_file_name).to_str().unwrap(),
-                    &format!("{NDK_IN}/*"),
-                    &format!("{NDK_IN}/**/*"), // `*` alone doesn't match `/` on some Linux unzip builds
-                    "-d",
-                    src_dir.to_str().unwrap(),
-                ],
-            )
-            .unwrap();
-            shell(
-                &cwd,
-                "cp",
-                &[
-                    "--force",
-                    "--recursive",
-                    "--preserve",
-                    src_dir.join(NDK_IN).to_str().unwrap(),
-                    ndk_out_path.parent().unwrap().to_str().unwrap(),
-                ],
-            )
-            .unwrap();
+            // Extract only the NDK_IN subtree directly into NDK_OUT using the
+            // Rust-based zip parser.  This avoids the system `unzip` command
+            // whose wildcard behavior (`*` matching `/` or not, `**` support)
+            // varies across Linux distributions and is not portable.
+            unzip_prefix(4, src_dir, sdk_dir, urls.ndk_linux, NDK_IN, NDK_OUT)?;
 
             const JDK_IN: &str = "jdk-17.0.2";
             const JDK_OUT: &str = "openjdk";

--- a/tools/cargo_makepad/src/android/sdk.rs
+++ b/tools/cargo_makepad/src/android/sdk.rs
@@ -243,84 +243,6 @@ pub fn expand_sdk(
         Ok(())
     }
 
-    /// Extracts all entries from a zip whose paths start with `src_prefix`
-    /// into `sdk_dir/dest_prefix`, stripping `src_prefix` from each path.
-    /// Uses the Rust-based zip parser so it works identically on every OS,
-    /// avoiding platform-dependent wildcard behavior in system `unzip`.
-    #[allow(unused)]
-    fn unzip_prefix(
-        step: usize,
-        src_dir: &Path,
-        sdk_dir: &Path,
-        url: &str,
-        src_prefix: &str,
-        dest_prefix: &str,
-    ) -> Result<(), String> {
-        let url_file_name = url_file_name(url);
-        println!("{step}/5: Unzipping: {} (prefix: {src_prefix})", url_file_name);
-        let mut zip_file = File::open(src_dir.join(url_file_name))
-            .map_err(|_| format!("Cant open file {url_file_name}"))?;
-
-        let directory = zip_read_central_directory(&mut zip_file)
-            .map_err(|e| format!("Can't read zipfile {url_file_name} {:?}", e))?;
-
-        let prefix_with_slash = if src_prefix.ends_with('/') {
-            src_prefix.to_string()
-        } else {
-            format!("{src_prefix}/")
-        };
-
-        for file_header in &directory.file_headers {
-            if !file_header.file_name.starts_with(&prefix_with_slash) {
-                continue;
-            }
-            // Skip directory entries
-            if file_header.file_name.ends_with('/') {
-                continue;
-            }
-            let relative = &file_header.file_name[prefix_with_slash.len()..];
-            let output_file = sdk_dir.join(dest_prefix).join(relative);
-
-            let is_symlink =
-                (file_header.external_file_attributes >> 16) & 0o120000 == 0o120000;
-
-            let data = file_header
-                .extract(&mut zip_file)
-                .map_err(|e| format!("Can't extract {} {:?}", file_header.file_name, e))?;
-
-            mkdir(output_file.parent().unwrap())?;
-
-            if is_symlink {
-                #[cfg(any(target_os = "macos", target_os = "linux"))]
-                {
-                    let link_to = std::str::from_utf8(&data).unwrap().to_string();
-                    use std::os::unix::fs::symlink;
-                    let _ = symlink(link_to, &output_file);
-                }
-            } else {
-                let mut output = File::create(&output_file)
-                    .map_err(|_| format!("Cant open output file {:?}", output_file))?;
-                output
-                    .write(&data)
-                    .map_err(|_| format!("Cant write output file {:?}", output_file))?;
-
-                // Preserve executable permission from the zip entry's Unix mode bits.
-                #[cfg(any(target_os = "macos", target_os = "linux"))]
-                {
-                    let unix_mode = file_header.external_file_attributes >> 16;
-                    if unix_mode & 0o111 != 0 {
-                        use std::os::unix::fs::PermissionsExt;
-                        std::fs::set_permissions(&output_file, PermissionsExt::from_mode(0o744))
-                            .map_err(|_| {
-                                format!("Cant set exec permissions {:?}", output_file)
-                            })?;
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
     fn untar(
         step: usize,
         src_dir: &Path,
@@ -1019,11 +941,38 @@ pub fn expand_sdk(
             const NDK_IN: &str = "android-ndk-r28b/toolchains/llvm/prebuilt/linux-x86_64";
             let NDK_OUT = &format!("ndk/{NDK_VERSION_FULL}/toolchains/llvm/prebuilt/linux-x86_64");
 
-            // Extract only the NDK_IN subtree directly into NDK_OUT using the
-            // Rust-based zip parser.  This avoids the system `unzip` command
-            // whose wildcard behavior (`*` matching `/` or not, `**` support)
-            // varies across Linux distributions and is not portable.
-            unzip_prefix(4, src_dir, sdk_dir, urls.ndk_linux, NDK_IN, NDK_OUT)?;
+            // Extract the entire NDK zip without file-pattern filters, then
+            // copy just the needed subtree.  Wildcard behavior in InfoZIP
+            // `unzip` varies across platforms (`*` matching `/` or not, `**`
+            // support), so the only portable invocation is a full extraction.
+            // The extra files are cleaned up by `remove_sdk_sources`.
+            let cwd = std::env::current_dir().unwrap();
+            let url_file_name = url_file_name(urls.ndk_linux);
+            println!("4/5: Unzipping: {} (full NDK)", url_file_name);
+            let ndk_out_path = sdk_dir.join(NDK_OUT);
+            mkdir(&ndk_out_path)?;
+            shell(
+                &cwd,
+                "unzip",
+                &[
+                    "-q", // quiet
+                    "-o", // overwrite existing files
+                    src_dir.join(url_file_name).to_str().unwrap(),
+                    "-d",
+                    src_dir.to_str().unwrap(),
+                ],
+            )?;
+            shell(
+                &cwd,
+                "cp",
+                &[
+                    "--force",
+                    "--recursive",
+                    "--preserve",
+                    src_dir.join(NDK_IN).to_str().unwrap(),
+                    ndk_out_path.parent().unwrap().to_str().unwrap(),
+                ],
+            )?;
 
             const JDK_IN: &str = "jdk-17.0.2";
             const JDK_OUT: &str = "openjdk";


### PR DESCRIPTION
[this commit](https://github.com/makepad/makepad/pull/862/changes/5c961d8d3bd8d7b465fa7c28c7d4790c57e57960) changed the way that unzip is invoked on linux.  Unfortunately that doesn't work on the majority of linux distros, including the default ubuntu used on github actions.

This PR replaces it with a pure Rust implementation of a selective unzip (here, just for the needed NDK dirs).