### PR TITLE
Fix shader compilation bug on linux and window positioning

### DIFF
--- a/platform/script/src/shader_control.rs
+++ b/platform/script/src/shader_control.rs
@@ -553,6 +553,16 @@ impl ShaderFnCompiler {
                         )
                         .ok();
                     }
+                    ShaderBackend::Glsl => {
+                        // GLSL ES 3.0 disallows implicit casts from int to uint,
+                        // so we must explicitly cast the bounds to the loop variable type.
+                        write!(
+                            self.out,
+                            "for({3} {0} = {3}({1}); {0} < {3}({2}); {0}++){{\n",
+                            loop_var_name, start, end, ty_name
+                        )
+                        .ok();
+                    }
                     _ => {
                         write!(
                             self.out,

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -1044,10 +1044,12 @@ impl GlShader {
             .map_or(source.len(), |bytes| bytes.len()) as i32
     }
 
+    #[cfg(target_os = "android")]
     fn shader_source_hash(source: &str) -> LiveId {
         live_id!(glsl_source).str_append(source)
     }
 
+    #[cfg(target_os = "android")]
     fn shader_source_preview(source: &str) -> String {
         source
             .lines()
@@ -1178,7 +1180,9 @@ impl GlShader {
             } else {
                 let vertex_len = Self::shader_source_len(vertex);
                 let pixel_len = Self::shader_source_len(pixel);
+                #[cfg(target_os = "android")]
                 let vertex_hash = Self::shader_source_hash(vertex);
+                #[cfg(target_os = "android")]
                 let pixel_hash = Self::shader_source_hash(pixel);
 
                 #[cfg(target_os = "android")]

--- a/platform/src/os/linux/x11/x11_sys.rs
+++ b/platform/src/os/linux/x11/x11_sys.rs
@@ -29,6 +29,12 @@ pub const None: u32 = 0;
 pub const True: u32 = 1;
 pub const False: u32 = 0;
 
+// XSizeHints flags: user/program-specified position and size
+pub const USPosition: c_long = 1 << 0; // user-specified x, y
+pub const USSize: c_long = 1 << 1; // user-specified width, height
+pub const PPosition: c_long = 1 << 2; // program-specified position
+pub const PSize: c_long = 1 << 3; // program-specified size
+
 pub const VisualIDMask: u32 = 1;
 
 pub const CurrentTime: u32 = 0;
@@ -397,6 +403,17 @@ extern "C" {
         arg1: *mut Display,
         arg2: Window,
         arg3: *mut XWindowAttributes,
+    ) -> c_int;
+
+    pub fn XTranslateCoordinates(
+        display: *mut Display,
+        src_window: Window,
+        dest_window: Window,
+        src_x: c_int,
+        src_y: c_int,
+        dest_x_return: *mut c_int,
+        dest_y_return: *mut c_int,
+        child_return: *mut Window,
     ) -> c_int;
 
     pub fn XResourceManagerString(arg1: *mut Display) -> *mut c_char;

--- a/platform/src/os/linux/x11/xlib_window.rs
+++ b/platform/src/os/linux/x11/xlib_window.rs
@@ -5,7 +5,7 @@ use {
         cell::Cell,
         ffi::{CStr, CString, OsStr},
         mem,
-        os::raw::{c_char, c_long, c_ulong, c_void},
+        os::raw::{c_char, c_int, c_long, c_ulong, c_void},
         ptr,
         rc::Rc,
     },
@@ -165,6 +165,17 @@ impl XlibWindow {
             // The title should be set prior to mapping the window.
             let title_bytes = format!("{}\0", title);
             let title_ptr = title_bytes.as_ptr() as *mut c_char;
+
+            // Set USPosition so the WM (e.g. GNOME/Mutter) honors our requested position.
+            // Without this hint many WMs ignore the position from XCreateWindow and apply
+            // their own smart-placement algorithm instead.
+            let mut size_hints = mem::zeroed::<x11_sys::XSizeHints>();
+            if let Some(pos) = position {
+                size_hints.flags = x11_sys::USPosition | x11_sys::PPosition;
+                size_hints.x = pos.x as c_int;
+                size_hints.y = pos.y as c_int;
+            }
+
             x11_sys::Xutf8SetWMProperties(
                 display,
                 window,
@@ -172,7 +183,7 @@ impl XlibWindow {
                 title_ptr,
                 ptr::null_mut(),
                 0,
-                ptr::null_mut(),
+                &mut size_hints,
                 ptr::null_mut(),
                 ptr::null_mut(),
             );
@@ -209,17 +220,19 @@ impl XlibWindow {
             // Set window icon via _NET_WM_ICON
             Self::set_x11_icon(display, window);
 
+            // Reinforce the requested position before mapping. Calling XMoveWindow before
+            // XMapWindow ensures the coordinates are root-relative (the window's parent is
+            // still the root window at this point). After XMapWindow the WM reparents the
+            // window into a decoration frame, and any subsequent XMoveWindow would be
+            // interpreted relative to that frame rather than the root, which can cause the
+            // client area to end up at an unexpected position inside the WM frame.
+            if let Some(pos) = position {
+                x11_sys::XMoveWindow(display, window, pos.x as i32, pos.y as i32);
+            }
+
             // Map the window to the screen
             x11_sys::XMapWindow(display, window);
             x11_sys::XFlush(display);
-
-            // Explicitly set the window position after mapping
-            // This is necessary because some window managers might ignore the initial position
-            // and override it with their own heuristics.
-            if let Some(pos) = position {
-                x11_sys::XMoveWindow(display, window, pos.x as i32, pos.y as i32);
-                x11_sys::XFlush(display);
-            }
 
             let xic = if !get_xlib_app_global().xim.is_null() {
                 Some(x11_sys::XCreateIC(
@@ -564,22 +577,29 @@ impl XlibWindow {
 
     pub fn get_position(&self) -> Vec2d {
         unsafe {
-            let mut xwa = mem::MaybeUninit::uninit();
             let display = get_xlib_app_global().display;
-            x11_sys::XGetWindowAttributes(display, self.window.unwrap(), xwa.as_mut_ptr());
-            let xwa = xwa.assume_init();
-            return Vec2d {
-                x: xwa.x as f64,
-                y: xwa.y as f64,
-            };
-            /*
-            let mut child = mem::uninitialized();
-            let default_screen = X11_sys::XDefaultScreen(display);
-            let root_window = X11_sys::XRootWindow(display, default_screen);
-            let mut x:c_int = 0;
-            let mut y:c_int = 0;
-            X11_sys::XTranslateCoordinates(display, self.window.unwrap(), root_window, 0, 0, &mut x, &mut y, &mut child );
-            */
+            let default_screen = x11_sys::XDefaultScreen(display);
+            let root_window = x11_sys::XRootWindow(display, default_screen);
+            let mut x: c_int = 0;
+            let mut y: c_int = 0;
+            let mut child = mem::MaybeUninit::uninit();
+            // XGetWindowAttributes returns position relative to the parent window,
+            // which after WM reparenting is the decoration frame (not the root).
+            // XTranslateCoordinates gives the correct root-relative (screen) position.
+            x11_sys::XTranslateCoordinates(
+                display,
+                self.window.unwrap(),
+                root_window,
+                0,
+                0,
+                &mut x,
+                &mut y,
+                child.as_mut_ptr(),
+            );
+            Vec2d {
+                x: x as f64,
+                y: y as f64,
+            }
         }
     }
 


### PR DESCRIPTION
TL;DR: the shader compiler needed explicit casts in for loop bounds, and the window positioning was messed up, causing the app-level title bar to overlap with the native OS-level title bar (which means you couldn't see or press the window chrome buttons)

I also fixed various compiler warnings, since they seemed important but actually weren't.

--------

here's an AI-generated summary of the changes, for more details:

On OpenGL ES 3.0 targets (Linux/EGL, Android), shaders containing `for` loops over `uint` variables failed to compile with a GLSL type-error. The shader compiler emitted the loop header as:

```glsl
for(uint i = 0; i < 4; i++) { … }
```

The integer literals `0` and `4` are of type `int` in GLSL. GLSL ES 3.0 forbids implicit casts between `int` and `uint`, so the initialiser and the comparison both produce a compile error. The other shader backends (Metal/WGSL/Rust) do not have this restriction, so no corresponding arm existed for GLSL.

**`platform/script/src/shader_control.rs`** — Add a `ShaderBackend::Glsl` arm to `handle_for_1` that wraps both loop bounds in an explicit constructor call for the loop variable's type:

```glsl
for(uint i = uint(0); i < uint(4); i++) { … }
```

This satisfies GLSL ES 3.0's strict no-implicit-cast rule and matches the behavior already implemented for the WGSL backend (which uses typed variable declarations for the same reason).

**`platform/src/os/linux/opengl.rs`** — Gate the helper functions `shader_source_hash` and `shader_source_preview` (and their call-sites) behind `#[cfg(target_os = "android")]`. These functions are only referenced from Android-specific shader-cache code paths; without the attribute the compiler emits dead-code warnings on every other Linux/OpenGL build.

- `platform/script/src/shader_control.rs`
- `platform/src/os/linux/opengl.rs`

----------------------------------------------------------------------------

On GNOME (and likely other modern WMs), restoring a saved window position would consistently produce two visual artifacts:

1. **No WM title bar visible** — the client area was rendered where the title bar should appear.
2. **Black bar at the bottom** — the bottom portion of the window surface was not covered by rendered content.

The root cause was two related issues in `xlib_window.rs`:

**Issue 1 — `XMoveWindow` called after `XMapWindow` (races with WM reparenting)**

After `XMapWindow`, the window manager asynchronously reparents the client window into a decoration frame. If `XMoveWindow` is called after reparenting has occurred, the coordinates are interpreted relative to the WM frame rather than the root window. For example, calling `XMoveWindow(client, 23, 89)` after GNOME reparents places the client 89 px from the top of the WM frame. Since the title bar is only ~37 px tall, the client ends up 52 px below the title bar, and its bottom edge extends 52 px *beyond* the bottom of the WM frame. GNOME responds by resizing or repositioning the client, producing the rendering artifacts described above.

**Issue 2 — No `USPosition` hint set**

Without the `USPosition` flag in `WM_NORMAL_HINTS`, GNOME ignores the position provided to `XCreateWindow` and applies its own smart-placement algorithm. This meant the application relied entirely on the post-map `XMoveWindow` call described above, which was itself broken.

**`platform/src/os/linux/x11/x11_sys.rs`** — Add the standard `XSizeHints` flag constants:

- `USPosition` (`1 << 0`) — user-specified x, y
- `USSize` (`1 << 1`) — user-specified width, height
- `PPosition` (`1 << 2`) — program-specified position
- `PSize` (`1 << 3`) — program-specified size

**`platform/src/os/linux/x11/xlib_window.rs`** — Two changes in `XlibWindow::init()`:

1. Before calling `Xutf8SetWMProperties`, populate an `XSizeHints` struct with `flags = USPosition | PPosition` (and `x`/`y` set to the requested coordinates) when a position was provided. Pass this struct as the `WM_NORMAL_HINTS` argument instead of the previous `ptr::null_mut()`. This tells GNOME/Mutter to honor the requested position rather than running its own placement heuristic.

2. Move the `XMoveWindow` call to *before* `XMapWindow`. At that point the window is still a direct child of the root window, so the coordinates are unambiguously root-relative. This eliminates the race with WM reparenting entirely.