### PR TITLE
Redraw overlay draw_list on open/close

### DIFF
--- a/widgets/src/modal.rs
+++ b/widgets/src/modal.rs
@@ -171,6 +171,11 @@ impl Widget for Modal {
 impl Modal {
     pub fn open(&mut self, cx: &mut Cx) {
         self.is_open = true;
+        // Redraw the overlay draw_list directly so the first open is visible
+        // even before the overlay content has refreshed its draw area.
+        if let Some(draw_list) = &self.draw_list {
+            draw_list.redraw(cx);
+        }
         self.draw_bg.redraw(cx);
         let content = self.view.widget(cx, ids!(content));
         cx.set_key_focus(content.area());
@@ -185,6 +190,11 @@ impl Modal {
             &mut Scope::empty(),
         );
         self.is_open = false;
+        // Overlay widgets need their dedicated draw_list invalidated explicitly;
+        // a background redraw alone can leave the previous frame visible too long.
+        if let Some(draw_list) = &self.draw_list {
+            draw_list.redraw(cx);
+        }
         self.draw_bg.redraw(cx);
         cx.revert_key_focus();
         cx.unblock_scrolling();

--- a/widgets/src/popup_notification.rs
+++ b/widgets/src/popup_notification.rs
@@ -100,11 +100,21 @@ impl Widget for PopupNotification {
 impl PopupNotification {
     pub fn open(&mut self, cx: &mut Cx) {
         self.opened = true;
+        // Redraw the overlay draw_list directly so the first open is visible
+        // even before the overlay view has established a reusable draw area.
+        if let Some(draw_list) = &self.draw_list {
+            draw_list.redraw(cx);
+        }
         self.redraw(cx);
     }
 
     pub fn close(&mut self, cx: &mut Cx) {
         self.opened = false;
+        // Overlay widgets need their dedicated draw_list invalidated explicitly;
+        // a background redraw alone can leave the last frame visible too long.
+        if let Some(draw_list) = &self.draw_list {
+            draw_list.redraw(cx);
+        }
         self.draw_bg.redraw(cx);
     }
 }


### PR DESCRIPTION
Explicitly redraw the overlay widget draw_list when opening and closing Modal and PopupNotification. This makes the overlay visible immediately on the first open (before the overlay content has refreshed or established a reusable draw area) and ensures the previous frame isn't left visible too long on close. Keeps existing background redraws intact.

We have something similar for tooltip as well