### PR TITLE
Introduce knowledge of device screen bounds/"safe inset areas"

### DIFF
--- a/draw/src/shader/draw_svg.rs
+++ b/draw/src/shader/draw_svg.rs
@@ -37,31 +37,9 @@ script_mod! {
 
         vertex: fn() {
             var pos = vec2(self.geom.x, self.geom.y);
-            // Fill fringe outer vertices (u=0, stroke_mult>1e5) have
-            // the outward normal stored in (v, stroke_dist). Expand
-            // them so the fringe is ~1px wide on screen regardless of
-            // svg_scale. We keep the edge centered like NanoVG:
-            // fill/body verts move inward by 0.5px, outer fringe verts
-            // move outward by 0.5px.
-            if self.geom.stroke_mult > 1e5 {
-                let normal = vec2(self.geom.v, self.geom.stroke_dist);
-                let nlen = length(normal);
-                if nlen > 0.0001 {
-                    let un = normal / nlen;
-                    // Convert screen px into local-space distance along un.
-                    let screen_scale = length(vec2(un.x * self.svg_scale.x, un.y * self.svg_scale.y));
-                    if screen_scale > 0.0001 {
-                        let half_px = 0.5 / screen_scale;
-                        if self.geom.u < 0.25 {
-                            // transparent outer fringe vertex
-                            pos = pos + un * half_px;
-                        } else if self.geom.u > 0.25 {
-                            // opaque edge/body vertex
-                            pos = pos - un * half_px;
-                        }
-                    }
-                }
-            }
+            // SVG fill uses pre-computed fringe (not GPU-expand), so fringe
+            // vertices already have physically offset positions. No GPU-side
+            // expansion needed.
             // Keep tessellated SVG geometry relative and apply rect_pos as the
             // final anchor so turtle alignment can move it like DrawQuad.
             let transformed_local = self.transform_svg_point(pos * self.svg_scale + self.svg_offset);

--- a/draw/src/svg/render.rs
+++ b/draw/src/svg/render.rs
@@ -607,7 +607,9 @@ fn emit_shape(
             build_path(dv);
             let fill_alpha = style.fill_opacity * opacity;
             set_paint(dv, paint, defs, fill_alpha, xf, bbox, grad_map);
-            dv.fill_gpu();
+            // Use pre-computed fringe (not GPU-expand) to avoid coincident-vertex
+            // triangles that cause Metal GPU rasterization artifacts.
+            dv.fill();
             dv.cur_gradient_row_v = -1.0; // reset after fill
             dv.path.clear();
         }

--- a/libs/apple_sys/src/lib.rs
+++ b/libs/apple_sys/src/lib.rs
@@ -1123,6 +1123,15 @@ pub struct MTLViewport {
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
+pub struct MTLScissorRect {
+    pub x: u64,
+    pub y: u64,
+    pub width: u64,
+    pub height: u64,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
 pub struct CGSize {
     pub width: f64,
     pub height: f64,

--- a/libs/apple_sys/src/lib.rs
+++ b/libs/apple_sys/src/lib.rs
@@ -674,6 +674,28 @@ unsafe impl Encode for NSRect {
     }
 }
 
+#[repr(C)]
+#[derive(Copy, Debug, Clone)]
+pub struct UIEdgeInsets {
+    pub top: f64,
+    pub left: f64,
+    pub bottom: f64,
+    pub right: f64,
+}
+
+unsafe impl Encode for UIEdgeInsets {
+    fn encode() -> Encoding {
+        let encoding = format!(
+            "{{UIEdgeInsets={}{}{}{}}}",
+            f64::encode().as_str(),
+            f64::encode().as_str(),
+            f64::encode().as_str(),
+            f64::encode().as_str()
+        );
+        unsafe { Encoding::from_str(&encoding) }
+    }
+}
+
 pub const NSURLSessionResponseAllow: u64 = 1;
 
 #[repr(u64)] // NSUInteger

--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -125,6 +125,10 @@ pub struct Cx {
     /// Display context for the main window, used by AdaptiveView
     pub display_context: DisplayContext,
 
+    /// When true, a script re-apply (LiveEdit) will be triggered on the next
+    /// event loop iteration to pick up changed dynamic values like safe area insets.
+    pub pending_script_reapply: bool,
+
     pub debug: Debug,
 
     #[allow(dead_code)]
@@ -431,6 +435,7 @@ impl Cx {
             performance_stats: Default::default(),
 
             display_context: Default::default(),
+            pending_script_reapply: false,
 
             widget_tree_dump_requests: Default::default(),
             widget_snapshot_requests: Default::default(),

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -11,7 +11,8 @@ use {
         event::keyboard::CharOffset,
         event::xr::XrAnchor,
         event::{
-            video_playback::CameraPreviewMode, DragItem, NextFrame, Timer, Trigger, VideoSource,
+            video_playback::CameraPreviewMode, DragItem, NextFrame, Timer, Trigger,
+            VideoSource,
         },
         gpu_info::GpuInfo,
         ime::TextInputConfig,
@@ -426,6 +427,14 @@ impl Cx {
 
     /// Updates the `mod.widgets.SAFE_INSET_PAD_*` values on the script heap
     /// so that Splash code can reference them in widget definitions.
+    /// Requests a deferred re-application of all script/Splash widget definitions,
+    /// causing widgets to pick up updated values from the script heap.
+    /// The re-apply happens on the next event loop iteration (not synchronously),
+    /// to avoid re-entrancy issues when called from within an event handler.
+    pub fn request_script_reapply(&mut self) {
+        self.pending_script_reapply = true;
+    }
+
     pub fn update_safe_inset_script_values(&mut self, insets: crate::event::SafeAreaInsets) {
         use makepad_script::trap::NoTrap;
         let Some(vm) = self.script_vm.as_mut() else {

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -424,6 +424,20 @@ impl Cx {
         self.in_draw_event
     }
 
+    /// Updates the `mod.widgets.SAFE_INSET_PAD_*` values on the script heap
+    /// so that Splash code can reference them in widget definitions.
+    pub fn update_safe_inset_script_values(&mut self, insets: crate::event::SafeAreaInsets) {
+        use makepad_script::trap::NoTrap;
+        let Some(vm) = self.script_vm.as_mut() else {
+            return;
+        };
+        let widgets = vm.heap.module(id!(widgets));
+        vm.heap.set_value(widgets, id!(SAFE_INSET_PAD_TOP).into(), insets.top.into(), NoTrap);
+        vm.heap.set_value(widgets, id!(SAFE_INSET_PAD_BOTTOM).into(), insets.bottom.into(), NoTrap);
+        vm.heap.set_value(widgets, id!(SAFE_INSET_PAD_LEFT).into(), insets.left.into(), NoTrap);
+        vm.heap.set_value(widgets, id!(SAFE_INSET_PAD_RIGHT).into(), insets.right.into(), NoTrap);
+    }
+
     pub fn xr_capabilities(&self) -> &XrCapabilities {
         &self.xr_capabilities
     }

--- a/platform/src/display_context.rs
+++ b/platform/src/display_context.rs
@@ -1,3 +1,4 @@
+use crate::event::SafeAreaInsets;
 use crate::Vec2d;
 
 const DEFAULT_MIN_DESKTOP_WIDTH: f64 = 860.;
@@ -10,6 +11,9 @@ pub struct DisplayContext {
     pub updated_on_event_id: u64,
     /// The current screen size
     pub screen_size: Vec2d,
+    /// Safe area insets for the current window (non-zero on devices with notches,
+    /// rounded corners, home indicators, etc.)
+    pub safe_area_insets: SafeAreaInsets,
 }
 
 impl DisplayContext {

--- a/platform/src/event/window.rs
+++ b/platform/src/event/window.rs
@@ -4,6 +4,17 @@ use {
     std::rc::Rc,
 };
 
+/// Safe area insets describing regions of the screen that should not contain
+/// interactive content (e.g., notch/Dynamic Island, home indicator, rounded corners).
+/// Values are in logical points (not physical pixels).
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct SafeAreaInsets {
+    pub top: f64,
+    pub right: f64,
+    pub bottom: f64,
+    pub left: f64,
+}
+
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct WindowGeom {
     pub dpi_factor: f64,
@@ -14,6 +25,9 @@ pub struct WindowGeom {
     pub position: Vec2d,
     pub inner_size: Vec2d,
     pub outer_size: Vec2d,
+    /// Safe area insets for this window (non-zero on devices with notches,
+    /// rounded corners, home indicators, etc.)
+    pub safe_area_insets: SafeAreaInsets,
 }
 
 #[derive(Clone, Debug)]

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -555,6 +555,12 @@ impl Cx {
             IosEvent::Init => {
                 with_ios_app(|app| app.start_timer(0, 0.008, true));
                 self.start_studio_websocket_delayed();
+                // Populate display_context and script heap with safe area insets
+                // BEFORE Startup, so app script_mod! definitions can use them.
+                let geom = with_ios_app(|app| app.last_window_geom.clone());
+                self.display_context.screen_size = geom.inner_size;
+                self.display_context.safe_area_insets = geom.safe_area_insets;
+                self.update_safe_inset_script_values(geom.safe_area_insets);
                 self.call_event_handler(&Event::Startup);
                 self.redraw_all();
             }

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -573,7 +573,6 @@ impl Cx {
                 self.call_event_handler(&Event::WindowLostFocus(window_id));
             }
             IosEvent::WindowGeomChange(re) => {
-                // do this here because mac
                 let window_id = CxWindowPool::id_zero();
                 let window = &mut self.windows[window_id];
                 window.window_geom = re.new_geom.clone();
@@ -797,6 +796,14 @@ impl Cx {
             IosEvent::PermissionResult(result) => {
                 self.call_event_handler(&Event::PermissionResult(result))
             }
+        }
+
+        // If a script re-apply was requested (e.g., safe area insets changed
+        // on rotation), fire LiveEdit now that all event handlers have returned.
+        if self.pending_script_reapply {
+            self.pending_script_reapply = false;
+            self.call_event_handler(&Event::LiveEdit);
+            self.redraw_all();
         }
 
         if self.any_passes_dirty()

--- a/platform/src/os/apple/ios/ios_app.rs
+++ b/platform/src/os/apple/ios/ios_app.rs
@@ -454,6 +454,24 @@ impl IosApp {
             screen_rect.size.height as f64,
         );
 
+        // Query safe area insets from the MTKView (accounts for notch/Dynamic Island,
+        // home indicator, rounded corners, etc.)
+        let safe_area_insets = with_ios_app(|app| {
+            if let Some(mtk_view) = app.mtk_view {
+                unsafe {
+                    let insets: UIEdgeInsets = msg_send![mtk_view, safeAreaInsets];
+                    crate::event::SafeAreaInsets {
+                        top: insets.top,
+                        right: insets.right,
+                        bottom: insets.bottom,
+                        left: insets.left,
+                    }
+                }
+            } else {
+                crate::event::SafeAreaInsets::default()
+            }
+        });
+
         let new_geom = WindowGeom {
             xr_is_presenting: false,
             is_topmost: false,
@@ -463,6 +481,7 @@ impl IosApp {
             outer_size: new_size,
             dpi_factor,
             position: dvec2(0.0, 0.0),
+            safe_area_insets,
         };
 
         let first_draw = with_ios_app(|app| app.first_draw);

--- a/platform/src/os/apple/ios/ios_app.rs
+++ b/platform/src/os/apple/ios/ios_app.rs
@@ -259,6 +259,10 @@ impl IosApp {
             let () = msg_send![mtk_view_obj, setUserInteractionEnabled: YES];
             let () = msg_send![mtk_view_obj, setAutoResizeDrawable: YES];
             let () = msg_send![mtk_view_obj, setMultipleTouchEnabled: YES];
+            // UIViewAutoresizingFlexibleWidth (2) | UIViewAutoresizingFlexibleHeight (16)
+            // Ensures the view resizes with the window on rotation, which is
+            // required for safeAreaInsets to update correctly.
+            let () = msg_send![mtk_view_obj, setAutoresizingMask: 18u64];
 
             let text_input_view: ObjcId = msg_send![get_ios_class_global().text_input_view, alloc];
             let text_input_view: ObjcId = msg_send![text_input_view, initWithFrame: NSRect {
@@ -377,8 +381,9 @@ impl IosApp {
             // Store the delegate for cleanup
             self.keyboard_observer_delegate = Some(textfield_dlg);
 
-            let () = msg_send![window_obj, addSubview: mtk_view_obj];
-
+            // Don't manually addSubview — setRootViewController manages the
+            // view controller's view in the window hierarchy, which is required
+            // for proper safe area inset propagation on device rotation.
             let () = msg_send![window_obj, setRootViewController: view_ctrl_obj];
             self.view_controller = Some(view_ctrl_obj);
             let () = msg_send![window_obj, makeKeyAndVisible];

--- a/platform/src/os/apple/ios/ios_delegates.rs
+++ b/platform/src/os/apple/ios/ios_delegates.rs
@@ -50,6 +50,21 @@ pub fn define_makepad_view_controller() -> *const Class {
         unsafe { *this.get_ivar("_prefersHomeIndicatorAutoHidden") }
     }
 
+    // Called by iOS when the safe area insets change (e.g., device rotation).
+    // At this point the view's safeAreaInsets reflect the new orientation,
+    // unlike draw_size_will_change which may fire before the update.
+    extern "C" fn view_safe_area_insets_did_change(_this: &Object, _: Sel) {
+        let should_call = IOS_APP
+            .try_with(|app| match app.try_borrow_mut() {
+                Ok(app_ref) => app_ref.is_some(),
+                Err(_) => false,
+            })
+            .unwrap_or(false);
+        if should_call {
+            IosApp::check_window_geom();
+        }
+    }
+
     unsafe {
         decl.add_method(
             sel!(prefersStatusBarHidden),
@@ -58,6 +73,10 @@ pub fn define_makepad_view_controller() -> *const Class {
         decl.add_method(
             sel!(prefersHomeIndicatorAutoHidden),
             prefers_home_indicator_auto_hidden as extern "C" fn(&Object, Sel) -> BOOL,
+        );
+        decl.add_method(
+            sel!(viewSafeAreaInsetsDidChange),
+            view_safe_area_insets_did_change as extern "C" fn(&Object, Sel),
         );
     }
 

--- a/platform/src/os/apple/macos/macos_window.rs
+++ b/platform/src/os/apple/macos/macos_window.rs
@@ -571,6 +571,7 @@ impl MacosWindow {
             outer_size: self.get_outer_size(),
             dpi_factor: self.get_dpi_factor(),
             position: self.get_position(),
+            ..Default::default()
         }
     }
 

--- a/platform/src/os/apple/metal.rs
+++ b/platform/src/os/apple/metal.rs
@@ -813,6 +813,28 @@ impl Cx {
             }]
         };
 
+        // Set a scissor rect to clip rendering to the safe content area,
+        // preventing stray geometry (e.g., SVG tessellation artifacts) from
+        // rendering in the system-reserved safe area inset zones.
+        // The safe area background is filled by the pass's clear color.
+        let insets = &self.display_context.safe_area_insets;
+        if insets.top > 0.0 || insets.bottom > 0.0 || insets.left > 0.0 || insets.right > 0.0 {
+            let scissor_x = (insets.left * dpi_factor) as u64;
+            let scissor_y = (insets.top * dpi_factor) as u64;
+            let scissor_w = ((pass_rect.size.x - insets.left - insets.right) * dpi_factor) as u64;
+            let scissor_h = ((pass_rect.size.y - insets.top - insets.bottom) * dpi_factor) as u64;
+            if scissor_w > 0 && scissor_h > 0 {
+                let () = unsafe {
+                    msg_send![encoder, setScissorRect: MTLScissorRect {
+                        x: scissor_x,
+                        y: scissor_y,
+                        width: scissor_w,
+                        height: scissor_h,
+                    }]
+                };
+            }
+        }
+
         let mut zbias = 0.0;
         let zbias_step = self.passes[draw_pass_id].zbias_step;
 

--- a/platform/src/os/apple/metal.rs
+++ b/platform/src/os/apple/metal.rs
@@ -146,8 +146,6 @@ impl Cx {
         zbias_step: f32,
         encoder: ObjcId,
         metal_cx: &MetalCx,
-        dpi_factor: f64,
-        pass_size: (f64, f64),
     ) {
         // tad ugly otherwise the borrow checker locks 'self' and we can't recur
         let draw_order_len = self.draw_lists[draw_list_id].draw_item_order_len();
@@ -187,8 +185,6 @@ impl Cx {
                     zbias_step,
                     encoder,
                     metal_cx,
-                    dpi_factor,
-                    pass_size,
                 );
             } else {
                 let draw_list = &mut self.draw_lists[draw_list_id];
@@ -500,30 +496,6 @@ impl Cx {
                     );
                 }
 
-                // For draw calls with custom tessellated geometry (DrawSvg/DrawVector),
-                // apply a scissor rect to clip the safe area inset zones. The sweep-line
-                // tessellator produces extreme-aspect-ratio triangles that span hundreds
-                // of SVG units, causing GPU rasterization artifacts where fragments appear
-                // at unexpected screen positions. Standard quad geometry (<=6 indices) is
-                // naturally bounded by its rect and doesn't need this.
-                let insets = &self.display_context.safe_area_insets;
-                let has_safe_insets = insets.top > 0.0 || insets.bottom > 0.0
-                    || insets.left > 0.0 || insets.right > 0.0;
-                let is_custom_geometry = geometry.indices.len() > 6;
-                if has_safe_insets && is_custom_geometry {
-                    let sx = (insets.left * dpi_factor) as u64;
-                    let sy = (insets.top * dpi_factor) as u64;
-                    let sw = ((pass_size.0 - insets.left - insets.right) * dpi_factor) as u64;
-                    let s_h = ((pass_size.1 - insets.top - insets.bottom) * dpi_factor) as u64;
-                    if sw > 0 && s_h > 0 {
-                        let () = unsafe {
-                            msg_send![encoder, setScissorRect: MTLScissorRect {
-                                x: sx, y: sy, width: sw, height: s_h,
-                            }]
-                        };
-                    }
-                }
-
                 self.os.draw_calls_done += 1;
                 self.os.instances_done = self.os.instances_done.saturating_add(instances);
                 self.os.vertices_done = self
@@ -544,17 +516,6 @@ impl Cx {
                     };
                 } else {
                     crate::error!("Drawing error: index_buffer None")
-                }
-
-                // Reset scissor to full screen after custom geometry draw calls
-                if has_safe_insets && is_custom_geometry {
-                    let () = unsafe {
-                        msg_send![encoder, setScissorRect: MTLScissorRect {
-                            x: 0, y: 0,
-                            width: (pass_size.0 * dpi_factor) as u64,
-                            height: (pass_size.1 * dpi_factor) as u64,
-                        }]
-                    };
                 }
             }
         }
@@ -862,8 +823,6 @@ impl Cx {
             zbias_step,
             encoder,
             &metal_cx,
-            dpi_factor,
-            (pass_rect.size.x, pass_rect.size.y),
         );
         let gpu_counters = GpuSampleCounters {
             draw_calls: self.os.draw_calls_done as u64,

--- a/platform/src/os/apple/metal.rs
+++ b/platform/src/os/apple/metal.rs
@@ -146,6 +146,8 @@ impl Cx {
         zbias_step: f32,
         encoder: ObjcId,
         metal_cx: &MetalCx,
+        dpi_factor: f64,
+        pass_size: (f64, f64),
     ) {
         // tad ugly otherwise the borrow checker locks 'self' and we can't recur
         let draw_order_len = self.draw_lists[draw_list_id].draw_item_order_len();
@@ -185,6 +187,8 @@ impl Cx {
                     zbias_step,
                     encoder,
                     metal_cx,
+                    dpi_factor,
+                    pass_size,
                 );
             } else {
                 let draw_list = &mut self.draw_lists[draw_list_id];
@@ -496,6 +500,30 @@ impl Cx {
                     );
                 }
 
+                // For draw calls with custom tessellated geometry (DrawSvg/DrawVector),
+                // apply a scissor rect to clip the safe area inset zones. The sweep-line
+                // tessellator produces extreme-aspect-ratio triangles that span hundreds
+                // of SVG units, causing GPU rasterization artifacts where fragments appear
+                // at unexpected screen positions. Standard quad geometry (<=6 indices) is
+                // naturally bounded by its rect and doesn't need this.
+                let insets = &self.display_context.safe_area_insets;
+                let has_safe_insets = insets.top > 0.0 || insets.bottom > 0.0
+                    || insets.left > 0.0 || insets.right > 0.0;
+                let is_custom_geometry = geometry.indices.len() > 6;
+                if has_safe_insets && is_custom_geometry {
+                    let sx = (insets.left * dpi_factor) as u64;
+                    let sy = (insets.top * dpi_factor) as u64;
+                    let sw = ((pass_size.0 - insets.left - insets.right) * dpi_factor) as u64;
+                    let s_h = ((pass_size.1 - insets.top - insets.bottom) * dpi_factor) as u64;
+                    if sw > 0 && s_h > 0 {
+                        let () = unsafe {
+                            msg_send![encoder, setScissorRect: MTLScissorRect {
+                                x: sx, y: sy, width: sw, height: s_h,
+                            }]
+                        };
+                    }
+                }
+
                 self.os.draw_calls_done += 1;
                 self.os.instances_done = self.os.instances_done.saturating_add(instances);
                 self.os.vertices_done = self
@@ -516,6 +544,17 @@ impl Cx {
                     };
                 } else {
                     crate::error!("Drawing error: index_buffer None")
+                }
+
+                // Reset scissor to full screen after custom geometry draw calls
+                if has_safe_insets && is_custom_geometry {
+                    let () = unsafe {
+                        msg_send![encoder, setScissorRect: MTLScissorRect {
+                            x: 0, y: 0,
+                            width: (pass_size.0 * dpi_factor) as u64,
+                            height: (pass_size.1 * dpi_factor) as u64,
+                        }]
+                    };
                 }
             }
         }
@@ -813,28 +852,6 @@ impl Cx {
             }]
         };
 
-        // Set a scissor rect to clip rendering to the safe content area,
-        // preventing stray geometry (e.g., SVG tessellation artifacts) from
-        // rendering in the system-reserved safe area inset zones.
-        // The safe area background is filled by the pass's clear color.
-        let insets = &self.display_context.safe_area_insets;
-        if insets.top > 0.0 || insets.bottom > 0.0 || insets.left > 0.0 || insets.right > 0.0 {
-            let scissor_x = (insets.left * dpi_factor) as u64;
-            let scissor_y = (insets.top * dpi_factor) as u64;
-            let scissor_w = ((pass_rect.size.x - insets.left - insets.right) * dpi_factor) as u64;
-            let scissor_h = ((pass_rect.size.y - insets.top - insets.bottom) * dpi_factor) as u64;
-            if scissor_w > 0 && scissor_h > 0 {
-                let () = unsafe {
-                    msg_send![encoder, setScissorRect: MTLScissorRect {
-                        x: scissor_x,
-                        y: scissor_y,
-                        width: scissor_w,
-                        height: scissor_h,
-                    }]
-                };
-            }
-        }
-
         let mut zbias = 0.0;
         let zbias_step = self.passes[draw_pass_id].zbias_step;
 
@@ -845,6 +862,8 @@ impl Cx {
             zbias_step,
             encoder,
             &metal_cx,
+            dpi_factor,
+            (pass_rect.size.x, pass_rect.size.y),
         );
         let gpu_counters = GpuSampleCounters {
             draw_calls: self.os.draw_calls_done as u64,

--- a/platform/src/os/apple/tvos/tvos_app.rs
+++ b/platform/src/os/apple/tvos/tvos_app.rs
@@ -197,6 +197,7 @@ impl TvosApp {
             outer_size: new_size,
             dpi_factor,
             position: dvec2(0.0, 0.0),
+            ..Default::default()
         };
 
         if get_tvos_app_global().first_draw {

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -256,6 +256,11 @@ impl Cx {
     /// It handles all incoming messages, processes other events, and manages drawing operations.
     pub fn main_loop(&mut self, from_java_rx: mpsc::Receiver<FromJavaMessage>) {
         self.gpu_info.performance = GpuPerformance::Tier1;
+        // Populate display_context and script heap with safe area insets
+        // BEFORE Startup, so app script_mod! definitions can use them.
+        let insets = self.os.safe_area_insets;
+        self.display_context.safe_area_insets = insets;
+        self.update_safe_inset_script_values(insets);
         self.call_event_handler(&Event::Startup);
         self.redraw_all();
 

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -504,6 +504,8 @@ impl Cx {
                     position: dvec2(0.0, 0.0),
                     inner_size: size,
                     outer_size: size,
+                    safe_area_insets: self.os.safe_area_insets,
+                    ..Default::default()
                 };
                 let new_geom = window.window_geom.clone();
                 self.call_event_handler(&Event::WindowGeomChange(WindowGeomChangeEvent {
@@ -1056,6 +1058,26 @@ impl Cx {
                 let action = ImeAction::from_android_action_code(action_code);
                 let e = Event::ImeAction(ImeActionEvent { action });
                 self.call_event_handler(&e);
+            }
+            FromJavaMessage::SafeAreaInsets { top, right, bottom, left } => {
+                let new_insets = crate::event::SafeAreaInsets { top, right, bottom, left };
+                if self.os.safe_area_insets != new_insets {
+                    self.os.safe_area_insets = new_insets;
+                    // Update the WindowGeom with the new safe area insets
+                    let window_id = CxWindowPool::id_zero();
+                    let window = &mut self.windows[window_id];
+                    let old_geom = window.window_geom.clone();
+                    window.window_geom.safe_area_insets = new_insets;
+                    let new_geom = window.window_geom.clone();
+                    if old_geom != new_geom {
+                        self.call_event_handler(&Event::WindowGeomChange(WindowGeomChangeEvent {
+                            window_id,
+                            new_geom,
+                            old_geom,
+                        }));
+                        self.redraw_all();
+                    }
+                }
             }
             FromJavaMessage::Init(_) => {}
         }
@@ -1838,6 +1860,8 @@ impl Cx {
                         position: dvec2(0.0, 0.0),
                         inner_size: size,
                         outer_size: size,
+                        safe_area_insets: self.os.safe_area_insets,
+                        ..Default::default()
                     };
                     window.is_created = true;
                     //let ret = unsafe{ndk_sys::ANativeWindow_setFrameRate(self.os.display.as_ref().unwrap().window, 120.0, 0)};
@@ -1870,6 +1894,7 @@ impl Cx {
                         position,
                         inner_size: size,
                         outer_size: size,
+                        ..Default::default()
                     };
                     window.is_popup = true;
                     window.popup_parent = Some(parent_window_id);
@@ -2648,6 +2673,7 @@ impl Default for CxOs {
             frame_time: 0,
             display_size: dvec2(100., 100.),
             dpi_factor: 1.5,
+            safe_area_insets: Default::default(),
             keyboard_closed: 0.0,
             media: CxAndroidMedia::default(),
             display: None,
@@ -2703,6 +2729,7 @@ pub struct CxOs {
     pub first_after_resize: bool,
     pub display_size: Vec2d,
     pub dpi_factor: f64,
+    pub safe_area_insets: crate::event::SafeAreaInsets,
     pub keyboard_closed: f64,
     pub frame_time: i64,
     pub quit: bool,

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -288,6 +288,13 @@ impl Cx {
                         continue;
                     }
                     self.os.openxr.logged_waiting_for_session = false;
+                    // If a script re-apply was requested (e.g., safe area insets
+                    // changed on rotation), fire LiveEdit now.
+                    if self.pending_script_reapply {
+                        self.pending_script_reapply = false;
+                        self.call_event_handler(&Event::LiveEdit);
+                        self.redraw_all();
+                    }
                     self.handle_drawing();
                 }
                 Ok(message) => {

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -68,6 +68,12 @@ pub enum FromJavaMessage {
         keyboard_height: u32,
         is_open: bool,
     },
+    SafeAreaInsets {
+        top: f64,
+        right: f64,
+        bottom: f64,
+        left: f64,
+    },
     HttpResponse {
         request_id: u64,
         metadata_id: u64,
@@ -640,6 +646,23 @@ extern "C" fn Java_dev_makepad_android_MakepadNative_surfaceOnResizeTextIME(
     send_from_java_message(FromJavaMessage::ResizeTextIME {
         keyboard_height: keyboard_height as u32,
         is_open: is_open != 0,
+    });
+}
+
+#[no_mangle]
+extern "C" fn Java_dev_makepad_android_MakepadNative_surfaceOnSafeAreaInsets(
+    _: *mut jni_sys::JNIEnv,
+    _: jni_sys::jobject,
+    top: jni_sys::jfloat,
+    right: jni_sys::jfloat,
+    bottom: jni_sys::jfloat,
+    left: jni_sys::jfloat,
+) {
+    send_from_java_message(FromJavaMessage::SafeAreaInsets {
+        top: top as f64,
+        right: right as f64,
+        bottom: bottom as f64,
+        left: left as f64,
     });
 }
 

--- a/platform/src/os/linux/direct/linux_direct.rs
+++ b/platform/src/os/linux/direct/linux_direct.rs
@@ -284,6 +284,7 @@ impl Cx {
                         position: dvec2(0.0, 0.0),
                         inner_size: size,
                         outer_size: size,
+                        ..Default::default()
                     };
                     window.is_created = true;
                 }
@@ -304,6 +305,7 @@ impl Cx {
                         position,
                         inner_size: size,
                         outer_size: size,
+                        ..Default::default()
                     };
                     window.is_popup = true;
                     window.popup_parent = Some(parent_window_id);

--- a/platform/src/os/linux/open_harmony/open_harmony.rs
+++ b/platform/src/os/linux/open_harmony/open_harmony.rs
@@ -185,6 +185,7 @@ impl Cx {
                     position: dvec2(0.0, 0.0),
                     inner_size: size,
                     outer_size: size,
+                    ..Default::default()
                 };
                 let new_geom = window.window_geom.clone();
                 self.call_event_handler(&Event::WindowGeomChange(WindowGeomChangeEvent {
@@ -527,6 +528,7 @@ impl Cx {
                         position: dvec2(0.0, 0.0),
                         inner_size: size,
                         outer_size: size,
+                        ..Default::default()
                     };
                     window.is_created = true;
                 }

--- a/platform/src/os/linux/wayland/opengl_wayland.rs
+++ b/platform/src/os/linux/wayland/opengl_wayland.rs
@@ -111,6 +111,7 @@ impl WaylandWindow {
             outer_size: inner_size,
             dpi_factor: 1.0,
             position: position,
+            ..Default::default()
         };
         Self {
             base_surface,
@@ -338,6 +339,7 @@ impl WaylandPopupWindow {
             outer_size: size,
             dpi_factor: 1.0,
             position,
+            ..Default::default()
         };
 
         Self {

--- a/platform/src/os/linux/wayland/wayland_state.rs
+++ b/platform/src/os/linux/wayland/wayland_state.rs
@@ -418,6 +418,7 @@ impl Dispatch<xdg_toplevel::XdgToplevel, WindowId> for WaylandState {
                             position: dvec2(0., 0.),
                             inner_size,
                             outer_size: inner_size,
+                            ..Default::default()
                         },
                     }));
                 }

--- a/platform/src/os/linux/x11/xlib_window.rs
+++ b/platform/src/os/linux/x11/xlib_window.rs
@@ -472,6 +472,7 @@ impl XlibWindow {
             outer_size: self.get_outer_size(),
             dpi_factor: self.get_dpi_factor(),
             position: self.get_position(),
+            ..Default::default()
         }
     }
 

--- a/platform/src/os/web/to_wasm.rs
+++ b/platform/src/os/web/to_wasm.rs
@@ -75,6 +75,7 @@ impl Into<WindowGeom> for WWindowInfo {
             position: Vec2d { x: 0., y: 0. },
             xr_is_presenting: self.xr_is_presenting,
             can_fullscreen: self.can_fullscreen,
+            ..Default::default()
         }
     }
 }

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -854,6 +854,7 @@ impl Win32Window {
             outer_size: self.get_outer_size(),
             dpi_factor: self.get_dpi_factor(),
             position: self.get_position(),
+            ..Default::default()
         }
     }
 

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -620,6 +620,20 @@ class ResizingLayout
     public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
         Insets imeInsets = insets.getInsets(WindowInsets.Type.ime());
         v.setPadding(0, 0, 0, imeInsets.bottom);
+
+        // Compute safe area insets from system bars and display cutout.
+        // These are in physical pixels; convert to logical points by dividing by density.
+        float density = getResources().getDisplayMetrics().density;
+        Insets systemBarInsets = insets.getInsets(
+            WindowInsets.Type.systemBars() | WindowInsets.Type.displayCutout()
+        );
+        MakepadNative.surfaceOnSafeAreaInsets(
+            systemBarInsets.top / density,
+            systemBarInsets.right / density,
+            systemBarInsets.bottom / density,
+            systemBarInsets.left / density
+        );
+
         return insets;
     }
 }

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadNative.java
@@ -29,6 +29,7 @@ public class MakepadNative {
     public native static void surfaceOnKeyUp(int keycode, int meta_state);
     public native static void surfaceOnCharacter(int character);
     public native static void surfaceOnResizeTextIME(int keyboard_height, boolean is_open);
+    public native static void surfaceOnSafeAreaInsets(float top, float right, float bottom, float left);
 
     // networking
     public native static void onHttpResponse(long id, long metadata_id, int status_code, String headers, byte[] body);

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -590,6 +590,19 @@ pub fn widgets_mod(vm: &mut ScriptVm) {
     crate::map::view::script_mod(vm);
     crate::math_view::script_mod(vm);
 
+    // Safe area inset values (in logical points). Populated from the platform's
+    // display_context which is set before Startup on iOS/Android. On desktop
+    // platforms these remain 0.0. Updated at runtime on WindowGeomChange events.
+    {
+        use makepad_script::trap::NoTrap;
+        let insets = vm.cx().display_context.safe_area_insets;
+        let widgets = vm.module(id!(widgets));
+        vm.bx.heap.set_value(widgets, id!(SAFE_INSET_PAD_TOP).into(), insets.top.into(), NoTrap);
+        vm.bx.heap.set_value(widgets, id!(SAFE_INSET_PAD_BOTTOM).into(), insets.bottom.into(), NoTrap);
+        vm.bx.heap.set_value(widgets, id!(SAFE_INSET_PAD_LEFT).into(), insets.left.into(), NoTrap);
+        vm.bx.heap.set_value(widgets, id!(SAFE_INSET_PAD_RIGHT).into(), insets.right.into(), NoTrap);
+    }
+
     script_eval!(vm, {
         mod.prelude.widgets = {
             ..mod.prelude.widgets_header,

--- a/widgets/src/stack_navigation.rs
+++ b/widgets/src/stack_navigation.rs
@@ -189,15 +189,17 @@ impl Widget for StackNavigationView {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        let parent_rect = cx.peek_walk_turtle(walk);
         let abs_pos = if self.full_screen {
-            // In full screen mode, position at the offset, respecting safe area insets.
+            // In full screen mode, position at the offset.
+            // Use the larger of the safe area inset or the parent's y position
+            // so the view respects both mobile safe areas and desktop title bars.
             let safe_top = cx.display_context.safe_area_insets.top;
             Vec2d {
                 x: self.offset,
-                y: safe_top,
+                y: safe_top.max(parent_rect.pos.y),
             }
         } else {
-            let parent_rect = cx.peek_walk_turtle(walk);
             // Non-fullscreen: ignore offset, position at parent.
             Vec2d {
                 x: parent_rect.pos.x,

--- a/widgets/src/stack_navigation.rs
+++ b/widgets/src/stack_navigation.rs
@@ -190,10 +190,11 @@ impl Widget for StackNavigationView {
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         let abs_pos = if self.full_screen {
-            // In full screen mode, position at the offset.
+            // In full screen mode, position at the offset, respecting safe area insets.
+            let safe_top = cx.display_context.safe_area_insets.top;
             Vec2d {
                 x: self.offset,
-                y: 0.,
+                y: safe_top,
             }
         } else {
             let parent_rect = cx.peek_walk_turtle(walk);

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -308,7 +308,18 @@ impl Window {
         self.main_draw_list.begin_always(cx);
 
         let size = cx.current_pass_size();
-        cx.begin_root_turtle(size, Layout::flow_down());
+
+        // Apply safe area insets as root padding so content doesn't overlap
+        // with notch/Dynamic Island, home indicator, or rounded screen corners.
+        let insets = cx.display_context.safe_area_insets;
+        let mut layout = Layout::flow_down();
+        layout.padding = Inset {
+            left: insets.left,
+            top: insets.top,
+            right: insets.right,
+            bottom: insets.bottom,
+        };
+        cx.begin_root_turtle(size, layout);
 
         self.overlay.begin(cx);
 
@@ -538,6 +549,7 @@ impl Widget for Window {
 
                     // Update the display context if the screen size has changed
                     cx.display_context.screen_size = ev.new_geom.inner_size;
+                    cx.display_context.safe_area_insets = ev.new_geom.safe_area_insets;
                     cx.display_context.updated_on_event_id = cx.event_id();
 
                     cx.widget_action(uid, WindowAction::WindowGeomChange(ev.clone()));

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -308,18 +308,7 @@ impl Window {
         self.main_draw_list.begin_always(cx);
 
         let size = cx.current_pass_size();
-
-        // Apply safe area insets as root padding so content doesn't overlap
-        // with notch/Dynamic Island, home indicator, or rounded screen corners.
-        let insets = cx.display_context.safe_area_insets;
-        let mut layout = Layout::flow_down();
-        layout.padding = Inset {
-            left: insets.left,
-            top: insets.top,
-            right: insets.right,
-            bottom: insets.bottom,
-        };
-        cx.begin_root_turtle(size, layout);
+        cx.begin_root_turtle(size, Layout::flow_down());
 
         self.overlay.begin(cx);
 
@@ -551,6 +540,10 @@ impl Widget for Window {
                     cx.display_context.screen_size = ev.new_geom.inner_size;
                     cx.display_context.safe_area_insets = ev.new_geom.safe_area_insets;
                     cx.display_context.updated_on_event_id = cx.event_id();
+
+                    // Update safe area inset values on the script heap so
+                    // Splash code can reference mod.widgets.SAFE_INSET_PAD_*.
+                    cx.update_safe_inset_script_values(ev.new_geom.safe_area_insets);
 
                     cx.widget_action(uid, WindowAction::WindowGeomChange(ev.clone()));
                     return;

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -537,6 +537,7 @@ impl Widget for Window {
                     }
 
                     // Update the display context if the screen size has changed
+                    let old_insets = cx.display_context.safe_area_insets;
                     cx.display_context.screen_size = ev.new_geom.inner_size;
                     cx.display_context.safe_area_insets = ev.new_geom.safe_area_insets;
                     cx.display_context.updated_on_event_id = cx.event_id();
@@ -544,6 +545,12 @@ impl Widget for Window {
                     // Update safe area inset values on the script heap so
                     // Splash code can reference mod.widgets.SAFE_INSET_PAD_*.
                     cx.update_safe_inset_script_values(ev.new_geom.safe_area_insets);
+
+                    // If safe area insets changed (e.g., device rotation), trigger
+                    // a script re-apply so widgets pick up new values.
+                    if old_insets != ev.new_geom.safe_area_insets {
+                        cx.request_script_reapply();
+                    }
 
                     cx.widget_action(uid, WindowAction::WindowGeomChange(ev.clone()));
                     return;


### PR DESCRIPTION
Tested working on iOS and Android, though I tested it a lot more thoroughly on iOS because of the huge device notches/"dynamic island" that apple devices have. It works on Android but the test cases aren't as clear, at least on the devices I have.

This also fixes a problem with SVG/vector drawing that caused weird linear artifacts due to degenerate triangles, which itself was caused by GPU fill. We now do it on the CPU, which fixes both the artifacts that appeared in the safe inset areas (and elsewhere), as well as made SVGs super sharp, especially on the edges.