### PR TITLE
Add running-builds UI and refactor HTTP server bind

### DIFF
--- a/libs/makepad_test/src/runtime.rs
+++ b/libs/makepad_test/src/runtime.rs
@@ -1152,7 +1152,7 @@ fn start_headless_app(config: &TestConfig) -> TestResult<(TestConnection, QueryI
                 name: config.mount_name.clone(),
                 path: config.manifest_dir.clone(),
             }],
-            enable_in_process_gateway: true,
+            enable_in_process_gateway: false,
             ..Default::default()
         })
         .map_err(TestError::new)?,

--- a/platform/network/src/http_server.rs
+++ b/platform/network/src/http_server.rs
@@ -59,13 +59,16 @@ pub enum HttpServerRequest {
     },
 }
 
-pub fn start_http_server(http_server: HttpServer) -> Option<std::thread::JoinHandle<()>> {
+pub fn bind_http_server(
+    http_server: HttpServer,
+) -> Option<(SocketAddr, std::thread::JoinHandle<()>)> {
     let listener = if let Ok(listener) = TcpListener::bind(http_server.listen_address) {
         listener
     } else {
         println!("Cannot bind http server port");
         return None;
     };
+    let listen_address = listener.local_addr().ok()?;
 
     let listen_thread = {
         std::thread::spawn(move || {
@@ -105,7 +108,11 @@ pub fn start_http_server(http_server: HttpServer) -> Option<std::thread::JoinHan
             }
         })
     };
-    Some(listen_thread)
+    Some((listen_address, listen_thread))
+}
+
+pub fn start_http_server(http_server: HttpServer) -> Option<std::thread::JoinHandle<()>> {
+    bind_http_server(http_server).map(|(_, thread)| thread)
 }
 
 fn handle_post(http_server: HttpServer, mut tcp_stream: TcpStream, headers: HttpServerHeaders) {

--- a/platform/network/src/lib.rs
+++ b/platform/network/src/lib.rs
@@ -12,7 +12,7 @@ pub mod web_socket_parser;
 pub use makepad_error_log;
 pub use crate::backend::{EventSink, NetworkBackend, UnsupportedBackend};
 pub use crate::http_server::{
-    start_http_server, HttpServer, HttpServerRequest, HttpServerResponse,
+    bind_http_server, start_http_server, HttpServer, HttpServerRequest, HttpServerResponse,
 };
 pub use crate::runtime::{NetworkConfig, NetworkRuntime};
 pub use crate::socket_stream::SocketStream;

--- a/studio/desktop/src/app_backend.rs
+++ b/studio/desktop/src/app_backend.rs
@@ -543,6 +543,22 @@ impl App {
             return;
         };
         if let Some(workspace) = self.mount_workspace_widget(cx, &active_mount) {
+            let has_running_builds = self
+                .data
+                .build_to_mount
+                .iter()
+                .any(|(build_id, mount)| {
+                    mount == &active_mount
+                        && self
+                            .data
+                            .build_package
+                            .get(build_id)
+                            .map(String::as_str)
+                            != Some("makepad.splash")
+                });
+            workspace
+                .button(cx, ids!(run_stop_all))
+                .set_visible(cx, has_running_builds);
             workspace.widget(cx, ids!(run_list)).redraw(cx);
         }
     }

--- a/studio/desktop/src/app_messages.rs
+++ b/studio/desktop/src/app_messages.rs
@@ -290,6 +290,9 @@ impl App {
                     }
                 }
                 self.set_status(cx, &format!("build started: {}", package));
+                if self.data.active_mount.as_deref() == Some(mount.as_str()) {
+                    self.refresh_active_mount_run_list(cx);
+                }
             }
             HubToClient::BuildStopped {
                 build_id,
@@ -302,7 +305,7 @@ impl App {
                     self.data.build_to_mount.remove(&build_id);
                     return;
                 }
-                self.data.build_to_mount.remove(&build_id);
+                let mount_for_run_list = self.data.build_to_mount.remove(&build_id);
                 self.stop_profiler_query_for_build(build_id);
                 self.data.profiler_running_by_build.insert(build_id, false);
                 if let Some(tab_id) = self.data.run_tab_by_build.get(&build_id).copied() {
@@ -326,6 +329,11 @@ impl App {
                                 .clear_run_target(cx);
                             dock.redraw_tab(cx, tab_id);
                         }
+                    }
+                }
+                if let Some(mount) = mount_for_run_list {
+                    if self.data.active_mount.as_deref() == Some(mount.as_str()) {
+                        self.refresh_active_mount_run_list(cx);
                     }
                 }
             }

--- a/studio/desktop/src/app_tabs.rs
+++ b/studio/desktop/src/app_tabs.rs
@@ -966,6 +966,9 @@ impl App {
         self.data.build_to_mount.remove(&build_id);
         self.data.build_package.remove(&build_id);
         if let Some(mount) = mount_for_sync {
+            if self.data.active_mount.as_deref() == Some(mount.as_str()) {
+                self.refresh_active_mount_run_list(cx);
+            }
             self.sync_run_preview_splitter(cx, &mount);
         }
     }
@@ -983,6 +986,42 @@ impl App {
         };
         self.close_mount_run_and_log_tabs(cx, mount);
         self.set_status(cx, &format!("running {} on {}", name, mount));
+    }
+
+    pub(super) fn stop_builds(
+        &mut self,
+        cx: &mut Cx,
+        build_ids: &[QueryId],
+        mount: &str,
+        name: &str,
+    ) {
+        if self.data.active_mount.as_deref() != Some(mount) {
+            self.select_mount(cx, mount);
+        }
+        if build_ids.is_empty() {
+            return;
+        }
+        let mut sent_any = false;
+        for build_id in build_ids {
+            if self
+                .send_studio(ClientToHub::StopBuild {
+                    build_id: *build_id,
+                })
+                .is_some()
+            {
+                sent_any = true;
+            }
+        }
+        if !sent_any {
+            self.set_status(cx, "backend not connected");
+            return;
+        }
+        let build_label = if build_ids.len() == 1 {
+            "1 build".to_string()
+        } else {
+            format!("{} builds", build_ids.len())
+        };
+        self.set_status(cx, &format!("stopping {} for {} on {}", build_label, name, mount));
     }
 
     pub(super) fn handle_log_view_actions(&mut self, cx: &mut Cx, actions: &Actions) {
@@ -1217,12 +1256,14 @@ impl App {
             return;
         };
         self.data.run_tab_by_build.remove(&state.build_id);
-        self.data.build_to_mount.remove(&state.build_id);
         let _ = self.send_studio(ClientToHub::StopBuild {
             build_id: state.build_id,
         });
         if let Some(dock) = self.mount_workspace_dock(cx, &state.mount) {
             dock.close_tab(cx, tab_id);
+        }
+        if self.data.active_mount.as_deref() == Some(state.mount.as_str()) {
+            self.refresh_active_mount_run_list(cx);
         }
         self.sync_run_preview_splitter(cx, &state.mount);
     }

--- a/studio/desktop/src/app_ui.rs
+++ b/studio/desktop/src/app_ui.rs
@@ -34,7 +34,7 @@ script_mod! {
 
     let SidebarFilterInput = TextInputFlat {
         margin: Inset {}
-        padding: Inset {left: 12.0 right: 12.0 top: 0.0 bottom: 0.0}
+        padding: Inset {left: 12.0 right: 12.0 top: 5.0 bottom: 5.0}
         draw_bg +: {
             border_radius: 4.0
 

--- a/studio/desktop/src/desktop_run_list.rs
+++ b/studio/desktop/src/desktop_run_list.rs
@@ -1,4 +1,5 @@
 use crate::{app_data::AppData, makepad_widgets::*};
+use makepad_studio_protocol::hub_protocol::QueryId;
 
 script_mod! {
     use mod.prelude.widgets_internal.*
@@ -25,6 +26,23 @@ script_mod! {
         }
     }
 
+    mod.widgets.RunStopIcon = View {
+        width: 14.0
+        height: 14.0
+        margin: Inset {left: 3.0 right: 3.0 top: 0.0 bottom: 0.0}
+        show_bg: true
+        visible: false
+        draw_bg +: {
+            hover: instance(0.0)
+            pixel: fn() {
+                let sdf = Sdf2d.viewport(self.pos * self.rect_size)
+                sdf.box(3.0, 3.0, 8.0, 8.0, 0.0)
+                sdf.fill(#xE38AA6.mix(#xFFD2E1, self.hover))
+                return sdf.result
+            }
+        }
+    }
+
     mod.widgets.RunListItem = View {
         width: Fill
         height: 34.0
@@ -36,11 +54,13 @@ script_mod! {
 
         draw_bg +: {
             is_even: instance(0.0)
+            is_running: instance(0.0)
             pixel: fn() {
-                return theme.color_bg_even.mix(
+                let base = theme.color_bg_even.mix(
                     theme.color_bg_odd,
                     self.is_even
                 )
+                return base.mix(#xFFFFFF, self.is_running * 0.035)
             }
         }
 
@@ -51,7 +71,8 @@ script_mod! {
                 off: AnimatorState {
                     from: {all: Forward {duration: 0.08}}
                     apply: {
-                        icon: {draw_bg: {hover: 0.0}}
+                        play_icon: {draw_bg: {hover: 0.0}}
+                        stop_icon: {draw_bg: {hover: 0.0}}
                         row_button: {draw_text: {hover: 0.0}}
                     }
                 }
@@ -59,14 +80,21 @@ script_mod! {
                     cursor: MouseCursor.Hand
                     from: {all: Snap}
                     apply: {
-                        icon: {draw_bg: {hover: 1.0}}
+                        play_icon: {draw_bg: {hover: 1.0}}
+                        stop_icon: {draw_bg: {hover: 1.0}}
                         row_button: {draw_text: {hover: 1.0}}
                     }
                 }
             }
         }
 
-        icon := mod.widgets.RunPlayIcon {}
+        icon_wrap := View {
+            width: Fit
+            height: Fit
+            flow: Overlay
+            play_icon := mod.widgets.RunPlayIcon {}
+            stop_icon := mod.widgets.RunStopIcon {}
+        }
 
         row_button := ButtonFlat {
             width: Fill
@@ -79,13 +107,39 @@ script_mod! {
                 color: #0000
                 color_hover: #0000
                 color_pressed: #0000
+                color_focus: #0000
+                color_disabled: #0000
                 border_color: #0000
+                border_color_hover: #0000
+                border_color_pressed: #0000
+                border_color_focus: #0000
+                border_color_disabled: #0000
             }
             draw_text +: {
                 color: theme.color_label_inner
                 color_hover: #xFFFFFF
                 color_pressed: #xFFFFFF
                 color_focus: #xFFFFFF
+            }
+        }
+
+        status_badge := View {
+            width: Fit
+            height: Fit
+            visible: false
+            padding: Inset {left: 7.0 right: 7.0 top: 3.0 bottom: 3.0}
+            margin: Inset {left: 8.0 right: 0.0 top: 0.0 bottom: 0.0}
+            show_bg: true
+            draw_bg +: {
+                color: #x2C3130
+                border_radius: 9.0
+            }
+            badge_text := Label {
+                width: Fit
+                text: "Running"
+                draw_text +: {
+                    color: #xA9CDB4
+                }
             }
         }
     }
@@ -138,6 +192,11 @@ pub enum DesktopRunListAction {
         mount: String,
         name: String,
     },
+    StopBuilds {
+        build_ids: Vec<QueryId>,
+        mount: String,
+        name: String,
+    },
     #[default]
     None,
 }
@@ -145,6 +204,11 @@ pub enum DesktopRunListAction {
 #[derive(Clone, Debug, PartialEq, Default)]
 enum RunListRowData {
     RunItem {
+        mount: String,
+        name: String,
+    },
+    StopBuilds {
+        build_ids: Vec<QueryId>,
         mount: String,
         name: String,
     },
@@ -186,6 +250,23 @@ impl DesktopRunList {
             self.draw_empty(cx, list, "Loading run targets...");
             return;
         };
+        let mut running_builds_by_package: std::collections::HashMap<&str, Vec<QueryId>> =
+            std::collections::HashMap::new();
+        for (build_id, mount) in &data.build_to_mount {
+            if mount != active_mount {
+                continue;
+            }
+            let Some(package) = data.build_package.get(build_id) else {
+                continue;
+            };
+            running_builds_by_package
+                .entry(package.as_str())
+                .or_default()
+                .push(*build_id);
+        }
+        for build_ids in running_builds_by_package.values_mut() {
+            build_ids.sort_by_key(|build_id| build_id.0);
+        }
 
         if entries.is_empty() {
             self.draw_empty(cx, list, "No run items available");
@@ -208,17 +289,30 @@ impl DesktopRunList {
             };
 
             let mut item = list.item(cx, item_id, id!(Item)).as_view();
+            let is_running = running_builds_by_package.contains_key(entry.name.as_str());
             script_apply_eval!(cx, item, {
                 draw_bg +: {
                     is_even: #(is_even_f)
+                    is_running: #(if is_running {1.0} else {0.0})
                 }
             });
             let button = item.button(cx, ids!(row_button));
             button.set_text(cx, &entry.name);
-            button.set_action_data(RunListRowData::RunItem {
-                mount: active_mount.to_string(),
-                name: entry.name.clone(),
-            });
+            item.view(cx, ids!(play_icon)).set_visible(cx, !is_running);
+            item.view(cx, ids!(stop_icon)).set_visible(cx, is_running);
+            item.view(cx, ids!(status_badge)).set_visible(cx, is_running);
+            if let Some(build_ids) = running_builds_by_package.get(entry.name.as_str()) {
+                button.set_action_data(RunListRowData::StopBuilds {
+                    build_ids: build_ids.clone(),
+                    mount: active_mount.to_string(),
+                    name: entry.name.clone(),
+                });
+            } else {
+                button.set_action_data(RunListRowData::RunItem {
+                    mount: active_mount.to_string(),
+                    name: entry.name.clone(),
+                });
+            }
             item.draw_all(cx, &mut Scope::empty());
         }
     }
@@ -264,15 +358,31 @@ impl Widget for DesktopRunList {
             for (_item_id, item) in run_list.items_with_actions(actions) {
                 let button = item.button(cx, ids!(row_button));
                 if let Some(modifiers) = button.clicked_modifiers(actions) {
-                    if let RunListRowData::RunItem { mount, name } = button.action_data().cast_ref()
-                    {
-                        cx.widget_action(
-                            uid,
-                            DesktopRunListAction::RunItem {
-                                mount: mount.clone(),
-                                name: name.clone(),
-                            },
-                        );
+                    match button.action_data().cast_ref() {
+                        RunListRowData::RunItem { mount, name } => {
+                            cx.widget_action(
+                                uid,
+                                DesktopRunListAction::RunItem {
+                                    mount: mount.clone(),
+                                    name: name.clone(),
+                                },
+                            );
+                        }
+                        RunListRowData::StopBuilds {
+                            build_ids,
+                            mount,
+                            name,
+                        } => {
+                            cx.widget_action(
+                                uid,
+                                DesktopRunListAction::StopBuilds {
+                                    build_ids: build_ids.clone(),
+                                    mount: mount.clone(),
+                                    name: name.clone(),
+                                },
+                            );
+                        }
+                        RunListRowData::None => {}
                     }
                     let _ = modifiers;
                 }
@@ -282,11 +392,9 @@ impl Widget for DesktopRunList {
 }
 
 impl DesktopRunListRef {
-    pub fn run_requested(&self, actions: &Actions) -> Option<(String, String)> {
+    pub fn requested_action(&self, actions: &Actions) -> Option<DesktopRunListAction> {
         if let Some(item) = actions.find_widget_action(self.widget_uid()) {
-            if let DesktopRunListAction::RunItem { mount, name } = item.cast() {
-                return Some((mount, name));
-            }
+            return Some(item.cast());
         }
         None
     }

--- a/studio/desktop/src/main.rs
+++ b/studio/desktop/src/main.rs
@@ -184,11 +184,23 @@ impl MatchEvent for App {
                 {
                     self.queue_mount_file_filter(cx, &active_mount, filter);
                 }
-                if let Some((mount, name)) = workspace
+                if let Some(action) = workspace
                     .desktop_run_list(cx, ids!(run_list))
-                    .run_requested(actions)
+                    .requested_action(actions)
                 {
-                    self.run_item(cx, &mount, &name);
+                    match action {
+                        DesktopRunListAction::RunItem { mount, name } => {
+                            self.run_item(cx, &mount, &name);
+                        }
+                        DesktopRunListAction::StopBuilds {
+                            build_ids,
+                            mount,
+                            name,
+                        } => {
+                            self.stop_builds(cx, &build_ids, &mount, &name);
+                        }
+                        DesktopRunListAction::None => {}
+                    }
                 }
                 if workspace.button(cx, ids!(run_stop_all)).clicked(actions) {
                     self.request_stop_all_builds_for_mount(cx, &active_mount);

--- a/studio/hub/src/gateway.rs
+++ b/studio/hub/src/gateway.rs
@@ -1,7 +1,7 @@
 use crate::dispatch::HubEvent;
 use makepad_micro_serde::SerBin;
 use makepad_script_std::makepad_network::{
-    start_http_server, HttpServer, HttpServerRequest, HttpServerResponse, ToUISender,
+    bind_http_server, HttpServer, HttpServerRequest, HttpServerResponse, ToUISender,
 };
 use makepad_studio_protocol::hub_protocol::{HubToClient, QueryId};
 use std::collections::HashMap;
@@ -33,7 +33,7 @@ pub fn start_http_gateway(
     event_tx: Sender<HubEvent>,
 ) -> Result<GatewayHandle, String> {
     let (request_tx, request_rx) = mpsc::channel::<HttpServerRequest>();
-    let http_thread = start_http_server(HttpServer {
+    let (listen_address, http_thread) = bind_http_server(HttpServer {
         listen_address,
         request: request_tx,
         post_max_size,

--- a/studio/hub/src/process_manager.rs
+++ b/studio/hub/src/process_manager.rs
@@ -965,8 +965,9 @@ impl ProcessManager {
         event_tx: Sender<HubEvent>,
     ) -> Result<BuildInfo, String> {
         let package = parse_package_name(&args).unwrap_or_else(|| "unknown".to_string());
+        let use_stdio_bridge = should_use_direct_stdio_run(&args, &env);
         #[cfg(unix)]
-        if should_use_direct_stdio_run(&args, &env) {
+        if use_stdio_bridge {
             if let Some(script) = build_direct_stdio_run_script(cwd, &args, &env) {
                 return self.start_command_run(
                     build_id,
@@ -990,7 +991,7 @@ impl ProcessManager {
             "cargo".to_string(),
             args,
             env,
-            true,
+            !use_stdio_bridge,
             studio_addr,
             event_tx,
         )


### PR DESCRIPTION
Introduce stop-builds support in the desktop run list UI and refactor HTTP server binding. The run list now shows running state, a stop icon/badge, groups running builds by package, and sends a StopBuilds action; DesktopRunListRef.requested_action and handlers in main/app_tabs/app_backend/messages were updated to handle the new action and refresh the run list. Added bind_http_server that returns the actual bound SocketAddr plus the thread handle and kept start_http_server as a convenience wrapper; gateway now uses bind_http_server to obtain the listen address. process_manager now computes a use_stdio_bridge flag and passes the correct stdio flag into start_command_run. Minor UI and test tweaks: adjusted sidebar input padding, refreshed visibility for run_stop_all, and disabled in-process gateway in headless tests.