### PR TITLE
draw/text: treat fallback font families as complete for the text-specific subset they actually need

### DIFF
--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -900,13 +900,23 @@ impl FontFamily {
         (self.id.0).into()
     }
 
+    fn required_font_ids_for_text(&self, cx: &Cx, text: Option<&str>) -> Vec<FontId> {
+        self.members
+            .iter()
+            .filter(|member| font_member_is_needed_for_text(cx, member.handle, text))
+            .map(font_member_font_id)
+            .collect()
+    }
+
     fn update_font_definitions(&self, cx: &mut Cx, fonts: &mut Fonts, text: Option<&str>) {
         let mut font_ids = Vec::new();
+        let mut expected_member_count = 0;
 
         for member in &self.members {
             if !font_member_is_needed_for_text(cx, member.handle, text) {
                 continue;
             }
+            expected_member_count += 1;
             let font_id = font_member_font_id(member);
 
             if !fonts.is_font_known(font_id) {
@@ -936,7 +946,7 @@ impl FontFamily {
             self.to_font_family_id(),
             FontFamilyDefinition {
                 font_ids,
-                expected_member_count: self.members.len(),
+                expected_member_count,
             },
         );
     }
@@ -945,11 +955,12 @@ impl FontFamily {
         CxDraw::lazy_construct_fonts(cx);
 
         let family_id = self.to_font_family_id();
+        let required_font_ids = self.required_font_ids_for_text(cx, text);
         let fonts = cx.get_global::<Rc<RefCell<Fonts>>>().clone();
 
         {
             let fonts_ref = fonts.borrow();
-            if fonts_ref.is_font_family_complete(family_id) {
+            if fonts_ref.font_family_covers(family_id, &required_font_ids) {
                 return;
             }
         }
@@ -963,7 +974,7 @@ impl FontFamily {
         }
         {
             let fonts_ref = fonts.borrow();
-            if fonts_ref.is_font_family_complete(family_id) {
+            if fonts_ref.font_family_covers(family_id, &required_font_ids) {
                 return;
             }
         }

--- a/draw/src/text/fonts.rs
+++ b/draw/src/text/fonts.rs
@@ -117,6 +117,19 @@ impl Fonts {
             .unwrap_or(false)
     }
 
+    pub fn font_family_covers(&self, id: FontFamilyId, required_font_ids: &[FontId]) -> bool {
+        self.layouter
+            .loader
+            .font_family_definitions
+            .get(&id)
+            .map(|definition| {
+                required_font_ids
+                    .iter()
+                    .all(|font_id| definition.font_ids.contains(font_id))
+            })
+            .unwrap_or(required_font_ids.is_empty())
+    }
+
     pub fn is_font_known(&self, id: FontId) -> bool {
         self.layouter.is_font_known(id)
     }


### PR DESCRIPTION
## Summary

Fixes unnecessary text layouter cache invalidation when a `FontFamily` has conditional fallback members (e.g. CJK/emoji) but the current text only needs a subset.

Previously, `ensure_fonts_loaded_for_text(...)` could keep treating a family as incomplete unless all configured members were present, even when only a subset was required for the current text. That could repeatedly call `set_font_family_definition(...)`, which clears layouter caches.

## What changed

- Added `Fonts::font_family_covers(...)` in `draw/src/text/fonts.rs`
  - checks whether a family definition covers the required font ids for the current text
- In `draw/src/shader/draw_text.rs`:
  - added `required_font_ids_for_text(...)`
  - `ensure_fonts_loaded_for_text(...)` now uses `font_family_covers(...)` for fast-path readiness checks
  - `update_font_definitions(...)` now sets `expected_member_count` to the number of members actually needed for the current text subset

## Why this helps

This avoids repeated family redefinition / layouter cache clears for text that only needs part of a fallback family, while preserving behavior for text that does require additional fallback members.



