### PR TITLE
Add animated sidebar toggle and splitter APIs

### DIFF
--- a/studio/desktop/resources/icons/icon_sidebar_toggle.svg
+++ b/studio/desktop/resources/icons/icon_sidebar_toggle.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <rect x="3.5" y="4.5" width="17" height="15" rx="3" stroke="currentColor" stroke-width="1.8"/>
+  <path d="M9 6.5V17.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+</svg>

--- a/studio/desktop/src/app_backend.rs
+++ b/studio/desktop/src/app_backend.rs
@@ -111,6 +111,110 @@ const FILE_FILTER_DEBOUNCE_SECONDS: f64 = 0.14;
 const FILE_FILTER_MAX_RESULTS: usize = 600;
 
 impl App {
+    fn workspace_root_splitter_position(&mut self, cx: &mut Cx, mount: &str) -> Option<f64> {
+        let dock = self.mount_workspace_dock(cx, mount)?;
+        dock.splitter_position(id!(root))
+    }
+
+    fn set_workspace_root_splitter_width(&mut self, cx: &mut Cx, mount: &str, width: f64) -> bool {
+        let Some(dock) = self.mount_workspace_dock(cx, mount) else {
+            return false;
+        };
+        dock.set_splitter_align(cx, id!(root), SplitterAlign::FromA(width.max(0.0)), false)
+    }
+
+    fn start_sidebar_animation(&mut self, cx: &mut Cx, mount: &str, to_width: f64) {
+        let from_width = self
+            .workspace_root_splitter_position(cx, mount)
+            .unwrap_or(to_width);
+        self.sidebar_animation = Some(SidebarAnimation {
+            mount: mount.to_string(),
+            from_width,
+            to_width: to_width.max(0.0),
+            start_time: None,
+        });
+        self.sidebar_animation_next_frame = cx.new_next_frame();
+    }
+
+    pub(super) fn step_sidebar_animation(&mut self, cx: &mut Cx, time: f64) {
+        let Some(animation) = self.sidebar_animation.as_mut() else {
+            return;
+        };
+        let start_time = animation.start_time.get_or_insert(time);
+        let elapsed = (time - *start_time).max(0.0);
+        let duration = 0.16;
+        let progress = (elapsed / duration).min(1.0);
+        let eased = 1.0 - (1.0 - progress).powi(3);
+        let mount = animation.mount.clone();
+        let target = animation.to_width;
+        let width = animation.from_width + (target - animation.from_width) * eased;
+
+        if !self.set_workspace_root_splitter_width(cx, &mount, width) {
+            self.sidebar_animation = None;
+            return;
+        }
+
+        if progress >= 1.0 {
+            self.sidebar_animation = None;
+            self.set_workspace_root_splitter_width(cx, &mount, target);
+            self.save_state(cx, 0);
+        } else {
+            self.sidebar_animation_next_frame = cx.new_next_frame();
+        }
+    }
+
+    fn sync_mount_tab_bar_visibility(&mut self, cx: &mut Cx) {
+        let dock = self.ui.dock(cx, ids!(mount_dock));
+        let Some(mut dock_items) = dock.clone_state() else {
+            return;
+        };
+
+        let mut changed = false;
+        for item in dock_items.values_mut() {
+            let DockItem::Tabs {
+                tabs,
+                selected,
+                closable,
+                hide_tab_bar,
+            } = item
+            else {
+                continue;
+            };
+            let should_hide = tabs.len() <= 1;
+            if *hide_tab_bar == should_hide {
+                continue;
+            }
+            *item = DockItem::Tabs {
+                tabs: tabs.clone(),
+                selected: *selected,
+                closable: *closable,
+                hide_tab_bar: should_hide,
+            };
+            changed = true;
+        }
+
+        if changed {
+            dock.load_state(cx, dock_items);
+        }
+    }
+
+    pub(super) fn toggle_mount_sidebar(&mut self, cx: &mut Cx, mount: &str) {
+        let Some(current_width) = self.workspace_root_splitter_position(cx, mount) else {
+            return;
+        };
+        let restore_width = self
+            .mount_state(mount)
+            .and_then(|state| state.sidebar_restore_width)
+            .unwrap_or(310.0);
+
+        if current_width <= 1.0 {
+            self.start_sidebar_animation(cx, mount, restore_width);
+        } else {
+            self.mount_state_mut(mount).sidebar_restore_width = Some(current_width);
+            self.start_sidebar_animation(cx, mount, 0.0);
+        }
+    }
+
     pub(super) fn apply_mount_file_tree_diff(
         &mut self,
         cx: &mut Cx,
@@ -276,6 +380,7 @@ impl App {
         let dock = self.ui.dock(cx, ids!(mount_dock));
         if let Some(tab_id) = self.mount_state(mount).and_then(|state| state.tab_id) {
             if dock.find_tab_bar_of_tab(tab_id).is_some() {
+                self.sync_mount_tab_bar_visibility(cx);
                 return Some(tab_id);
             }
             self.data.tab_to_mount.remove(&tab_id);
@@ -319,6 +424,7 @@ impl App {
         dock.set_tab_title(cx, tab_id, mount.to_string());
         self.mount_state_mut(mount).tab_id = Some(tab_id);
         self.data.tab_to_mount.insert(tab_id, mount.to_string());
+        self.sync_mount_tab_bar_visibility(cx);
         Some(tab_id)
     }
 

--- a/studio/desktop/src/app_data.rs
+++ b/studio/desktop/src/app_data.rs
@@ -65,6 +65,7 @@ pub struct UiProfilerSamples {
 pub struct MountState {
     pub root: PathBuf,
     pub tab_id: Option<LiveId>,
+    pub sidebar_restore_width: Option<f64>,
     pub file_tree_data: Option<FileTreeData>,
     pub run_items: Vec<RunItem>,
     pub log_entries: VecDeque<UiLogEntry>,
@@ -86,6 +87,7 @@ impl Default for MountState {
         Self {
             root: PathBuf::new(),
             tab_id: None,
+            sidebar_restore_width: None,
             file_tree_data: None,
             run_items: Vec::new(),
             log_entries: VecDeque::new(),

--- a/studio/desktop/src/app_state.rs
+++ b/studio/desktop/src/app_state.rs
@@ -389,7 +389,7 @@ impl App {
         })
     }
 
-    fn save_state(&self, cx: &Cx, slot: usize) {
+    pub(super) fn save_state(&self, cx: &Cx, slot: usize) {
         let valid_mounts: HashSet<String> = self.data.mounts.keys().cloned().collect();
         let mount_dock_items = self
             .ui

--- a/studio/desktop/src/app_state.rs
+++ b/studio/desktop/src/app_state.rs
@@ -9,6 +9,7 @@ struct PersistedMountStateRon {
     dock_items: HashMap<LiveId, DockItem>,
     editor_tab_to_path: HashMap<LiveId, String>,
     terminal_tab_to_path: HashMap<LiveId, String>,
+    sidebar_restore_width: Option<f64>,
     file_filter: String,
     log_filter: String,
     log_tail: bool,
@@ -305,6 +306,7 @@ impl App {
                 mount_state.file_filter = saved.file_filter.clone();
                 mount_state.log_filter = saved.log_filter.clone();
                 mount_state.log_tail = saved.log_tail;
+                mount_state.sidebar_restore_width = saved.sidebar_restore_width;
                 mount_state.terminals_initialized = true;
                 mount_state.terminal_files = terminal_tab_to_path.values().cloned().collect();
                 mount_state.terminal_files.sort();
@@ -383,6 +385,7 @@ impl App {
             dock_items,
             editor_tab_to_path,
             terminal_tab_to_path,
+            sidebar_restore_width: mount_state.sidebar_restore_width,
             file_filter: mount_state.file_filter.clone(),
             log_filter: mount_state.log_filter.clone(),
             log_tail: mount_state.log_tail,
@@ -433,5 +436,47 @@ impl App {
         if needs_save {
             self.save_state(cx, 0);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn persisted_mount_state_round_trips_sidebar_restore_width() {
+        let state = PersistedMountStateRon {
+            mount: "makepad".to_string(),
+            dock_items: HashMap::new(),
+            editor_tab_to_path: HashMap::new(),
+            terminal_tab_to_path: HashMap::new(),
+            sidebar_restore_width: Some(420.0),
+            file_filter: String::new(),
+            log_filter: String::new(),
+            log_tail: true,
+        };
+
+        let restored = PersistedMountStateRon::deserialize_ron(&state.serialize_ron()).unwrap();
+
+        assert_eq!(restored.sidebar_restore_width, Some(420.0));
+    }
+
+    #[test]
+    fn persisted_mount_state_defaults_missing_sidebar_restore_width() {
+        let legacy = r#"
+            (
+                mount:"makepad",
+                dock_items:{},
+                editor_tab_to_path:{},
+                terminal_tab_to_path:{},
+                file_filter:"",
+                log_filter:"",
+                log_tail:true,
+            )
+        "#;
+
+        let restored = PersistedMountStateRon::deserialize_ron(legacy).unwrap();
+
+        assert_eq!(restored.sidebar_restore_width, None);
     }
 }

--- a/studio/desktop/src/app_ui.rs
+++ b/studio/desktop/src/app_ui.rs
@@ -139,6 +139,22 @@ script_mod! {
         }
     }
 
+    let CaptionSidebarToggle = ButtonFlatterIcon {
+        width: 38.0
+        height: 30.0
+        icon_walk: Walk {width: 17.0 height: 17.0}
+        draw_bg +: {
+            color: #x4C4C4C
+            color_hover: #x5C5C5C
+            color_down: #x3F3F3F
+            border_radius: 5.0
+        }
+        draw_icon +: {
+            color: #xD6D6D6
+            svg: crate_resource("self://resources/icons/icon_sidebar_toggle.svg")
+        }
+    }
+
     let STUDIO_PALETTE_1 = #B2FF64
     let STUDIO_PALETTE_2 = #80FFBF
     let STUDIO_PALETTE_3 = #80BFFF
@@ -209,9 +225,55 @@ script_mod! {
 
     mod.widgets.AppUI = Window {
         window.inner_size: vec2(1400 900)
-        caption_bar +: {
-            visible: false
-            height: 0.0
+        caption_bar := SolidView {
+            visible: true
+            height: 38.0
+            flow: Overlay
+            draw_bg.color: theme.color_bg_app
+
+            caption_label := View {
+                width: Fill
+                height: Fill
+                align: Center
+                label := Label {text: "Makepad"}
+            }
+
+            left_controls := View {
+                width: Fit
+                height: Fit
+                flow: Right
+                align: Align {x: 0.0 y: 0.5}
+                margin: Inset {left: 88.0 right: 0.0 top: 0.0 bottom: 0.0}
+
+                sidebar_toggle := CaptionSidebarToggle {}
+            }
+
+            voice_wave := VoiceWave {
+                width: Fit
+                height: Fit
+                align: Align {x: 1.0 y: 0.5}
+                margin: Inset {left: 0.0 right: 112.0 top: 0.0 bottom: 0.0}
+            }
+
+            windows_buttons := View {
+                visible: false
+                width: Fit
+                height: Fit
+                flow: Right
+                align: Align {x: 1.0 y: 0.5}
+                min := DesktopButton {draw_bg.button_type: DesktopButtonType.WindowsMin width: 46 height: 29}
+                max := DesktopButton {draw_bg.button_type: DesktopButtonType.WindowsMax width: 46 height: 29}
+                close := DesktopButton {draw_bg.button_type: DesktopButtonType.WindowsClose width: 46 height: 29}
+            }
+
+            web_fullscreen := View {
+                visible: false
+                width: Fit
+                height: Fit
+                align: Align {x: 1.0 y: 0.5}
+                margin: Inset {left: 0.0 right: 8.0 top: 0.0 bottom: 0.0}
+                fullscreen := DesktopButton {draw_bg.button_type: DesktopButtonType.Fullscreen width: 50 height: 36}
+            }
         }
         draw_bg +: {
             pixel: fn() {
@@ -224,7 +286,7 @@ script_mod! {
             height: Fill
             flow: Down
             spacing: 0.0
-            padding: 10.0
+            padding: Inset {left: 10.0 right: 10.0 top: 2.0 bottom: 10.0}
 
             RoundedView {
                 visible: false

--- a/studio/desktop/src/main.rs
+++ b/studio/desktop/src/main.rs
@@ -68,7 +68,7 @@ script_mod! {
 
     load_all_resources() do #(App::script_component(vm)) {
         ui: Root {
-            AppUI {}
+            main_window := AppUI {}
         }
     }
 }
@@ -78,6 +78,13 @@ fn push_capped_deque<T>(entries: &mut std::collections::VecDeque<T>, entry: T, m
     while entries.len() > max_len {
         entries.pop_front();
     }
+}
+
+pub struct SidebarAnimation {
+    mount: String,
+    from_width: f64,
+    to_width: f64,
+    start_time: Option<f64>,
 }
 
 fn parse_path_line_column_token(token: &str) -> Option<(String, usize, usize)> {
@@ -117,6 +124,10 @@ pub struct App {
     pub file_filter_debounce_timer: Timer,
     #[rust]
     pub pending_file_filter: Option<(String, String)>,
+    #[rust]
+    pub sidebar_animation: Option<SidebarAnimation>,
+    #[rust]
+    pub sidebar_animation_next_frame: NextFrame,
 }
 
 impl MatchEvent for App {
@@ -127,6 +138,12 @@ impl MatchEvent for App {
     }
 
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions) {
+        if self.ui.button(cx, ids!(sidebar_toggle)).clicked(actions) {
+            if let Some(active_mount) = self.data.active_mount.clone() {
+                self.toggle_mount_sidebar(cx, &active_mount);
+            }
+        }
+
         if let Some(active_mount) = self.data.active_mount.clone() {
             if let Some(workspace) = self.mount_workspace_widget(cx, &active_mount) {
                 if let Some(node_id) = workspace
@@ -300,6 +317,23 @@ impl AppMain for App {
         self.match_event(cx, event);
         self.ui
             .handle_event(cx, event, &mut Scope::with_data(&mut self.data));
+
+        if let Event::NextFrame(ne) = event {
+            if self.sidebar_animation_next_frame.is_event(event).is_some() {
+                self.step_sidebar_animation(cx, ne.time);
+            }
+        }
+
+        if let Event::WindowDragQuery(dq) = event {
+            let main_window = self.ui.window(cx, ids!(main_window));
+            if Some(dq.window_id) == main_window.window_id() {
+                let button_rect = self.ui.button(cx, ids!(sidebar_toggle)).area().rect(cx);
+                if button_rect.contains(dq.abs) {
+                    dq.response.set(WindowDragQueryResponse::Client);
+                    cx.set_cursor(MouseCursor::Default);
+                }
+            }
+        }
 
         if matches!(event, Event::Signal) {
             self.drain_studio_messages(cx)

--- a/widgets/src/dock.rs
+++ b/widgets/src/dock.rs
@@ -888,6 +888,44 @@ impl Dock {
         }
     }
 
+    fn splitter_position(&self, splitter_id: LiveId) -> Option<f64> {
+        self.splitters
+            .get(&splitter_id)
+            .map(|splitter| splitter.position())
+    }
+
+    fn set_splitter_align(
+        &mut self,
+        cx: &mut Cx,
+        splitter_id: LiveId,
+        align: SplitterAlign,
+        mark_dirty: bool,
+    ) -> bool {
+        let Some(DockItem::Splitter {
+            a,
+            b,
+            align: current_align,
+            ..
+        }) = self.dock_items.get_mut(&splitter_id)
+        else {
+            return false;
+        };
+
+        let a = *a;
+        let b = *b;
+        *current_align = align;
+        if let Some(splitter) = self.splitters.get_mut(&splitter_id) {
+            splitter.set_align(align);
+        }
+        self.redraw_item(cx, a);
+        self.redraw_item(cx, b);
+        self.area.redraw(cx);
+        if mark_dirty {
+            self.needs_save = true;
+        }
+        true
+    }
+
     fn unsplit_tabs(&mut self, cx: &mut Cx, tabs_id: LiveId) {
         self.needs_save = true;
         for (splitter_id, item) in self.dock_items.iter_mut() {
@@ -1737,6 +1775,23 @@ impl DockRef {
         if let Some(mut dock) = self.borrow_mut() {
             dock.redraw_tab(cx, tab_id);
         }
+    }
+
+    pub fn splitter_position(&self, splitter_id: LiveId) -> Option<f64> {
+        self.borrow()
+            .and_then(|dock| dock.splitter_position(splitter_id))
+    }
+
+    pub fn set_splitter_align(
+        &self,
+        cx: &mut Cx,
+        splitter_id: LiveId,
+        align: SplitterAlign,
+        mark_dirty: bool,
+    ) -> bool {
+        self.borrow_mut().is_some_and(|mut dock| {
+            dock.set_splitter_align(cx, splitter_id, align, mark_dirty)
+        })
     }
 
     pub fn unique_id(&self, base: u64) -> LiveId {

--- a/widgets/src/splitter.rs
+++ b/widgets/src/splitter.rs
@@ -423,6 +423,10 @@ impl Splitter {
         self.align
     }
 
+    pub fn position(&self) -> f64 {
+        self.position
+    }
+
     pub fn set_align(&mut self, align: SplitterAlign) {
         self.align = align;
     }
@@ -479,5 +483,9 @@ impl SplitterRef {
 
     pub fn align(&self) -> Option<SplitterAlign> {
         self.borrow().map(|inner| inner.align())
+    }
+
+    pub fn position(&self) -> Option<f64> {
+        self.borrow().map(|inner| inner.position())
     }
 }


### PR DESCRIPTION
Add an animated, persistent sidebar toggle and supporting splitter APIs/UI.

- New icon resource: studio/desktop/resources/icons/icon_sidebar_toggle.svg
- UI: replace hidden caption bar with a visible caption that includes a sidebar toggle button (CaptionSidebarToggle), layout adjustments and related controls.
- App behavior: add SidebarAnimation struct and App fields to track animation state and next-frame. Handle button actions, next-frame stepping, and window drag queries to avoid initiating window drag over the toggle.
- Add App methods to query/set the workspace root splitter position, start/step sidebar animations, toggle sidebar (remember/restore width), and sync tab-bar visibility for mounts.
- Persist mount sidebar restore width by adding sidebar_restore_width to MountState and initializing default.
- Make save_state pub(super) so App can save when animation finishes.
- Widgets: expose splitter position and set_splitter_align on Dock and Splitter to allow programmatic width changes and redrawing.

These changes improve UX by providing a smooth animated sidebar hide/show, remembering user width per mount, and ensuring the dock UI updates correctly during mount/tab changes.