### PR TITLE
TextInput: support multiline mode with proper scrolling

### DIFF
--- a/examples/uizoo/src/app.rs
+++ b/examples/uizoo/src/app.rs
@@ -229,6 +229,15 @@ impl MatchEvent for App {
             lbl.set_text(cx, &format!("{} {}", self.counter, txt));
         }
 
+        if let Some(is_multiline) = self
+            .ui
+            .check_box(cx, ids!(multiline_toggle))
+            .changed(actions)
+        {
+            let ti = self.ui.text_input(cx, ids!(multiline_toggleable));
+            ti.set_is_multiline(cx, is_multiline);
+        }
+
         if self.ui.button(cx, ids!(basicbutton)).clicked(&actions) {
             log!("BASIC BUTTON CLICKED {}", self.counter);
             self.counter += 1;

--- a/examples/uizoo/src/tab_textinput.rs
+++ b/examples/uizoo/src/tab_textinput.rs
@@ -47,6 +47,51 @@ script_mod! {
             Hr{}
             H4{text: "TextInputGradientY"}
             TextInputGradientY{empty_text: "Inline Label"}
+
+            Hr{}
+            H4{text: "Multiline TextInput (fixed height, scrollable)"}
+            P{text: "A multiline text input with a fixed height. Try typing or pasting enough text to overflow, then scroll with mouse wheel or drag the scrollbar."}
+            multiline_textinput := TextInput{
+                empty_text: "Type multiple lines here..."
+                is_multiline: true
+                height: 150.0
+                width: Fill
+            }
+
+            Hr{}
+            H4{text: "Multiline TextInput (taller, with pre-filled content)"}
+            P{text: "A taller multiline text input pre-filled with content that overflows."}
+            multiline_prefilled := TextInput{
+                empty_text: "Prefilled multiline"
+                is_multiline: true
+                height: 200.0
+                width: Fill
+                text: "Line 1: The quick brown fox jumps over the lazy dog.\nLine 2: Pack my box with five dozen liquor jugs.\nLine 3: How vexingly quick daft zebras jump!\nLine 4: The five boxing wizards jump quickly.\nLine 5: Sphinx of black quartz, judge my vow.\nLine 6: Two driven jocks help fax my big quiz.\nLine 7: Crazy Frederick bought many very exquisite opal jewels.\nLine 8: We promptly judged antique ivory buckles for the next prize.\nLine 9: A mad boxer shot a quick, gloved jab to the jaw of his dizzy opponent.\nLine 10: Jaded zombies acted quaintly but kept driving their oxen forward."
+            }
+
+            Hr{}
+            H4{text: "Multiline TextInput (read-only)"}
+            P{text: "A read-only multiline text input. You can scroll and select text, but cannot edit."}
+            multiline_readonly := TextInput{
+                empty_text: "Read-only multiline"
+                is_multiline: true
+                is_read_only: true
+                height: 120.0
+                width: Fill
+                text: "This is a read-only multiline text input.\nYou can scroll through the content and select text,\nbut you cannot modify it.\nLine 4\nLine 5\nLine 6\nLine 7\nLine 8\nLine 9\nLine 10"
+            }
+
+            Hr{}
+            H4{text: "Toggle Multiline"}
+            P{text: "Use the checkbox to toggle this text input between single-line and multiline mode."}
+            UIZooRowH{
+                multiline_toggle := CheckBox{text: "Multiline"}
+            }
+            multiline_toggleable := TextInput{
+                text: "Toggle me between single-line and multiline..."
+                height: Fit
+                width: Fill
+            }
         }
     }
 }

--- a/examples/uizoo/src/tab_textinput.rs
+++ b/examples/uizoo/src/tab_textinput.rs
@@ -82,6 +82,26 @@ script_mod! {
             }
 
             Hr{}
+            H4{text: "Multiline TextInput (Fit height with max bound)"}
+            P{text: "A multiline text input with Fit height that caps at 100px. The widget grows with content until hitting the max, then scrolls."}
+            TextInput{
+                empty_text: "Type several lines to grow this TextInput, then scroll..."
+                is_multiline: true
+                height: Fit{max: FitBound.Abs(100)}
+                width: Fill
+            }
+
+            Hr{}
+            H4{text: "Multiline TextInput (Fit height with relative max bound)"}
+            P{text: "A multiline text input with Fit height capped at 30% of the parent height. Uses FitBound.Rel with Base.Full."}
+            TextInput{
+                empty_text: "Type several lines to test relative max height..."
+                is_multiline: true
+                height: Fit{max: FitBound.Rel{base: Base.Full, factor: 0.3}}
+                width: Fill
+            }
+
+            Hr{}
             H4{text: "Toggle Multiline"}
             P{text: "Use the checkbox to toggle this text input between single-line and multiline mode."}
             UIZooRowH{

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -631,6 +631,7 @@ impl TextInput {
         self.is_multiline = is_multiline;
         if !is_multiline {
             self.scroll_y = 0.0;
+            self.cached_max_scroll_y = 0.0;
         }
         self.laidout_text = None;
         self.draw_bg.redraw(cx);
@@ -961,17 +962,6 @@ impl TextInput {
         rect(sel_x, sel_y, sel_width.max(10.0), sel_height.max(20.0))
     }
 
-    /// Returns the maximum scroll offset for the current text content and visible height.
-    /// `visible_height` is the inner height of the widget (excluding padding).
-    fn max_scroll_y(&self, visible_height: f64) -> f64 {
-        if let Some(laidout_text) = self.laidout_text.as_ref() {
-            let text_height = laidout_text.size_in_lpxs.height as f64;
-            (text_height - visible_height).max(0.0)
-        } else {
-            0.0
-        }
-    }
-
     fn scroll_to_cursor(&mut self, cx: &mut Cx2d) {
         // Compute the final size of the turtle, and obtain its inner height.
         cx.compute_final_size();
@@ -1003,8 +993,10 @@ impl TextInput {
         }
 
         // Always clamp the scroll position to valid bounds, and cache
-        // max_scroll_y so the event handler uses the exact same value.
-        let max_scroll_y = self.max_scroll_y(height);
+        // max_scroll_y so the event handler uses the exact same value
+        // (avoiding floating-point mismatch with relative Fit bounds).
+        let laidout_text_height = self.laidout_text.as_ref().unwrap().size_in_lpxs.height as f64;
+        let max_scroll_y = (laidout_text_height - height).max(0.0);
         self.cached_max_scroll_y = max_scroll_y;
         self.scroll_y = self.scroll_y.max(0.0).min(max_scroll_y);
 
@@ -1574,13 +1566,16 @@ impl Widget for TextInput {
 
             // If the scrollbar has captured the finger (user is dragging the handle),
             // sync scroll_y from the ScrollBar (which is the source of truth during
-            // drag) and prevent the text input from also processing finger events.
+            // drag).
             if self.scroll_bar.is_area_captured(cx) {
                 self.scroll_y = self.scroll_bar.get_scroll_pos();
                 self.draw_bg.redraw(cx);
-                return;
             }
         }
+
+        // Skip finger event processing if the scrollbar owns the finger,
+        // so dragging the scrollbar doesn't also move the text cursor.
+        let scrollbar_captured = self.is_multiline && self.scroll_bar.is_area_captured(cx);
 
         match event.hits(cx, self.draw_bg.area()) {
             Hit::FingerHoverIn(_) => {
@@ -1712,7 +1707,7 @@ impl Widget for TextInput {
                 tap_count,
                 device,
                 ..
-            }) if device.is_primary_hit() => {
+            }) if device.is_primary_hit() && !scrollbar_captured => {
                 self.reset_blink_timer(cx);
                 self.set_key_focus(cx);
                 let rel = abs - self.text_area.rect(cx).pos;
@@ -1824,7 +1819,7 @@ impl Widget for TextInput {
                 tap_count,
                 device,
                 ..
-            }) if device.is_primary_hit() => {
+            }) if device.is_primary_hit() && !scrollbar_captured => {
                 // Skip first move after long press to prevent selection changes
                 if self.ignore_next_move {
                     self.ignore_next_move = false;

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -17,6 +17,7 @@ use {
             *,
         },
         makepad_script::{ScriptFnRef, ScriptRefOptionExt},
+        scroll_bar::{ScrollBar, ScrollAxis},
         widget::*,
         widget_async::ScriptAsyncResult,
     },
@@ -40,6 +41,12 @@ script_mod! {
         is_read_only: false
         is_numeric_only: false
         empty_text: "Your text here"
+        scroll_bar: mod.widgets.ScrollBar {
+            bar_size: 8.0
+            bar_side_margin: 2.0
+            min_handle_size: 20.0
+            drag_scrolling: true
+        }
 
         draw_bg +: {
             hover: instance(0.0)
@@ -524,10 +531,12 @@ pub struct TextInput {
     #[live(false)]
     is_multiline: bool,
     #[live]
+    scroll_bar: ScrollBar,
+    #[live]
     scroll_y: f64,
     #[live]
     empty_text: String,
-    #[rust]
+    #[live]
     text: String,
     #[live(0.5)]
     blink_speed: f64,
@@ -546,6 +555,10 @@ pub struct TextInput {
     blink_timer: Timer,
     #[rust]
     preserved_selection_cursor: Option<Cursor>,
+    /// When true, the next draw will scroll to keep the cursor visible.
+    /// Set when the cursor/selection changes; cleared after scroll_to_cursor runs.
+    #[rust(true)]
+    needs_scroll_to_cursor: bool,
     /// Skip finger move after long press to prevent selection changes
     #[rust]
     ignore_next_move: bool,
@@ -603,6 +616,16 @@ impl TextInput {
                 vm.call(ScriptValue::from(handler), &[ScriptValue::from(str_val)]);
             });
         }
+    }
+
+    pub fn is_multiline(&self) -> bool {
+        self.is_multiline
+    }
+
+    pub fn set_is_multiline(&mut self, cx: &mut Cx, is_multiline: bool) {
+        self.is_multiline = is_multiline;
+        self.laidout_text = None;
+        self.draw_bg.redraw(cx);
     }
 
     pub fn is_password(&self) -> bool {
@@ -664,6 +687,7 @@ impl TextInput {
 
     pub fn set_selection(&mut self, cx: &mut Cx, selection: Selection) {
         self.selection = selection;
+        self.needs_scroll_to_cursor = true;
         self.history.force_new_edit_group();
         self.draw_bg.redraw(cx);
     }
@@ -800,7 +824,7 @@ impl TextInput {
         } else {
             None
         };
-        let wrap = cx.turtle().layout().flow == Flow::right_wrap();
+        let wrap = self.is_multiline && cx.turtle().layout().flow == Flow::right_wrap();
         self.laidout_text = Some(self.draw_text.layout(
             cx,
             0.0,
@@ -934,27 +958,34 @@ impl TextInput {
         cx.compute_final_size();
         let height = cx.turtle().inner_rect().size.y;
 
-        // Compute the min and max y of the row that the cursor is on.
         let laidout_text = self.laidout_text.as_ref().unwrap();
         let laidout_text_height = laidout_text.size_in_lpxs.height as f64;
-        let position = self.cursor_to_position(self.cursor()).unwrap();
-        let laidout_row = &laidout_text.rows[position.row_index];
-        let y_min = (laidout_row.origin_in_lpxs.y - laidout_row.ascender_in_lpxs) as f64;
-        let y_max = (laidout_row.origin_in_lpxs.y - laidout_row.descender_in_lpxs) as f64;
 
-        // If the min y of the row is less than the scroll position, scroll up so that the top of
-        // the row appears at the top.
-        if y_min < self.scroll_y {
-            self.scroll_y = y_min;
+        // Only auto-scroll to keep the cursor visible when the cursor has actually
+        // moved (typing, arrow keys, clicking). Don't do this on every redraw, as
+        // that would fight with user-initiated mouse wheel scrolling.
+        if self.needs_scroll_to_cursor {
+            self.needs_scroll_to_cursor = false;
+
+            let position = self.cursor_to_position(self.cursor()).unwrap();
+            let laidout_row = &laidout_text.rows[position.row_index];
+            let y_min = (laidout_row.origin_in_lpxs.y - laidout_row.ascender_in_lpxs) as f64;
+            let y_max = (laidout_row.origin_in_lpxs.y - laidout_row.descender_in_lpxs) as f64;
+
+            // If the min y of the row is less than the scroll position, scroll up so
+            // that the top of the row appears at the top.
+            if y_min < self.scroll_y {
+                self.scroll_y = y_min;
+            }
+
+            // If the max y of the row is greater than the scroll position, scroll down
+            // so that the bottom of the row appears at the bottom.
+            if y_max > self.scroll_y + height {
+                self.scroll_y = y_max - height;
+            }
         }
 
-        // If the max y of the row is greater than the scroll position, scroll down so that the
-        // bottom of the row appears at the bottom.
-        if y_max > self.scroll_y + height {
-            self.scroll_y = y_max - height;
-        }
-
-        // Clamp the scroll position so that we cannot scroll past the start or end of the text.
+        // Always clamp the scroll position to valid bounds.
         let max_scroll_y = laidout_text_height.max(height) - height;
         self.scroll_y = self.scroll_y.max(0.0).min(max_scroll_y);
 
@@ -968,6 +999,25 @@ impl TextInput {
             },
             dvec2(0.0, -self.scroll_y),
         );
+    }
+
+    /// Draws the vertical scrollbar when the text content overflows the visible area.
+    fn draw_scroll_bar(&mut self, cx: &mut Cx2d) {
+        if !self.is_multiline {
+            return;
+        }
+        let Some(laidout_text) = self.laidout_text.as_ref() else {
+            return;
+        };
+        let view_rect = cx.turtle().inner_rect();
+        let view_total = dvec2(
+            view_rect.size.x,
+            laidout_text.size_in_lpxs.height as f64,
+        );
+        // Sync scroll_y (which scroll_to_cursor may have updated) into the scrollbar.
+        self.scroll_bar.set_scroll_pos_no_action(cx, self.scroll_y);
+        self.scroll_bar
+            .draw_scroll_bar(cx, ScrollAxis::Vertical, view_rect, view_total);
     }
 
     /// Moves the cursor one column to the left.
@@ -1287,6 +1337,7 @@ impl TextInput {
     fn apply_edit(&mut self, cx: &mut Cx, edit: Edit) {
         self.selection.cursor.index = edit.start + edit.replace_with.len();
         self.selection.anchor.index = self.selection.cursor.index;
+        self.needs_scroll_to_cursor = true;
         self.history.apply_edit(edit, &mut self.text);
         self.laidout_text = None;
         self.check_text_is_empty(cx);
@@ -1296,6 +1347,7 @@ impl TextInput {
         if let Some(new_selection) = self.history.undo(self.selection, &mut self.text) {
             self.laidout_text = None;
             self.selection = new_selection;
+            self.needs_scroll_to_cursor = true;
             self.check_text_is_empty(cx);
             true
         } else {
@@ -1307,6 +1359,7 @@ impl TextInput {
         if let Some(new_selection) = self.history.redo(self.selection, &mut self.text) {
             self.laidout_text = None;
             self.selection = new_selection;
+            self.needs_scroll_to_cursor = true;
             self.check_text_is_empty(cx);
             true
         } else {
@@ -1388,6 +1441,7 @@ impl Widget for TextInput {
         self.draw_selection(cx, text_rect);
         self.draw_composition_underline(cx, text_rect);
         self.scroll_to_cursor(cx);
+        self.draw_scroll_bar(cx);
         self.draw_bg.end(cx);
         if cx.has_key_focus(self.draw_bg.area()) {
             if self.ime_update_frame != cx.redraw_id() {
@@ -1460,6 +1514,60 @@ impl Widget for TextInput {
                 cx.set_key_focus(Area::Empty);
                 // Handle focus loss locally
                 self.handle_focus_lost(cx, uid);
+            }
+        }
+
+        // Handle scrollbar events for multiline text inputs.
+        if self.is_multiline {
+            // Handle mouse wheel / trackpad scroll directly.
+            // Makepad convention: positive scroll.y = viewport moves down = scroll_pos increases.
+            // self.scroll_y is the single source of truth; the ScrollBar is synced from it
+            // during draw_scroll_bar, so we don't update the ScrollBar here (which would
+            // trigger next_frame callbacks and cause feedback loops).
+            if let Event::Scroll(e) = event {
+                let bg_rect = self.draw_bg.area().rect(cx);
+                if !e.handled_y.get() && bg_rect.contains(e.abs) {
+                    if let Some(laidout_text) = self.laidout_text.as_ref() {
+                        let visible_height = bg_rect.size.y
+                            - self.layout.padding.top as f64
+                            - self.layout.padding.bottom as f64;
+                        let laidout_text_height = laidout_text.size_in_lpxs.height as f64;
+                        let max_scroll_y = (laidout_text_height - visible_height).max(0.0);
+                        if max_scroll_y > 0.0 {
+                            let new_scroll_y = (self.scroll_y + e.scroll.y)
+                                .max(0.0)
+                                .min(max_scroll_y);
+                            if new_scroll_y != self.scroll_y {
+                                self.scroll_y = new_scroll_y;
+                                self.draw_bg.redraw(cx);
+                                e.handled_y.set(true);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Handle clicking/dragging on the scrollbar handle itself.
+            // Only sync scroll_y from the ScrollBar when the user is actively
+            // dragging the handle (area is captured). Otherwise, next_frame
+            // callbacks from draw_scroll_bar's clamping would overwrite scroll_y
+            // with a potentially different max, causing scroll to get stuck.
+            let scrollbar_captured = self.scroll_bar.is_area_captured(cx);
+            self.scroll_bar.handle_event_with(
+                cx,
+                event,
+                &mut |_, _| {},
+            );
+
+            if scrollbar_captured {
+                self.scroll_y = self.scroll_bar.get_scroll_pos();
+                self.draw_bg.redraw(cx);
+            }
+
+            // If the scrollbar captured the finger, don't let the text input
+            // also process finger events (which would move the cursor).
+            if self.scroll_bar.is_area_captured(cx) {
+                return;
             }
         }
 
@@ -1863,6 +1971,7 @@ impl Widget for TextInput {
 
                     let sel_start_byte = full_state.selection.start.to_byte_index(&self.text);
                     let sel_end_byte = full_state.selection.end.to_byte_index(&self.text);
+                    self.needs_scroll_to_cursor = true;
                     self.selection = Selection {
                         anchor: Cursor {
                             index: sel_start_byte,
@@ -2098,6 +2207,20 @@ impl Widget for TextInput {
 }
 
 impl TextInputRef {
+    pub fn is_multiline(&self) -> bool {
+        if let Some(inner) = self.borrow() {
+            inner.is_multiline()
+        } else {
+            false
+        }
+    }
+
+    pub fn set_is_multiline(&self, cx: &mut Cx, is_multiline: bool) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_is_multiline(cx, is_multiline);
+        }
+    }
+
     pub fn is_password(&self) -> bool {
         if let Some(inner) = self.borrow() {
             inner.is_password()

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -624,6 +624,9 @@ impl TextInput {
 
     pub fn set_is_multiline(&mut self, cx: &mut Cx, is_multiline: bool) {
         self.is_multiline = is_multiline;
+        if !is_multiline {
+            self.scroll_y = 0.0;
+        }
         self.laidout_text = None;
         self.draw_bg.redraw(cx);
     }
@@ -1529,8 +1532,8 @@ impl Widget for TextInput {
                 if !e.handled_y.get() && bg_rect.contains(e.abs) {
                     if let Some(laidout_text) = self.laidout_text.as_ref() {
                         let visible_height = bg_rect.size.y
-                            - self.layout.padding.top as f64
-                            - self.layout.padding.bottom as f64;
+                            - self.layout.padding.top
+                            - self.layout.padding.bottom;
                         let laidout_text_height = laidout_text.size_in_lpxs.height as f64;
                         let max_scroll_y = (laidout_text_height - visible_height).max(0.0);
                         if max_scroll_y > 0.0 {
@@ -1548,25 +1551,20 @@ impl Widget for TextInput {
             }
 
             // Handle clicking/dragging on the scrollbar handle itself.
-            // Only sync scroll_y from the ScrollBar when the user is actively
-            // dragging the handle (area is captured). Otherwise, next_frame
-            // callbacks from draw_scroll_bar's clamping would overwrite scroll_y
-            // with a potentially different max, causing scroll to get stuck.
-            let scrollbar_captured = self.scroll_bar.is_area_captured(cx);
+            // We pass an empty callback because we sync scroll_y from the ScrollBar
+            // below, only when the scrollbar has actually captured the finger.
             self.scroll_bar.handle_event_with(
                 cx,
                 event,
                 &mut |_, _| {},
             );
 
-            if scrollbar_captured {
+            // If the scrollbar has captured the finger (user is dragging the handle),
+            // sync scroll_y from the ScrollBar (which is the source of truth during
+            // drag) and prevent the text input from also processing finger events.
+            if self.scroll_bar.is_area_captured(cx) {
                 self.scroll_y = self.scroll_bar.get_scroll_pos();
                 self.draw_bg.redraw(cx);
-            }
-
-            // If the scrollbar captured the finger, don't let the text input
-            // also process finger events (which would move the cursor).
-            if self.scroll_bar.is_area_captured(cx) {
                 return;
             }
         }

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -559,6 +559,11 @@ pub struct TextInput {
     /// Set when the cursor/selection changes; cleared after scroll_to_cursor runs.
     #[rust(true)]
     needs_scroll_to_cursor: bool,
+    /// Cached maximum scroll offset from the last draw pass. Used during event
+    /// handling to ensure boundary checks match exactly (avoiding floating-point
+    /// mismatch between draw-time and event-time computations).
+    #[rust]
+    cached_max_scroll_y: f64,
     /// Skip finger move after long press to prevent selection changes
     #[rust]
     ignore_next_move: bool,
@@ -956,13 +961,21 @@ impl TextInput {
         rect(sel_x, sel_y, sel_width.max(10.0), sel_height.max(20.0))
     }
 
+    /// Returns the maximum scroll offset for the current text content and visible height.
+    /// `visible_height` is the inner height of the widget (excluding padding).
+    fn max_scroll_y(&self, visible_height: f64) -> f64 {
+        if let Some(laidout_text) = self.laidout_text.as_ref() {
+            let text_height = laidout_text.size_in_lpxs.height as f64;
+            (text_height - visible_height).max(0.0)
+        } else {
+            0.0
+        }
+    }
+
     fn scroll_to_cursor(&mut self, cx: &mut Cx2d) {
         // Compute the final size of the turtle, and obtain its inner height.
         cx.compute_final_size();
         let height = cx.turtle().inner_rect().size.y;
-
-        let laidout_text = self.laidout_text.as_ref().unwrap();
-        let laidout_text_height = laidout_text.size_in_lpxs.height as f64;
 
         // Only auto-scroll to keep the cursor visible when the cursor has actually
         // moved (typing, arrow keys, clicking). Don't do this on every redraw, as
@@ -970,6 +983,7 @@ impl TextInput {
         if self.needs_scroll_to_cursor {
             self.needs_scroll_to_cursor = false;
 
+            let laidout_text = self.laidout_text.as_ref().unwrap();
             let position = self.cursor_to_position(self.cursor()).unwrap();
             let laidout_row = &laidout_text.rows[position.row_index];
             let y_min = (laidout_row.origin_in_lpxs.y - laidout_row.ascender_in_lpxs) as f64;
@@ -988,8 +1002,10 @@ impl TextInput {
             }
         }
 
-        // Always clamp the scroll position to valid bounds.
-        let max_scroll_y = laidout_text_height.max(height) - height;
+        // Always clamp the scroll position to valid bounds, and cache
+        // max_scroll_y so the event handler uses the exact same value.
+        let max_scroll_y = self.max_scroll_y(height);
+        self.cached_max_scroll_y = max_scroll_y;
         self.scroll_y = self.scroll_y.max(0.0).min(max_scroll_y);
 
         // Shift the align range of the turtle with the scroll position, but do not include the
@@ -1530,21 +1546,18 @@ impl Widget for TextInput {
             if let Event::Scroll(e) = event {
                 let bg_rect = self.draw_bg.area().rect(cx);
                 if !e.handled_y.get() && bg_rect.contains(e.abs) {
-                    if let Some(laidout_text) = self.laidout_text.as_ref() {
-                        let visible_height = bg_rect.size.y
-                            - self.layout.padding.top
-                            - self.layout.padding.bottom;
-                        let laidout_text_height = laidout_text.size_in_lpxs.height as f64;
-                        let max_scroll_y = (laidout_text_height - visible_height).max(0.0);
-                        if max_scroll_y > 0.0 {
-                            let new_scroll_y = (self.scroll_y + e.scroll.y)
-                                .max(0.0)
-                                .min(max_scroll_y);
-                            if new_scroll_y != self.scroll_y {
-                                self.scroll_y = new_scroll_y;
-                                self.draw_bg.redraw(cx);
-                                e.handled_y.set(true);
-                            }
+                    // Use the cached max_scroll_y from the last draw pass to ensure
+                    // boundary checks match exactly, avoiding floating-point mismatch
+                    // with relative Fit bounds.
+                    let max_scroll_y = self.cached_max_scroll_y;
+                    if max_scroll_y > 0.0 {
+                        let new_scroll_y = (self.scroll_y + e.scroll.y)
+                            .max(0.0)
+                            .min(max_scroll_y);
+                        if new_scroll_y != self.scroll_y {
+                            self.scroll_y = new_scroll_y;
+                            self.draw_bg.redraw(cx);
+                            e.handled_y.set(true);
                         }
                     }
                 }


### PR DESCRIPTION
* ScrollBar integration with mouse wheel, scrollbar handle drag,
  and the correct way of dealing with `handled_y` propagation,
  which basically means that scrolling can be handled by the TextInput
  as a child, or not and left to the parent.
* Only auto-scroll to the cursor when it actually moves, not on every redraw
* `is_multiline` controls wrapping too, which makes more sense.
   Now a single-line mode TextINput shouldn't wrap the text
* Allow setting `text` in the Splash DSL (make it `#[live]`)

Also added some examples to the uizoo demo: empty, pre-filled, read-only, toggle
between multi and single line.