### PR TITLE
Windows: fix perf and flicker/stretch artifacts when resizing a window

### DIFF
--- a/platform/src/os/windows/d3d11.rs
+++ b/platform/src/os/windows/d3d11.rs
@@ -85,10 +85,10 @@ use crate::{
                         DXGI_FORMAT_R8_UNORM,
                         DXGI_SAMPLE_DESC,
                     },
-                    CreateDXGIFactory2, IDXGIFactory2, IDXGIResource, IDXGISwapChain1,
-                    DXGI_CREATE_FACTORY_FLAGS, DXGI_PRESENT, DXGI_RGBA, DXGI_SCALING_NONE,
-                    DXGI_SWAP_CHAIN_DESC1, DXGI_SWAP_CHAIN_FLAG, DXGI_SWAP_EFFECT_FLIP_DISCARD,
-                    DXGI_USAGE_RENDER_TARGET_OUTPUT,
+                    CreateDXGIFactory2, IDXGIDevice1, IDXGIFactory2, IDXGIResource,
+                    IDXGISwapChain1, DXGI_CREATE_FACTORY_FLAGS, DXGI_PRESENT, DXGI_RGBA,
+                    DXGI_SCALING, DXGI_SWAP_CHAIN_DESC1, DXGI_SWAP_CHAIN_FLAG,
+                    DXGI_SWAP_EFFECT_FLIP_DISCARD, DXGI_USAGE_RENDER_TARGET_OUTPUT,
                 },
             },
         },
@@ -650,6 +650,20 @@ fn texture_pixel_to_dx11_pixel(pix: &TexturePixel) -> DXGI_FORMAT {
     }
 }
 
+/// Calls DwmFlush to synchronize with the Desktop Window Manager compositor.
+/// This blocks until DWM has completed its current composition cycle, ensuring
+/// that a just-presented swap chain frame is picked up before the next desktop
+/// repaint. We ignore errors (e.g. DWM disabled on remote desktop sessions).
+fn dwm_flush() {
+    #[link(name = "dwmapi")]
+    extern "system" {
+        fn DwmFlush() -> i32;
+    }
+    unsafe {
+        let _ = DwmFlush();
+    }
+}
+
 pub struct D3d11Window {
     pub window_id: WindowId,
     pub is_in_resize: bool,
@@ -691,7 +705,11 @@ impl D3d11Window {
                 Count: 1,
                 Quality: 0,
             },
-            Scaling: DXGI_SCALING_NONE,
+            // Use DXGI_SCALING_STRETCH (0) instead of DXGI_SCALING_NONE (1)
+            // so that during the brief gap between a window resize and the
+            // next presented frame, DWM stretches the old content to fill
+            // the new window size rather than showing a hard edge/gap.
+            Scaling: DXGI_SCALING(0),
             Stereo: FALSE,
             SwapEffect: DXGI_SWAP_EFFECT_FLIP_DISCARD,
         };
@@ -753,7 +771,7 @@ impl D3d11Window {
                 Count: 1,
                 Quality: 0,
             },
-            Scaling: DXGI_SCALING_NONE,
+            Scaling: DXGI_SCALING(0), // DXGI_SCALING_STRETCH
             Stereo: FALSE,
             SwapEffect: DXGI_SWAP_EFFECT_FLIP_DISCARD,
         };
@@ -831,7 +849,16 @@ impl D3d11Window {
         unsafe {
             self.swap_chain
                 .Present(if vsync { 1 } else { 0 }, DXGI_PRESENT(0))
-                .unwrap()
+                .unwrap();
+
+            // During an active window resize, synchronize with the DWM
+            // compositor so the freshly-presented frame is composited
+            // before the desktop is repainted at the new window size.
+            // This is analogous to Metal's waitUntilScheduled()+present()
+            // path used on macOS during live resize.
+            if self.is_in_resize {
+                dwm_flush();
+            }
         };
     }
 }
@@ -867,6 +894,17 @@ impl D3d11Cx {
 
             let device = device.unwrap();
             let context = context.unwrap();
+
+            // Reduce DXGI frame latency from the default of 3 to 1.
+            // This minimizes the presentation queue depth so that
+            // freshly-rendered frames reach DWM sooner, which is
+            // critical during window resize to avoid rubber-banding.
+            if let Ok(dxgi_device) = device.cast::<IDXGIDevice1>() {
+                let _ = (Interface::vtable(&dxgi_device).SetMaximumFrameLatency)(
+                    Interface::as_raw(&dxgi_device),
+                    1,
+                );
+            }
 
             device
                 .CreateQuery(

--- a/platform/src/os/windows/d3d11.rs
+++ b/platform/src/os/windows/d3d11.rs
@@ -816,10 +816,10 @@ impl D3d11Window {
     pub fn sync_background_color(&self, clear_color: crate::makepad_math::Vec4f) {
         unsafe {
             let _ = self.swap_chain.SetBackgroundColor(&mut DXGI_RGBA {
-                r: clear_color.x as f32,
-                g: clear_color.y as f32,
-                b: clear_color.z as f32,
-                a: clear_color.w as f32,
+                r: clear_color.x,
+                g: clear_color.y,
+                b: clear_color.z,
+                a: clear_color.w,
             });
         }
     }
@@ -827,6 +827,11 @@ impl D3d11Window {
     pub fn resize_buffers(&mut self, d3d11_cx: &D3d11Cx) {
         if self.alloc_size == self.window_geom.inner_size {
             return;
+        }
+        let inner = self.window_geom.inner_size;
+        let dpi = self.window_geom.dpi_factor;
+        if (inner.x * dpi) < 1.0 || (inner.y * dpi) < 1.0 {
+            return; // ResizeBuffers rejects zero dimensions.
         }
         self.alloc_size = self.window_geom.inner_size;
         self.swap_texture = None;

--- a/platform/src/os/windows/d3d11.rs
+++ b/platform/src/os/windows/d3d11.rs
@@ -87,7 +87,7 @@ use crate::{
                     },
                     CreateDXGIFactory2, IDXGIDevice1, IDXGIFactory2, IDXGIResource,
                     IDXGISwapChain1, DXGI_CREATE_FACTORY_FLAGS, DXGI_PRESENT, DXGI_RGBA,
-                    DXGI_SCALING, DXGI_SWAP_CHAIN_DESC1, DXGI_SWAP_CHAIN_FLAG,
+                    DXGI_SCALING_NONE, DXGI_SWAP_CHAIN_DESC1, DXGI_SWAP_CHAIN_FLAG,
                     DXGI_SWAP_EFFECT_FLIP_DISCARD, DXGI_USAGE_RENDER_TARGET_OUTPUT,
                 },
             },
@@ -705,11 +705,7 @@ impl D3d11Window {
                 Count: 1,
                 Quality: 0,
             },
-            // Use DXGI_SCALING_STRETCH (0) instead of DXGI_SCALING_NONE (1)
-            // so that during the brief gap between a window resize and the
-            // next presented frame, DWM stretches the old content to fill
-            // the new window size rather than showing a hard edge/gap.
-            Scaling: DXGI_SCALING(0),
+            Scaling: DXGI_SCALING_NONE,
             Stereo: FALSE,
             SwapEffect: DXGI_SWAP_EFFECT_FLIP_DISCARD,
         };
@@ -771,7 +767,7 @@ impl D3d11Window {
                 Count: 1,
                 Quality: 0,
             },
-            Scaling: DXGI_SCALING(0), // DXGI_SCALING_STRETCH
+            Scaling: DXGI_SCALING_NONE,
             Stereo: FALSE,
             SwapEffect: DXGI_SWAP_EFFECT_FLIP_DISCARD,
         };
@@ -811,6 +807,21 @@ impl D3d11Window {
     pub fn stop_resize(&mut self) {
         self.is_in_resize = false;
         self.alloc_size = Vec2d::default();
+    }
+
+    /// Update the swap chain's background color to match the pass clear
+    /// color. With DXGI_SCALING_NONE, any gap between the (old-size) swap
+    /// chain buffer and the (new-size) window is filled with this color.
+    /// By matching the app's background, the gap becomes invisible.
+    pub fn sync_background_color(&self, clear_color: crate::makepad_math::Vec4f) {
+        unsafe {
+            let _ = self.swap_chain.SetBackgroundColor(&mut DXGI_RGBA {
+                r: clear_color.x as f32,
+                g: clear_color.y as f32,
+                b: clear_color.z as f32,
+                a: clear_color.w as f32,
+            });
+        }
     }
 
     pub fn resize_buffers(&mut self, d3d11_cx: &D3d11Cx) {

--- a/platform/src/os/windows/win32_app.rs
+++ b/platform/src/os/windows/win32_app.rs
@@ -43,7 +43,7 @@ use {
                     WindowsAndMessaging::{
                         DispatchMessageW, GetMessageW, IsGUIThread, IsProcessDPIAware, KillTimer,
                         LoadCursorW, LoadIconW, PeekMessageW, RegisterClassExW, SetCursor,
-                        SetTimer, ShowCursor, TranslateMessage, CS_HREDRAW, CS_OWNDC, CS_VREDRAW,
+                        SetTimer, ShowCursor, TranslateMessage, CS_OWNDC,
                         HICON, IDC_ARROW, IDC_CROSS, IDC_HAND, IDC_HELP, IDC_IBEAM, IDC_NO,
                         IDC_SIZEALL, IDC_SIZENESW, IDC_SIZENS, IDC_SIZENWSE, IDC_SIZEWE,
                         IDI_WINLOGO, PM_REMOVE, WM_QUIT, WNDCLASSEXW,
@@ -155,7 +155,7 @@ impl Win32App {
         let (hicon_big, hicon_small) = Self::create_default_icons();
         let class = WNDCLASSEXW {
             cbSize: mem::size_of::<WNDCLASSEXW>() as u32,
-            style: CS_HREDRAW | CS_VREDRAW | CS_OWNDC,
+            style: CS_OWNDC,
             lpfnWndProc: Some(Win32Window::window_class_proc),
             hInstance: unsafe { GetModuleHandleW(None).unwrap().into() },
             hIcon: hicon_big,

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -320,28 +320,6 @@ impl Win32Window {
                     return DefWindowProcW(hwnd, msg, wparam, lparam);
                 }
                 if wparam == WPARAM(1) {
-                    // When wParam is TRUE, lparam points to an NCCALCSIZE_PARAMS:
-                    //   rgrc[0]: proposed new window rect → output: new client rect
-                    //   rgrc[1]: old window rect → output: source rect for BitBlt
-                    //   rgrc[2]: old client rect → output: dest rect for BitBlt
-                    //
-                    // During resize, Windows BitBlts old client content into the
-                    // new client area using rgrc[1] (source) and rgrc[2] (dest).
-                    // This produces the "rubber-banding" effect: old pixels are
-                    // shifted/stretched to predict the new layout, then replaced
-                    // once the app redraws. By zeroing both rects and returning
-                    // WVR_VALIDRECTS, we tell Windows there is no valid old
-                    // content to copy, so it skips the BitBlt entirely.
-                    #[repr(C)]
-                    struct NcCalcSizeParams {
-                        rgrc: [RECT; 3],
-                        _lppos: *mut core::ffi::c_void,
-                    }
-                    let params = &mut *(lparam.0 as *mut NcCalcSizeParams);
-                    let zero_rect = RECT { left: 0, top: 0, right: 0, bottom: 0 };
-                    params.rgrc[1] = zero_rect;
-                    params.rgrc[2] = zero_rect;
-
                     let margins = MARGINS {
                         cxLeftWidth: 0,
                         cxRightWidth: 0,
@@ -349,8 +327,7 @@ impl Win32Window {
                         cyBottomHeight: 1,
                     };
                     DwmExtendFrameIntoClientArea(hwnd, &margins).unwrap();
-                    const WVR_VALIDRECTS: isize = 0x0400;
-                    return LRESULT(WVR_VALIDRECTS);
+                    return LRESULT(0);
                 }
             }
             WM_NCHITTEST => {
@@ -628,6 +605,14 @@ impl Win32Window {
             WM_EXITSIZEMOVE => {
                 with_win32_app(|app| app.stop_resize());
                 window.do_callback(Win32Event::WindowResizeLoopStop(window.window_id));
+            }
+            // WM_SIZING (0x0214) fires BEFORE the window is resized with
+            // the proposed new rect. By pre-rendering at this size, the
+            // swap chain frame is ready when DWM composites the window at
+            // the new size, eliminating the empty gap at growing edges.
+            0x0214 => {
+                let proposed_rect = &*(lparam.0 as *const RECT);
+                window.send_sizing_event(proposed_rect);
             }
             WM_SIZE | WM_DPICHANGED => {
                 window.send_change_event();
@@ -1142,6 +1127,40 @@ impl Win32Window {
             window_id: self.window_id,
             old_geom: old_geom,
             new_geom: new_geom,
+        }));
+        self.do_callback(Win32Event::Paint);
+    }
+
+    /// Pre-render at a proposed window size from WM_SIZING. This fires
+    /// BEFORE the window is actually resized, so the swap chain frame is
+    /// ready when DWM composites the window at the new size — eliminating
+    /// the empty-edge gap that appears when growing the window.
+    pub fn send_sizing_event(&mut self, proposed_rect: &RECT) {
+        let dpi = self.get_dpi_factor();
+        let proposed_size = Vec2d {
+            x: (proposed_rect.right - proposed_rect.left) as f64 / dpi,
+            y: (proposed_rect.bottom - proposed_rect.top) as f64 / dpi,
+        };
+
+        let mut new_geom = self.last_window_geom.clone();
+        // For custom chrome, inner size == outer size.
+        new_geom.inner_size = proposed_size;
+        new_geom.outer_size = proposed_size;
+        new_geom.position = Vec2d {
+            x: proposed_rect.left as f64,
+            y: proposed_rect.top as f64,
+        };
+
+        let old_geom = self.last_window_geom.clone();
+        if old_geom.inner_size == new_geom.inner_size {
+            return; // Size didn't change (e.g. just a move), nothing to pre-render.
+        }
+        self.last_window_geom = new_geom.clone();
+
+        self.do_callback(Win32Event::WindowGeomChange(WindowGeomChangeEvent {
+            window_id: self.window_id,
+            old_geom,
+            new_geom,
         }));
         self.do_callback(Win32Event::Paint);
     }

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -320,6 +320,28 @@ impl Win32Window {
                     return DefWindowProcW(hwnd, msg, wparam, lparam);
                 }
                 if wparam == WPARAM(1) {
+                    // When wParam is TRUE, lparam points to an NCCALCSIZE_PARAMS:
+                    //   rgrc[0]: proposed new window rect → output: new client rect
+                    //   rgrc[1]: old window rect → output: source rect for BitBlt
+                    //   rgrc[2]: old client rect → output: dest rect for BitBlt
+                    //
+                    // During resize, Windows BitBlts old client content into the
+                    // new client area using rgrc[1] (source) and rgrc[2] (dest).
+                    // This produces the "rubber-banding" effect: old pixels are
+                    // shifted/stretched to predict the new layout, then replaced
+                    // once the app redraws. By zeroing both rects and returning
+                    // WVR_VALIDRECTS, we tell Windows there is no valid old
+                    // content to copy, so it skips the BitBlt entirely.
+                    #[repr(C)]
+                    struct NcCalcSizeParams {
+                        rgrc: [RECT; 3],
+                        _lppos: *mut core::ffi::c_void,
+                    }
+                    let params = &mut *(lparam.0 as *mut NcCalcSizeParams);
+                    let zero_rect = RECT { left: 0, top: 0, right: 0, bottom: 0 };
+                    params.rgrc[1] = zero_rect;
+                    params.rgrc[2] = zero_rect;
+
                     let margins = MARGINS {
                         cxLeftWidth: 0,
                         cxRightWidth: 0,
@@ -327,7 +349,8 @@ impl Win32Window {
                         cyBottomHeight: 1,
                     };
                     DwmExtendFrameIntoClientArea(hwnd, &margins).unwrap();
-                    return LRESULT(0);
+                    const WVR_VALIDRECTS: isize = 0x0400;
+                    return LRESULT(WVR_VALIDRECTS);
                 }
             }
             WM_NCHITTEST => {

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -1155,6 +1155,10 @@ impl Win32Window {
         if old_geom.inner_size == new_geom.inner_size {
             return; // Size didn't change (e.g. just a move), nothing to pre-render.
         }
+        // Skip degenerate sizes — ResizeBuffers rejects zero dimensions.
+        if proposed_size.x < 1.0 || proposed_size.y < 1.0 {
+            return;
+        }
         self.last_window_geom = new_geom.clone();
 
         self.do_callback(Win32Event::WindowGeomChange(WindowGeomChangeEvent {

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -370,7 +370,9 @@ impl Cx {
                         d3d11_windows.iter_mut().find(|w| w.window_id == window_id)
                     {
                         //let dpi_factor = window.window_geom.dpi_factor;
-                        window.sync_background_color(self.passes[*draw_pass_id].clear_color);
+                        if window.is_in_resize {
+                            window.sync_background_color(self.passes[*draw_pass_id].clear_color);
+                        }
                         window.resize_buffers(&d3d11_cx);
                         self.draw_pass_to_window(*draw_pass_id, false, window, d3d11_cx);
                     }

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -370,6 +370,7 @@ impl Cx {
                         d3d11_windows.iter_mut().find(|w| w.window_id == window_id)
                     {
                         //let dpi_factor = window.window_geom.dpi_factor;
+                        window.sync_background_color(self.passes[*draw_pass_id].clear_color);
                         window.resize_buffers(&d3d11_cx);
                         self.draw_pass_to_window(*draw_pass_id, false, window, d3d11_cx);
                     }


### PR DESCRIPTION
I noticed that resizing the app window on Windows OS was really... harsh. Lots of flickering, especially around the edges, and content was sort of "rubber-banding" as it got shrunk or stretched to meet the size of the new window.

This fixes all of that, it looks pretty good now after about 12 back-n-forth A/B testing rounds w/ claude.

Generated summary below:

--------------------
Improve window resize responsiveness on Windows

Reduce visual artifacts (rubber-banding, edge flickering, empty gaps) during
live window resize by attacking latency at multiple levels:

**D3D11 presentation pipeline (d3d11.rs):**
- Set `IDXGIDevice1::SetMaximumFrameLatency(1)` on device init to reduce
  the DXGI presentation queue from the default 3 frames to 1, so freshly
  rendered frames reach DWM sooner.
- Call `DwmFlush()` after `Present()` when `is_in_resize` is true, forcing
  DWM to composite the new frame before repainting the desktop. This is the
  D3D11 analog of Metal's `waitUntilScheduled()`+`present()` path used on
  macOS during live resize.
- Add `sync_background_color()` to match the swap chain's background color
  to the app's pass clear color during resize, so any DXGI_SCALING_NONE gap
  blends with the app background instead of flashing gray.
- Guard `resize_buffers()` against zero physical pixel dimensions to prevent
  `ResizeBuffers` panics when the window is collapsed.

**Pre-render during WM_SIZING (win32_window.rs):**
- Handle `WM_SIZING` (0x0214) to pre-render at the proposed window size
  *before* Windows commits the resize. This ensures the swap chain frame is
  already at the new size when DWM composites, eliminating the empty-edge
  gap that appears when growing the window.
- Guard against degenerate (< 1px) proposed sizes.

**Window class style (win32_app.rs):**
- Remove `CS_HREDRAW | CS_VREDRAW` from the window class style. These flags
  caused Windows to invalidate the entire client area on every resize step,
  making DWM discard all old content. Without them, DWM preserves old content
  in non-resized areas, significantly reducing flicker.
