### PR TITLE
set surface_alive=true at startup

### DIFF
--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -1740,6 +1740,7 @@ impl Cx {
 
             //cx.maybe_warn_hardware_support();
 
+            cx.os.surface_alive = true;
             cx.os.display = Some(CxAndroidDisplay {
                 libegl,
                 libgl,


### PR DESCRIPTION
Recent patch introduces surface_alive state, but it seems not set at startup.

This patch simply set it, but there may be more suitable way(I don't understand whole codes).
