### PR TITLE
cargo-makepad: support builds that need cmake/bindgen (Android/iOS)

### DIFF
--- a/tools/cargo_makepad/src/android/compile.rs
+++ b/tools/cargo_makepad/src/android/compile.rs
@@ -365,10 +365,19 @@ fn rust_build(
     } else {
         args.to_vec()
     };
-    let (_ndk_version, ndk_prebuilt_root) =
+    let (ndk_version, ndk_prebuilt_root) =
         resolve_ndk_prebuilt_root(sdk_dir, host_os, urls.ndk_version_full)?;
+    // Derive ndk_root from ndk_prebuilt_root by going up through
+    // `toolchains/llvm/prebuilt/<host>/` (4 levels).
+    let ndk_root = ndk_prebuilt_root
+        .parent().unwrap()   // prebuilt/
+        .parent().unwrap()   // llvm/
+        .parent().unwrap()   // toolchains/
+        .parent().unwrap()   // ndk root
+        .to_path_buf();
     for android_target in android_targets {
         let clang_filename = format!("{}{}-clang", android_target.clang(), urls.sdk_version);
+        let clangpp_filename = format!("{}{}-clang++", android_target.clang(), urls.sdk_version);
 
         let bin_name = |bin_filename: &str, windows_extension: &str| match host_os {
             HostOs::WindowsX64 => format!("{bin_filename}.{windows_extension}"),
@@ -378,6 +387,9 @@ fn rust_build(
         let full_clang_path = ndk_prebuilt_root
             .join("bin")
             .join(bin_name(&clang_filename, "cmd"));
+        let full_clangpp_path = ndk_prebuilt_root
+            .join("bin")
+            .join(bin_name(&clangpp_filename, "cmd"));
         let full_llvm_ar_path = ndk_prebuilt_root
             .join("bin")
             .join(bin_name("llvm-ar", "exe"));
@@ -450,8 +462,16 @@ fn rust_build(
             ),
             ("JAVA_HOME".to_string(), java_home),
             (
+                "ANDROID_NDK_ROOT".to_string(),
+                ndk_root.to_string_lossy().to_string(),
+            ),
+            (
                 format!("CC_{toolchain}"),
                 full_clang_path.to_string_lossy().to_string(),
+            ),
+            (
+                format!("CXX_{toolchain}"),
+                full_clangpp_path.to_string_lossy().to_string(),
             ),
             (
                 format!("AR_{toolchain}"),
@@ -461,6 +481,11 @@ fn rust_build(
                 format!("RANLIB_{toolchain}"),
                 full_llvm_ranlib_path.to_string_lossy().to_string(),
             ),
+            // The aws-lc-sys crate requires the cmake builder (not the cc builder)
+            // for Android cross-compilation targets. With ANDROID_NDK_ROOT set
+            // and the full NDK installed (via --full-ndk), cmake's built-in
+            // Android module handles the cross-compilation setup automatically.
+            ("AWS_LC_SYS_CMAKE_BUILDER".to_string(), "1".to_string()),
             ("RUSTFLAGS".to_string(), cfg_flag.clone()),
         ];
         if let Some(makepad_env) = makepad_env {

--- a/tools/cargo_makepad/src/android/sdk.rs
+++ b/tools/cargo_makepad/src/android/sdk.rs
@@ -155,7 +155,7 @@ pub fn expand_sdk(
     _targets: &[AndroidTarget],
     urls: &AndroidSDKUrls,
 ) -> Result<(), String> {
-    let full_ndk = !args.contains(&String::from("--strip-ndk"));
+    let full_ndk = args.contains(&String::from("--full-ndk"));
     let src_dir = &sdk_dir.join("sources");
 
     fn unzip(
@@ -479,66 +479,105 @@ pub fn expand_sdk(
                     ("platform-tools/AdbWinUsbApi.dll", false),
                 ],
             )?;
-            const NDK_IN: &str = "android-ndk-r28b/toolchains/llvm/prebuilt/windows-x86_64";
-            let NDK_OUT =
-                &format!("ndk/{NDK_VERSION_FULL}/toolchains/llvm/prebuilt/windows-x86_64");
+            const NDK_ZIP_ROOT: &str = "android-ndk-r28b";
+            let NDK_OUT_BASE = format!("ndk/{NDK_VERSION_FULL}");
 
-            // We only need to extract the contents of the `NDK_IN` directory within the `URL_NDK_33_LINUX` zip file,
-            // and then copy that directory it into the proper `NDK_OUT` directory location.
             let cwd = std::env::current_dir().unwrap();
             let url_file_name = url_file_name(urls.ndk_windows);
-            println!("4/5: Unzipping: {} (full NDK)", url_file_name);
-            let ndk_out_path = sdk_dir.join(NDK_OUT);
-            mkdir(&ndk_out_path)?;
+            println!("4/5: Unzipping: {} ({})", url_file_name, if full_ndk { "full NDK" } else { "stripped NDK" });
 
-            // Some shell environments on Windows are Linux-like (Git Bash, cygwin, mingw, etc),
-            // and therefore support `unzip` and `cp`.
-            let unzip_result = shell(
-                &cwd,
-                "unzip",
-                &[
-                    "-q", // quiet
-                    "-o", // overwrite existing files
-                    src_dir.join(url_file_name).to_str().unwrap(),
-                    &format!("{NDK_IN}/**/*"),
-                    "-d",
-                    src_dir.to_str().unwrap(),
-                ],
-            );
-            if unzip_result.is_ok() {
-                shell(
+            if full_ndk {
+                // Extract the entire NDK zip into src_dir, then move it.
+                let ndk_out = sdk_dir.join(&NDK_OUT_BASE);
+                mkdir(&ndk_out)?;
+
+                let unzip_result = shell(
                     &cwd,
-                    "cp",
+                    "unzip",
                     &[
-                        "--force",
-                        "--recursive",
-                        "--preserve",
-                        src_dir.join(NDK_IN).to_str().unwrap(),
-                        ndk_out_path.parent().unwrap().to_str().unwrap(),
-                    ],
-                )
-                .unwrap();
-            } else {
-                // If `unzip` failed, we're running on a true Windows shell (cmd, powershell),
-                // so we instead use `tar` (which is the BSD version of tar) to extract the zip file.
-                // Bonus: the BSD tar utility supports extracting files directly into NDK_OUT.
-                let num_path_components = Path::new(NDK_IN).iter().count();
-                shell(
-                    &cwd,
-                    "tar",
-                    &[
-                        "-x",
-                        "-z",
-                        "-f",
+                        "-q", "-o",
                         src_dir.join(url_file_name).to_str().unwrap(),
-                        "--strip-components",
-                        &num_path_components.to_string(),
-                        "-C",
-                        ndk_out_path.to_str().unwrap(),
-                        NDK_IN,
+                        "-d",
+                        src_dir.to_str().unwrap(),
                     ],
-                )
-                .unwrap();
+                );
+                if unzip_result.is_ok() {
+                    shell(
+                        &cwd,
+                        "cp",
+                        &[
+                            "--force", "--recursive", "--preserve",
+                            src_dir.join(NDK_ZIP_ROOT).to_str().unwrap(),
+                            ndk_out.parent().unwrap().to_str().unwrap(),
+                        ],
+                    ).unwrap();
+                    // Rename extracted dir to versioned name.
+                    let extracted = sdk_dir.join("ndk").join(NDK_ZIP_ROOT);
+                    if extracted.exists() && extracted != ndk_out {
+                        std::fs::rename(&extracted, &ndk_out)
+                            .map_err(|e| format!("Failed to rename {extracted:?} to {ndk_out:?}: {e}"))?;
+                    }
+                } else {
+                    // Windows native shell: use tar.
+                    let num_path_components = Path::new(NDK_ZIP_ROOT).iter().count();
+                    shell(
+                        &cwd,
+                        "tar",
+                        &[
+                            "-x", "-z", "-f",
+                            src_dir.join(url_file_name).to_str().unwrap(),
+                            "--strip-components",
+                            &num_path_components.to_string(),
+                            "-C",
+                            ndk_out.to_str().unwrap(),
+                            NDK_ZIP_ROOT,
+                        ],
+                    ).unwrap();
+                }
+            } else {
+                // Stripped: only extract toolchains/llvm/prebuilt/<host>.
+                let NDK_IN = format!("{NDK_ZIP_ROOT}/toolchains/llvm/prebuilt/windows-x86_64");
+                let NDK_OUT = format!("{NDK_OUT_BASE}/toolchains/llvm/prebuilt/windows-x86_64");
+                let ndk_out_path = sdk_dir.join(&NDK_OUT);
+                mkdir(&ndk_out_path)?;
+
+                let unzip_result = shell(
+                    &cwd,
+                    "unzip",
+                    &[
+                        "-q", "-o",
+                        src_dir.join(url_file_name).to_str().unwrap(),
+                        &format!("{NDK_IN}/**/*"),
+                        "-d",
+                        src_dir.to_str().unwrap(),
+                    ],
+                );
+                if unzip_result.is_ok() {
+                    shell(
+                        &cwd,
+                        "cp",
+                        &[
+                            "--force", "--recursive", "--preserve",
+                            src_dir.join(&NDK_IN).to_str().unwrap(),
+                            ndk_out_path.parent().unwrap().to_str().unwrap(),
+                        ],
+                    ).unwrap();
+                } else {
+                    let num_path_components = Path::new(&NDK_IN).iter().count();
+                    shell(
+                        &cwd,
+                        "tar",
+                        &[
+                            "-x", "-z", "-f",
+                            src_dir.join(url_file_name).to_str().unwrap(),
+                            "--strip-components",
+                            &num_path_components.to_string(),
+                            "-C",
+                            ndk_out_path.to_str().unwrap(),
+                            &NDK_IN,
+                        ],
+                    ).unwrap();
+                }
             }
             /*
             else {
@@ -746,18 +785,30 @@ pub fn expand_sdk(
                 urls.platform_tools_macos,
                 &[("platform-tools/adb", true)],
             )?;
-            let NDK_IN = "AndroidNDK13676358.app/Contents/NDK/toolchains/llvm/prebuilt";
-            let NDK_OUT = &format!("ndk/{NDK_VERSION_FULL}/toolchains/llvm/prebuilt");
+            let NDK_BASE_IN = "AndroidNDK13676358.app/Contents/NDK";
+            let NDK_BASE_OUT = &format!("ndk/{NDK_VERSION_FULL}");
 
-            let toolchain_dir = copy_map(NDK_IN, NDK_OUT, "");
-            let files = [(toolchain_dir.as_str(), false)];
-            dmg_extract(4, src_dir, sdk_dir, urls.ndk_macos, &files, full_ndk)?;
+            if full_ndk {
+                // Extract the entire NDK, which includes cmake toolchain files,
+                // source.properties, and everything else needed by crates that
+                // use cmake for cross-compilation (e.g., aws-lc-sys).
+                let ndk_all = copy_map(NDK_BASE_IN, NDK_BASE_OUT, "");
+                let files = [(ndk_all.as_str(), false)];
+                dmg_extract(4, src_dir, sdk_dir, urls.ndk_macos, &files, full_ndk)?;
+            } else {
+                // Stripped NDK: only extract the toolchain binaries.
+                let NDK_IN = &format!("{NDK_BASE_IN}/toolchains/llvm/prebuilt");
+                let NDK_OUT = &format!("{NDK_BASE_OUT}/toolchains/llvm/prebuilt");
+                let toolchain_dir = copy_map(NDK_IN, NDK_OUT, "");
+                let files = [(toolchain_dir.as_str(), false)];
+                dmg_extract(4, src_dir, sdk_dir, urls.ndk_macos, &files, full_ndk)?;
+            }
             // We copied over the entire contents of `toolchains/llvm/prebuilt/*`,
             // but we still need to make each host prebuilt's `bin/*` executable.
             #[cfg(any(target_os = "macos", target_os = "linux"))]
             {
                 use std::os::unix::fs::PermissionsExt;
-                let prebuilt_root = sdk_dir.join(NDK_OUT);
+                let prebuilt_root = sdk_dir.join(format!("{NDK_BASE_OUT}/toolchains/llvm/prebuilt"));
                 std::fs::read_dir(&prebuilt_root)
                     .expect("failed to read NDK `prebuilt/` dir: {prebuilt_root:?}")
                     .filter_map(|r| {
@@ -938,19 +989,13 @@ pub fn expand_sdk(
                 urls.platform_tools_linux,
                 &[("platform-tools/adb", true)],
             )?;
-            const NDK_IN: &str = "android-ndk-r28b/toolchains/llvm/prebuilt/linux-x86_64";
-            let NDK_OUT = &format!("ndk/{NDK_VERSION_FULL}/toolchains/llvm/prebuilt/linux-x86_64");
+            const NDK_ZIP_ROOT: &str = "android-ndk-r28b";
+            let NDK_OUT_BASE = format!("ndk/{NDK_VERSION_FULL}");
 
-            // Extract the entire NDK zip without file-pattern filters, then
-            // copy just the needed subtree.  Wildcard behavior in InfoZIP
-            // `unzip` varies across platforms (`*` matching `/` or not, `**`
-            // support), so the only portable invocation is a full extraction.
-            // The extra files are cleaned up by `remove_sdk_sources`.
+            // Extract the entire NDK zip, then copy the needed subtree(s).
             let cwd = std::env::current_dir().unwrap();
             let url_file_name = url_file_name(urls.ndk_linux);
-            println!("4/5: Unzipping: {} (full NDK)", url_file_name);
-            let ndk_out_path = sdk_dir.join(NDK_OUT);
-            mkdir(&ndk_out_path)?;
+            println!("4/5: Unzipping: {} ({})", url_file_name, if full_ndk { "full NDK" } else { "stripped NDK" });
             shell(
                 &cwd,
                 "unzip",
@@ -962,17 +1007,46 @@ pub fn expand_sdk(
                     src_dir.to_str().unwrap(),
                 ],
             )?;
-            shell(
-                &cwd,
-                "cp",
-                &[
-                    "--force",
-                    "--recursive",
-                    "--preserve",
-                    src_dir.join(NDK_IN).to_str().unwrap(),
-                    ndk_out_path.parent().unwrap().to_str().unwrap(),
-                ],
-            )?;
+
+            if full_ndk {
+                // Copy the entire NDK directory tree.
+                let ndk_out = sdk_dir.join(&NDK_OUT_BASE);
+                mkdir(&ndk_out)?;
+                shell(
+                    &cwd,
+                    "cp",
+                    &[
+                        "--force",
+                        "--recursive",
+                        "--preserve",
+                        src_dir.join(NDK_ZIP_ROOT).to_str().unwrap(),
+                        ndk_out.parent().unwrap().to_str().unwrap(),
+                    ],
+                )?;
+                // Rename the extracted directory to the versioned name.
+                let extracted = sdk_dir.join("ndk").join(NDK_ZIP_ROOT);
+                if extracted.exists() && extracted != ndk_out {
+                    std::fs::rename(&extracted, &ndk_out)
+                        .map_err(|e| format!("Failed to rename {extracted:?} to {ndk_out:?}: {e}"))?;
+                }
+            } else {
+                // Stripped: only copy toolchains/llvm/prebuilt/<host>.
+                let NDK_IN = format!("{NDK_ZIP_ROOT}/toolchains/llvm/prebuilt/linux-x86_64");
+                let NDK_OUT = format!("{NDK_OUT_BASE}/toolchains/llvm/prebuilt/linux-x86_64");
+                let ndk_out_path = sdk_dir.join(&NDK_OUT);
+                mkdir(&ndk_out_path)?;
+                shell(
+                    &cwd,
+                    "cp",
+                    &[
+                        "--force",
+                        "--recursive",
+                        "--preserve",
+                        src_dir.join(&NDK_IN).to_str().unwrap(),
+                        ndk_out_path.parent().unwrap().to_str().unwrap(),
+                    ],
+                )?;
+            }
 
             const JDK_IN: &str = "jdk-17.0.2";
             const JDK_OUT: &str = "openjdk";

--- a/tools/cargo_makepad/src/android/sdk.rs
+++ b/tools/cargo_makepad/src/android/sdk.rs
@@ -514,6 +514,12 @@ pub fn expand_sdk(
                     // Rename extracted dir to versioned name.
                     let extracted = sdk_dir.join("ndk").join(NDK_ZIP_ROOT);
                     if extracted.exists() && extracted != ndk_out {
+                        // Remove the destination first (it may exist from a
+                        // previous install or from mkdir above).
+                        if ndk_out.exists() {
+                            std::fs::remove_dir_all(&ndk_out)
+                                .map_err(|e| format!("Failed to remove {ndk_out:?}: {e}"))?;
+                        }
                         std::fs::rename(&extracted, &ndk_out)
                             .map_err(|e| format!("Failed to rename {extracted:?} to {ndk_out:?}: {e}"))?;
                     }
@@ -1026,6 +1032,10 @@ pub fn expand_sdk(
                 // Rename the extracted directory to the versioned name.
                 let extracted = sdk_dir.join("ndk").join(NDK_ZIP_ROOT);
                 if extracted.exists() && extracted != ndk_out {
+                    if ndk_out.exists() {
+                        std::fs::remove_dir_all(&ndk_out)
+                            .map_err(|e| format!("Failed to remove {ndk_out:?}: {e}"))?;
+                    }
                     std::fs::rename(&extracted, &ndk_out)
                         .map_err(|e| format!("Failed to rename {extracted:?} to {ndk_out:?}: {e}"))?;
                 }

--- a/tools/cargo_makepad/src/apple/compile.rs
+++ b/tools/cargo_makepad/src/apple/compile.rs
@@ -688,6 +688,9 @@ pub fn build(
     let mut rust_env = vec![
         ("RUST_BACKTRACE", "1"),
         ("MAKEPAD", if stable { "" } else { "lines" }),
+        // The aws-lc-sys crate requires the cmake builder (not the cc builder)
+        // for iOS/tvOS cross-compilation targets.
+        ("AWS_LC_SYS_CMAKE_BUILDER", "1"),
     ];
     if matches!(apple_target.os(), AppleOs::Ios) {
         rust_env.push(("IPHONEOS_DEPLOYMENT_TARGET", IOS_DEPLOYMENT_TARGET));


### PR DESCRIPTION
The newly-emerging `aws-lc-rs` crate is quite popular and is
gradually replacing `ring`, which means we need to support it,
which is especially difficult to get right on Android and iOS targets.

This changeset makes it really easy to build that crate as part of
your app, if desired. There's no cost to apps that don't use it.

Android: make the stripped NDK installation the default, and make the
`full-ndk` option actually install the FULL NDK, not just the full set
of prebuilts. Like the whole thing, including build tooling like cmake
and other libraries.