### PR TITLE
TextInput: reflow text upon widget resize (width changes)

### DIFF
--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -537,6 +537,8 @@ pub struct TextInput {
     #[rust]
     laidout_text: Option<Rc<LaidoutText>>,
     #[rust]
+    laidout_width: Option<f32>,
+    #[rust]
     text_area: Area,
     #[rust]
     selection: Selection,
@@ -781,7 +783,13 @@ impl TextInput {
     }
 
     fn layout_text(&mut self, cx: &mut Cx2d) {
-        if self.laidout_text.is_some() {
+        let turtle_rect = cx.turtle().inner_rect();
+        let max_width_in_lpxs = if !turtle_rect.size.x.is_nan() {
+            Some(turtle_rect.size.x as f32)
+        } else {
+            None
+        };
+        if self.laidout_text.is_some() && self.laidout_width == max_width_in_lpxs {
             return;
         }
         let text = if self.is_password {
@@ -794,13 +802,8 @@ impl TextInput {
         } else {
             &self.text
         };
-        let turtle_rect = cx.turtle().inner_rect();
-        let max_width_in_lpxs = if !turtle_rect.size.x.is_nan() {
-            Some(turtle_rect.size.x as f32)
-        } else {
-            None
-        };
         let wrap = cx.turtle().layout().flow == Flow::right_wrap();
+        self.laidout_width = max_width_in_lpxs;
         self.laidout_text = Some(self.draw_text.layout(
             cx,
             0.0,


### PR DESCRIPTION
Fixes a minor bug in which the entered text within a TextInput widget would not get its layout recalculated if the width changed, meaning that text could get cutoff on the right side of the widget.

Now we ensure that the text layout gets re-done (and the cached value is not incorrectly used) if the width has changed since the last layout.