### PR TITLE
Choose sane defaults for platform-specific title/caption bar config

### DIFF
--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -105,7 +105,7 @@ pub use {
         audio::*,
         component::{ComponentInfo, ComponentRegistries, ComponentRegistry},
         cursor::MouseCursor,
-        cx::{Cx, CxRef, OsType},
+        cx::{Cx, CxRef, LinuxWindowParams, OsType},
         cx_api::{AccessibilityUpdatePayload, CxOsApi, CxOsOp, CxThreadPriority, OpenUrlInPlace},
         draw_list::{CxDrawCall, CxDrawItem, CxDrawListPool, CxRectArea, DrawList, DrawListId},
         draw_matrix::DrawMatrix,

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -243,9 +243,6 @@ pub enum WindowAction {
 
 impl Window {
     fn sync_caption_bar_state(&mut self, cx: &mut Cx) {
-        let linux_custom_window_chrome =
-            matches!(cx.os_type(), OsType::LinuxWindow(params) if params.custom_window_chrome);
-
         match cx.os_type() {
             OsType::Windows => {
                 self.view(cx, ids!(caption_bar))
@@ -256,10 +253,14 @@ impl Window {
                 self.view(cx, ids!(caption_bar))
                     .set_visible(cx, self.show_caption_bar);
             }
-            OsType::LinuxWindow(_) => {
+            OsType::LinuxWindow(params) => {
+                // Only show the caption bar if we're drawing our own window chrome
+                // (e.g. Wayland without server-side decorations). On X11 the WM
+                // provides native decorations, so we hide the in-app caption bar.
+                let custom_chrome = params.custom_window_chrome;
                 self.view(cx, ids!(caption_bar))
-                    .set_visible(cx, self.show_caption_bar);
-                if linux_custom_window_chrome {
+                    .set_visible(cx, self.show_caption_bar && custom_chrome);
+                if custom_chrome {
                     self.view(cx, ids!(windows_buttons)).set_visible(cx, true);
                 }
             }


### PR DESCRIPTION
Primarily on Linux, ensure that we show the title/caption bar and draw it within Makepad (i.e., client-side drawing) if the DE/WM doesn't show it by default.
This should make things behave as expected on Linux X11 and Wayland both.