### PR TITLE
Show "ghost" dock tab during drag animation. Fix drag-n-drop rules, target zones, etc

### DIFF
--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -746,30 +746,24 @@ impl Cx {
 
                 // Synthesize internal drag-and-drop events from touch gestures.
                 if self.os.internal_drag_items.is_some() {
-                    let has_move = e.touches.iter().any(|t| {
-                        t.state == crate::event::TouchState::Move
-                    });
-                    let stop_touch = e.touches.iter().find(|t| {
+                    if let Some(touch) = e.touches.iter().find(|t| {
                         t.state == crate::event::TouchState::Stop
-                    });
-                    if let Some(touch) = stop_touch {
+                    }) {
                         if let Some(items) = self.os.internal_drag_items.take() {
-                            let abs = touch.abs;
                             self.call_event_handler(&Event::Drop(DropEvent {
                                 modifiers: e.modifiers.clone(),
                                 handled: Arc::new(Mutex::new(false)),
-                                abs,
+                                abs: touch.abs,
                                 items,
                             }));
                             self.drag_drop.cycle_drag();
                             self.call_event_handler(&Event::DragEnd);
                             self.drag_drop.cycle_drag();
                         }
-                    } else if has_move {
+                    } else if let Some(touch) = e.touches.iter().find(|t| {
+                        t.state == crate::event::TouchState::Move
+                    }) {
                         if let Some(items) = self.os.internal_drag_items.as_ref() {
-                            let touch = e.touches.iter().find(|t| {
-                                t.state == crate::event::TouchState::Move
-                            }).unwrap();
                             self.call_event_handler(&Event::Drag(DragEvent {
                                 modifiers: e.modifiers.clone(),
                                 handled: Arc::new(Mutex::new(false)),

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -10,6 +10,7 @@ use {
                 VideoSeekableRangesEvent, VideoSource, VideoTextureUpdatedEvent,
                 VideoYuvTexturesReady,
             },
+            drag_drop::{DragEvent, DragItem, DragResponse, DropEvent},
             Event, KeyEvent, TextInputEvent, TextRangeReplaceEvent,
         },
         makepad_live_id::*,
@@ -742,6 +743,45 @@ impl Cx {
                 } else {
                     panic!()
                 };
+
+                // Synthesize internal drag-and-drop events from touch gestures.
+                if self.os.internal_drag_items.is_some() {
+                    let has_move = e.touches.iter().any(|t| {
+                        t.state == crate::event::TouchState::Move
+                    });
+                    let stop_touch = e.touches.iter().find(|t| {
+                        t.state == crate::event::TouchState::Stop
+                    });
+                    if let Some(touch) = stop_touch {
+                        if let Some(items) = self.os.internal_drag_items.take() {
+                            let abs = touch.abs;
+                            self.call_event_handler(&Event::Drop(DropEvent {
+                                modifiers: e.modifiers.clone(),
+                                handled: Arc::new(Mutex::new(false)),
+                                abs,
+                                items,
+                            }));
+                            self.drag_drop.cycle_drag();
+                            self.call_event_handler(&Event::DragEnd);
+                            self.drag_drop.cycle_drag();
+                        }
+                    } else if has_move {
+                        if let Some(items) = self.os.internal_drag_items.as_ref() {
+                            let touch = e.touches.iter().find(|t| {
+                                t.state == crate::event::TouchState::Move
+                            }).unwrap();
+                            self.call_event_handler(&Event::Drag(DragEvent {
+                                modifiers: e.modifiers.clone(),
+                                handled: Arc::new(Mutex::new(false)),
+                                abs: touch.abs,
+                                items: items.clone(),
+                                response: Arc::new(Mutex::new(DragResponse::None)),
+                            }));
+                            self.drag_drop.cycle_drag();
+                        }
+                    }
+                }
+
                 self.fingers.process_touch_update_end(&e.touches);
             }
             IosEvent::LongPress(e) => {
@@ -1247,6 +1287,9 @@ impl Cx {
                         window.popup_size = None;
                     }
                 }
+                CxOsOp::StartDragging(items) => {
+                    self.os.internal_drag_items = Some(Arc::new(items));
+                }
                 e => {
                     crate::error!("Not implemented on this platform: CxOsOp::{:?}", e);
                 }
@@ -1536,6 +1579,7 @@ pub struct CxOs {
     pub(crate) camera_players: HashMap<LiveId, IosCameraPlayer>,
     pub(crate) native_camera_previews: HashMap<LiveId, IosNativeCameraPreview>,
     pub(crate) system_browsers: HashMap<LiveId, IosSystemBrowser>,
+    pub(crate) internal_drag_items: Option<Arc<Vec<DragItem>>>,
 }
 
 pub struct PermissionResultChannel {

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -9,6 +9,7 @@ use {
                 VideoPlaybackPreparedEvent, VideoPlaybackResourcesReleasedEvent,
                 VideoSeekableRangesEvent, VideoTextureUpdatedEvent, VideoYuvTexturesReady,
             },
+            drag_drop::{DragEvent, DragItem, DragResponse, DropEvent},
             Event, GameInputEventChannel, MouseButton, MouseUpEvent, VideoSource, WindowGeom,
         },
         makepad_live_id::*,
@@ -744,16 +745,43 @@ impl Cx {
             }
             MacosEvent::MouseMove(mut e) => {
                 self.dpi_override_scale(&mut e.abs, e.window_id);
+                let abs = e.abs;
+                let modifiers = e.modifiers;
                 self.call_event_handler(&Event::MouseMove(e.into()));
+                if let Some(items) = self.os.internal_drag_items.as_ref() {
+                    self.call_event_handler(&Event::Drag(DragEvent {
+                        modifiers,
+                        handled: Arc::new(Mutex::new(false)),
+                        abs,
+                        items: items.clone(),
+                        response: Arc::new(Mutex::new(DragResponse::None)),
+                    }));
+                    self.drag_drop.cycle_drag();
+                }
                 self.fingers.cycle_hover_area(live_id!(mouse).into());
                 self.fingers.switch_captures();
             }
             MacosEvent::MouseUp(mut e) => {
                 self.dpi_override_scale(&mut e.abs, e.window_id);
                 let button = e.button;
+                let abs = e.abs;
+                let modifiers = e.modifiers;
                 self.call_event_handler(&Event::MouseUp(e.into()));
                 self.fingers.mouse_up(button);
                 self.fingers.cycle_hover_area(live_id!(mouse).into());
+                if button == MouseButton::PRIMARY {
+                    if let Some(items) = self.os.internal_drag_items.take() {
+                        self.call_event_handler(&Event::Drop(DropEvent {
+                            modifiers,
+                            handled: Arc::new(Mutex::new(false)),
+                            abs,
+                            items,
+                        }));
+                        self.drag_drop.cycle_drag();
+                        self.call_event_handler(&Event::DragEnd);
+                        self.drag_drop.cycle_drag();
+                    }
+                }
             }
             MacosEvent::Scroll(mut e) => {
                 self.dpi_override_scale(&mut e.abs, e.window_id);
@@ -1033,11 +1061,10 @@ impl Cx {
                     with_macos_app(|app| app.stop_timer(timer_id));
                 }
                 CxOsOp::StartDragging(items) => {
-                    //  lets start dragging on the right window
-                    if let Some(metal_window) = metal_windows.iter_mut().next() {
-                        metal_window.cocoa_window.start_dragging(items);
-                        break;
-                    }
+                    // Use internal drag-and-drop (synthesizing Drag/Drop events
+                    // from mouse move/up) instead of OS-level drag, which delays
+                    // DragEnd by ~1 second due to the macOS fly-back animation.
+                    self.os.internal_drag_items = Some(Arc::new(items));
                 }
                 CxOsOp::UpdateMacosMenu(menu) => with_macos_app(|app| app.update_macos_menu(&menu)),
                 CxOsOp::HttpRequest {
@@ -1657,4 +1684,5 @@ pub struct CxOs {
     pub(crate) video_players: HashMap<LiveId, AppleUnifiedVideoPlayer>,
     pub(crate) native_camera_previews: HashMap<LiveId, MacosNativeCameraPreview>,
     pub(crate) system_browsers: HashMap<LiveId, MacosSystemBrowser>,
+    pub(crate) internal_drag_items: Option<Arc<Vec<DragItem>>>,
 }

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -612,32 +612,26 @@ impl Cx {
 
                 // Synthesize internal drag-and-drop events from touch gestures.
                 if self.os.internal_drag_items.is_some() {
-                    let has_move = e.touches.iter().any(|t| {
-                        t.state == crate::event::finger::TouchState::Move
-                    });
-                    let stop_touch = e.touches.iter().find(|t| {
+                    if let Some(touch) = e.touches.iter().find(|t| {
                         t.state == crate::event::finger::TouchState::Stop
-                    });
-                    if let Some(touch) = stop_touch {
+                    }) {
                         // Touch lifted: fire Drop + DragEnd
                         if let Some(items) = self.os.internal_drag_items.take() {
-                            let abs = touch.abs;
                             self.call_event_handler(&Event::Drop(DropEvent {
                                 modifiers: e.modifiers.clone(),
                                 handled: Arc::new(Mutex::new(false)),
-                                abs,
+                                abs: touch.abs,
                                 items,
                             }));
                             self.drag_drop.cycle_drag();
                             self.call_event_handler(&Event::DragEnd);
                             self.drag_drop.cycle_drag();
                         }
-                    } else if has_move {
-                        // Finger moving: fire Drag event using the first moving touch
+                    } else if let Some(touch) = e.touches.iter().find(|t| {
+                        t.state == crate::event::finger::TouchState::Move
+                    }) {
+                        // Finger moving: fire Drag event
                         if let Some(items) = self.os.internal_drag_items.as_ref() {
-                            let touch = e.touches.iter().find(|t| {
-                                t.state == crate::event::finger::TouchState::Move
-                            }).unwrap();
                             self.call_event_handler(&Event::Drag(DragEvent {
                                 modifiers: e.modifiers.clone(),
                                 handled: Arc::new(Mutex::new(false)),

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -1,4 +1,5 @@
 use std::cell::Cell;
+use std::sync::{Arc, Mutex};
 
 #[cfg(use_vulkan)]
 use self::super::super::vulkan::CxVulkan;
@@ -40,6 +41,7 @@ use {
             TextClipboardEvent,
             //TimerEvent,
             TextInputEvent,
+            drag_drop::{DragEvent, DragItem, DragResponse, DropEvent},
             //TouchPoint,
             TouchUpdateEvent,
             VideoDecodingErrorEvent,
@@ -607,6 +609,47 @@ impl Cx {
                 } else {
                     panic!()
                 };
+
+                // Synthesize internal drag-and-drop events from touch gestures.
+                if self.os.internal_drag_items.is_some() {
+                    let has_move = e.touches.iter().any(|t| {
+                        t.state == crate::event::finger::TouchState::Move
+                    });
+                    let stop_touch = e.touches.iter().find(|t| {
+                        t.state == crate::event::finger::TouchState::Stop
+                    });
+                    if let Some(touch) = stop_touch {
+                        // Touch lifted: fire Drop + DragEnd
+                        if let Some(items) = self.os.internal_drag_items.take() {
+                            let abs = touch.abs;
+                            self.call_event_handler(&Event::Drop(DropEvent {
+                                modifiers: e.modifiers.clone(),
+                                handled: Arc::new(Mutex::new(false)),
+                                abs,
+                                items,
+                            }));
+                            self.drag_drop.cycle_drag();
+                            self.call_event_handler(&Event::DragEnd);
+                            self.drag_drop.cycle_drag();
+                        }
+                    } else if has_move {
+                        // Finger moving: fire Drag event using the first moving touch
+                        if let Some(items) = self.os.internal_drag_items.as_ref() {
+                            let touch = e.touches.iter().find(|t| {
+                                t.state == crate::event::finger::TouchState::Move
+                            }).unwrap();
+                            self.call_event_handler(&Event::Drag(DragEvent {
+                                modifiers: e.modifiers.clone(),
+                                handled: Arc::new(Mutex::new(false)),
+                                abs: touch.abs,
+                                items: items.clone(),
+                                response: Arc::new(Mutex::new(DragResponse::None)),
+                            }));
+                            self.drag_drop.cycle_drag();
+                        }
+                    }
+                }
+
                 self.fingers.process_touch_update_end(&e.touches);
             }
             FromJavaMessage::Character { character } => {
@@ -2477,6 +2520,9 @@ impl Cx {
                 CxOsOp::SetCursor(_) => {
                     // no need
                 }
+                CxOsOp::StartDragging(items) => {
+                    self.os.internal_drag_items = Some(Arc::new(items));
+                }
                 e => {
                     crate::error!("Not implemented on this platform: CxOsOp::{:?}", e);
                 }
@@ -2728,6 +2774,7 @@ impl Default for CxOs {
             pending_camera_preview_windows: HashMap::new(),
             software_video_players: HashMap::new(),
             websocket_parsers: HashMap::new(),
+            internal_drag_items: None,
             openxr: CxOpenXr::default(),
             activity_thread_id: None,
             render_thread_id: None,
@@ -2789,6 +2836,7 @@ pub struct CxOs {
     pub(crate) pending_camera_preview_windows: HashMap<LiveId, *mut ndk_sys::ANativeWindow>,
     pub(crate) software_video_players: HashMap<LiveId, AndroidSoftwarePlayer>,
     websocket_parsers: HashMap<u64, WebSocketImpl>,
+    pub(crate) internal_drag_items: Option<Arc<Vec<DragItem>>>,
     pub(crate) openxr: CxOpenXr,
     pub(crate) activity_thread_id: Option<u64>,
     pub(crate) render_thread_id: Option<u64>,

--- a/widgets/src/dock.rs
+++ b/widgets/src/dock.rs
@@ -207,7 +207,6 @@ pub struct Dock {
 
 /// Holds a clone of the tab being dragged so we can render it as a ghost overlay.
 struct DraggingTab {
-    _tab_id: LiveId,
     cursor: Vec2d,
     name: String,
     /// The size of the original tab, used for fixed-size rendering.
@@ -1446,12 +1445,13 @@ impl Widget for Dock {
                             .unwrap_or(dvec2(100.0, 30.0));
                         if let Some(ghost) = tab_bar.tab_bar.create_ghost_tab(cx, item) {
                             self.dragging_tab = Some(DraggingTab {
-                                _tab_id: item,
                                 cursor: Vec2d::default(),
                                 name,
                                 size: tab_size,
                                 ghost,
                             });
+                        } else {
+                            warning!("Dock: could not create ghost tab for {:?}", item);
                         }
                         cx.widget_action(uid, DockAction::ShouldTabStartDrag(item))
                     }

--- a/widgets/src/dock.rs
+++ b/widgets/src/dock.rs
@@ -3,6 +3,7 @@ use crate::{
     makepad_draw::*,
     makepad_micro_serde::*,
     splitter::{Splitter, SplitterAction, SplitterAlign, SplitterAxis},
+    tab::Tab,
     tab_bar::{TabBar, TabBarAction},
     widget::*,
     widget_tree::CxWidgetExt,
@@ -171,6 +172,8 @@ pub struct Dock {
     round_corner: DrawRoundCorner,
     #[live]
     drag_target_preview: DrawColor,
+    #[live]
+    ghost_tab_draw_list: DrawList2d,
 
     #[live]
     tab_bar: ScriptObjectRef,
@@ -195,8 +198,21 @@ pub struct Dock {
     items: ComponentMap<LiveId, (LiveId, WidgetRef)>,
     #[rust]
     drop_state: Option<DropPosition>,
+    /// Info about the tab currently being dragged, for ghost tab rendering.
+    #[rust]
+    dragging_tab: Option<DraggingTab>,
     #[rust]
     dock_item_iter_stack: Vec<(LiveId, usize)>,
+}
+
+/// Holds a clone of the tab being dragged so we can render it as a ghost overlay.
+struct DraggingTab {
+    _tab_id: LiveId,
+    cursor: Vec2d,
+    name: String,
+    /// The size of the original tab, used for fixed-size rendering.
+    size: Vec2d,
+    ghost: Tab,
 }
 
 impl ScriptHook for Dock {
@@ -701,6 +717,31 @@ impl Dock {
             self.drop_target_draw_list.end(cx);
         }
 
+        // Draw the ghost tab overlay BEFORE retaining/ending, so it's
+        // registered as the last overlay and renders on top of everything.
+        if self.dragging_tab.is_some() {
+            self.ghost_tab_draw_list.begin_overlay_last(cx);
+            let size = cx.current_pass_size();
+            cx.begin_root_turtle(size, Layout::default());
+            let dt = self.dragging_tab.as_mut().unwrap();
+            let ghost_pos = dvec2(dt.cursor.x + 8.0, dt.cursor.y - 30.0);
+            dt.ghost.walk = Walk {
+                abs_pos: Some(ghost_pos),
+                width: Size::Fixed(dt.size.x),
+                height: Size::Fixed(dt.size.y),
+                ..Walk::default()
+            };
+            // Ensure the ghost tab renders above the drop target preview (draw_depth 10.0).
+            dt.ghost.set_draw_depth(20.0);
+            dt.ghost.draw(cx, &dt.name);
+            cx.end_pass_sized_turtle();
+            self.ghost_tab_draw_list.end(cx);
+        } else {
+            // Clear the ghost tab overlay when not dragging.
+            self.ghost_tab_draw_list.begin_always(cx);
+            self.ghost_tab_draw_list.end(cx);
+        }
+
         self.tab_bars.retain_visible();
         self.splitters.retain_visible();
 
@@ -717,6 +758,10 @@ impl Dock {
 
     fn find_drop_position(&self, cx: &Cx, abs: Vec2d) -> Option<DropPosition> {
         for (tab_bar_id, tab_bar) in self.tab_bars.iter() {
+            // Skip panels with hidden tab bars — they should not be drop targets.
+            if let Some(DockItem::Tabs { hide_tab_bar: true, .. }) = self.dock_items.get(tab_bar_id) {
+                continue;
+            }
             let rect = tab_bar.contents_rect;
             if let Some((tab_id, rect)) = tab_bar.tab_bar.is_over_tab(cx, abs) {
                 return Some(DropPosition {
@@ -1391,6 +1436,23 @@ impl Widget for Dock {
             for action in cx.capture_actions(|cx| tab_bar.tab_bar.handle_event(cx, event, scope)) {
                 match action.as_widget_action().cast() {
                     TabBarAction::ShouldTabStartDrag(item) => {
+                        let name = if let Some(DockItem::Tab { name, .. }) = dock_items.get(&item) {
+                            name.clone()
+                        } else {
+                            String::new()
+                        };
+                        let tab_size = tab_bar.tab_bar.tab_rect(cx, item)
+                            .map(|r| r.size)
+                            .unwrap_or(dvec2(100.0, 30.0));
+                        if let Some(ghost) = tab_bar.tab_bar.create_ghost_tab(cx, item) {
+                            self.dragging_tab = Some(DraggingTab {
+                                _tab_id: item,
+                                cursor: Vec2d::default(),
+                                name,
+                                size: tab_size,
+                                ghost,
+                            });
+                        }
                         cx.widget_action(uid, DockAction::ShouldTabStartDrag(item))
                     }
                     TabBarAction::TabWasPressed(tab_id) => {
@@ -1433,12 +1495,26 @@ impl Widget for Dock {
 
         if let Event::DragEnd = event {
             self.drop_state = None;
-            self.drop_target_draw_list.redraw(cx);
+            self.dragging_tab = None;
+            let redraw_id = cx.redraw_id;
+            let ghost_dl_id = self.ghost_tab_draw_list.draw_list_id();
+            cx.draw_lists[ghost_dl_id].clear_draw_items(redraw_id);
+            if let Some(pass_id) = cx.draw_lists[ghost_dl_id].draw_pass_id {
+                cx.repaint_pass_and_child_passes(pass_id);
+            }
+            let drop_dl_id = self.drop_target_draw_list.draw_list_id();
+            cx.draw_lists[drop_dl_id].clear_draw_items(redraw_id);
+            self.area.redraw(cx);
         }
 
         match event.drag_hits(cx, self.area) {
             DragHit::Drag(f) => {
                 self.drop_state = None;
+                // Update ghost tab cursor position.
+                if let Some(ref mut dt) = self.dragging_tab {
+                    dt.cursor = f.abs;
+                }
+                self.area.redraw(cx);
                 self.drop_target_draw_list.redraw(cx);
                 match f.state {
                     DragState::In | DragState::Over => {
@@ -1450,8 +1526,24 @@ impl Widget for Dock {
             DragHit::Drop(f) => {
                 self.needs_save = true;
                 self.drop_state = None;
-                self.drop_target_draw_list.redraw(cx);
+                self.dragging_tab = None;
+                let redraw_id = cx.redraw_id;
+                cx.draw_lists[self.ghost_tab_draw_list.draw_list_id()]
+                    .clear_draw_items(redraw_id);
+                cx.draw_lists[self.drop_target_draw_list.draw_list_id()]
+                    .clear_draw_items(redraw_id);
+                self.area.redraw(cx);
                 cx.widget_action(uid, DockAction::Drop(f.clone()))
+            }
+            DragHit::DragEnd => {
+                self.drop_state = None;
+                self.dragging_tab = None;
+                let redraw_id = cx.redraw_id;
+                cx.draw_lists[self.ghost_tab_draw_list.draw_list_id()]
+                    .clear_draw_items(redraw_id);
+                cx.draw_lists[self.drop_target_draw_list.draw_list_id()]
+                    .clear_draw_items(redraw_id);
+                self.area.redraw(cx);
             }
             _ => {}
         }

--- a/widgets/src/scroll_bar.rs
+++ b/widgets/src/scroll_bar.rs
@@ -477,7 +477,10 @@ impl ScrollBar {
                     let scroll = match self.axis {
                         ScrollAxis::Horizontal => {
                             if self.use_vertical_finger_scroll {
-                                e.scroll.y
+                                // Accept both horizontal and vertical scroll input,
+                                // so trackpad horizontal scrolling and mouse wheel
+                                // vertical scrolling both work.
+                                e.scroll.x + e.scroll.y
                             } else {
                                 e.scroll.x
                             }

--- a/widgets/src/tab.rs
+++ b/widgets/src/tab.rs
@@ -303,6 +303,12 @@ pub enum TabAction {
     CloseWasPressed,
     ShouldTabStartDrag,
     ShouldTabStopDrag,
+    /// A touch finger went down on this tab (for scroll tracking).
+    TouchDown { abs: Vec2d, time: f64 },
+    /// A touch finger moved on this tab without a long press (scroll the tab bar).
+    TouchScroll { abs: Vec2d, time: f64 },
+    /// A touch finger lifted off this tab without a long press (end scroll / flick).
+    TouchUp { abs: Vec2d, time: f64 },
 }
 
 impl Tab {
@@ -359,23 +365,68 @@ impl Tab {
                 }
             }
             Hit::FingerMove(e) => {
-                if !self.is_dragging && (e.abs - e.abs_start).length() > self.min_drag_dist {
-                    self.is_dragging = true;
-                    dispatch_action(cx, TabAction::ShouldTabStartDrag);
+                if e.device.is_touch() {
+                    if e.has_long_press_occurred {
+                        // Touch: drag the tab only after a long press.
+                        if !self.is_dragging
+                            && (e.abs - e.abs_start).length() > self.min_drag_dist
+                        {
+                            self.is_dragging = true;
+                            dispatch_action(cx, TabAction::ShouldTabStartDrag);
+                        }
+                    } else {
+                        // Touch without long press: scroll the tab bar.
+                        dispatch_action(cx, TabAction::TouchScroll {
+                            abs: e.abs,
+                            time: e.time,
+                        });
+                    }
+                } else {
+                    // Mouse: drag the tab after exceeding the minimum drag distance.
+                    if !self.is_dragging
+                        && (e.abs - e.abs_start).length() > self.min_drag_dist
+                    {
+                        self.is_dragging = true;
+                        dispatch_action(cx, TabAction::ShouldTabStartDrag);
+                    }
                 }
             }
-            Hit::FingerUp(_) => {
+            Hit::FingerUp(fue) => {
                 if self.is_dragging {
                     dispatch_action(cx, TabAction::ShouldTabStopDrag);
                     self.is_dragging = false;
                 }
+                if fue.device.is_touch() {
+                    if !fue.has_long_press_occurred {
+                        dispatch_action(cx, TabAction::TouchUp {
+                            abs: fue.abs,
+                            time: fue.time,
+                        });
+                    }
+                    // For touch: only select the tab if it was a simple tap,
+                    // not a scroll gesture or long-press drag.
+                    if fue.was_tap() {
+                        dispatch_action(cx, TabAction::WasPressed);
+                    }
+                }
             }
             Hit::FingerDown(fde) => {
-                // A primary click/touch selects the tab, but a middle click closes it.
-                if fde.is_primary_hit() {
-                    dispatch_action(cx, TabAction::WasPressed);
-                } else if self.closeable && fde.mouse_button().is_some_and(|b| b.is_middle()) {
-                    dispatch_action(cx, TabAction::CloseWasPressed);
+                if fde.device.is_touch() {
+                    // For touch: don't select on finger down; selection happens
+                    // on finger up if no gesture was recognized (see FingerUp above).
+                    if fde.is_primary_hit() {
+                        dispatch_action(cx, TabAction::TouchDown {
+                            abs: fde.abs,
+                            time: fde.time,
+                        });
+                    }
+                } else {
+                    // Mouse: select immediately on click, middle-click to close.
+                    if fde.is_primary_hit() {
+                        dispatch_action(cx, TabAction::WasPressed);
+                    } else if self.closeable && fde.mouse_button().is_some_and(|b| b.is_middle()) {
+                        dispatch_action(cx, TabAction::CloseWasPressed);
+                    }
                 }
             }
             _ => {}

--- a/widgets/src/tab.rs
+++ b/widgets/src/tab.rs
@@ -293,9 +293,9 @@ pub struct Tab {
     min_drag_dist: f64,
 
     #[walk]
-    walk: Walk,
+    pub walk: Walk,
     #[layout]
-    layout: Layout,
+    pub layout: Layout,
 }
 
 pub enum TabAction {
@@ -335,6 +335,12 @@ impl Tab {
 
     pub fn area(&self) -> Area {
         self.draw_bg.area()
+    }
+
+    /// Sets the draw depth on all draw primitives of this tab.
+    pub fn set_draw_depth(&mut self, depth: f32) {
+        self.draw_bg.draw_depth = depth;
+        self.draw_text.draw_depth = depth;
     }
 
     pub fn handle_event_with(

--- a/widgets/src/tab.rs
+++ b/widgets/src/tab.rs
@@ -341,6 +341,7 @@ impl Tab {
     pub fn set_draw_depth(&mut self, depth: f32) {
         self.draw_bg.draw_depth = depth;
         self.draw_text.draw_depth = depth;
+        self.close_button.set_draw_depth(depth);
     }
 
     pub fn handle_event_with(

--- a/widgets/src/tab_bar.rs
+++ b/widgets/src/tab_bar.rs
@@ -8,6 +8,24 @@ use crate::{
 };
 use std::collections::HashMap;
 
+/// A sample of finger position and time, used for flick velocity calculation.
+#[derive(Copy, Clone)]
+struct FingerScrollSample {
+    abs: f64,
+    time: f64,
+}
+
+/// Tracks the state of a finger-based drag-to-scroll gesture on the tab bar.
+enum FingerScrollState {
+    Idle,
+    Dragging { samples: Vec<FingerScrollSample> },
+    Flicking { delta: f64, next_frame: NextFrame },
+}
+
+impl Default for FingerScrollState {
+    fn default() -> Self { Self::Idle }
+}
+
 script_mod! {
     use mod.prelude.widgets_internal.*
     use mod.widgets.*
@@ -231,6 +249,10 @@ pub struct TabBar {
     active_tab_id: Option<LiveId>,
     #[rust]
     next_active_tab_id: Option<LiveId>,
+
+    /// State for finger-based drag-to-scroll on the tab bar.
+    #[rust]
+    finger_scroll: FingerScrollState,
 }
 
 impl ScriptHook for TabBar {
@@ -290,6 +312,8 @@ impl Widget for TabBar {
             self.view_area.redraw(cx);
         };
 
+        self.handle_finger_scroll_flick(cx, event);
+
         if let Some(tab_id) = self.next_active_tab_id.take() {
             cx.widget_action(uid, TabBarAction::TabWasPressed(tab_id));
         }
@@ -305,6 +329,57 @@ impl Widget for TabBar {
                     cx.widget_action(uid, TabBarAction::ShouldTabStartDrag(*tab_id));
                 }
                 TabAction::ShouldTabStopDrag => {}
+                TabAction::TouchDown { abs, time } => {
+                    self.finger_scroll = FingerScrollState::Dragging {
+                        samples: vec![FingerScrollSample { abs: abs.x, time }],
+                    };
+                }
+                TabAction::TouchScroll { abs, time } => {
+                    if let FingerScrollState::Dragging { samples } = &mut self.finger_scroll {
+                        let old_abs = samples.last().unwrap().abs;
+                        samples.push(FingerScrollSample { abs: abs.x, time });
+                        if samples.len() > 4 {
+                            samples.remove(0);
+                        }
+                        let delta = abs.x - old_abs;
+                        let scroll_pos = self.scroll_bars.get_scroll_pos();
+                        if self.scroll_bars.set_scroll_pos(cx, Vec2d { x: scroll_pos.x - delta, y: scroll_pos.y }) {
+                            self.view_area.redraw(cx);
+                        }
+                    }
+                }
+                TabAction::TouchUp { abs: _, time: _, } => {
+                    if let FingerScrollState::Dragging { samples } = &self.finger_scroll {
+                        // Calculate flick velocity from recent samples.
+                        let mut last: Option<&FingerScrollSample> = None;
+                        let mut scaled_delta = 0.0;
+                        let mut total_delta = 0.0;
+                        for sample in samples.iter().rev() {
+                            if let Some(prev) = last {
+                                let time_delta = prev.time - sample.time;
+                                if time_delta > 0.0 {
+                                    let abs_delta = prev.abs - sample.abs;
+                                    total_delta += abs_delta;
+                                    scaled_delta += abs_delta / time_delta;
+                                }
+                            }
+                            last = Some(sample);
+                        }
+                        const FLICK_SCALING: f64 = 0.005;
+                        const FLICK_MINIMUM: f64 = 0.2;
+                        const FLICK_MAXIMUM: f64 = 80.0;
+                        scaled_delta *= FLICK_SCALING;
+                        if total_delta.abs() > 10.0 && scaled_delta.abs() > FLICK_MINIMUM {
+                            let delta = scaled_delta.min(FLICK_MAXIMUM).max(-FLICK_MAXIMUM);
+                            self.finger_scroll = FingerScrollState::Flicking {
+                                delta,
+                                next_frame: cx.new_next_frame(),
+                            };
+                        } else {
+                            self.finger_scroll = FingerScrollState::Idle;
+                        }
+                    }
+                }
             });
         }
     }
@@ -321,6 +396,38 @@ impl Widget for TabBar {
 }
 
 impl TabBar {
+    /// Drives the flick animation for finger-based scroll on each frame.
+    fn handle_finger_scroll_flick(&mut self, cx: &mut Cx, event: &Event) {
+        const FLICK_DECAY: f64 = 0.97;
+        const FLICK_MINIMUM: f64 = 0.2;
+
+        let flick_delta = if let FingerScrollState::Flicking { delta, next_frame } = &self.finger_scroll {
+            if next_frame.is_event(event).is_some() {
+                Some(*delta)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        if let Some(mut delta) = flick_delta {
+            delta *= FLICK_DECAY;
+            if delta.abs() > FLICK_MINIMUM {
+                let scroll_pos = self.scroll_bars.get_scroll_pos();
+                if self.scroll_bars.set_scroll_pos(cx, Vec2d { x: scroll_pos.x - delta, y: scroll_pos.y }) {
+                    self.view_area.redraw(cx);
+                }
+                self.finger_scroll = FingerScrollState::Flicking {
+                    delta,
+                    next_frame: cx.new_next_frame(),
+                };
+            } else {
+                self.finger_scroll = FingerScrollState::Idle;
+            }
+        }
+    }
+
     pub fn begin(&mut self, cx: &mut Cx2d, active_tab: Option<usize>, walk: Walk) {
         self.active_tab = active_tab;
         self.scroll_bars.begin(cx, walk, Layout::flow_right());

--- a/widgets/src/tab_bar.rs
+++ b/widgets/src/tab_bar.rs
@@ -487,6 +487,17 @@ impl TabBar {
         tab
     }
 
+    /// Creates a new Tab from the same template as the given tab, with the same active state.
+    /// Returns `None` if the tab_id isn't found.
+    pub fn create_ghost_tab(&self, cx: &mut Cx, tab_id: LiveId) -> Option<Tab> {
+        let (tab, template_id) = self.tabs.get(&tab_id)?;
+        let is_active = tab.is_active();
+        let template_value: ScriptValue = self.templates.get(template_id)?.as_object().into();
+        let mut ghost = cx.with_vm(|vm| Tab::script_from_value(vm, template_value));
+        ghost.set_is_active(cx, is_active, Animate::No);
+        Some(ghost)
+    }
+
     pub fn active_tab_id(&self) -> Option<LiveId> {
         self.active_tab_id
     }

--- a/widgets/src/tab_bar.rs
+++ b/widgets/src/tab_bar.rs
@@ -336,7 +336,7 @@ impl Widget for TabBar {
                 }
                 TabAction::TouchScroll { abs, time } => {
                     if let FingerScrollState::Dragging { samples } = &mut self.finger_scroll {
-                        let old_abs = samples.last().unwrap().abs;
+                        let Some(old_abs) = samples.last().map(|s| s.abs) else { return };
                         samples.push(FingerScrollSample { abs: abs.x, time });
                         if samples.len() > 4 {
                             samples.remove(0);

--- a/widgets/src/tab_close_button.rs
+++ b/widgets/src/tab_close_button.rs
@@ -84,6 +84,10 @@ impl TabCloseButton {
         self.draw_button.draw_walk(cx, self.walk);
     }
 
+    pub fn set_draw_depth(&mut self, depth: f32) {
+        self.draw_button.draw_depth = depth;
+    }
+
     pub fn handle_event(&mut self, cx: &mut Cx, event: &Event) -> TabCloseButtonAction {
         self.animator_handle_event(cx, event);
         match event.hits(cx, self.draw_button.area()) {


### PR DESCRIPTION
Details below:

1. **Finger-based tab drag-and-drop via long press** (tab.rs, android.rs, ios.rs):
   - On touch devices, tab dragging now requires a long press before moving,
     distinguishing it from scroll gestures.
   - Added internal drag-and-drop support for Android and iOS backends,
     synthesizing Drag/Drop/DragEnd events from touch move/up, matching the
     existing Linux X11/Wayland approach.

2. **Finger-based drag-scrolling through the tab bar** (tab.rs, tab_bar.rs):
   - A finger down + move (without long press) on a tab now scrolls the tab bar
     horizontally instead of initiating a tab drag.
   - Includes flick-to-scroll with velocity and decay for natural momentum.
   - Touch tab selection is deferred to finger-up and only fires on a clean tap
     (no long press, no scroll gesture), so scrolling/dragging doesn't
     accidentally select tabs.

3. **Horizontal scroll input for tab bar** (scroll_bar.rs):
   - When `use_vertical_finger_scroll` is enabled on a horizontal scroll bar,
     both horizontal (trackpad) and vertical (mouse wheel) scroll inputs are
     accepted, so trackpad users can scroll the tab list in either direction.