### PR TITLE
Properly handle caption bar when entering/exiting macOS fullscreen

### DIFF
--- a/platform/src/os/apple/macos/macos_delegates.rs
+++ b/platform/src/os/apple/macos/macos_delegates.rs
@@ -218,26 +218,38 @@ pub fn define_macos_window_delegate() -> *const Class {
         //WindowDelegate::emit_event(state, WindowEvent::HoveredFileCancelled);
     }
 
-    // Invoked when entered fullscreen
-    extern "C" fn window_did_enter_fullscreen(this: &Object, _: Sel, _: ObjcId) {
+    // Fullscreen lifecycle: set `is_fullscreen` in the `will` callbacks so the
+    // widget layer can show/hide the caption bar at the START of the animation,
+    // not after it finishes.  The `did` callbacks fire a second change event so
+    // the final geometry (after the animation) is also picked up.
+
+    extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: ObjcId) {
         let cw = get_cocoa_window(this);
         cw.is_fullscreen = true;
         cw.send_change_event();
     }
 
-    // Invoked when before enter fullscreen
-    extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: ObjcId) {
-        let _cw = get_cocoa_window(this);
+    extern "C" fn window_did_enter_fullscreen(this: &Object, _: Sel, _: ObjcId) {
+        let cw = get_cocoa_window(this);
+        cw.send_change_event();
     }
 
-    // Invoked when exited fullscreen
-    extern "C" fn window_did_exit_fullscreen(this: &Object, _: Sel, _: ObjcId) {
+    extern "C" fn window_will_exit_fullscreen(this: &Object, _: Sel, _: ObjcId) {
         let cw = get_cocoa_window(this);
         cw.is_fullscreen = false;
         cw.send_change_event();
     }
 
-    extern "C" fn window_did_fail_to_enter_fullscreen(_this: &Object, _: Sel, _: ObjcId) {}
+    extern "C" fn window_did_exit_fullscreen(this: &Object, _: Sel, _: ObjcId) {
+        let cw = get_cocoa_window(this);
+        cw.send_change_event();
+    }
+
+    extern "C" fn window_did_fail_to_enter_fullscreen(this: &Object, _: Sel, _: ObjcId) {
+        let cw = get_cocoa_window(this);
+        cw.is_fullscreen = false;
+        cw.send_change_event();
+    }
 
     let superclass = class!(NSObject);
     let mut decl = ClassDecl::new("RenderWindowDelegate", superclass).unwrap();
@@ -316,6 +328,10 @@ pub fn define_macos_window_delegate() -> *const Class {
         decl.add_method(
             sel!(windowWillEnterFullScreen:),
             window_will_enter_fullscreen as extern "C" fn(&Object, Sel, ObjcId),
+        );
+        decl.add_method(
+            sel!(windowWillExitFullScreen:),
+            window_will_exit_fullscreen as extern "C" fn(&Object, Sel, ObjcId),
         );
         decl.add_method(
             sel!(windowDidExitFullScreen:),

--- a/platform/src/os/apple/macos/macos_window.rs
+++ b/platform/src/os/apple/macos/macos_window.rs
@@ -604,6 +604,15 @@ impl MacosWindow {
             let right  = r0.max(r1).max(r2);
             let bottom = b0.max(b1).max(b2);
 
+            // During a fullscreen transition the content view resizes before
+            // the buttons' superview repositions, so the Y-flip can place the
+            // buttons near the bottom of the view.  Traffic-light buttons are
+            // always near the top of the window, so discard bogus geometry
+            // where they appear in the lower half of the content area.
+            if top > h * 0.5 {
+                return None;
+            }
+
             let rect = Rect {
                 pos: Vec2d { x: left, y: top },
                 size: Vec2d { x: right - left, y: bottom - top },

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -258,8 +258,11 @@ impl Window {
                 self.view(cx, ids!(windows_buttons)).set_visible(cx, true);
             }
             OsType::Macos => {
+                // In macOS fullscreen, the OS provides its own auto-hiding
+                // toolbar with traffic-light buttons, so hide our caption bar.
+                let is_fullscreen = self.window.handle.is_fullscreen(cx);
                 self.view(cx, ids!(caption_bar))
-                    .set_visible(cx, self.show_caption_bar);
+                    .set_visible(cx, self.show_caption_bar && !is_fullscreen);
             }
             OsType::LinuxWindow(params) => {
                 // Only show the caption bar if we're drawing our own window chrome
@@ -620,8 +623,6 @@ impl Widget for Window {
                     // If the platform reports native chrome button geometry, derive
                     // the caption bar height so the buttons are vertically centered:
                     // height = top_margin * 2 + button_height = pos.y * 2 + size.y.
-                    // If the platform reports native chrome button geometry, derive
-                    // the caption bar height so the buttons are vertically centered.
                     let new_buttons = ev.new_geom.window_chrome_buttons;
                     if new_buttons != Rect::default() {
                         let h = (new_buttons.pos.y * 2.0 + new_buttons.size.y).ceil();


### PR DESCRIPTION
add handlers for "will enter/exit fullscreen" instead of just handling "did" enter/exit, in order to properly animate. Otherwise it looks janky for a split second where the traffic light buttons are on top of the old app content before it refreshes.