### PR TITLE
fix(base64): handle single '=' padding in base64_decode

### DIFF
--- a/libs/base64/src/base64.rs
+++ b/libs/base64/src/base64.rs
@@ -91,9 +91,83 @@ pub fn base64_decode(input: &[u8]) -> Result<Vec<u8>, Base64DecodeError> {
         i += 4;
         o += 3;
     }
+    if input[input.len() - 1] == b'=' {
+        o -= 1; // single padding: 2 bytes encoded in last 4-char group
+    }
     if input[input.len() - 2] == b'=' {
-        o -= 1;
+        o -= 1; // double padding: 1 byte encoded in last 4-char group
     }
     out.resize(o, 0u8);
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_no_padding() {
+        // 3 bytes → 4 base64 chars, no padding
+        let input = b"abc";
+        let encoded = base64_encode(input, &BASE64_STANDARD);
+        let decoded = base64_decode(&encoded).unwrap();
+        assert_eq!(decoded, input);
+    }
+
+    #[test]
+    fn roundtrip_single_padding() {
+        // 2 bytes → 4 base64 chars with single '=' padding
+        let input = b"ab";
+        let encoded = base64_encode(input, &BASE64_STANDARD);
+        assert_eq!(encoded.last(), Some(&b'='));
+        assert_ne!(encoded[encoded.len() - 2], b'='); // single, not double
+        let decoded = base64_decode(&encoded).unwrap();
+        assert_eq!(decoded, input, "Single-padding roundtrip failed");
+    }
+
+    #[test]
+    fn roundtrip_double_padding() {
+        // 1 byte → 4 base64 chars with '==' padding
+        let input = b"a";
+        let encoded = base64_encode(input, &BASE64_STANDARD);
+        assert_eq!(&encoded[encoded.len() - 2..], b"==");
+        let decoded = base64_decode(&encoded).unwrap();
+        assert_eq!(decoded, input, "Double-padding roundtrip failed");
+    }
+
+    #[test]
+    fn roundtrip_empty() {
+        let input = b"";
+        let encoded = base64_encode(input, &BASE64_STANDARD);
+        assert!(encoded.is_empty() || base64_decode(&encoded).unwrap().is_empty());
+    }
+
+    #[test]
+    fn roundtrip_various_lengths() {
+        // Test lengths 1-20 to cover all padding cases
+        for len in 1..=20 {
+            let input: Vec<u8> = (0..len).map(|i| i as u8).collect();
+            let encoded = base64_encode(&input, &BASE64_STANDARD);
+            let decoded = base64_decode(&encoded).unwrap();
+            assert_eq!(decoded, input, "Roundtrip failed for length {}", len);
+        }
+    }
+
+    #[test]
+    fn roundtrip_binary_data() {
+        // All byte values
+        let input: Vec<u8> = (0..=255).collect();
+        let encoded = base64_encode(&input, &BASE64_STANDARD);
+        let decoded = base64_decode(&encoded).unwrap();
+        assert_eq!(decoded, input);
+    }
+
+    #[test]
+    fn roundtrip_url_safe() {
+        let input = b"hello world!";
+        let encoded = base64_encode(input, &BASE64_URL_SAFE);
+        // URL-safe uses - and _ instead of + and /
+        let decoded = base64_decode(&encoded).unwrap();
+        assert_eq!(decoded, input);
+    }
 }


### PR DESCRIPTION
## Summary

`base64_decode` only handled double padding (`==`) but not single padding (`=`), causing decoded output to contain 1 extra garbage byte for inputs where `len % 3 == 2`.

This affects 2 out of 3 possible input lengths — any data that produces a single `=` pad character when encoded.

## The Bug

```rust
// Before: only checks for '==' (double padding)
if input[input.len() - 2] == b'=' {
    o -= 1;
}
```

When input has single padding (e.g., `"YWI="` encoding `"ab"`), `input[len-2]` is `I` (not `=`), so no bytes are subtracted. The decoded output is 3 bytes instead of the correct 2.

## The Fix

```rust
// After: check for single '=' first, then '=='
if input[input.len() - 1] == b'=' {
    o -= 1; // single padding: 2 bytes encoded in last 4-char group
}
if input[input.len() - 2] == b'=' {
    o -= 1; // double padding: 1 byte encoded in last 4-char group
}
```

## Tests Added

7 roundtrip tests covering all padding cases:
- No padding (3n bytes)
- Single padding (3n+2 bytes) — **previously broken**
- Double padding (3n+1 bytes)
- Empty input
- Lengths 1–20 (covers all padding patterns)
- All 256 byte values
- URL-safe alphabet

## Impact

Any consumer of `base64_decode` that processes data not divisible by 3 bytes receives an extra garbage byte. This includes audio data, binary payloads, and any serialized content.