### PR TITLE
Packaging directory-related fixes (for robius-packaging-commands to work)

### DIFF
--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -1604,12 +1604,6 @@ impl CxOsApi for Cx {
         if let Some(item) = std::option_env!("MAKEPAD_PACKAGE_DIR") {
             self.package_root = Some(item.to_string());
         }
-        //self.live_expand();
-        #[cfg(debug_assertions)]
-        if !Self::has_studio_web_socket() {
-            //self.start_disk_live_file_watcher(100);
-        }
-        //self.live_scan_dependencies();
 
         #[cfg(apple_bundle)]
         self.apple_bundle_load_dependencies();

--- a/platform/src/os/linux/direct/linux_direct.rs
+++ b/platform/src/os/linux/direct/linux_direct.rs
@@ -380,11 +380,9 @@ impl Cx {
 
 impl CxOsApi for Cx {
     fn init_cx_os(&mut self) {
-        self.live_expand();
-        if !Self::has_studio_web_socket() {
-            self.start_disk_live_file_watcher(100);
+        if let Some(item) = std::option_env!("MAKEPAD_PACKAGE_DIR") {
+            self.package_root = Some(item.to_string());
         }
-        self.live_scan_dependencies();
         self.native_load_dependencies();
     }
 

--- a/platform/src/os/linux/open_harmony/open_harmony.rs
+++ b/platform/src/os/linux/open_harmony/open_harmony.rs
@@ -595,9 +595,8 @@ impl Cx {
 
 impl CxOsApi for Cx {
     fn init_cx_os(&mut self) {
-        self.live_registry.borrow_mut().package_root = Some("makepad".to_string());
-        self.live_expand();
-        self.live_scan_dependencies();
+        self.package_root = Some("makepad".to_string());
+        self.native_load_dependencies();
     }
 
     fn spawn_thread<F>(&mut self, f: F)

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -798,15 +798,10 @@ impl CxGameInputApi for Cx {
 impl CxOsApi for Cx {
     fn init_cx_os(&mut self) {
         self.os.start_time = Some(Instant::now());
-        if let Some(_item) = std::option_env!("MAKEPAD_PACKAGE_DIR") {
-            //    self.live_registry.borrow_mut().package_root = Some(item.to_string());
+        if let Some(item) = std::option_env!("MAKEPAD_PACKAGE_DIR") {
+            self.package_root = Some(item.to_string());
         }
 
-        //self.live_expand();
-        //if std::env::args().find( | v | v == "--stdin-loop").is_none() {
-        //    self.start_disk_live_file_watcher(100);
-        //}
-        //self.live_scan_dependencies();
         self.native_load_dependencies();
 
         self.os.windows_game_input = Some(WindowsGameInput::init());

--- a/platform/src/script/res.rs
+++ b/platform/src/script/res.rs
@@ -143,8 +143,9 @@ impl CxScriptResources {
 //       3. error
 // ---------------------------------------------------------------------------
 
-/// Try to load a resource from the packaged location on iOS/tvOS.
-#[cfg(any(target_os = "ios", target_os = "tvos"))]
+/// Try to load a resource from the packaged location on Apple platforms
+/// using NSBundle to resolve the app bundle's resource path.
+#[cfg(any(target_os = "ios", target_os = "tvos", all(target_os = "macos", apple_bundle)))]
 fn load_packaged_resource(cx: &Cx, dep_path: &str) -> Option<Rc<Vec<u8>>> {
     let bundle_path = if let Some(root) = cx.package_root.as_deref() {
         format!("{}/{}", root, dep_path)
@@ -158,7 +159,8 @@ fn load_packaged_resource(cx: &Cx, dep_path: &str) -> Option<Rc<Vec<u8>>> {
 /// Returns None when not in packaged mode (package_root is None).
 #[cfg(all(
     not(target_arch = "wasm32"),
-    not(any(target_os = "android", target_os = "ios", target_os = "tvos"))
+    not(any(target_os = "android", target_os = "ios", target_os = "tvos")),
+    not(all(target_os = "macos", apple_bundle))
 ))]
 fn load_packaged_resource(cx: &Cx, dep_path: &str) -> Option<Rc<Vec<u8>>> {
     let root = cx.package_root.as_deref()?;


### PR DESCRIPTION
Some things got broken or left out during the Makepad 2.0 migration, so this fixes them.

Platform testing:
- [x] macOS bundle
- [x] macOS DMG
- [x] Linux Wayland (Ubuntu 25.10)
   - [x] AppImage
   - [x] .deb
- [x] Linux X11 (Ubuntu 20.04)
   - [x] AppImage
   - [x] .deb
- [ ] pacman (Arch Linux) PKGBUILD
   * Can't test, don't have an Arch Linux installation
- [x] Windows NSIS
- [x] iOS Simulator  (already working via cargo-makepad)
- [x] Android APK  (already working via cargo-makepad)