### PR TITLE
Fix key repeat timer issue and `Event::Shutdown` delivery

### DIFF
--- a/platform/src/os/linux/direct/linux_direct.rs
+++ b/platform/src/os/linux/direct/linux_direct.rs
@@ -114,6 +114,7 @@ impl Cx {
         event: DirectEvent,
     ) -> EventFlow {
         if let EventFlow::Exit = self.handle_platform_ops(direct_app) {
+            self.call_event_handler(&Event::Shutdown);
             return EventFlow::Exit;
         }
 

--- a/platform/src/os/linux/direct/raw_input.rs
+++ b/platform/src/os/linux/direct/raw_input.rs
@@ -1008,12 +1008,26 @@ impl RawInput {
                     })),
                 }
             }
-            KeyAction::KeyRepeat => dir_evts.push(DirectEvent::KeyDown(KeyEvent {
-                key_code,
-                is_repeat: false,
-                modifiers: self.modifiers,
-                time,
-            })),
+            KeyAction::KeyRepeat => {
+                if !self.modifiers.control && !self.modifiers.alt && !self.modifiers.logo {
+                    let uc = self.modifiers.shift;
+                    let inp = key_code.to_char(uc);
+                    if let Some(inp) = inp {
+                        dir_evts.push(DirectEvent::TextInput(TextInputEvent {
+                            input: format!("{}", inp),
+                            was_paste: false,
+                            replace_last: false,
+                            ..Default::default()
+                        }));
+                    }
+                }
+                dir_evts.push(DirectEvent::KeyDown(KeyEvent {
+                    key_code,
+                    is_repeat: true,
+                    modifiers: self.modifiers,
+                    time,
+                }))
+            }
         }
     }
 }

--- a/platform/src/os/linux/open_harmony/open_harmony.rs
+++ b/platform/src/os/linux/open_harmony/open_harmony.rs
@@ -84,6 +84,7 @@ impl Cx {
                 }
             }
         }
+        self.call_event_handler(&Event::Shutdown);
     }
 
     fn handle_all_pending_messages(&mut self, from_ohos_rx: &mpsc::Receiver<FromOhosMessage>) {

--- a/platform/src/os/linux/select_timer.rs
+++ b/platform/src/os/linux/select_timer.rs
@@ -81,8 +81,11 @@ impl SelectTimers {
             let timer = *self.timers.front().unwrap();
             select_time_used -= timer.delta_timeout;
 
-            // Stop the timer to remove it from the list.
-            self.stop_timer(timer.id);
+            // Remove the fired timer directly from the front of the queue.
+            // We intentionally do NOT use `stop_timer` here because `select_time_used`
+            // already accounts for the removed timer's delta — using `stop_timer` would
+            // double-count it by also adding the delta to the successor.
+            self.timers.pop_front();
             // If the timer is repeating, simply start it again.
             if timer.repeats {
                 self.start_timer(timer.id, timer.timeout, timer.repeats);
@@ -155,8 +158,14 @@ impl SelectTimers {
             return;
         };
 
-        // Remove the timer from the list.
-        // The timer being removed is always the first one in the queue, so it can just be removed directly.
+        // When removing a timer that has a successor, the successor's `delta_timeout` must be
+        // adjusted to account for the removed timer's delta, since deltas are relative to the
+        // predecessor in the queue.
+        let removed_delta = self.timers[index].delta_timeout;
+        if index + 1 < self.timers.len() {
+            self.timers[index + 1].delta_timeout += removed_delta;
+        }
+
         self.timers.remove(index);
     }
 }

--- a/platform/src/os/linux/wayland/linux_wayland.rs
+++ b/platform/src/os/linux/wayland/linux_wayland.rs
@@ -130,6 +130,8 @@ impl WaylandCx {
             }));
         }
         if let EventFlow::Exit = self.handle_platform_ops(state) {
+            let mut cx = self.cx.borrow_mut();
+            cx.call_event_handler(&Event::Shutdown);
             state.event_loop_running = false;
             return EventFlow::Exit;
         }

--- a/platform/src/os/linux/wayland/wayland_app.rs
+++ b/platform/src/os/linux/wayland/wayland_app.rs
@@ -43,10 +43,12 @@ impl WaylandApp {
                     let time = self.time_now();
                     self.state.timers.update_timers(&mut timer_ids);
                     for timer_id in &timer_ids {
-                        self.do_callback(XlibEvent::Timer(TimerEvent {
-                            timer_id: *timer_id,
-                            time: Some(time),
-                        }));
+                        if !self.state.handle_key_repeat_timer(*timer_id) {
+                            self.do_callback(XlibEvent::Timer(TimerEvent {
+                                timer_id: *timer_id,
+                                time: Some(time),
+                            }));
+                        }
                     }
                     if let Some(guard) = self.event_queue.prepare_read() {
                         self.state.timers.select(guard.connection_fd().as_raw_fd());
@@ -57,10 +59,12 @@ impl WaylandApp {
                     let time = self.time_now();
                     self.state.timers.update_timers(&mut timer_ids);
                     for timer_id in &timer_ids {
-                        self.do_callback(XlibEvent::Timer(TimerEvent {
-                            timer_id: *timer_id,
-                            time: Some(time),
-                        }));
+                        if !self.state.handle_key_repeat_timer(*timer_id) {
+                            self.do_callback(XlibEvent::Timer(TimerEvent {
+                                timer_id: *timer_id,
+                                time: Some(time),
+                            }));
+                        }
                     }
                     self.event_loop_poll();
                 }

--- a/platform/src/os/linux/wayland/wayland_state.rs
+++ b/platform/src/os/linux/wayland/wayland_state.rs
@@ -58,6 +58,17 @@ use crate::{
 
 use super::opengl_wayland::{WaylandPopupWindow, WaylandWindow};
 
+/// Reserved timer ID for keyboard repeat. Uses a high value to avoid conflicts with app timers.
+const KEY_REPEAT_TIMER_ID: u64 = u64::MAX - 1;
+
+/// State for tracking keyboard key repeat.
+struct KeyRepeatState {
+    key_code: KeyCode,
+    text: String,
+    /// True while waiting for the initial delay; false during steady-state repeat.
+    in_initial_delay: bool,
+}
+
 pub(crate) struct ClipboardOffer {
     offer: wl_data_offer::WlDataOffer,
     mime_types: Vec<String>,
@@ -119,6 +130,13 @@ pub(crate) struct WaylandState {
     pub(crate) last_scroll_time: f64,
     pub(crate) event_flow: EventFlow,
     pub(crate) event_loop_running: bool,
+
+    /// Keyboard repeat rate in keys per second (0 = disabled).
+    key_repeat_rate: i32,
+    /// Keyboard repeat delay in milliseconds before repeat starts.
+    key_repeat_delay: i32,
+    /// Currently repeating key state, if any.
+    key_repeat: Option<KeyRepeatState>,
 }
 
 impl WaylandState {
@@ -169,6 +187,9 @@ impl WaylandState {
             last_scroll_time: 0.0,
             event_flow: EventFlow::Wait,
             event_loop_running: true,
+            key_repeat_rate: 25,
+            key_repeat_delay: 600,
+            key_repeat: None,
         }
     }
 
@@ -847,6 +868,10 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandState {
                 }
             }
             wl_keyboard::Event::Leave { serial, surface } => {
+                // Cancel any active key repeat when keyboard focus is lost
+                state.timers.stop_timer(KEY_REPEAT_TIMER_ID);
+                state.key_repeat = None;
+
                 state.keyboard_serial = Some(serial);
                 state.flush_pending_clipboard_copy(qhandle, serial);
                 if let Some(window_id) = state.window_id_for_surface(&surface) {
@@ -877,11 +902,12 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandState {
                         wl_keyboard::KeyState::Pressed => {
                             state.keyboard_serial = Some(serial);
                             state.flush_pending_clipboard_copy(qhandle, serial);
-                            let (key_code, text_str) =
+                            let (key_code, text_str, should_repeat) =
                                 if let Some(xkb_state) = state.xkb_state.as_mut() {
                                     (
                                         xkb_state.keycode_to_makepad_keycode(key + 8),
                                         xkb_state.key_get_utf8(key + 8),
+                                        xkb_state.key_repeats(key + 8),
                                     )
                                 } else {
                                     return;
@@ -927,16 +953,35 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandState {
 
                             if !block_text && text_str.chars().any(|ch| !ch.is_control()) {
                                 state.do_callback(XlibEvent::TextInput(TextInputEvent {
-                                    input: text_str,
+                                    input: text_str.clone(),
                                     replace_last: false,
                                     was_paste: false,
                                     ..Default::default()
                                 }));
                             }
+
+                            // Start key repeat timer if the key supports it
+                            if should_repeat && state.key_repeat_rate > 0 {
+                                state.timers.stop_timer(KEY_REPEAT_TIMER_ID);
+                                state.key_repeat = Some(KeyRepeatState {
+                                    key_code,
+                                    text: text_str,
+                                    in_initial_delay: true,
+                                });
+                                let delay_secs = state.key_repeat_delay as f64 / 1000.0;
+                                state.timers.start_timer(KEY_REPEAT_TIMER_ID, delay_secs, false);
+                            }
                         }
                         wl_keyboard::KeyState::Released => {
                             if let Some(xkb_state) = state.xkb_state.as_mut() {
                                 let key_code = xkb_state.keycode_to_makepad_keycode(key + 8);
+
+                                // Stop key repeat if this is the key being repeated
+                                if state.key_repeat.as_ref().is_some_and(|r| r.key_code == key_code) {
+                                    state.timers.stop_timer(KEY_REPEAT_TIMER_ID);
+                                    state.key_repeat = None;
+                                }
+
                                 state.do_callback(XlibEvent::KeyUp(KeyEvent {
                                     key_code,
                                     is_repeat: false,
@@ -949,7 +994,10 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandState {
                     };
                 }
             }
-            // wl_keyboard::Event::RepeatInfo { rate, delay } => {},
+            wl_keyboard::Event::RepeatInfo { rate, delay } => {
+                state.key_repeat_rate = rate;
+                state.key_repeat_delay = delay;
+            }
             wl_keyboard::Event::Modifiers {
                 serial: _,
                 mods_depressed,
@@ -1552,6 +1600,44 @@ impl WaylandState {
             callback(self, event);
             self.event_callback = Some(callback);
         }
+    }
+
+    /// Called from the event loop when the key repeat timer fires.
+    /// Returns true if the timer was handled (i.e., it was the key repeat timer).
+    pub(crate) fn handle_key_repeat_timer(&mut self, timer_id: u64) -> bool {
+        if timer_id != KEY_REPEAT_TIMER_ID {
+            return false;
+        }
+        if let Some(repeat) = self.key_repeat.as_mut() {
+            let key_code = repeat.key_code;
+            let text = repeat.text.clone();
+            let modifiers = self.modifiers;
+
+            if repeat.in_initial_delay {
+                // Initial delay has elapsed; switch to steady-state repeat interval.
+                repeat.in_initial_delay = false;
+                let interval_secs = 1.0 / self.key_repeat_rate as f64;
+                self.timers.start_timer(KEY_REPEAT_TIMER_ID, interval_secs, true);
+            }
+
+            self.do_callback(XlibEvent::KeyDown(KeyEvent {
+                key_code,
+                is_repeat: true,
+                modifiers,
+                time: self.time_now(),
+            }));
+
+            let block_text = modifiers.control || modifiers.logo || modifiers.alt;
+            if !block_text && text.chars().any(|ch| !ch.is_control()) {
+                self.do_callback(XlibEvent::TextInput(TextInputEvent {
+                    input: text,
+                    replace_last: false,
+                    was_paste: false,
+                    ..Default::default()
+                }));
+            }
+        }
+        true
     }
 
     pub fn start_timer(&mut self, id: u64, timeout: f64, repeats: bool) {

--- a/platform/src/os/linux/wayland/xkb_sys.rs
+++ b/platform/src/os/linux/wayland/xkb_sys.rs
@@ -404,6 +404,9 @@ extern "C" {
     // Key repeat
     pub fn xkb_keymap_key_repeats(keymap: *mut xkb_keymap, key: xkb_keycode_t) -> c_int;
 
+    // Get keymap from state
+    pub fn xkb_state_get_keymap(state: *mut xkb_state) -> *mut xkb_keymap;
+
     // Keysym utilities
     pub fn xkb_keysym_get_name(keysym: xkb_keysym_t, buffer: *mut c_char, size: usize) -> c_int;
 
@@ -700,6 +703,14 @@ impl XkbState {
             None
         } else {
             Some(XkbState { ptr })
+        }
+    }
+
+    /// Check if a key should repeat according to the keymap
+    pub fn key_repeats(&self, keycode: u32) -> bool {
+        unsafe {
+            let keymap = xkb_state_get_keymap(self.ptr);
+            xkb_keymap_key_repeats(keymap, keycode) != 0
         }
     }
 

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -107,6 +107,8 @@ impl X11Cx {
         opengl_windows: &mut Vec<OpenglWindow>,
     ) -> EventFlow {
         if let EventFlow::Exit = self.handle_platform_ops(opengl_windows, xlib_app) {
+            let mut cx = self.cx.borrow_mut();
+            cx.call_event_handler(&Event::Shutdown);
             return EventFlow::Exit;
         }
 

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -79,6 +79,7 @@ impl Cx {
         d3d11_windows: &mut Vec<D3d11Window>,
     ) -> EventFlow {
         if let EventFlow::Exit = self.handle_platform_ops(d3d11_windows, d3d11_cx) {
+            self.call_event_handler(&Event::Shutdown);
             return EventFlow::Exit;
         }
 


### PR DESCRIPTION
Key repeat (holding down a key) did not work on Linux Wayland. The `RepeatInfo` event from the compositor was commented out, and all key events had `is_repeat: false` hardcoded.

- **`xkb_sys.rs`**: Added `xkb_state_get_keymap` FFI binding and a `key_repeats()` method on `XkbState` to check whether a key supports repeat (e.g., modifiers don't repeat).
- **`wayland_state.rs`**:
  - Added `KeyRepeatState` struct and `KEY_REPEAT_TIMER_ID` constant.
  - Added `key_repeat_rate`, `key_repeat_delay`, and `key_repeat` fields to `WaylandState`.
  - Handled the previously-ignored `RepeatInfo` event to store the compositor's repeat rate/delay.
  - On key press: start a one-shot timer with the repeat delay if the key supports repeat.
  - On key release / keyboard leave: cancel the repeat timer.
  - Added `handle_key_repeat_timer()` which fires `KeyDown(is_repeat: true)` and `TextInput` events, transitioning from the initial delay to a steady-state repeating timer.
- **`wayland_app.rs`**: Intercept the key repeat timer ID in the event loop and route it to `handle_key_repeat_timer()` instead of sending a generic `Timer` event.

- **`raw_input.rs`**: The evdev backend already received `KeyAction::KeyRepeat` from the OS but hardcoded `is_repeat: false` and didn't emit `TextInput` events. Fixed both.

- **`select_timer.rs`**: Fixed a pre-existing bug in `stop_timer` where removing a timer from the delta chain didn't adjust the successor's `delta_timeout`. This caused successor timers to fire early by the removed timer's delta. Also changed `update_timers` to use `pop_front()` instead of `stop_timer()` internally, since `select_time_used` already accounts for the removed timer's delta.

--------------

On Linux Wayland (and several other platforms), Makepad apps never received `Event::Shutdown` when the window was closed via the client-side decoration close button or when the app called `cx.quit()`.

When the CSD close button is clicked, it pushes `CxOsOp::CloseWindow`, which is processed by `handle_platform_ops()`. When the last window is removed (or `CxOsOp::Quit` is handled), this function returns `EventFlow::Exit`. However, most backends did **not** call `Event::Shutdown` before exiting — only macOS did it correctly.

Added `call_event_handler(&Event::Shutdown)` in the `handle_platform_ops() → Exit` path for all affected backends, matching the existing macOS behavior:

- **Linux Wayland** (`linux_wayland.rs`) — added Shutdown call
- **Linux X11** (`linux_x11.rs`) — added Shutdown call
- **Windows** (`windows.rs`) — added Shutdown call
- **Linux Direct** (`linux_direct.rs`) — added Shutdown call
- **OpenHarmony** (`open_harmony.rs`) — added Shutdown call after main loop exit (this backend uses `self.os.quit` instead of `EventFlow::Exit`)

- **macOS** — already correct
- **Android** — Shutdown is delivered via `FromJavaMessage::Destroy`
- **iOS / tvOS / Web** — different lifecycle models where explicit shutdown doesn't apply (suspended by OS, or no reliable browser mechanism)