### PR TITLE
Additional opptimizations for windows shader compilation

### DIFF
--- a/libs/windows/windows-rs/src/Windows/mod.rs
+++ b/libs/windows/windows-rs/src/Windows/mod.rs
@@ -44836,6 +44836,40 @@ pub struct XINPUT_STATE {
 }
 }
 pub mod Shell{
+pub const FOLDERID_LocalAppData: windows_core::GUID = windows_core::GUID::from_u128(0xf1b32785_6fba_4fcf_9d55_7b8e7f157091);
+pub const KF_FLAG_DEFAULT: KNOWN_FOLDER_FLAG = KNOWN_FOLDER_FLAG(0i32);
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct KNOWN_FOLDER_FLAG(pub i32);
+impl KNOWN_FOLDER_FLAG {
+    pub const fn contains(&self, other: Self) -> bool { self.0 & other.0 == other.0 }
+}
+impl core::ops::BitOr for KNOWN_FOLDER_FLAG {
+    type Output = Self;
+    fn bitor(self, other: Self) -> Self { Self(self.0 | other.0) }
+}
+impl core::ops::BitAnd for KNOWN_FOLDER_FLAG {
+    type Output = Self;
+    fn bitand(self, other: Self) -> Self { Self(self.0 & other.0) }
+}
+impl core::ops::BitOrAssign for KNOWN_FOLDER_FLAG {
+    fn bitor_assign(&mut self, other: Self) { self.0.bitor_assign(other.0) }
+}
+impl core::ops::BitAndAssign for KNOWN_FOLDER_FLAG {
+    fn bitand_assign(&mut self, other: Self) { self.0.bitand_assign(other.0) }
+}
+impl core::ops::Not for KNOWN_FOLDER_FLAG {
+    type Output = Self;
+    fn not(self) -> Self { Self(self.0.not()) }
+}
+#[inline]
+pub unsafe fn SHGetKnownFolderPath(rfid: *const windows_core::GUID, dwflags: KNOWN_FOLDER_FLAG, htoken: Option<super::super::Foundation::HANDLE>) -> windows_core::Result<windows_core::PWSTR> {
+    windows_core::link!("shell32.dll" "system" fn SHGetKnownFolderPath(rfid : *const windows_core::GUID, dwflags : u32, htoken : super::super::Foundation::HANDLE, ppszpath : *mut windows_core::PWSTR) -> windows_core::HRESULT);
+    unsafe {
+        let mut result__ = core::mem::zeroed();
+        SHGetKnownFolderPath(rfid, dwflags.0 as _, htoken.unwrap_or(core::mem::zeroed()), &mut result__).map(|| result__)
+    }
+}
 pub mod PropertiesSystem{
 windows_core::imp::define_interface!(IPropertyStore, IPropertyStore_Vtbl, 0x886d8eeb_8cf2_4446_8d02_cdba1dbdcf99);
 windows_core::imp::interface_hierarchy!(IPropertyStore, windows_core::IUnknown);

--- a/platform/src/os/windows/d3d11.rs
+++ b/platform/src/os/windows/d3d11.rs
@@ -602,7 +602,7 @@ impl Cx {
                     CxDrawShaderCode::Combined { code } => CxOsDrawShader::new(
                         d3d11_cx,
                         code,
-                        cache_dir.as_deref(),
+                        cache_dir,
                         &cx_shader.mapping,
                         &cx_shader.mapping.uniform_buffer_bindings,
                     ),
@@ -1802,13 +1802,24 @@ impl DrawVars {
     }
 }
 
-fn shader_cache_dir() -> Option<std::path::PathBuf> {
-    let local_app_data = std::env::var("LOCALAPPDATA").ok()?;
-    let path = std::path::PathBuf::from(local_app_data)
-        .join("makepad")
-        .join("d3d11_shader_cache");
-    std::fs::create_dir_all(&path).ok()?;
-    Some(path)
+fn shader_cache_dir() -> Option<&'static std::path::Path> {
+    use std::sync::OnceLock;
+    use windows::Win32::{
+        System::Com::CoTaskMemFree,
+        UI::Shell::{FOLDERID_LocalAppData, KF_FLAG_DEFAULT, SHGetKnownFolderPath},
+    };
+
+    static DIR: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
+    DIR.get_or_init(|| {
+        let path_ptr = unsafe { SHGetKnownFolderPath(&FOLDERID_LocalAppData, KF_FLAG_DEFAULT, None) }.ok()?;
+        let path_str = unsafe { path_ptr.to_string().ok() };
+        unsafe { CoTaskMemFree(Some(path_ptr.as_ptr() as _)) };
+        let path = std::path::PathBuf::from(path_str?)
+            .join("makepad")
+            .join("d3d11_shader_cache");
+        std::fs::create_dir_all(&path).ok()?;
+        Some(path)
+    }).as_deref()
 }
 
 #[derive(Clone)]

--- a/platform/src/os/windows/d3d11.rs
+++ b/platform/src/os/windows/d3d11.rs
@@ -581,52 +581,39 @@ impl Cx {
     }
 
     pub(crate) fn hlsl_compile_shaders(&mut self, d3d11_cx: &D3d11Cx) {
-        for draw_shader_id in self
-            .draw_shaders
-            .compile_set
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>()
-        {
-            let cx_shader = &self.draw_shaders.shaders[draw_shader_id];
-
-            let hlsl = match &cx_shader.mapping.code {
-                CxDrawShaderCode::Combined { code } => code.clone(),
-                CxDrawShaderCode::Separate { .. } => {
-                    crate::error!("D3D11 does not support separate vertex/fragment sources");
-                    continue;
+        if self.draw_shaders.compile_set.is_empty() {
+            return;
+        }
+        let compile_set = std::mem::take(&mut self.draw_shaders.compile_set);
+        let cache_dir = shader_cache_dir();
+        for draw_shader_id in compile_set {
+            let shp = {
+                let cx_shader = &self.draw_shaders.shaders[draw_shader_id];
+                if cx_shader.mapping.flags.debug_code {
+                    if let CxDrawShaderCode::Combined { code } = &cx_shader.mapping.code {
+                        crate::log!("{}", code);
+                    }
+                }
+                match &cx_shader.mapping.code {
+                    CxDrawShaderCode::Separate { .. } => {
+                        crate::error!("D3D11 does not support separate vertex/fragment sources");
+                        None
+                    }
+                    CxDrawShaderCode::Combined { code } => CxOsDrawShader::new(
+                        d3d11_cx,
+                        code,
+                        cache_dir.as_deref(),
+                        &cx_shader.mapping,
+                        &cx_shader.mapping.uniform_buffer_bindings,
+                    ),
                 }
             };
-
-            if cx_shader.mapping.flags.debug_code {
-                crate::log!("{}", hlsl);
-            }
-
-            // Get the uniform buffer bindings from the mapping
-            let bindings = cx_shader.mapping.uniform_buffer_bindings.clone();
-
-            // Check if we already have an os_shader with the same source
-            let mut found_os_shader_id = None;
-            for (index, ds) in self.draw_shaders.os_shaders.iter().enumerate() {
-                if ds.hlsl == hlsl {
-                    found_os_shader_id = Some(index);
-                    break;
-                }
-            }
-
-            let cx_shader = &mut self.draw_shaders.shaders[draw_shader_id];
-            if let Some(os_shader_id) = found_os_shader_id {
-                cx_shader.os_shader_id = Some(os_shader_id);
-            } else {
-                if let Some(shp) =
-                    CxOsDrawShader::new(d3d11_cx, hlsl, &cx_shader.mapping, &bindings)
-                {
-                    cx_shader.os_shader_id = Some(self.draw_shaders.os_shaders.len());
-                    self.draw_shaders.os_shaders.push(shp);
-                }
+            if let Some(shp) = shp {
+                let cx_shader = &mut self.draw_shaders.shaders[draw_shader_id];
+                cx_shader.os_shader_id = Some(self.draw_shaders.os_shaders.len());
+                self.draw_shaders.os_shaders.push(shp);
             }
         }
-        self.draw_shaders.compile_set.clear();
     }
 
     pub fn share_texture_for_presentable_image(&mut self, texture: &Texture) -> u64 {
@@ -1815,9 +1802,17 @@ impl DrawVars {
     }
 }
 
+fn shader_cache_dir() -> Option<std::path::PathBuf> {
+    let local_app_data = std::env::var("LOCALAPPDATA").ok()?;
+    let path = std::path::PathBuf::from(local_app_data)
+        .join("makepad")
+        .join("d3d11_shader_cache");
+    std::fs::create_dir_all(&path).ok()?;
+    Some(path)
+}
+
 #[derive(Clone)]
 pub struct CxOsDrawShader {
-    pub hlsl: String,
     pub const_table_uniforms: D3d11Buffer,
     pub live_uniforms: D3d11Buffer,
     pub scope_uniforms: D3d11Buffer,
@@ -1838,7 +1833,8 @@ pub struct CxOsDrawShader {
 impl CxOsDrawShader {
     fn new(
         d3d11_cx: &D3d11Cx,
-        hlsl: String,
+        hlsl: &str,
+        cache_dir: Option<&std::path::Path>,
         mapping: &CxDrawShaderMapping,
         bindings: &UniformBufferBindings,
     ) -> Option<Self> {
@@ -1884,15 +1880,6 @@ impl CxOsDrawShader {
                 hash = hash.wrapping_mul(0x100000001b3);
             }
             hash
-        }
-
-        fn shader_cache_dir() -> Option<std::path::PathBuf> {
-            let local_app_data = std::env::var("LOCALAPPDATA").ok()?;
-            let path = std::path::PathBuf::from(local_app_data)
-                .join("makepad")
-                .join("d3d11_shader_cache");
-            std::fs::create_dir_all(&path).ok()?;
-            Some(path)
         }
 
         fn get_shader_bytes(
@@ -1973,28 +1960,26 @@ impl CxOsDrawShader {
             std::char::from_u32(index as u32 + 65).unwrap_or('?')
         }
 
-        let cache_key = hlsl_cache_key(&hlsl);
-        let cache_dir = shader_cache_dir();
-        let cache_dir_ref = cache_dir.as_deref();
+        let cache_key = hlsl_cache_key(hlsl);
 
-        let vs_bytes = match get_shader_bytes(cache_dir_ref, cache_key, "_vs", "vs_5_0\0", "vertex_main\0", &hlsl) {
+        let vs_bytes = match get_shader_bytes(cache_dir, cache_key, "_vs", "vs_5_0\0", "vertex_main\0", hlsl) {
             Err(msg) => {
                 println!(
                     "Cannot compile vertexshader\n{}\n{}",
                     msg,
-                    split_source(&hlsl)
+                    split_source(hlsl)
                 );
                 std::process::exit(1);
             }
             Ok(bytes) => bytes,
         };
 
-        let ps_bytes = match get_shader_bytes(cache_dir_ref, cache_key, "_ps", "ps_5_0\0", "pixel_main\0", &hlsl) {
+        let ps_bytes = match get_shader_bytes(cache_dir, cache_key, "_ps", "ps_5_0\0", "pixel_main\0", hlsl) {
             Err(msg) => {
                 println!(
                     "Cannot compile pixelshader\n{}\n{}",
                     msg,
-                    split_source(&hlsl)
+                    split_source(hlsl)
                 );
                 std::process::exit(1);
             }
@@ -2140,7 +2125,7 @@ impl CxOsDrawShader {
                 println!("  {}", item);
             }
             if std::env::var("MAKEPAD_D3D11_DUMP_HLSL").is_ok() {
-                println!("HLSL source\n{}", split_source(&hlsl));
+                println!("HLSL source\n{}", split_source(hlsl));
             } else {
                 println!("Set MAKEPAD_D3D11_DUMP_HLSL=1 to dump full HLSL source.");
             }
@@ -2174,7 +2159,6 @@ impl CxOsDrawShader {
         let scope_uniform_buffer_id = bindings.scope_uniform_buffer_index.map(|i| i as u32);
 
         Some(Self {
-            hlsl,
             const_table_uniforms,
             live_uniforms,
             scope_uniforms,


### PR DESCRIPTION
* Properly get the Local AppData directory instead of using the env var %LOCALAPPDATA, which may not always be there.
 
   * Now we do it with `SHGetKnownFolderPath(FOLDERID_LocalAppData)`,
 which is canonically correct.

* `hlsl_compile_shaders` was called unconditionally after every draw event, even on
frames where no new shaders needed compilation. Added an early return:
```rust
if self.draw_shaders.compile_set.is_empty() {
    return;
}
```
* The loop previously collected `compile_set` into a temporary `Vec` before
iterating, in order to release the borrow on `compile_set` so the loop body
could mutate other `draw_shaders` fields. This caused a heap allocation and a
full copy of all indices on every compilation batch.
* `std::mem::take` atomically replaces `compile_set` with an empty `BTreeSet` and
returns ownership of the original — no intermediate allocation, no copy, and no
separate `.clear()` needed at the end:
```rust
let compile_set = std::mem::take(&mut self.draw_shaders.compile_set);
for draw_shader_id in compile_set { ... }
// no .clear() needed
```
* Previously `shader_cache_dir()` was an inner function called inside
`CxOsDrawShader::new`, meaning it ran once **per shader** on every compilation.
Each call performs two syscalls: `env::var("LOCALAPPDATA")` and
`fs::create_dir_all`. With N shaders compiling on first launch, this was 2N
unnecessary syscalls.
* `shader_cache_dir()` is now a module-level function called **once** before the
loop in `hlsl_compile_shaders`, and the resulting `Option<&Path>` is passed into
`new` as a parameter.
* The HLSL source already lives in `cx_shader.mapping.code`. The previous code
cloned it into an owned `String` before passing it to `new`, even though all
downstream uses (hashing, `D3DCompile`, cache I/O, error printing) only need a
`&str`. Changed the parameter type to `&str` and restructured the loop body into
a block scope so the immutable borrow on `cx_shader` ends before the mutable
reborrow — eliminating the clone entirely.
* `CxOsDrawShader::new` already took `&UniformBufferBindings` by reference. The
clone existed only because the immutable borrow on `cx_shader` had to be released
before the mutable reborrow. The same block-scope restructuring from fix #4
resolves this: `&cx_shader.mapping.uniform_buffer_bindings` is now passed
directly.
  * This field was written once on construction and **never read** — the only reader
was the O(n) deduplication scan removed in the previous round of fixes. It held
a full copy of each shader's HLSL source for the entire lifetime of the
application. At tens of KB per shader and dozens of shaders, this was megabytes
of permanently retained dead storage. The field is gone.