### PR TITLE
Fix Metal backend shift overflow panic on 64-bit systems

### DIFF
--- a/libs/voice/src/metal/backend.rs
+++ b/libs/voice/src/metal/backend.rs
@@ -3755,7 +3755,7 @@ mod imp {
             let n_head_log2 = if n_head <= 1 {
                 1i32
             } else {
-                let p = (usize::BITS - 1) - (n_head as u32).leading_zeros();
+                let p = (u32::BITS - 1) - (n_head as u32).leading_zeros();
                 (1u32 << p) as i32
             };
             let m0 = (2.0f32).powf(-(max_bias) / (n_head_log2 as f32));
@@ -4095,7 +4095,7 @@ mod imp {
             let n_head_log2 = if n_head <= 1 {
                 1i32
             } else {
-                let p = (usize::BITS - 1) - (n_head as u32).leading_zeros();
+                let p = (u32::BITS - 1) - (n_head as u32).leading_zeros();
                 (1u32 << p) as i32
             };
             let m0 = (2.0f32).powf(-(max_bias) / (n_head_log2 as f32));


### PR DESCRIPTION
## Summary                                                                                                                          
                                                                                                                                      
  - Fix shift overflow panic in Metal voice backend on 64-bit macOS systems                                                           
  - Changed `usize::BITS` to `u32::BITS` when calculating `n_head_log2` for flash attention                                           
                                                                                                                                      
  ## Problem                                                                                                                          
                                                                                                                                      
  On 64-bit systems, `usize::BITS` is 64, but the value is cast to `u32` for `leading_zeros()`. This causes the subtraction to produce
   a value > 31, leading to shift overflow when computing `1u32 << p`.                                                                
                                                                                                                                      
  ## Error                                                                                                                            
                                                                                                                                      
  thread '' panicked at libs/voice/src/metal/backend.rs:3759:17:                                                                      
  attempt to shift left with overflow                                                                                                 
  stack backtrace:                                                                                                                    
     3: core::panicking::panic_const::panic_const_shl_overflow                                                                        
     4: makepad_voice::metal_backend::imp::MetalContext::dispatch_flash_attn_ext_f32                                                  
               at ./libs/voice/src/metal/backend.rs:3759:17                                                                           
                                                                                                                                      
  ## Fix                                                                                                                              
                                                                                                                                      
  Changed from:                                                                                                                       
  ```rust                                                                                                                             
  let p = (usize::BITS - 1) - (n_head as u32).leading_zeros();                                                                        
                                                                                                                                      
  To:                                                                                                                                 
  let p = (u32::BITS - 1) - (n_head as u32).leading_zeros();                                                                          
                                                                                                                                      
  Test plan                                                                                                                           
                                                                                                                                      
  - Tested voice transcription on macOS ARM64                                                                                         
  - Verified Metal backend initializes without panic                                                                                  
  - Confirmed transcription produces correct output