### PR TITLE
Add table rendering to TextFlow engine for Markdown and Html widgets

### DIFF
--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -137,50 +137,10 @@ script_mod! {
             quote_fg_color: theme.color_label_inner
             code_color: theme.color_bg_highlight
             selection_color: theme.color_selection_focus
+            table_header_bg_color: theme.color_bg_highlight
+            table_border_color: theme.color_shadow
             space_1: uniform(theme.space_1)
             space_2: uniform(theme.space_2)
-
-            pixel: fn() {
-                let sdf = Sdf2d.viewport(self.pos * self.rect_size)
-                match self.block_type {
-                    FlowBlockType.Quote => {
-                        sdf.box(0. 0. self.rect_size.x self.rect_size.y 2.)
-                        sdf.fill(self.quote_bg_color)
-                        sdf.box(self.space_1 self.space_1 self.space_1 self.rect_size.y-self.space_2 1.5)
-                        sdf.fill(self.quote_fg_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.Sep => {
-                        sdf.box(0. 1. self.rect_size.x-1. self.rect_size.y-2. 2.)
-                        sdf.fill(self.sep_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.Code => {
-                        sdf.box(0. 0. self.rect_size.x self.rect_size.y 2.)
-                        sdf.fill(self.code_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.InlineCode => {
-                        sdf.box(1. 1. self.rect_size.x-2. self.rect_size.y-2. 2.)
-                        sdf.fill(self.code_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.Underline => {
-                        sdf.box(0. self.rect_size.y-2. self.rect_size.x 2.0 0.5)
-                        sdf.fill(self.line_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.Strikethrough => {
-                        sdf.box(0. self.rect_size.y * 0.45 self.rect_size.x 2.0 0.5)
-                        sdf.fill(self.line_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.Selection => {
-                        return vec4(self.selection_color.rgb * self.selection_color.a, self.selection_color.a)
-                    }
-                }
-                return #f00
-            }
         }
     }
 }
@@ -258,6 +218,42 @@ impl ScriptHook for Html {
 }
 
 impl Html {
+    fn count_table_columns(nodes: &[HtmlNode], start_index: usize) -> usize {
+        let mut count = 0;
+        let mut in_first_row = false;
+        let mut depth = 0;
+        for node in &nodes[start_index + 1..] {
+            match node {
+                HtmlNode::OpenTag { lc, .. } => {
+                    if *lc == live_id!(table) {
+                        depth += 1;
+                    } else if depth == 0 && *lc == live_id!(tr) && !in_first_row {
+                        in_first_row = true;
+                    } else if depth == 0
+                        && in_first_row
+                        && (*lc == live_id!(td) || *lc == live_id!(th))
+                    {
+                        count += 1;
+                    }
+                }
+                HtmlNode::CloseTag { lc, .. } => {
+                    if *lc == live_id!(table) {
+                        if depth > 0 {
+                            depth -= 1;
+                        } else {
+                            return count;
+                        }
+                    }
+                    if depth == 0 && *lc == live_id!(tr) && in_first_row {
+                        return count;
+                    }
+                }
+                _ => {}
+            }
+        }
+        count
+    }
+
     fn handle_open_tag(
         cx: &mut Cx2d,
         tf: &mut TextFlow,
@@ -401,6 +397,34 @@ impl Html {
                 tf.new_line_collapsed(cx);
                 tf.begin_list_item(cx, marker, pad);
             }
+            some_id!(table) => {
+                tf.new_line_collapsed(cx);
+                let col_count = Self::count_table_columns(node.nodes, node.index);
+                tf.begin_table(cx, col_count);
+                trim_whitespace_in_text = TrimWhitespaceInText::Trim;
+            }
+            some_id!(thead) => {
+                tf.in_table_header = true;
+            }
+            some_id!(tbody) => {}
+            some_id!(tr) => {
+                if tf.in_table_header {
+                    tf.begin_table_header_row(cx);
+                } else {
+                    tf.begin_table_row(cx);
+                }
+                trim_whitespace_in_text = TrimWhitespaceInText::Trim;
+            }
+            some_id!(th) => {
+                tf.table_row_is_header = true;
+                tf.begin_table_cell(cx);
+                tf.bold.push();
+                trim_whitespace_in_text = TrimWhitespaceInText::Trim;
+            }
+            some_id!(td) => {
+                tf.begin_table_cell(cx);
+                trim_whitespace_in_text = TrimWhitespaceInText::Trim;
+            }
             Some(x) => return (Some(x), trim_whitespace_in_text),
             _ => (),
         }
@@ -462,6 +486,19 @@ impl Html {
             some_id!(li) => tf.end_list_item(cx),
             some_id!(u) => tf.underline.pop(),
             some_id!(del) | some_id!(s) | some_id!(strike) => tf.strikethrough.pop(),
+            some_id!(table) => tf.end_table(cx),
+            some_id!(thead) => {
+                tf.in_table_header = false;
+            }
+            some_id!(tbody) => {}
+            some_id!(tr) => {
+                tf.end_table_row(cx);
+            }
+            some_id!(th) => {
+                tf.bold.pop();
+                tf.end_table_cell(cx);
+            }
+            some_id!(td) => tf.end_table_cell(cx),
             _ => (),
         }
         None
@@ -479,6 +516,9 @@ impl Html {
             } else {
                 text
             };
+            if tf.table_num_columns > 0 && node.text_is_all_ws() {
+                return false;
+            }
             tf.draw_text(cx, text);
             true
         } else {

--- a/widgets/src/markdown.rs
+++ b/widgets/src/markdown.rs
@@ -183,50 +183,10 @@ script_mod! {
             quote_fg_color: theme.color_label_inner
             code_color: theme.color_bg_highlight
             selection_color: theme.color_selection_focus
+            table_header_bg_color: theme.color_bg_highlight
+            table_border_color: theme.color_shadow
             space_1: uniform(theme.space_1)
             space_2: uniform(theme.space_2)
-
-            pixel: fn() {
-                let sdf = Sdf2d.viewport(self.pos * self.rect_size)
-                match self.block_type {
-                    FlowBlockType.Quote => {
-                        sdf.box(0. 0. self.rect_size.x self.rect_size.y 2.)
-                        sdf.fill(self.quote_bg_color)
-                        sdf.box(self.space_1 self.space_1 self.space_1 self.rect_size.y-self.space_2 1.5)
-                        sdf.fill(self.quote_fg_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.Sep => {
-                        sdf.box(0. 1. self.rect_size.x-1. self.rect_size.y-2. 2.)
-                        sdf.fill(self.sep_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.Code => {
-                        sdf.box(0. 0. self.rect_size.x self.rect_size.y 2.)
-                        sdf.fill(self.code_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.InlineCode => {
-                        sdf.box(1. 1. self.rect_size.x-2. self.rect_size.y-2. 2.)
-                        sdf.fill(self.code_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.Underline => {
-                        sdf.box(0. self.rect_size.y-2. self.rect_size.x 2.0 0.5)
-                        sdf.fill(self.line_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.Strikethrough => {
-                        sdf.box(0. self.rect_size.y * 0.45 self.rect_size.x 2.0 0.5)
-                        sdf.fill(self.line_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.Selection => {
-                        return vec4(self.selection_color.rgb * self.selection_color.a, self.selection_color.a)
-                    }
-                }
-                return #f00
-            }
         }
 
         link := mod.widgets.MarkdownLink{}
@@ -575,29 +535,41 @@ impl Markdown {
                 MdEvent::TaskListMarker(_) => {
                     // TODO: Implement task list markers
                 }
-                MdEvent::Start(Tag::Table(_)) => {
-                    // TODO: Implement table support
+                MdEvent::Start(Tag::Table(alignments)) => {
+                    if !is_first_block {
+                        tf.new_line_collapsed_with_spacing(cx, self.paragraph_spacing);
+                    }
+                    is_first_block = false;
+                    tf.begin_table(cx, alignments.len());
                 }
                 MdEvent::End(TagEnd::Table) => {
-                    // TODO: Implement table support
+                    tf.end_table(cx);
+                    tf.new_line_collapsed_with_spacing(cx, self.paragraph_spacing);
                 }
                 MdEvent::Start(Tag::TableHead) => {
-                    // TODO: Implement table header support
+                    tf.begin_table_header_row(cx);
                 }
                 MdEvent::End(TagEnd::TableHead) => {
-                    // TODO: Implement table header support
+                    tf.end_table_row(cx);
+                    tf.in_table_header = false;
                 }
                 MdEvent::Start(Tag::TableRow) => {
-                    // TODO: Implement table row support
+                    tf.begin_table_row(cx);
                 }
                 MdEvent::End(TagEnd::TableRow) => {
-                    // TODO: Implement table row support
+                    tf.end_table_row(cx);
                 }
                 MdEvent::Start(Tag::TableCell) => {
-                    // TODO: Implement table cell support
+                    tf.begin_table_cell(cx);
+                    if tf.in_table_header {
+                        tf.bold.push();
+                    }
                 }
                 MdEvent::End(TagEnd::TableCell) => {
-                    // TODO: Implement table cell support
+                    if tf.in_table_header {
+                        tf.bold.pop();
+                    }
+                    tf.end_table_cell(cx);
                 }
                 _ => {} // Unimplemented or unnecessary events
             }

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -26,9 +26,62 @@ script_mod! {
         quote_bg_color: #222
         quote_fg_color: #aaa
         selection_color: #FF5C3966
+        table_header_bg_color: #FFFFFF22
+        table_border_color: #666
 
         space_1: uniform(4.0)
         space_2: uniform(8.0)
+
+        pixel: fn() {
+            let sdf = Sdf2d.viewport(self.pos * self.rect_size)
+            match self.block_type {
+                FlowBlockType.Quote => {
+                    sdf.box(0. 0. self.rect_size.x self.rect_size.y 2.)
+                    sdf.fill(self.quote_bg_color)
+                    sdf.box(self.space_1 self.space_1 self.space_1 self.rect_size.y-self.space_2 1.5)
+                    sdf.fill(self.quote_fg_color)
+                    return sdf.result
+                }
+                FlowBlockType.Sep => {
+                    sdf.box(0. 1. self.rect_size.x-1. self.rect_size.y-2. 2.)
+                    sdf.fill(self.sep_color)
+                    return sdf.result
+                }
+                FlowBlockType.Code => {
+                    sdf.box(0. 0. self.rect_size.x self.rect_size.y 2.)
+                    sdf.fill(self.code_color)
+                    return sdf.result
+                }
+                FlowBlockType.InlineCode => {
+                    sdf.box(1. 1. self.rect_size.x-2. self.rect_size.y-2. 2.)
+                    sdf.fill(self.code_color)
+                    return sdf.result
+                }
+                FlowBlockType.Underline => {
+                    sdf.box(0. self.rect_size.y-2. self.rect_size.x 2.0 0.5)
+                    sdf.fill(self.line_color)
+                    return sdf.result
+                }
+                FlowBlockType.Strikethrough => {
+                    sdf.box(0. self.rect_size.y * 0.45 self.rect_size.x 2.0 0.5)
+                    sdf.fill(self.line_color)
+                    return sdf.result
+                }
+                FlowBlockType.Selection => {
+                    return vec4(self.selection_color.rgb * self.selection_color.a, self.selection_color.a)
+                }
+                FlowBlockType.TableCell => {
+                    sdf.rect(0. 0. self.rect_size.x self.rect_size.y)
+                    sdf.fill(self.table_header_bg_color)
+                    sdf.rect(self.rect_size.x-1. 0. 1. self.rect_size.y)
+                    sdf.fill(self.table_border_color)
+                    sdf.rect(0. self.rect_size.y-1. self.rect_size.x 1.)
+                    sdf.fill(self.table_border_color)
+                    return sdf.result
+                }
+            }
+            return #f00
+        }
     }
 
     mod.widgets.FlowBlockType = FlowBlockType
@@ -147,6 +200,15 @@ script_mod! {
             margin: theme.mspace_v_1
         }
 
+        table_walk: Walk{width: Fill, height: Fit}
+        table_layout: Layout{flow: Flow.Down}
+        table_row_walk: Walk{width: Fill, height: Fit}
+        table_row_layout: Layout{flow: Flow.Right}
+        table_cell_layout: Layout{
+            flow: Flow.Right{wrap: true}
+            padding: Inset{left: 6, right: 6, top: 4, bottom: 4}
+        }
+
         link := mod.widgets.TextFlowLink{}
 
         draw_block +: {
@@ -156,49 +218,10 @@ script_mod! {
             quote_fg_color: theme.color_text
             code_color: theme.color_bg_highlight
             selection_color: theme.color_selection_focus
+            table_header_bg_color: theme.color_bg_highlight
+            table_border_color: theme.color_shadow
             space_1: uniform(theme.space_1)
             space_2: uniform(theme.space_2)
-            pixel: fn() {
-                let sdf = Sdf2d.viewport(self.pos * self.rect_size)
-                match self.block_type {
-                    FlowBlockType.Quote => {
-                        sdf.box(0. 0. self.rect_size.x self.rect_size.y 2.)
-                        sdf.fill(self.quote_bg_color)
-                        sdf.box(self.space_1 self.space_1 self.space_1 self.rect_size.y-self.space_2 1.5)
-                        sdf.fill(self.quote_fg_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.Sep => {
-                        sdf.box(0. 1. self.rect_size.x-1. self.rect_size.y-2. 2.)
-                        sdf.fill(self.sep_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.Code => {
-                        sdf.box(0. 0. self.rect_size.x self.rect_size.y 2.)
-                        sdf.fill(self.code_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.InlineCode => {
-                        sdf.box(1. 1. self.rect_size.x-2. self.rect_size.y-2. 2.)
-                        sdf.fill(self.code_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.Underline => {
-                        sdf.box(0. self.rect_size.y-2. self.rect_size.x 2.0 0.5)
-                        sdf.fill(self.line_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.Strikethrough => {
-                        sdf.box(0. self.rect_size.y * 0.45 self.rect_size.x 2.0 0.5)
-                        sdf.fill(self.line_color)
-                        return sdf.result
-                    }
-                    FlowBlockType.Selection => {
-                        return vec4(self.selection_color.rgb * self.selection_color.a, self.selection_color.a)
-                    }
-                }
-                return #f00
-            }
         }
     }
 }
@@ -214,6 +237,7 @@ pub enum FlowBlockType {
     Underline = 5,
     Strikethrough = 6,
     Selection = 7,
+    TableCell = 8,
 }
 
 #[derive(Script, ScriptHook)]
@@ -233,6 +257,10 @@ pub struct DrawFlowBlock {
     pub quote_fg_color: Vec4f,
     #[live]
     pub selection_color: Vec4f,
+    #[live]
+    pub table_header_bg_color: Vec4f,
+    #[live]
+    pub table_border_color: Vec4f,
     #[live]
     pub block_type: FlowBlockType,
 }
@@ -655,6 +683,26 @@ pub struct TextFlow {
     #[live(5.0)]
     list_item_marker_pad: f64,
     #[live]
+    table_walk: Walk,
+    #[live]
+    table_layout: Layout,
+    #[live]
+    table_row_walk: Walk,
+    #[live]
+    table_row_layout: Layout,
+    #[live]
+    table_cell_layout: Layout,
+    #[rust]
+    pub table_num_columns: usize,
+    #[rust]
+    pub in_table_header: bool,
+    #[rust]
+    table_row_cell_rects: Vec<Rect>,
+    #[rust]
+    pub table_row_is_header: bool,
+    #[rust]
+    table_is_first_row: bool,
+    #[live]
     pub inline_code_padding: Inset,
     #[live]
     pub inline_code_margin: Inset,
@@ -1063,6 +1111,11 @@ impl TextFlow {
         self.combine_spaces.clear();
         self.ignore_newlines.clear();
         self.first_thing_on_a_line = true;
+        self.table_num_columns = 0;
+        self.in_table_header = false;
+        self.table_row_cell_rects.clear();
+        self.table_row_is_header = false;
+        self.table_is_first_row = false;
     }
 
     pub fn push_size_rel_scale(&mut self, scale: f64) {
@@ -1377,6 +1430,105 @@ impl TextFlow {
         if self.selectable {
             self.selection_tracker.push_newline();
         }
+    }
+
+    pub fn begin_table(&mut self, cx: &mut Cx2d, num_columns: usize) {
+        self.table_num_columns = num_columns;
+        self.table_is_first_row = true;
+        cx.begin_turtle(self.table_walk, self.table_layout);
+    }
+
+    pub fn end_table(&mut self, cx: &mut Cx2d) {
+        cx.end_turtle();
+        self.table_num_columns = 0;
+        self.in_table_header = false;
+        if self.selectable {
+            self.selection_tracker.push_newline();
+        }
+    }
+
+    pub fn begin_table_header_row(&mut self, cx: &mut Cx2d) {
+        self.in_table_header = true;
+        self.table_row_is_header = true;
+        self.table_row_cell_rects.clear();
+        cx.begin_turtle(self.table_row_walk, self.table_row_layout);
+    }
+
+    pub fn begin_table_row(&mut self, cx: &mut Cx2d) {
+        self.table_row_is_header = false;
+        self.table_row_cell_rects.clear();
+        cx.begin_turtle(self.table_row_walk, self.table_row_layout);
+    }
+
+    pub fn end_table_row(&mut self, cx: &mut Cx2d) {
+        let row_rect = cx.end_turtle();
+        self.draw_row_cell_borders(cx, row_rect);
+        if self.selectable {
+            self.selection_tracker.push_newline();
+        }
+    }
+
+    /// Draw cell borders/backgrounds after the row has been laid out,
+    /// so all cells use the row's height for uniform borders.
+    fn draw_row_cell_borders(&mut self, cx: &mut Cx2d, row_rect: Rect) {
+        let row_height = row_rect.size.y;
+        let is_first_row = self.table_is_first_row;
+        let cell_count = self.table_row_cell_rects.len();
+        let saved_bg = self.draw_block.table_header_bg_color;
+        let transparent = Vec4f::default();
+        self.draw_block.block_type = FlowBlockType::TableCell;
+
+        for i in 0..cell_count {
+            let cell_rect = self.table_row_cell_rects[i];
+
+            self.draw_block.table_header_bg_color = if self.table_row_is_header {
+                saved_bg
+            } else {
+                transparent
+            };
+            self.draw_block.draw_abs(cx, Rect {
+                pos: cell_rect.pos,
+                size: dvec2(cell_rect.size.x, row_height),
+            });
+
+            if is_first_row {
+                self.draw_block.table_header_bg_color = transparent;
+                self.draw_block.draw_abs(cx, Rect {
+                    pos: cell_rect.pos,
+                    size: dvec2(cell_rect.size.x, 1.0),
+                });
+            }
+
+            if i == 0 {
+                self.draw_block.table_header_bg_color = transparent;
+                self.draw_block.draw_abs(cx, Rect {
+                    pos: cell_rect.pos,
+                    size: dvec2(1.0, row_height),
+                });
+            }
+        }
+        self.draw_block.table_header_bg_color = saved_bg;
+        self.table_is_first_row = false;
+    }
+
+    pub fn begin_table_cell(&mut self, cx: &mut Cx2d) {
+        let cell_width = if self.table_num_columns > 0 {
+            cx.turtle().inner_width() / self.table_num_columns as f64
+        } else {
+            100.0
+        };
+        let walk = Walk {
+            width: Size::Fixed(cell_width),
+            height: Size::Fit { min: None, max: None },
+            ..Walk::default()
+        };
+        cx.begin_turtle(walk, self.table_cell_layout);
+        self.first_thing_on_a_line = true;
+    }
+
+    pub fn end_table_cell(&mut self, cx: &mut Cx2d) {
+        let cell_rect = cx.end_turtle();
+        self.table_row_cell_rects.push(cell_rect);
     }
 
     pub fn draw_item_counted(&mut self, cx: &mut Cx2d, template: LiveId) -> LiveId {


### PR DESCRIPTION
Implement streaming-compatible table support in the shared TextFlow layout engine. Tables render incrementally as events arrive — no buffering needed since pulldown_cmark provides column count upfront via the header separator line.

- Add FlowBlockType::TableCell variant with SDF shader for cell borders and header backgrounds in DrawFlowBlock base definition
- Add begin/end table, row, and cell methods to TextFlow using turtle layout with equal-width column distribution
- Draw cell borders after row layout completes so all cells share the row's max height for uniform borders
- Replace 8 TODO stubs in markdown.rs with direct TextFlow calls
- Add table/thead/tbody/tr/th/td tag handling in html.rs with column counting via HtmlNode lookahead
- Skip whitespace-only text nodes inside HTML tables using the pre-computed all_ws flag

Before:
<img width="1136" height="880" alt="Screenshot 2026-04-10 at 5 04 12 pm" src="https://github.com/user-attachments/assets/0ad0b66b-9d1c-4968-beb0-97dd1a8f53dd" />


After:
<img width="1136" height="880" alt="Screenshot 2026-04-10 at 9 32 11 pm" src="https://github.com/user-attachments/assets/a7addacc-2519-44a2-adb2-aa3a9bab896a" />

An issue with rendering strikethrough text is tracked at #1033 