### PR TITLE
Introduce UI constants and tweak studio layout

### DIFF
--- a/studio/desktop/src/app_backend.rs
+++ b/studio/desktop/src/app_backend.rs
@@ -829,7 +829,7 @@ impl App {
                     tab_id,
                     id!(TerminalPane),
                     Self::terminal_tab_title(path),
-                    id!(CloseableTab),
+                    id!(TerminalCloseableTab),
                     Some(pos.saturating_sub(1)),
                 )
                 .is_none()

--- a/studio/desktop/src/app_ui.rs
+++ b/studio/desktop/src/app_ui.rs
@@ -301,6 +301,48 @@ script_mod! {
         }
     }
 
+    let TerminalCloseableTab = TabFlat {
+        closeable: true
+        spacing: theme.space_1
+        draw_text +: {
+            color: theme.color_label_inner_inactive
+            color_hover: theme.color_label_inner
+            color_active: theme.color_label_inner_active
+        }
+        close_button +: {
+            width: 12.0
+            height: 12.0
+            margin: Inset {left: -1.0 right: 8.0 top: 0.0 bottom: 0.0}
+            draw_button +: {
+                color: #x9A9A9A
+                color_hover: #xD0D0D0
+                color_active: #xE2E2E2
+            }
+        }
+    }
+
+    let TerminalAddTab = TabFlat {
+        closeable: false
+        width: 28.0
+        spacing: 0.0
+        align: Center
+        padding: Inset {left: 0.0 right: 0.0 top: theme.space_2 bottom: theme.space_2}
+        icon_walk: Walk {width: 0.0 height: 0.0}
+        draw_text +: {
+            color: theme.color_label_inner_inactive
+            color_hover: theme.color_label_inner
+            color_active: theme.color_label_inner_active
+            text_style: theme.font_bold{
+                font_size: theme.font_size_p + 1.0
+            }
+        }
+        draw_bg +: {
+            color: theme.color_bg_app * 0.82
+            color_hover: theme.color_bg_app * 0.94
+            color_active: theme.color_fg_app
+        }
+    }
+
     let StudioDock = DockFlat {
         tab_bar +: {
             height: STUDIO_HEADER_HEIGHT
@@ -459,6 +501,8 @@ script_mod! {
                             LogFirstTab := LogFirstTab {}
                             LogTab := LogTab {}
                             TerminalTab := TerminalTab {}
+                            TerminalCloseableTab := TerminalCloseableTab {}
+                            TerminalAddTab := TerminalAddTab {}
                         }
 
                         root := DockSplitter {
@@ -544,7 +588,7 @@ script_mod! {
 
                         terminal_add := DockTab {
                             name: "+"
-                            template: @PermanentTab
+                            template: @TerminalAddTab
                             kind: @TerminalAddPane
                         }
 

--- a/studio/desktop/src/app_ui.rs
+++ b/studio/desktop/src/app_ui.rs
@@ -4,9 +4,11 @@ script_mod! {
     use mod.prelude.widgets.*
     use mod.widgets.*
 
+    let STUDIO_HEADER_HEIGHT = 36.0
+
     let PaneToolbar = RectView {
         width: Fill
-        height: 36.0
+        height: STUDIO_HEADER_HEIGHT
         flow: Right
         align: Align {x: 0.0 y: 0.5}
         padding: Inset {left: 8.0 right: 8.0 top: 0.0 bottom: 0.0}
@@ -79,29 +81,61 @@ script_mod! {
         height: Fill
         flow: Down
         PaneToolbar {
-            log_tail_toggle := Toggle {
-                text: "Tail"
-                active: true
+            View {
+                width: Fit
+                height: Fit
+                flow: Right
+                align: Align {x: 0.0 y: 0.5}
+                spacing: theme.space_1
+
+                log_tail_toggle := Toggle {
+                    text: "Tail"
+                    margin: Inset {}
+                    active: true
+                }
             }
             Filler {}
-            log_filter := TextInputFlat {
-                width: 200.0
-                empty_text: "Filter"
+            View {
+                width: Fit
+                height: Fit
+                flow: Right
+                align: Align {x: 0.0 y: 0.5}
+                spacing: 6.0
+
+                log_filter := TextInputFlat {
+                    width: 232.0
+                    margin: Inset {}
+                    empty_text: "Filter"
+                }
+                clear_log_filter := ButtonFlatter {
+                    width: 24.0
+                    height: 24.0
+                    text: "x"
+                    margin: Inset {}
+                    padding: Inset {left: 0.0 right: 0.0 top: 0.0 bottom: 0.0}
+                }
             }
-            clear_log_filter := ButtonFlatter {
-                text: "x"
-                padding: Inset {left: 4.0 right: 4.0 top: 0.0 bottom: 0.0}
-            }
-            clear_log := ButtonFlatter {
-                text: "Clear"
-            }
-            log_open_profiler := ButtonFlatterIcon {
-                width: 24.0
-                height: 24.0
-                icon_walk: Walk {width: 14.0 height: 14.0}
-                draw_icon +: {
-                    color: theme.color_label_outer
-                    svg: crate_resource("self://resources/icons/icon_profiler.svg")
+            View {
+                width: Fit
+                height: Fit
+                flow: Right
+                align: Align {x: 0.0 y: 0.5}
+                spacing: theme.space_1
+
+                clear_log := ButtonFlatter {
+                    text: "Clear"
+                    margin: Inset {}
+                    padding: Inset {left: 10.0 right: 10.0 top: 0.0 bottom: 0.0}
+                }
+                log_open_profiler := ButtonFlatterIcon {
+                    width: 24.0
+                    height: 24.0
+                    margin: Inset {}
+                    icon_walk: Walk {width: 14.0 height: 14.0}
+                    draw_icon +: {
+                        color: theme.color_label_outer
+                        svg: crate_resource("self://resources/icons/icon_profiler.svg")
+                    }
                 }
             }
         }
@@ -192,6 +226,24 @@ script_mod! {
         closeable: false
         spacing: theme.space_1
         icon_walk: Walk {width: Fit height: 16.0}
+        draw_text +: {
+            color: theme.color_label_inner_inactive
+            color_hover: theme.color_label_inner
+            color_active: theme.color_label_inner_active
+        }
+        draw_bg +: {
+            color: theme.color_bg_app * 0.84
+            color_hover: theme.color_bg_app * 0.96
+            color_active: theme.color_fg_app
+
+            border_color: theme.color_bg_app * 0.84
+            border_color_hover: theme.color_bg_app
+            border_color_active: theme.color_fg_app
+
+            border_color_2: theme.color_bg_app * 0.84
+            border_color_2_hover: theme.color_bg_app
+            border_color_2_active: theme.color_fg_app
+        }
     }
 
     let MountTab = IconTab {
@@ -249,11 +301,26 @@ script_mod! {
         }
     }
 
+    let StudioDock = DockFlat {
+        tab_bar +: {
+            height: STUDIO_HEADER_HEIGHT
+        }
+        splitter +: {
+            draw_bg +: {
+                color: theme.color_bg_container
+                color_hover: theme.color_bevel_outset_1_hover * 0.45
+                color_drag: theme.color_bevel_outset_1_hover * 0.7
+                border_radius: 1.5
+                splitter_pad: 1.5
+            }
+        }
+    }
+
     mod.widgets.AppUI = Window {
         window.inner_size: vec2(1400 900)
         caption_bar := SolidView {
             visible: true
-            height: 38.0
+            height: STUDIO_HEADER_HEIGHT
             flow: Right
             align: Align {x: 0.0 y: 0.5}
             draw_bg.color: theme.color_bg_app
@@ -263,7 +330,7 @@ script_mod! {
                 height: Fit
                 flow: Right
                 align: Align {x: 0.0 y: 0.5}
-                margin: Inset {left: 88.0 right: 0.0 top: 0.0 bottom: 0.0}
+                margin: Inset {left: 72.0 right: 0.0 top: 0.0 bottom: 0.0}
 
                 sidebar_toggle := CaptionSidebarToggle {}
             }
@@ -272,15 +339,24 @@ script_mod! {
                 width: Fill
                 height: Fill
                 align: Center
-                label := Label {text: "Makepad"}
+                label := Label {
+                    text: "Makepad"
+                    padding: 0.0
+                    draw_text +: {
+                        color: theme.color_label_outer
+                        text_style: theme.font_bold{
+                            font_size: theme.font_size_p + 0.5
+                        }
+                    }
+                }
             }
 
             right_caption_tools := View {
                 width: Fit
                 height: Fit
                 flow: Right
-                spacing: theme.space_2
-                margin: Inset {left: 0.0 right: 112.0 top: 0.0 bottom: 0.0}
+                spacing: theme.space_1
+                margin: Inset {left: 0.0 right: 96.0 top: 0.0 bottom: 0.0}
 
                 bottom_panel_toggle := CaptionPanelToggle {}
                 voice_wave := VoiceWave {
@@ -345,7 +421,7 @@ script_mod! {
                 }
             }
 
-            mount_dock := DockFlat {
+            mount_dock := StudioDock {
                 width: Fill
                 height: Fill
 
@@ -369,7 +445,7 @@ script_mod! {
                     width: Fill
                     height: Fill
 
-                    dock := DockFlat {
+                    dock := StudioDock {
                         width: Fill
                         height: Fill
 

--- a/studio/desktop/src/app_ui.rs
+++ b/studio/desktop/src/app_ui.rs
@@ -273,6 +273,16 @@ script_mod! {
         closeable: false
         spacing: theme.space_1
         icon_walk: Walk {width: Fit height: 16.0}
+        close_button +: {
+            width: 11.0
+            height: 11.0
+            margin: Inset {left: 1.0 right: 7.0 top: 0.0 bottom: 0.0}
+            draw_button +: {
+                color: #x8C8C8C
+                color_hover: #xC8C8C8
+                color_active: #xDEDEDE
+            }
+        }
         draw_text +: {
             color: theme.color_label_inner_inactive
             color_hover: theme.color_label_inner
@@ -370,13 +380,13 @@ script_mod! {
             border_color_2_active: theme.color_bg_app * 0.92
         }
         close_button +: {
-            width: 12.0
-            height: 12.0
-            margin: Inset {left: -1.0 right: 8.0 top: 0.0 bottom: 0.0}
+            width: 11.0
+            height: 11.0
+            margin: Inset {left: 1.0 right: 7.0 top: 0.0 bottom: 0.0}
             draw_button +: {
-                color: #x9A9A9A
-                color_hover: #xD0D0D0
-                color_active: #xE2E2E2
+                color: #x8C8C8C
+                color_hover: #xC8C8C8
+                color_active: #xDEDEDE
             }
         }
     }

--- a/studio/desktop/src/app_ui.rs
+++ b/studio/desktop/src/app_ui.rs
@@ -18,12 +18,59 @@ script_mod! {
         }
     }
 
+    let LogToolbarToggle = Toggle {
+        margin: Inset {}
+        padding: Inset {left: 0.0 right: 0.0 top: 0.0 bottom: 0.0}
+        label_walk: Walk {width: Fit height: Fit margin: Inset {left: 24.0 right: 0.0 top: 0.0 bottom: 0.0}}
+        draw_bg +: {
+            size: 13.0
+        }
+        draw_text +: {
+            color: theme.color_label_outer_off
+            color_hover: theme.color_label_outer
+            color_active: theme.color_label_outer
+        }
+    }
+
+    let SidebarFilterInput = TextInputFlat {
+        margin: Inset {}
+        padding: Inset {left: 12.0 right: 12.0 top: 0.0 bottom: 0.0}
+        draw_bg +: {
+            border_radius: 4.0
+
+            color: theme.color_bg_app * 0.78
+            color_hover: theme.color_bg_app * 0.86
+            color_focus: theme.color_bg_app * 0.9
+            color_down: theme.color_bg_app * 0.82
+            color_empty: theme.color_bg_app * 0.78
+
+            border_color: theme.color_u_hidden
+            border_color_hover: theme.color_u_hidden
+            border_color_focus: theme.color_u_hidden
+            border_color_down: theme.color_u_hidden
+            border_color_empty: theme.color_u_hidden
+            border_color_disabled: theme.color_u_hidden
+
+            border_color_2: theme.color_u_hidden
+            border_color_2_hover: theme.color_u_hidden
+            border_color_2_focus: theme.color_u_hidden
+            border_color_2_down: theme.color_u_hidden
+            border_color_2_empty: theme.color_u_hidden
+            border_color_2_disabled: theme.color_u_hidden
+        }
+        draw_text +: {
+            color_empty: theme.color_label_outer_off
+            color_empty_hover: theme.color_label_outer_off
+            color_empty_focus: theme.color_label_outer
+        }
+    }
+
     let FileTreePane = View {
         width: Fill
         height: Fill
         flow: Down
         PaneToolbar {
-            file_tree_filter := TextInputFlat {
+            file_tree_filter := SidebarFilterInput {
                 width: Fill
                 empty_text: "Filter"
             }
@@ -88,9 +135,8 @@ script_mod! {
                 align: Align {x: 0.0 y: 0.5}
                 spacing: theme.space_1
 
-                log_tail_toggle := Toggle {
+                log_tail_toggle := LogToolbarToggle {
                     text: "Tail"
-                    margin: Inset {}
                     active: true
                 }
             }
@@ -100,32 +146,33 @@ script_mod! {
                 height: Fit
                 flow: Right
                 align: Align {x: 0.0 y: 0.5}
-                spacing: 6.0
+                spacing: 4.0
 
                 log_filter := TextInputFlat {
-                    width: 232.0
+                    width: 216.0
                     margin: Inset {}
                     empty_text: "Filter"
                 }
                 clear_log_filter := ButtonFlatter {
-                    width: 24.0
-                    height: 24.0
+                    width: 20.0
+                    height: 20.0
                     text: "x"
                     margin: Inset {}
                     padding: Inset {left: 0.0 right: 0.0 top: 0.0 bottom: 0.0}
                 }
             }
+            View {width: 10.0 height: Fit}
             View {
                 width: Fit
                 height: Fit
                 flow: Right
                 align: Align {x: 0.0 y: 0.5}
-                spacing: theme.space_1
+                spacing: 8.0
 
                 clear_log := ButtonFlatter {
                     text: "Clear"
                     margin: Inset {}
-                    padding: Inset {left: 10.0 right: 10.0 top: 0.0 bottom: 0.0}
+                    padding: Inset {left: 8.0 right: 8.0 top: 0.0 bottom: 0.0}
                 }
                 log_open_profiler := ButtonFlatterIcon {
                     width: 24.0
@@ -151,11 +198,16 @@ script_mod! {
 
     let LogFirstPane = LogPane {}
 
+    let StudioTerminalView = DesktopTerminalView {
+        pad_x: 6.0
+        pad_y: 4.0
+    }
+
     let TerminalPane = View {
         width: Fill
         height: Fill
         flow: Down
-        terminal_view := DesktopTerminalView {}
+        terminal_view := StudioTerminalView {}
     }
 
     let TerminalFirstPane = RectView {
@@ -183,34 +235,29 @@ script_mod! {
         }
     }
 
-    let CaptionSidebarToggle = ButtonFlatterIcon {
-        width: 38.0
-        height: 30.0
-        icon_walk: Walk {width: 17.0 height: 17.0}
+    let CaptionChromeToggle = ButtonFlatterIcon {
+        width: 36.0
+        height: 28.0
+        icon_walk: Walk {width: 16.0 height: 16.0}
         draw_bg +: {
-            color: #x4C4C4C
-            color_hover: #x5C5C5C
-            color_down: #x3F3F3F
-            border_radius: 5.0
+            color: #x474747
+            color_hover: #x525252
+            color_down: #x414141
+            border_radius: 4.0
         }
         draw_icon +: {
-            color: #xD6D6D6
+            color: #xCBCBCB
+        }
+    }
+
+    let CaptionSidebarToggle = CaptionChromeToggle {
+        draw_icon +: {
             svg: crate_resource("self://resources/icons/icon_sidebar_toggle.svg")
         }
     }
 
-    let CaptionPanelToggle = ButtonFlatterIcon {
-        width: 38.0
-        height: 30.0
-        icon_walk: Walk {width: 17.0 height: 17.0}
-        draw_bg +: {
-            color: #x4C4C4C
-            color_hover: #x5C5C5C
-            color_down: #x3F3F3F
-            border_radius: 5.0
-        }
+    let CaptionPanelToggle = CaptionChromeToggle {
         draw_icon +: {
-            color: #xD6D6D6
             svg: crate_resource("self://resources/icons/icon_panel_toggle.svg")
         }
     }

--- a/studio/desktop/src/app_ui.rs
+++ b/studio/desktop/src/app_ui.rs
@@ -236,13 +236,13 @@ script_mod! {
             color_hover: theme.color_bg_app * 0.96
             color_active: theme.color_fg_app
 
-            border_color: theme.color_bg_app * 0.84
-            border_color_hover: theme.color_bg_app
-            border_color_active: theme.color_fg_app
+            border_color: theme.color_u_hidden
+            border_color_hover: theme.color_u_hidden
+            border_color_active: theme.color_bg_app * 0.92
 
-            border_color_2: theme.color_bg_app * 0.84
-            border_color_2_hover: theme.color_bg_app
-            border_color_2_active: theme.color_fg_app
+            border_color_2: theme.color_u_hidden
+            border_color_2_hover: theme.color_u_hidden
+            border_color_2_active: theme.color_bg_app * 0.92
         }
     }
 
@@ -309,6 +309,19 @@ script_mod! {
             color_hover: theme.color_label_inner
             color_active: theme.color_label_inner_active
         }
+        draw_bg +: {
+            color: theme.color_bg_app * 0.84
+            color_hover: theme.color_bg_app * 0.95
+            color_active: theme.color_fg_app
+
+            border_color: theme.color_u_hidden
+            border_color_hover: theme.color_u_hidden
+            border_color_active: theme.color_bg_app * 0.92
+
+            border_color_2: theme.color_u_hidden
+            border_color_2_hover: theme.color_u_hidden
+            border_color_2_active: theme.color_bg_app * 0.92
+        }
         close_button +: {
             width: 12.0
             height: 12.0
@@ -340,6 +353,14 @@ script_mod! {
             color: theme.color_bg_app * 0.82
             color_hover: theme.color_bg_app * 0.94
             color_active: theme.color_fg_app
+
+            border_color: theme.color_u_hidden
+            border_color_hover: theme.color_u_hidden
+            border_color_active: theme.color_bg_app * 0.92
+
+            border_color_2: theme.color_u_hidden
+            border_color_2_hover: theme.color_u_hidden
+            border_color_2_active: theme.color_bg_app * 0.92
         }
     }
 

--- a/studio/desktop/src/app_ui.rs
+++ b/studio/desktop/src/app_ui.rs
@@ -38,11 +38,11 @@ script_mod! {
         draw_bg +: {
             border_radius: 4.0
 
-            color: theme.color_bg_app * 0.78
-            color_hover: theme.color_bg_app * 0.86
-            color_focus: theme.color_bg_app * 0.9
-            color_down: theme.color_bg_app * 0.82
-            color_empty: theme.color_bg_app * 0.78
+            color: theme.color_bg_app * 0.82
+            color_hover: theme.color_bg_app * 0.88
+            color_focus: theme.color_bg_app * 0.92
+            color_down: theme.color_bg_app * 0.85
+            color_empty: theme.color_bg_app * 0.82
 
             border_color: theme.color_u_hidden
             border_color_hover: theme.color_u_hidden
@@ -59,9 +59,66 @@ script_mod! {
             border_color_2_disabled: theme.color_u_hidden
         }
         draw_text +: {
-            color_empty: theme.color_label_outer_off
-            color_empty_hover: theme.color_label_outer_off
+            color_empty: theme.color_label_inner_inactive
+            color_empty_hover: theme.color_label_inner_inactive
             color_empty_focus: theme.color_label_outer
+        }
+    }
+
+    let LogToolbarFilterInput = TextInputFlat {
+        margin: Inset {}
+        padding: Inset {left: 10.0 right: 10.0 top: 0.0 bottom: 0.0}
+        draw_bg +: {
+            border_radius: 4.0
+
+            color: theme.color_bg_app * 0.84
+            color_hover: theme.color_bg_app * 0.9
+            color_focus: theme.color_bg_app * 0.94
+            color_down: theme.color_bg_app * 0.87
+            color_empty: theme.color_bg_app * 0.84
+
+            border_color: theme.color_u_hidden
+            border_color_hover: theme.color_u_hidden
+            border_color_focus: theme.color_u_hidden
+            border_color_down: theme.color_u_hidden
+            border_color_empty: theme.color_u_hidden
+            border_color_disabled: theme.color_u_hidden
+
+            border_color_2: theme.color_u_hidden
+            border_color_2_hover: theme.color_u_hidden
+            border_color_2_focus: theme.color_u_hidden
+            border_color_2_down: theme.color_u_hidden
+            border_color_2_empty: theme.color_u_hidden
+            border_color_2_disabled: theme.color_u_hidden
+        }
+        draw_text +: {
+            color_empty: theme.color_label_inner_inactive
+            color_empty_hover: theme.color_label_inner_inactive
+            color_empty_focus: theme.color_label_outer
+        }
+    }
+
+    let LogToolbarButton = ButtonFlatter {
+        margin: Inset {}
+        padding: Inset {left: 8.0 right: 8.0 top: 0.0 bottom: 0.0}
+        draw_text +: {
+            color: theme.color_label_outer_off
+            color_hover: theme.color_label_outer
+            color_down: theme.color_label_outer
+            color_focus: theme.color_label_outer
+        }
+    }
+
+    let LogToolbarIconButton = ButtonFlatterIcon {
+        width: 22.0
+        height: 22.0
+        margin: Inset {}
+        icon_walk: Walk {width: 13.0 height: 13.0}
+        draw_icon +: {
+            color: theme.color_label_outer_off
+            color_hover: theme.color_label_outer
+            color_down: theme.color_label_outer
+            color_focus: theme.color_label_outer
         }
     }
 
@@ -148,16 +205,14 @@ script_mod! {
                 align: Align {x: 0.0 y: 0.5}
                 spacing: 4.0
 
-                log_filter := TextInputFlat {
+                log_filter := LogToolbarFilterInput {
                     width: 216.0
-                    margin: Inset {}
                     empty_text: "Filter"
                 }
-                clear_log_filter := ButtonFlatter {
+                clear_log_filter := LogToolbarButton {
                     width: 20.0
                     height: 20.0
                     text: "x"
-                    margin: Inset {}
                     padding: Inset {left: 0.0 right: 0.0 top: 0.0 bottom: 0.0}
                 }
             }
@@ -169,18 +224,11 @@ script_mod! {
                 align: Align {x: 0.0 y: 0.5}
                 spacing: 8.0
 
-                clear_log := ButtonFlatter {
+                clear_log := LogToolbarButton {
                     text: "Clear"
-                    margin: Inset {}
-                    padding: Inset {left: 8.0 right: 8.0 top: 0.0 bottom: 0.0}
                 }
-                log_open_profiler := ButtonFlatterIcon {
-                    width: 24.0
-                    height: 24.0
-                    margin: Inset {}
-                    icon_walk: Walk {width: 14.0 height: 14.0}
+                log_open_profiler := LogToolbarIconButton {
                     draw_icon +: {
-                        color: theme.color_label_outer
                         svg: crate_resource("self://resources/icons/icon_profiler.svg")
                     }
                 }

--- a/studio/desktop/src/desktop_file_tree.rs
+++ b/studio/desktop/src/desktop_file_tree.rs
@@ -8,11 +8,14 @@ script_mod! {
     use mod.prelude.widgets_internal.*
     use mod.widgets.*
 
+    let STUDIO_FILE_TREE_ROW_HEIGHT = 28.0
+    let STUDIO_FILE_TREE_NODE_HEIGHT = 22.0
+
     mod.widgets.DesktopFileTreeBase = #(DesktopFileTree::register_widget(vm))
 
     mod.widgets.FilteredFileItem = View {
         width: Fill
-        height: 30.0
+        height: STUDIO_FILE_TREE_ROW_HEIGHT
         flow: Right
         align: Align {x: 0.0 y: 0.5}
         padding: Inset {left: 8.0 right: 8.0 top: 0.0 bottom: 0.0}
@@ -65,8 +68,8 @@ script_mod! {
 
     mod.widgets.FilteredFileEmpty = View {
         width: Fill
-        height: 30.0
-        padding: Inset {left: 8.0 right: 8.0 top: 6.0 bottom: 6.0}
+        height: STUDIO_FILE_TREE_ROW_HEIGHT
+        padding: Inset {left: 8.0 right: 8.0 top: 5.0 bottom: 5.0}
         show_bg: true
         draw_bg +: {
             is_even: instance(0.0)
@@ -89,7 +92,9 @@ script_mod! {
             active_page: @file_tree_page
             width: Fill
             height: Fill
-            file_tree_page := FileTree {}
+            file_tree_page := FileTree {
+                node_height: STUDIO_FILE_TREE_NODE_HEIGHT
+            }
             filter_list_page := PortalList {
                 width: Fill
                 height: Fill
@@ -138,7 +143,7 @@ pub struct DesktopFileTree {
 }
 
 impl DesktopFileTree {
-    const ROW_HEIGHT: f64 = 30.0;
+    const ROW_HEIGHT: f64 = 28.0;
 
     fn status_dot_color(status: GitStatusDotKind) -> Vec4 {
         match status {

--- a/studio/desktop/src/desktop_log_view.rs
+++ b/studio/desktop/src/desktop_log_view.rs
@@ -147,7 +147,8 @@ script_mod! {
     mod.widgets.LogEmptyItem = View {
         cursor: MouseCursor.Default
         width: Fill
-        height: 25.0
+        height: 32.0
+        align: Align {x: 0.0 y: 0.5}
         show_bg: true
         draw_bg +: {
             color_even: uniform(theme.color_bg_even)
@@ -160,10 +161,14 @@ script_mod! {
                 )
             }
         }
-        padding: Inset {left: 8.0 right: 8.0 top: 4.0 bottom: 4.0}
+        padding: Inset {left: 14.0 right: 14.0 top: 7.0 bottom: 7.0}
         empty_label := Label {
             width: Fill
             text: ""
+            padding: 0.0
+            draw_text +: {
+                color: theme.color_label_outer_off
+            }
         }
     }
 
@@ -219,7 +224,7 @@ impl ScriptHook for DesktopLogView {
 }
 
 impl DesktopLogView {
-    const EMPTY_ROW_HEIGHT: f64 = 25.0;
+    const EMPTY_ROW_HEIGHT: f64 = 32.0;
 
     fn tab_id(&self, cx: &Cx) -> LiveId {
         let path = cx.widget_tree().path_to(self.widget_uid());


### PR DESCRIPTION
Consolidate and adjust studio UI sizing, spacing and styling across desktop widgets.

Key changes:
- studio/desktop/src/app_ui.rs: Add STUDIO_HEADER_HEIGHT and StudioDock; use constant for various header/caption heights; reorganize PaneToolbar into grouped Views, adjust spacing/margins, refine caption label styling, and apply custom draw_text/draw_bg for tabs.
- studio/desktop/src/desktop_file_tree.rs: Add STUDIO_FILE_TREE_ROW_HEIGHT and STUDIO_FILE_TREE_NODE_HEIGHT; switch hardcoded row/node heights to constants, adjust padding and pass node_height to FileTree; update DesktopFileTree::ROW_HEIGHT.
- studio/desktop/src/desktop_log_view.rs: Increase LogEmptyItem height, adjust padding/alignment and label text style; update DesktopLogView::EMPTY_ROW_HEIGHT.

Why: unify header/row sizing via constants, improve spacing and visual consistency, and centralize small styling tweaks for easier future adjustments.