### PR TITLE
Avoid double-shutdown Event dispatch on WIndows

### DIFF
--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -495,7 +495,6 @@ impl Cx {
                         d3d11_windows[index].win32_window.close_window();
                         d3d11_windows.remove(index);
                         if d3d11_windows.len() == 0 {
-                            self.call_event_handler(&Event::Shutdown);
                             ret = EventFlow::Exit
                         }
                     }


### PR DESCRIPTION
Windows was issuing two shutdown events any time the window was closed, so it no longer does that. Might've been my fault in a previous change, not sure.