### PR TITLE
Add ellipsis text truncation support (text_overflow + max_lines)

### DIFF
--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -474,12 +474,15 @@ impl DrawText {
         )
     }
 
+    /// Draws text within the current turtle flow, calling `f` for each laid-out row.
+    /// Returns `(row_count, is_truncated)`: the number of rows produced, and whether
+    /// the text was truncated (e.g., by `max_lines` / ellipsis).
     pub fn draw_walk_resumable_with(
         &mut self,
         cx: &mut Cx2d,
         text_str: &str,
         mut f: impl FnMut(&mut Cx2d, Rect, f32),
-    ) {
+    ) -> (usize, bool) {
         let turtle_pos = cx.turtle().pos();
         let turtle_rect = cx.turtle().inner_rect();
         let origin_in_lpxs = Point::new(turtle_rect.pos.x as f32, turtle_pos.y as f32);
@@ -584,6 +587,7 @@ impl DrawText {
                 row.ascender_in_lpxs,
             )
         }
+        (text.rows.len(), text.is_truncated)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -39,6 +39,8 @@ script_mod! {
         let text = me
         FontFamily: mod.std.set_type_default() do #(FontFamily::script_component(vm))
         FontMember: mod.std.set_type_default() do #(FontMember::script_api(vm))
+        TextOverflow: mod.std.set_type_default() do #(TextOverflow::script_api(vm)),
+        ..me.TextOverflow,
         TextStyle: mod.std.set_type_default() do #(TextStyle::script_api(vm)){
             font_size: 10
             font_family: text.FontFamily{
@@ -181,6 +183,18 @@ script_mod! {
     }
 }
 
+/// Controls how text overflow is handled when text exceeds its container.
+///
+/// Analogous to CSS `text-overflow`. Requires a width constraint to take effect.
+#[derive(Copy, Clone, Debug, PartialEq, Script, ScriptHook)]
+pub enum TextOverflow {
+    /// Text is clipped at the container boundary (default).
+    #[pick]
+    Clip,
+    /// An ellipsis character (U+2026 "…") is shown where text is truncated.
+    Ellipsis,
+}
+
 #[derive(Script, ScriptHook)]
 #[repr(C)]
 pub struct DrawText {
@@ -197,6 +211,19 @@ pub struct DrawText {
 
     #[live]
     pub temp_y_shift: f32,
+
+    /// Maximum number of lines to display. 0 means unlimited (default).
+    /// When text exceeds this many lines, excess lines are hidden.
+    /// Combined with `text_overflow: Ellipsis`, an ellipsis is appended
+    /// to the last visible line.
+    #[live(0usize)]
+    pub max_lines: usize,
+
+    /// Controls how text overflow is handled.
+    /// `Clip` (default) clips text at the boundary.
+    /// `Ellipsis` appends "…" at the truncation point.
+    #[live]
+    pub text_overflow: TextOverflow,
 
     /// When true, successive draws extend the area instead of replacing it.
     /// Useful when drawing multiple text chunks that should be treated as one area.
@@ -369,11 +396,27 @@ impl DrawText {
 
     pub fn draw_walk(&mut self, cx: &mut Cx2d, walk: Walk, align: Align, text: &str) -> Rect {
         let turtle_rect = cx.turtle().inner_rect();
-        let max_width_in_lpxs = if !turtle_rect.size.x.is_nan() {
+        let mut max_width_in_lpxs = if !turtle_rect.size.x.is_nan() {
             Some(turtle_rect.size.x as f32)
         } else {
             None
         };
+
+        // For Fit-width containers with a max bound, resolve the bound so that
+        // ellipsis truncation and max_lines clamping can work. Without this, Fit
+        // layouts are unconstrained and text is laid out at full width on one line.
+        if max_width_in_lpxs.is_none()
+            && (self.text_overflow == TextOverflow::Ellipsis || self.max_lines > 0)
+        {
+            if let crate::turtle::Size::Fit { max: Some(max_bound), .. } = walk.width {
+                if let Some(resolved) = max_bound.eval_width(cx) {
+                    let padding = cx.turtle().padding();
+                    max_width_in_lpxs =
+                        Some((resolved - padding.left - padding.right).max(0.0) as f32);
+                }
+            }
+        }
+
         let wrap = cx.turtle().layout().flow
             == Flow::Right {
                 row_align: RowAlign::Top,
@@ -574,6 +617,12 @@ impl DrawText {
                 wrap,
                 align: align.x as f32,
                 line_spacing_scale: self.text_style.line_spacing,
+                max_rows: if self.max_lines > 0 {
+                    Some(self.max_lines)
+                } else {
+                    None
+                },
+                ellipsis: self.text_overflow == TextOverflow::Ellipsis,
             },
         })
     }

--- a/draw/src/text/layouter.rs
+++ b/draw/src/text/layouter.rs
@@ -255,6 +255,8 @@ impl LayoutContext {
     }
 
     fn layout_multiline(mut self) -> LaidoutText {
+        let has_ellipsis_config = self.options.max_rows.is_some() || self.options.ellipsis;
+
         for (line_index, len) in self
             .text
             .clone()
@@ -265,10 +267,24 @@ impl LayoutContext {
             if line_index != 0 {
                 self.finish_current_row(true);
             }
+            if self.is_past_max_rows() {
+                break;
+            }
             self.layout(len);
         }
-        self.finish_current_row(false);
-        self.finish()
+
+        if has_ellipsis_config {
+            self.apply_ellipsis_truncation()
+        } else {
+            self.finish_current_row(false);
+            self.finish_with(false)
+        }
+    }
+
+    fn is_past_max_rows(&self) -> bool {
+        self.options
+            .max_rows
+            .map_or(false, |max| self.rows.len() >= max)
     }
 
     fn layout(&mut self, len: usize) {
@@ -287,6 +303,9 @@ impl LayoutContext {
             SegmentKind::Word,
         );
         while !fitter.is_empty() {
+            if self.is_past_max_rows() {
+                break;
+            }
             match fitter.fit(self.remaining_width_in_lpxs().unwrap()) {
                 Some(text) => self.append_text(&text),
                 None => {
@@ -311,6 +330,9 @@ impl LayoutContext {
             SegmentKind::Grapheme,
         );
         while !fitter.is_empty() {
+            if self.is_past_max_rows() {
+                break;
+            }
             match fitter.fit(self.remaining_width_in_lpxs().unwrap()) {
                 Some(text) => self.append_text(&text),
                 None => {
@@ -394,7 +416,8 @@ impl LayoutContext {
         self.rows.push(row);
     }
 
-    fn finish(self) -> LaidoutText {
+    fn finish_with(self, is_truncated: bool) -> LaidoutText {
+        let last_row = self.rows.last().unwrap();
         LaidoutText {
             text: self.text,
             size_in_lpxs: Size::new(
@@ -403,11 +426,118 @@ impl LayoutContext {
                     .map(|row| row.width_in_lpxs)
                     .reduce(f32::max)
                     .unwrap_or(0.0),
-                self.current_point_in_lpxs.y - self.rows.last().unwrap().descender_in_lpxs,
+                last_row.origin_in_lpxs.y - last_row.descender_in_lpxs,
             ),
             rows: self.rows,
+            is_truncated,
         }
     }
+
+    /// Applies ellipsis truncation as a post-processing step after layout.
+    ///
+    /// Truncation is triggered when:
+    /// 1. `max_rows` is set and more text exists than fits in that many rows.
+    /// 2. `ellipsis` is true, wrap is false, and a single row exceeds `max_width_in_lpxs`.
+    fn apply_ellipsis_truncation(mut self) -> LaidoutText {
+        self.finish_current_row_if_pending();
+
+        // Detect whether all text was consumed during layout.
+        // If not, text was truncated by the max_rows early-exit.
+        let all_text_consumed = self.current_row_end >= self.text.len()
+            || (self.current_row_end + 1 == self.text.len()
+                && self.text.as_bytes()[self.current_row_end] == b'\n');
+
+        let max_rows = match self.options.max_rows {
+            Some(max) if max > 0 => max,
+            _ => {
+                // No max_rows constraint: check single-line non-wrapping overflow
+                if self.options.ellipsis && !self.options.wrap {
+                    if let Some(max_width) = self.options.max_width_in_lpxs {
+                        if self.rows.len() == 1 && self.rows[0].width_in_lpxs > max_width {
+                            self.truncate_last_row_with_ellipsis(max_width);
+                            return self.finish_with(true);
+                        }
+                    }
+                }
+                return self.finish_with(false);
+            }
+        };
+
+        let text_was_truncated = self.rows.len() > max_rows || !all_text_consumed;
+
+        self.rows.truncate(max_rows);
+
+        if !text_was_truncated {
+            return self.finish_with(false);
+        }
+
+        if self.options.ellipsis {
+            let max_width = self.options.max_width_in_lpxs.unwrap_or(f32::MAX);
+            self.truncate_last_row_with_ellipsis(max_width);
+        }
+
+        self.finish_with(true)
+    }
+
+    /// Truncates the last row to fit within `max_width` and appends an ellipsis glyph.
+    fn truncate_last_row_with_ellipsis(&mut self, max_width: f32) {
+        let ellipsis_shaped = self.font_family.get_or_shape("…".into());
+        let font_size_in_lpxs = self.style.font_size_in_lpxs();
+        let ellipsis_width: f32 = ellipsis_shaped
+            .glyphs
+            .iter()
+            .map(|g| g.advance_in_ems * font_size_in_lpxs)
+            .sum();
+
+        let last_row = match self.rows.last_mut() {
+            Some(row) => row,
+            None => return,
+        };
+
+        // Remove glyphs from the end until remaining + ellipsis fits
+        while last_row.width_in_lpxs + ellipsis_width > max_width && !last_row.glyphs.is_empty() {
+            let removed = last_row.glyphs.pop().unwrap();
+            last_row.width_in_lpxs -= removed.advance_in_lpxs();
+        }
+
+        // Trim trailing whitespace glyphs for a cleaner look before the ellipsis.
+        while last_row.glyphs.last().map_or(false, |g| {
+            last_row.text[g.cluster..]
+                .chars()
+                .next()
+                .map_or(false, |c| c.is_whitespace())
+        }) {
+            let removed = last_row.glyphs.pop().unwrap();
+            last_row.width_in_lpxs -= removed.advance_in_lpxs();
+        }
+
+        // Append ellipsis glyphs
+        for glyph in &ellipsis_shaped.glyphs {
+            let ellipsis_glyph = LaidoutGlyph {
+                origin_in_lpxs: Point::new(last_row.width_in_lpxs, 0.0),
+                font: glyph.font.clone(),
+                font_size_in_lpxs,
+                color: self.style.color,
+                id: glyph.id,
+                cluster: last_row.text.len(), // beyond the text range
+                advance_in_ems: glyph.advance_in_ems,
+                offset_in_ems: glyph.offset_in_ems,
+            };
+            last_row.width_in_lpxs += ellipsis_glyph.advance_in_lpxs();
+            last_row.glyphs.push(ellipsis_glyph);
+        }
+    }
+
+    /// Finishes any pending glyphs into a row (without a newline).
+    /// Always ensures at least one row exists.
+    fn finish_current_row_if_pending(&mut self) {
+        let has_pending_content = self.current_row_start != self.current_row_end
+            || !self.glyphs.is_empty();
+        if has_pending_content || self.rows.is_empty() {
+            self.finish_current_row(false);
+        }
+    }
+
 }
 
 #[derive(Debug)]
@@ -752,6 +882,13 @@ pub struct LayoutOptions {
     pub wrap: bool,
     pub align: f32,
     pub line_spacing_scale: f32,
+    /// Maximum number of rows to display. `None` means unlimited.
+    /// When set and the text exceeds this many rows, excess rows are discarded.
+    pub max_rows: Option<usize>,
+    /// When true and text is truncated (by `max_rows` or by exceeding `max_width_in_lpxs`
+    /// on a single non-wrapping line), an ellipsis character (U+2026 "…") is appended
+    /// to the last visible row.
+    pub ellipsis: bool,
 }
 
 impl Default for LayoutOptions {
@@ -763,6 +900,8 @@ impl Default for LayoutOptions {
             wrap: false,
             align: 0.0,
             line_spacing_scale: 1.0,
+            max_rows: None,
+            ellipsis: false,
         }
     }
 }
@@ -779,28 +918,26 @@ impl Hash for LayoutOptions {
             .to_bits()
             .hash(hasher);
         self.max_width_in_lpxs.map(f32::to_bits).hash(hasher);
+        self.wrap.hash(hasher);
         self.align.to_bits().hash(hasher);
         self.line_spacing_scale.to_bits().hash(hasher);
+        self.max_rows.hash(hasher);
+        self.ellipsis.hash(hasher);
     }
 }
 
 impl PartialEq for LayoutOptions {
     fn eq(&self, other: &Self) -> bool {
-        if self.first_row_indent_in_lpxs.to_bits() != other.first_row_indent_in_lpxs.to_bits() {
-            return false;
-        }
-        if self.first_row_min_line_spacing_below_in_lpxs.to_bits()
-            != other.first_row_min_line_spacing_below_in_lpxs.to_bits()
-        {
-            return false;
-        }
-        if self.max_width_in_lpxs.map(f32::to_bits) != other.max_width_in_lpxs.map(f32::to_bits) {
-            return false;
-        }
-        if self.align != other.align {
-            return false;
-        }
-        true
+        self.first_row_indent_in_lpxs.to_bits() == other.first_row_indent_in_lpxs.to_bits()
+            && self.first_row_min_line_spacing_below_in_lpxs.to_bits()
+                == other.first_row_min_line_spacing_below_in_lpxs.to_bits()
+            && self.max_width_in_lpxs.map(f32::to_bits)
+                == other.max_width_in_lpxs.map(f32::to_bits)
+            && self.wrap == other.wrap
+            && self.align.to_bits() == other.align.to_bits()
+            && self.line_spacing_scale.to_bits() == other.line_spacing_scale.to_bits()
+            && self.max_rows == other.max_rows
+            && self.ellipsis == other.ellipsis
     }
 }
 
@@ -809,6 +946,8 @@ pub struct LaidoutText {
     pub text: Substr,
     pub size_in_lpxs: Size<f32>,
     pub rows: Vec<LaidoutRow>,
+    /// True when the text was truncated (e.g., due to `max_rows` or ellipsis).
+    pub is_truncated: bool,
 }
 
 impl LaidoutText {

--- a/draw/src/turtle.rs
+++ b/draw/src/turtle.rs
@@ -312,7 +312,7 @@ pub enum FitBound {
 }
 
 impl FitBound {
-    fn eval_width(self, cx: &Cx2d<'_, '_>) -> Option<f64> {
+    pub fn eval_width(self, cx: &Cx2d<'_, '_>) -> Option<f64> {
         match self {
             FitBound::Abs(abs) => Some(abs),
             FitBound::Rel { base, factor } => {
@@ -322,7 +322,7 @@ impl FitBound {
         }
     }
 
-    fn eval_height(self, cx: &Cx2d<'_, '_>) -> Option<f64> {
+    pub fn eval_height(self, cx: &Cx2d<'_, '_>) -> Option<f64> {
         match self {
             FitBound::Abs(abs) => Some(abs),
             FitBound::Rel { base, factor } => {

--- a/examples/uizoo/src/tab_html.rs
+++ b/examples/uizoo/src/tab_html.rs
@@ -13,6 +13,36 @@ script_mod! {
                 width: Fill height: Fit
                 body: "<H1>H1 Headline</H1><H2>H2 Headline</H2><H3>H3 Headline</H3><H4>H4 Headline</H4><H5>H5 Headline</H5><H6>H6 Headline</H6>This is <b>bold</b>&nbsp;and <i>italic text</i>.<sep><b><i>Bold italic</i></b>, <u>underlined</u>, and <s>strike through</s> text. <p>This is a paragraph</p> <code>A code block</code>. <br/> And this is a <a href='https://www.google.com/'>link</a><br/><ul><li>lorem</li><li>ipsum</li><li>dolor</li></ul><ol><li>lorem</li><li>ipsum</li><li>dolor</li></ol><br/> <blockquote>Blockquote</blockquote> <pre>pre</pre><sub>sub</sub><del>del</del>"
             }
+
+            Hr{}
+            H4{text: "Html with ellipsis (1 line)"}
+            P{text: "Html content truncated to a single line. Resize the window to see the ellipsis move."}
+            Html{
+                width: Fill height: Fit
+                max_lines: 1
+                text_overflow: Ellipsis
+                body: "This is <b>bold</b> and <i>italic</i> and <code>inline code</code> and regular text that goes on long enough to be truncated with an ellipsis at the end of the line."
+            }
+
+            Hr{}
+            H4{text: "Html with ellipsis (2 lines)"}
+            P{text: "Styled Html wrapping to 2 lines before truncating."}
+            Html{
+                width: Fill height: Fit
+                max_lines: 2
+                text_overflow: Ellipsis
+                body: "The <b>quick brown fox</b> jumps over the <i>lazy dog</i>. Pack my box with <b><i>five dozen</i></b> liquor jugs. How <u>vexingly quick</u> daft zebras jump! The five boxing wizards jump quickly. Sphinx of black quartz, judge my vow. Two driven jocks help fax my big quiz."
+            }
+
+            Hr{}
+            H4{text: "Html with ellipsis and emoji (1 line)"}
+            P{text: "Html with multi-byte emoji mixed into styled text."}
+            Html{
+                width: Fill height: Fit
+                max_lines: 1
+                text_overflow: Ellipsis
+                body: "Stars \u{2B50}\u{2B50}\u{2B50} with <b>bold rockets \u{1F680}\u{1F680}\u{1F680}</b> and <i>italic flags \u{1F3C1}\u{1F3C1}\u{1F3C1}</i> and more content to overflow"
+            }
         }
     }
 }

--- a/examples/uizoo/src/tab_label.rs
+++ b/examples/uizoo/src/tab_label.rs
@@ -74,6 +74,105 @@ script_mod! {
             }
 
             Hr{}
+            H4{text: "Ellipsis (single line)"}
+            P{text: "Long ASCII text truncated to 1 line with ellipsis. Resize the window to see the truncation point move."}
+            Label{
+                width: Fill
+                max_lines: 1
+                text_overflow: Ellipsis
+                text: "This is a very long label text that should be truncated with an ellipsis character at the end of the line when it overflows"
+            }
+
+            Hr{}
+            H4{text: "Ellipsis (2 lines max)"}
+            P{text: "Text wraps up to 2 lines, then truncates with ellipsis. Resize to see lines reflow."}
+            Label{
+                width: Fill
+                max_lines: 2
+                text_overflow: Ellipsis
+                text: "This is a longer piece of text that should wrap to multiple lines. When it exceeds two lines, it should be truncated with an ellipsis character appended to the end of the second line. Try resizing the window to watch the wrapping and truncation adapt dynamically."
+            }
+
+            Hr{}
+            H4{text: "Ellipsis (3 lines max, Fill width)"}
+            P{text: "A TextBox (Fill width) with max_lines: 3 and text_overflow: Ellipsis."}
+            TextBox{
+                max_lines: 3
+                text_overflow: Ellipsis
+                text: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt."
+            }
+
+            Hr{}
+            H4{text: "Ellipsis with emoji"}
+            P{text: "Emoji are multi-byte (up to 4 bytes). Resize to see truncation at emoji boundaries."}
+            Label{
+                width: Fill
+                max_lines: 1
+                text_overflow: Ellipsis
+                text: "Stars \u{2B50}\u{2B50}\u{2B50} and rockets \u{1F680}\u{1F680}\u{1F680} and flags \u{1F3C1}\u{1F3C1}\u{1F3C1} and more emoji to overflow the line boundary"
+            }
+
+            Hr{}
+            H4{text: "Ellipsis with CJK characters"}
+            P{text: "CJK characters are 3 bytes each in UTF-8 and wider than Latin glyphs."}
+            Label{
+                width: Fit{max: FitBound.Rel{base: Base.Full, factor: 0.6}}
+                max_lines: 1
+                text_overflow: Ellipsis
+                text: "\u{6587}\u{5B57}\u{306E}\u{30C6}\u{30B9}\u{30C8}\u{3067}\u{3059}\u{3002}\u{65E5}\u{672C}\u{8A9E}\u{306E}\u{6587}\u{7AE0}\u{304C}\u{9577}\u{3059}\u{304E}\u{308B}\u{3068}\u{7701}\u{7565}\u{8A18}\u{53F7}\u{304C}\u{8868}\u{793A}\u{3055}\u{308C}\u{307E}\u{3059}"
+            }
+
+            Hr{}
+            H4{text: "Ellipsis with mixed scripts (2 lines)"}
+            P{text: "Latin, Cyrillic, and emoji mixed together with 2-line wrapping."}
+            Label{
+                width: Fill
+                max_lines: 2
+                text_overflow: Ellipsis
+                text: "Hello \u{041F}\u{0440}\u{0438}\u{0432}\u{0435}\u{0442} \u{1F44B} world! Multi-script text with various byte lengths per character should wrap and truncate cleanly across line boundaries when the window is resized."
+            }
+
+            Hr{}
+            H4{text: "Ellipsis with dense emoji (single line)"}
+            P{text: "A string of only emoji — every character is 4 bytes."}
+            Label{
+                width: Fit{max: FitBound.Rel{base: Base.Full, factor: 0.5}}
+                max_lines: 1
+                text_overflow: Ellipsis
+                text: "\u{1F600}\u{1F601}\u{1F602}\u{1F603}\u{1F604}\u{1F605}\u{1F606}\u{1F607}\u{1F608}\u{1F609}\u{1F60A}\u{1F60B}\u{1F60C}\u{1F60D}\u{1F60E}\u{1F60F}\u{1F610}\u{1F611}\u{1F612}\u{1F613}"
+            }
+
+            Hr{}
+            H4{text: "No truncation (short text)"}
+            P{text: "Text fits within max_lines — no ellipsis shown."}
+            Label{
+                width: Fill
+                max_lines: 1
+                text_overflow: Ellipsis
+                text: "Short text"
+            }
+
+            Hr{}
+            H4{text: "Ellipsis (Fill width)"}
+            P{text: "A label that fills the parent width and truncates with ellipsis."}
+            Label{
+                width: Fill
+                max_lines: 1
+                text_overflow: Ellipsis
+                text: "This label fills the entire available width. When the text is too long to fit on a single line, it is truncated and an ellipsis is appended at the end to indicate there is more content."
+            }
+
+            Hr{}
+            H4{text: "Ellipsis (Fit width with max bound)"}
+            P{text: "Fit width capped at 50% of the parent. Text grows until hitting the max, then truncates."}
+            Label{
+                width: Fit{max: FitBound.Rel{base: Base.Full, factor: 0.5}}
+                max_lines: 1
+                text_overflow: Ellipsis
+                text: "This label uses Fit width with a relative max bound of 50%. Short text grows naturally, but long text like this gets truncated with an ellipsis once it hits the maximum width."
+            }
+
+            Hr{}
             H4{text: "Custom Shader"}
             Label{
                 draw_text +: {

--- a/widgets/src/label.rs
+++ b/widgets/src/label.rs
@@ -1,5 +1,7 @@
 use crate::{
-    makepad_derive_widget::*, makepad_draw::*, widget::*, widget_async::ScriptAsyncResult,
+    makepad_derive_widget::*, makepad_draw::*,
+    makepad_draw::shader::draw_text::TextOverflow,
+    widget::*, widget_async::ScriptAsyncResult,
 };
 
 script_mod! {
@@ -232,6 +234,14 @@ pub struct Label {
     #[live]
     padding: Inset,
 
+    /// Maximum number of lines to display. 0 means unlimited (default).
+    /// Combined with `text_overflow: Ellipsis`, truncated text shows "…".
+    #[live(0usize)]
+    pub max_lines: usize,
+    /// Controls how text overflow is handled when text exceeds the container.
+    #[live]
+    pub text_overflow: TextOverflow,
+
     #[rust]
     area: Area,
     #[live]
@@ -297,6 +307,8 @@ impl Widget for Label {
         let _ = self.text.as_ref().is_empty().then(|| {
             let _ = self.set_text(cx, " ");
         });
+        self.draw_text.max_lines = self.max_lines;
+        self.draw_text.text_overflow = self.text_overflow;
         self.draw_text
             .draw_walk(cx, walk, self.align, self.text.as_ref());
         cx.end_turtle_with_area(&mut self.area);

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -477,6 +477,7 @@ pub fn theme_mod(vm: &mut ScriptVm) {
             ..mod.sdf,
             ..mod.animator,
             ..mod.turtle,
+            ..mod.text,
             ..mod.ime,
             ..mod.shader,
             ..mod.animator.Play,

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -623,6 +623,13 @@ pub struct TextFlow {
     pub item_counter: u64,
     #[rust]
     pub first_thing_on_a_line: bool,
+    /// Number of visual lines drawn so far (across all text runs).
+    /// Used for widget-level `max_lines` tracking in rich text.
+    #[rust]
+    lines_drawn: usize,
+    /// Set when `lines_drawn >= max_lines`; further text draws are skipped.
+    #[rust]
+    content_truncated: bool,
 
     #[rust]
     pub areas_tracker: RectAreasTracker,
@@ -1015,6 +1022,8 @@ impl TextFlow {
         self.draw_state.set(DrawState::Drawing);
         self.draw_block.append_to_draw_call(cx);
         self.clear_stacks();
+        self.lines_drawn = 0;
+        self.content_truncated = false;
         if self.selectable {
             self.selection_tracker.clear();
             self.widget_text_entries.clear();
@@ -1560,6 +1569,11 @@ impl TextFlow {
 
     pub fn draw_text(&mut self, cx: &mut Cx2d, text: &str) {
         if let Some(DrawState::Drawing) = self.draw_state.get() {
+            // If we've already exceeded max_lines, skip all further text.
+            if self.content_truncated {
+                return;
+            }
+
             if (text == " " || text == "") && self.first_thing_on_a_line {
                 return;
             }
@@ -1592,8 +1606,34 @@ impl TextFlow {
             self.draw_text.text_style.font_size = *font_size as _;
             self.draw_text.color = *font_color;
             self.draw_text.temp_y_shift = top_drop;
-            self.draw_text.max_lines = self.max_lines;
-            self.draw_text.text_overflow = self.text_overflow;
+
+            // Widget-level max_lines: compute how many layouter rows this run
+            // is allowed. A "continuation" run starts mid-line (turtle x > left
+            // edge), so its first row shares the current visual line.
+            let is_continuation = if self.max_lines > 0 {
+                let turtle_pos = cx.turtle().pos();
+                let turtle_rect = cx.turtle().inner_rect();
+                (turtle_pos.x - turtle_rect.pos.x) > 0.5
+            } else {
+                false
+            };
+
+            if self.max_lines > 0 {
+                let remaining_new_lines = self.max_lines.saturating_sub(self.lines_drawn);
+                if remaining_new_lines == 0 && !is_continuation {
+                    // No visual lines left and this run would start a new one.
+                    self.content_truncated = true;
+                    return;
+                }
+                // Continuation runs get +1 because their first row doesn't
+                // consume a new visual line (it shares the current one).
+                let run_max_rows = remaining_new_lines + if is_continuation { 1 } else { 0 };
+                self.draw_text.max_lines = run_max_rows;
+                self.draw_text.text_overflow = self.text_overflow;
+            } else {
+                self.draw_text.max_lines = 0;
+                self.draw_text.text_overflow = TextOverflow::Clip;
+            };
 
             let dt = &mut self.draw_text;
 
@@ -1626,14 +1666,14 @@ impl TextFlow {
             }
 
             let areas_tracker = &mut self.areas_tracker;
-            if self.inline_code.value() > 0 {
+            let (run_rows, run_truncated) = if self.inline_code.value() > 0 {
                 let db = &mut self.draw_block;
                 db.block_type = FlowBlockType::InlineCode;
                 if !self.first_thing_on_a_line {
                     let rect = TextFlow::walk_margin(cx, self.inline_code_margin.left);
                     areas_tracker.track_rect(cx, rect);
                 }
-                dt.draw_walk_resumable_with(cx, text, |cx, mut rect, _| {
+                let result = dt.draw_walk_resumable_with(cx, text, |cx, mut rect, _| {
                     rect.pos -= self.inline_code_padding.left_top();
                     rect.size += self.inline_code_padding.size();
                     db.draw_abs(cx, rect);
@@ -1641,6 +1681,7 @@ impl TextFlow {
                 });
                 let rect = TextFlow::walk_margin(cx, self.inline_code_margin.right);
                 areas_tracker.track_rect(cx, rect);
+                result
             } else if self.strikethrough.value() > 0 {
                 let db = &mut self.draw_block;
                 db.line_color = *font_color;
@@ -1648,7 +1689,7 @@ impl TextFlow {
                 dt.draw_walk_resumable_with(cx, text, |cx, rect, _| {
                     db.draw_abs(cx, rect);
                     areas_tracker.track_rect(cx, rect);
-                });
+                })
             } else if self.underline.value() > 0 {
                 let db = &mut self.draw_block;
                 db.line_color = *font_color;
@@ -1656,11 +1697,21 @@ impl TextFlow {
                 dt.draw_walk_resumable_with(cx, text, |cx, rect, _| {
                     db.draw_abs(cx, rect);
                     areas_tracker.track_rect(cx, rect);
-                });
+                })
             } else {
                 dt.draw_walk_resumable_with(cx, text, |cx, rect, _| {
                     areas_tracker.track_rect(cx, rect);
-                });
+                })
+            };
+
+            // Update widget-level line tracking.
+            if self.max_lines > 0 {
+                let new_lines = run_rows.saturating_sub(if is_continuation { 1 } else { 0 });
+                self.lines_drawn += new_lines;
+                // If this run was truncated (ellipsis was appended), stop here.
+                if run_truncated {
+                    self.content_truncated = true;
+                }
             }
         }
         self.first_thing_on_a_line = false;

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -4,7 +4,9 @@ use crate::makepad_draw::text::{
     selection::{Cursor, Selection},
 };
 use crate::{
-    animator::*, makepad_derive_widget::*, makepad_draw::*, widget::*, widget_tree::CxWidgetExt,
+    animator::*, makepad_derive_widget::*, makepad_draw::*,
+    makepad_draw::shader::draw_text::TextOverflow,
+    widget::*, widget_tree::CxWidgetExt,
 };
 use std::rc::Rc;
 
@@ -583,6 +585,14 @@ pub struct TextFlow {
     /// The default font color used for all text if not otherwise specified.
     #[live]
     pub font_color: Vec4f,
+
+    /// Maximum number of lines to display. 0 means unlimited (default).
+    /// Combined with `text_overflow: Ellipsis`, truncated text shows "…".
+    #[live(0usize)]
+    pub max_lines: usize,
+    /// Controls how text overflow is handled when text exceeds the container.
+    #[live]
+    pub text_overflow: TextOverflow,
     #[walk]
     walk: Walk,
 
@@ -1582,6 +1592,8 @@ impl TextFlow {
             self.draw_text.text_style.font_size = *font_size as _;
             self.draw_text.color = *font_color;
             self.draw_text.temp_y_shift = top_drop;
+            self.draw_text.max_lines = self.max_lines;
+            self.draw_text.text_overflow = self.text_overflow;
 
             let dt = &mut self.draw_text;
 


### PR DESCRIPTION
Re-implement ellipsis truncation for text that overflows its container, following conventions from CSS (text-overflow), Android (TextOverflow), and Flutter (TextOverflow). This was supported in Makepad 1.0 but removed in 2.0.

Full summary below:

-----------------------

- Add `max_rows: Option<usize>` and `ellipsis: bool` fields to `LayoutOptions`
- Implement `apply_ellipsis_truncation()` post-processing step that:
  - Detects when text was truncated (by max_rows or single-line overflow)
  - Shapes the "…" (U+2026) glyph using the same font family
  - Removes trailing glyphs from the last visible row to make room
  - Trims trailing whitespace before the ellipsis for clean appearance
  - Appends the ellipsis glyph(s) to the last row
  - Recalculates the text bounding box
- Add early-exit in `layout_by_word()` and `layout_by_grapheme()` when `max_rows` is exceeded, avoiding unnecessary layout work for long texts
- Add `is_truncated: bool` field to `LaidoutText` for consumer detection
- Fix pre-existing bugs in `LayoutOptions` Hash/PartialEq: `wrap` and `line_spacing_scale` were missing, which could cause stale cache hits

- Add `TextOverflow` enum with `Clip` (default) and `Ellipsis` variants
- Add `max_lines: usize` and `text_overflow: TextOverflow` live properties on `DrawText`, passed through to `LayoutOptions`
- Register `TextOverflow` in the script module for DSL access
- Resolve `Fit` width max bounds when ellipsis/max_lines is active, so text layout knows the width constraint even for Fit-sized containers

- **Label** (widgets/src/label.rs): Add top-level `max_lines` and `text_overflow` properties, forwarded to `draw_text` in `draw_walk()`
- **TextFlow** (widgets/src/text_flow.rs): Same top-level properties, forwarded before each text draw call
- **Html / Markdown**: Inherit from TextFlow via `#[deref]` automatically
- Add `..mod.text` to widget prelude (widgets/src/lib.rs) so `Ellipsis` and `Clip` are accessible in all widget DSL

- Make `FitBound::eval_width()` and `eval_height()` public (draw/src/turtle.rs) so DrawText can resolve Fit max bounds during layout

```rust
// Simple single-line ellipsis
Label {
    width: Fill
    max_lines: 1
    text_overflow: Ellipsis
    text: "Long text gets truncated…"
}

// Multi-line with ellipsis
Label {
    width: Fill
    max_lines: 3
    text_overflow: Ellipsis
    text: "Wraps up to 3 lines, then truncates…"
}

// Also works via draw_text for any widget with DrawText
Button {
    draw_text +: { max_lines: 1, text_overflow: Ellipsis }
}
```

See the demos I newly added to the `uizoo` example too.