### PR TITLE
Flow right wrap fix

### DIFF
--- a/draw/src/turtle.rs
+++ b/draw/src/turtle.rs
@@ -378,6 +378,10 @@ pub struct Layout {
     #[live]
     pub spacing: f64,
 
+    /// The vertical spacing between rows when wrapping in a `Flow::Right { wrap: true }` layout.
+    #[live]
+    pub wrap_spacing: f64,
+
     /// The padding around the inner rectangle of each walk.
     #[live]
     pub padding: Inset,
@@ -472,6 +476,7 @@ impl Default for Layout {
             align: Align::default(),
             flow: Flow::default(),
             spacing: 0.0,
+            wrap_spacing: 0.0,
         }
     }
 }
@@ -1312,7 +1317,7 @@ impl<'a, 'b> Cx2d<'a, 'b> {
                 x: layout.padding.left,
                 y: layout.padding.top,
             },
-            wrap_spacing: 0.0,
+            wrap_spacing: layout.wrap_spacing,
             origin: dvec2(0.0, 0.0),
             width: size.x,
             height: size.y,
@@ -1409,7 +1414,7 @@ impl<'a, 'b> Cx2d<'a, 'b> {
             finished_walks_start: self.finished_walks.len(),
             deferred_fills: Vec::new(),
             resolved_fills: Vec::new(),
-            wrap_spacing: 0.0,
+            wrap_spacing: layout.wrap_spacing,
             pos: Vec2d {
                 x: origin.x + layout.padding.left,
                 y: origin.y + layout.padding.top,

--- a/draw/src/turtle.rs
+++ b/draw/src/turtle.rs
@@ -2041,7 +2041,7 @@ impl<'a, 'b> Cx2d<'a, 'b> {
     }
 
     fn wrap_turtle(&mut self, align_list_start: usize) {
-        let old_pos = self.turtle().pos() - self.turtle_next_walk_offset();
+        let old_pos = self.turtle().pos() + self.turtle_next_walk_offset();
         self.turtle_new_line_internal(self.turtle().wrap_spacing, align_list_start);
         let new_pos = self.turtle().pos();
         let shift = new_pos - old_pos;


### PR DESCRIPTION
This tiny math bug was causing widgets that got wrapped to the next line
in a `Flow: Right { wrap: true}` view to not get properly drawn
(the left side would get cut off).

Expose `wrap_spacing` in Layout and splash script, 
which allows you to set the vertical spacing between widgets when
they wrap to the next line in a Right wrap flow layout.