### PR TITLE
Switch to SLUG/DrawGlyph font drawing stack

### DIFF
--- a/draw/src/shader/draw_glyph.rs
+++ b/draw/src/shader/draw_glyph.rs
@@ -113,7 +113,7 @@ script_mod! {
                 (col + 0.5) / tex_size.x,
                 (row + 0.5) / tex_size.y
             )
-            return self.curve_texture.sample(uv)
+            return self.curve_texture.sample_nearest(uv)
         }
 
         fetch_band_texel: fn(texel_idx: float) -> vec4 {
@@ -124,7 +124,7 @@ script_mod! {
                 (col + 0.5) / tex_size.x,
                 (row + 0.5) / tex_size.y
             )
-            return self.band_texture.sample(uv)
+            return self.band_texture.sample_nearest(uv)
         }
 
         pick_channel: fn(v: vec4, channel: float) -> float {

--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -28,9 +28,9 @@ use {
     },
 };
 
-#[cfg(target_os = "linux")]
-fn register_draw_text_linux_slug(vm: &mut ScriptVm) {
-    let slug_shader = DrawTextLinuxSlug::script_shader(vm);
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+fn register_draw_text_slug(vm: &mut ScriptVm) {
+    let slug_shader = DrawTextSlug::script_shader(vm);
     let script_mod = script! {
         use mod.pod.*
         use mod.math.*
@@ -527,7 +527,7 @@ fn register_draw_text_linux_slug(vm: &mut ScriptVm) {
     vm.eval(script_mod);
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 script_mod! {
     use mod.pod.*
     use mod.math.*
@@ -679,7 +679,7 @@ script_mod! {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 script_mod! {
     use mod.pod.*
     use mod.math.*
@@ -1268,18 +1268,18 @@ pub struct DrawText {
     pending_slug_flush_generation: u64,
     #[rust]
     slug_flush_defer_depth: u64,
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     #[rust]
-    slug_draw: Option<DrawTextLinuxSlug>,
-    #[cfg(target_os = "linux")]
+    slug_draw: Option<DrawTextSlug>,
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     #[rust]
-    linux_slug_promotion: LinuxSlugPromotionState,
-    #[cfg(target_os = "linux")]
+    slug_promotion: SlugPromotionState,
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     #[rust]
-    linux_slug_sync_plan: LinuxSlugDrawSyncPlan,
-    #[cfg(target_os = "linux")]
+    slug_sync_plan: SlugDrawSyncPlan,
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     #[rust]
-    linux_slug_layout_pad: u64,
+    slug_layout_pad: u64,
     #[live]
     pub text_style: TextStyle,
     #[live(1.0)]
@@ -1350,10 +1350,10 @@ pub struct DrawText {
     pub stem_darken_max: f32,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 #[derive(Script, ScriptHook)]
 #[repr(C)]
-struct DrawTextLinuxSlug {
+struct DrawTextSlug {
     #[rust]
     many_instances: Option<ManyInstances>,
     #[deref]
@@ -1402,36 +1402,36 @@ enum ResolvedGlyph {
     Slug(crate::text::slug_atlas::SlugGlyphInfo),
 }
 
-#[cfg(target_os = "linux")]
-const LINUX_SLUG_HELPER_BUILDS_PER_REDRAW: usize = 1;
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+const SLUG_HELPER_BUILDS_PER_REDRAW: usize = 1;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 #[derive(Default)]
-struct LinuxSlugHelperWarmupState {
+struct SlugHelperWarmupState {
     redraw_id: u64,
     builds_this_redraw: usize,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 #[derive(Default)]
-struct LinuxSlugHelperPrewarmState {
+struct SlugHelperPrewarmState {
     registered: bool,
     initialized: bool,
     requested_redraw_id: u64,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 #[derive(Default)]
-struct LinuxSlugPromotionState {
+struct SlugPromotionState {
     redraw_id: u64,
     saw_slug_candidates_this_redraw: bool,
     saw_unready_this_redraw: bool,
     allow_slug_this_redraw: bool,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 #[derive(Default)]
-struct LinuxSlugDrawSyncPlan {
+struct SlugDrawSyncPlan {
     source_shader_id: Option<usize>,
     target_shader_id: Option<usize>,
     instance_ids: Vec<LiveId>,
@@ -1439,8 +1439,8 @@ struct LinuxSlugDrawSyncPlan {
     source_has_color_2: bool,
 }
 
-#[cfg(target_os = "linux")]
-impl LinuxSlugDrawSyncPlan {
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+impl SlugDrawSyncPlan {
     fn ensure(
         &mut self,
         cx: &Cx,
@@ -1526,25 +1526,25 @@ impl LinuxSlugDrawSyncPlan {
     }
 }
 
-#[cfg(target_os = "linux")]
-fn linux_slug_try_consume_helper_build_budget(cx: &mut Cx) -> bool {
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+fn slug_try_consume_helper_build_budget(cx: &mut Cx) -> bool {
     let redraw_id = cx.redraw_id;
-    let state = cx.global::<LinuxSlugHelperWarmupState>();
+    let state = cx.global::<SlugHelperWarmupState>();
     if state.redraw_id != redraw_id {
         state.redraw_id = redraw_id;
         state.builds_this_redraw = 0;
     }
-    if state.builds_this_redraw >= LINUX_SLUG_HELPER_BUILDS_PER_REDRAW {
+    if state.builds_this_redraw >= SLUG_HELPER_BUILDS_PER_REDRAW {
         return false;
     }
     state.builds_this_redraw += 1;
     true
 }
 
-#[cfg(target_os = "linux")]
-fn linux_slug_register_helper_if_needed(cx: &mut Cx) {
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+fn slug_register_helper_if_needed(cx: &mut Cx) {
     let should_register = {
-        let state = cx.global::<LinuxSlugHelperPrewarmState>();
+        let state = cx.global::<SlugHelperPrewarmState>();
         if state.registered {
             false
         } else {
@@ -1553,12 +1553,12 @@ fn linux_slug_register_helper_if_needed(cx: &mut Cx) {
         }
     };
     if should_register {
-        cx.with_vm(register_draw_text_linux_slug);
+        cx.with_vm(register_draw_text_slug);
     }
 }
 
-#[cfg(target_os = "linux")]
-fn linux_slug_maybe_prewarm_helper(cx: &mut Cx2d) -> bool {
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+fn slug_maybe_prewarm_helper(cx: &mut Cx2d) -> bool {
     enum PrewarmAction {
         Ready,
         RequestFollowupRedraw,
@@ -1567,7 +1567,7 @@ fn linux_slug_maybe_prewarm_helper(cx: &mut Cx2d) -> bool {
 
     let redraw_id = cx.cx.redraw_id;
     let action = {
-        let state = cx.cx.global::<LinuxSlugHelperPrewarmState>();
+        let state = cx.cx.global::<SlugHelperPrewarmState>();
         if state.initialized {
             PrewarmAction::Ready
         } else if state.requested_redraw_id == 0 {
@@ -1589,20 +1589,20 @@ fn linux_slug_maybe_prewarm_helper(cx: &mut Cx2d) -> bool {
             false
         }
         PrewarmAction::TryPrewarm => {
-            if !linux_slug_try_consume_helper_build_budget(cx.cx) {
+            if !slug_try_consume_helper_build_budget(cx.cx) {
                 cx.redraw_all();
                 return false;
             }
-            linux_slug_register_helper_if_needed(cx.cx);
+            slug_register_helper_if_needed(cx.cx);
             {
-                let state = cx.cx.global::<LinuxSlugHelperPrewarmState>();
+                let state = cx.cx.global::<SlugHelperPrewarmState>();
                 if state.initialized {
                     return true;
                 }
                 state.initialized = true;
             }
             cx.cx.with_vm(|vm| {
-                let _ = DrawTextLinuxSlug::script_new_with_default(vm);
+                let _ = DrawTextSlug::script_new_with_default(vm);
             });
             cx.redraw_all();
             false
@@ -1610,23 +1610,23 @@ fn linux_slug_maybe_prewarm_helper(cx: &mut Cx2d) -> bool {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 impl DrawText {
-    fn linux_slug_run_is_ready(&mut self, cx: &mut Cx2d, text: &LaidoutText) -> bool {
+    fn slug_run_is_ready(&mut self, cx: &mut Cx2d, text: &LaidoutText) -> bool {
         let dpi_factor = cx.current_dpi_factor() as f32;
         let redraw_id = cx.cx.redraw_id;
         let mut has_slug_candidates = false;
         let mut all_slug_candidates_ready = true;
         let mut pending_slug_generation = 0;
 
-        if self.linux_slug_promotion.redraw_id != redraw_id {
-            self.linux_slug_promotion.allow_slug_this_redraw =
-                self.linux_slug_promotion.redraw_id != 0
-                    && self.linux_slug_promotion.saw_slug_candidates_this_redraw
-                    && !self.linux_slug_promotion.saw_unready_this_redraw;
-            self.linux_slug_promotion.redraw_id = redraw_id;
-            self.linux_slug_promotion.saw_slug_candidates_this_redraw = false;
-            self.linux_slug_promotion.saw_unready_this_redraw = false;
+        if self.slug_promotion.redraw_id != redraw_id {
+            self.slug_promotion.allow_slug_this_redraw =
+                self.slug_promotion.redraw_id != 0
+                    && self.slug_promotion.saw_slug_candidates_this_redraw
+                    && !self.slug_promotion.saw_unready_this_redraw;
+            self.slug_promotion.redraw_id = redraw_id;
+            self.slug_promotion.saw_slug_candidates_this_redraw = false;
+            self.slug_promotion.saw_unready_this_redraw = false;
         }
 
         for row in &text.rows {
@@ -1671,26 +1671,26 @@ impl DrawText {
             return false;
         }
 
-        self.linux_slug_promotion.saw_slug_candidates_this_redraw = true;
+        self.slug_promotion.saw_slug_candidates_this_redraw = true;
 
         if !all_slug_candidates_ready {
-            self.linux_slug_promotion.saw_unready_this_redraw = true;
+            self.slug_promotion.saw_unready_this_redraw = true;
             cx.redraw_all();
             return false;
         }
 
-        if !linux_slug_maybe_prewarm_helper(cx) {
-            self.linux_slug_promotion.saw_unready_this_redraw = true;
+        if !slug_maybe_prewarm_helper(cx) {
+            self.slug_promotion.saw_unready_this_redraw = true;
             return false;
         }
 
-        if !self.ensure_linux_slug_draw(cx) {
-            self.linux_slug_promotion.saw_unready_this_redraw = true;
+        if !self.ensure_slug_draw(cx) {
+            self.slug_promotion.saw_unready_this_redraw = true;
             cx.redraw_all();
             return false;
         }
 
-        if !self.linux_slug_promotion.allow_slug_this_redraw {
+        if !self.slug_promotion.allow_slug_this_redraw {
             cx.redraw_all();
             return false;
         }
@@ -1699,7 +1699,7 @@ impl DrawText {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 impl ScriptHook for DrawText {
     fn on_after_apply(
         &mut self,
@@ -1710,13 +1710,13 @@ impl ScriptHook for DrawText {
     ) {
         if apply.is_from_script() {
             self.slug_draw = None;
-            self.linux_slug_promotion = Default::default();
-            self.linux_slug_sync_plan = Default::default();
+            self.slug_promotion = Default::default();
+            self.slug_sync_plan = Default::default();
         }
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 impl ScriptHook for DrawText {}
 
 #[derive(Clone, Debug)]
@@ -1736,8 +1736,8 @@ pub struct PreparedTextRun {
     pub glyphs: Vec<PreparedTextGlyph>,
 }
 
-#[cfg(target_os = "linux")]
-impl DrawTextLinuxSlug {
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+impl DrawTextSlug {
     fn has_open_batch(&self) -> bool {
         self.many_instances.is_some()
     }
@@ -1896,8 +1896,8 @@ impl DrawTextLinuxSlug {
 }
 
 impl DrawText {
-    #[cfg(target_os = "linux")]
-    fn linux_slug_draw_is_ready(&self, cx: &mut Cx2d) -> bool {
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    fn slug_draw_is_ready(&self, cx: &mut Cx2d) -> bool {
         let Some(shader_id) = self
             .slug_draw
             .as_ref()
@@ -1908,18 +1908,18 @@ impl DrawText {
         cx.cx.is_draw_shader_window_ready(shader_id)
     }
 
-    #[cfg(target_os = "linux")]
-    fn ensure_linux_slug_draw(&mut self, cx: &mut Cx2d) -> bool {
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    fn ensure_slug_draw(&mut self, cx: &mut Cx2d) -> bool {
         if self.slug_draw.is_some() {
-            self.sync_linux_slug_draw_state(cx);
-            return self.linux_slug_draw_is_ready(cx);
+            self.sync_slug_draw_state(cx);
+            return self.slug_draw_is_ready(cx);
         }
 
-        linux_slug_register_helper_if_needed(cx.cx);
+        slug_register_helper_if_needed(cx.cx);
         let mut created = None;
 
         cx.cx.with_vm(|vm| {
-            let slug_draw = DrawTextLinuxSlug::script_new_with_default(vm);
+            let slug_draw = DrawTextSlug::script_new_with_default(vm);
             created = Some(slug_draw);
         });
 
@@ -1928,14 +1928,14 @@ impl DrawText {
             if let Some(slug_draw) = self.slug_draw.as_mut() {
                 slug_draw.draw_vars.options = self.draw_vars.options.clone();
             }
-            self.sync_linux_slug_draw_state(cx);
-            return self.linux_slug_draw_is_ready(cx);
+            self.sync_slug_draw_state(cx);
+            return self.slug_draw_is_ready(cx);
         }
         false
     }
 
-    #[cfg(target_os = "linux")]
-    fn sync_linux_slug_draw_state(&mut self, cx: &mut Cx2d) {
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    fn sync_slug_draw_state(&mut self, cx: &mut Cx2d) {
         let Some(source_shader_id) = self.draw_vars.draw_shader_id else {
             return;
         };
@@ -1946,27 +1946,27 @@ impl DrawText {
         else {
             return;
         };
-        self.linux_slug_sync_plan
+        self.slug_sync_plan
             .ensure(cx.cx, source_shader_id.index, target_shader_id.index);
         let Some(slug_draw) = self.slug_draw.as_mut() else {
             return;
         };
         slug_draw.draw_vars.options = self.draw_vars.options.clone();
 
-        for &id in &self.linux_slug_sync_plan.instance_ids {
+        for &id in &self.slug_sync_plan.instance_ids {
             let mut value = [0.0; 4];
             self.draw_vars.get_instance(cx.cx, id, &mut value);
             slug_draw.draw_vars.set_dyn_instance(cx.cx, id, &value);
         }
 
-        for &id in &self.linux_slug_sync_plan.uniform_ids {
+        for &id in &self.slug_sync_plan.uniform_ids {
             let mut value = [0.0; 4];
             self.draw_vars.get_uniform(cx.cx, id, &mut value);
             slug_draw.draw_vars.set_uniform(cx.cx, id, &value);
         }
 
         let mut color_2 = [-1.0; 4];
-        if self.linux_slug_sync_plan.source_has_color_2 {
+        if self.slug_sync_plan.source_has_color_2 {
             self.draw_vars.get_uniform(cx.cx, live_id!(color_2), &mut color_2);
         }
         slug_draw.draw_vars.set_uniform(
@@ -1994,7 +1994,7 @@ impl DrawText {
             self.flush_slug_textures_if_allowed(cx);
             self.finish_many_instances(cx, instances);
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "windows"))]
         if let Some(mut slug_draw) = self.slug_draw.take() {
             slug_draw.end_many_instances(cx, self.extend_area);
             self.slug_draw = Some(slug_draw);
@@ -2356,17 +2356,17 @@ impl DrawText {
     }
 
     fn draw_text(&mut self, cx: &mut Cx2d, origin_in_lpxs: Point<f32>, text: &LaidoutText) {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "windows"))]
         {
             self.update_draw_vars(cx);
             self.glyph_depth = self.draw_depth;
-            let use_linux_slug_this_frame = self.linux_slug_run_is_ready(cx, text);
+            let use_slug_this_frame = self.slug_run_is_ready(cx, text);
             let slug_area_was_empty = self
                 .slug_draw
                 .as_ref()
                 .map(|slug_draw| slug_draw.draw_vars.area.is_empty())
                 .unwrap_or(true);
-            let shadow_slug_this_frame = use_linux_slug_this_frame && slug_area_was_empty;
+            let shadow_slug_this_frame = use_slug_this_frame && slug_area_was_empty;
 
             let mut raster_instances = None::<ManyInstances>;
             let mut drew_raster_this_frame = false;
@@ -2383,12 +2383,12 @@ impl DrawText {
                             + glyph.offset_in_lpxs() * self.font_scale,
                         row_origin.y + glyph.origin_in_lpxs.y * self.font_scale,
                     );
-                    if !use_linux_slug_this_frame {
+                    if !use_slug_this_frame {
                         if raster_instances.is_none() {
                             raster_instances = cx.begin_many_aligned_instances(&self.draw_vars);
                         }
                         if let Some(instances) = raster_instances.as_mut() {
-                            drew_raster_this_frame |= self.draw_linux_raster_fallback_glyph(
+                            drew_raster_this_frame |= self.draw_slug_raster_fallback_glyph(
                                 cx,
                                 glyph_origin,
                                 glyph,
@@ -2401,11 +2401,11 @@ impl DrawText {
                         Some(ResolvedGlyph::Slug(slug_glyph)) => {
                             let mut drew_slug = false;
                             let mut needs_raster_fallback = shadow_slug_this_frame;
-                            if self.ensure_linux_slug_draw(cx) {
+                            if self.ensure_slug_draw(cx) {
                                 if let Some(instances) = raster_instances.take() {
                                     self.finish_many_instances(cx, instances);
                                 }
-                                self.sync_linux_slug_draw_state(cx);
+                                self.sync_slug_draw_state(cx);
                                 if let Some(mut slug_draw) = self.slug_draw.take() {
                                     if slug_draw.begin_many_instances(
                                         cx,
@@ -2437,7 +2437,7 @@ impl DrawText {
                                         cx.begin_many_aligned_instances(&self.draw_vars);
                                 }
                                 if let Some(instances) = raster_instances.as_mut() {
-                                    drew_raster_this_frame |= self.draw_linux_raster_fallback_glyph(
+                                    drew_raster_this_frame |= self.draw_slug_raster_fallback_glyph(
                                         cx,
                                         glyph_origin,
                                         glyph,
@@ -2507,7 +2507,7 @@ impl DrawText {
             return;
         }
 
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
         {
             self.update_draw_vars(cx);
             if let Some(mut instances) = self.many_instances.take() {
@@ -2541,19 +2541,19 @@ impl DrawText {
     }
 
     fn flush_slug_textures_if_allowed(&mut self, cx: &mut Cx2d) {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "windows"))]
         let _ = cx;
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "windows"))]
         return;
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
         if self.slug_flush_defer_depth != 0 {
             return;
         }
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
         self.flush_slug_textures_if_needed(cx);
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
     fn flush_slug_textures_if_needed(&mut self, cx: &mut Cx2d) {
         if self.pending_slug_flush_generation == 0 {
             return;
@@ -2589,7 +2589,7 @@ impl DrawText {
         self.draw_vars.texture_slots[0] = Some(fonts.grayscale_texture().clone());
         self.draw_vars.texture_slots[1] = Some(fonts.color_texture().clone());
         self.draw_vars.texture_slots[2] = Some(fonts.msdf_texture().clone());
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
         {
             self.draw_vars.texture_slots[3] = Some(fonts.slug_curve_texture().clone());
             self.draw_vars.texture_slots[4] = Some(fonts.slug_band_texture().clone());
@@ -2666,7 +2666,7 @@ impl DrawText {
         cx.cx.debug.area(area, vec4(0.0, 0.0, 1.0, 1.0));
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
     fn draw_row(
         &mut self,
         cx: &mut Cx2d,
@@ -2698,7 +2698,7 @@ impl DrawText {
                 SlugGlyphCacheResult::Ready(slug_glyph) => {
                     return Some(ResolvedGlyph::Slug(slug_glyph));
                 }
-                #[cfg(target_os = "linux")]
+                #[cfg(any(target_os = "linux", target_os = "windows"))]
                 SlugGlyphCacheResult::NeedsUpload {
                     generation,
                     glyph: _,
@@ -2707,7 +2707,7 @@ impl DrawText {
                         self.pending_slug_flush_generation.max(generation);
                     cx.redraw_all();
                 }
-                #[cfg(not(target_os = "linux"))]
+                #[cfg(not(any(target_os = "linux", target_os = "windows")))]
                 SlugGlyphCacheResult::NeedsUpload {
                     generation,
                     glyph: slug_glyph,
@@ -2728,7 +2728,7 @@ impl DrawText {
             .map(ResolvedGlyph::Raster)
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
     fn draw_glyph(
         &mut self,
         cx: &mut Cx2d,
@@ -2764,7 +2764,7 @@ impl DrawText {
         }
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
     fn draw_slug_glyph(
         &mut self,
         cx: &mut Cx2d,
@@ -2814,8 +2814,8 @@ impl DrawText {
         self.char_index += 1.0;
     }
 
-    #[cfg(target_os = "linux")]
-    fn draw_linux_raster_fallback_glyph(
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    fn draw_slug_raster_fallback_glyph(
         &mut self,
         cx: &mut Cx2d,
         origin_in_lpxs: Point<f32>,
@@ -2933,7 +2933,7 @@ impl DrawText {
     pub fn set_total_chars(&mut self, cx: &mut Cx, total: f32) {
         self.draw_vars
             .set_instance_on_area(cx, live_id!(total_chars), &[total]);
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "windows"))]
         if let Some(slug_draw) = self.slug_draw.as_mut() {
             slug_draw
                 .draw_vars
@@ -2943,7 +2943,7 @@ impl DrawText {
 
     pub fn redraw_areas(&self, cx: &mut Cx) {
         self.draw_vars.area.redraw(cx);
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "windows"))]
         if let Some(slug_draw) = self.slug_draw.as_ref() {
             slug_draw.draw_vars.area.redraw(cx);
         }
@@ -2963,7 +2963,7 @@ impl DrawText {
     }
 
     pub fn get_aa_pad_px(&self, cx: &mut Cx) -> f32 {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "windows"))]
         if let Some(slug_draw) = self.slug_draw.as_ref() {
             let mut value = [0.0];
             slug_draw
@@ -3273,11 +3273,11 @@ impl ScriptHook for FontFamily {
 #[cfg(test)]
 mod tests {
     use super::DrawText;
-    #[cfg(target_os = "linux")]
-    use super::{register_draw_text_linux_slug, DrawTextLinuxSlug};
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    use super::{register_draw_text_slug, DrawTextSlug};
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     use crate::makepad_platform::{live_id, LiveId, ScriptNew, ScriptVmCx};
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     use crate::makepad_platform::{vec4, Cx};
 
     #[test]
@@ -3285,14 +3285,14 @@ mod tests {
         assert_eq!(std::mem::size_of::<DrawText>() % 16, 0);
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     fn read_instance(draw_vars: &super::DrawVars, cx: &mut Cx, id: LiveId) -> [f32; 4] {
         let mut value = [0.0; 4];
         draw_vars.get_instance(cx, id, &mut value);
         value
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     #[test]
     fn draw_text_color_is_visible_through_instance_slice() {
         let mut cx = Cx::new(Box::new(|_, _| {}));
@@ -3309,15 +3309,15 @@ mod tests {
         });
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     #[test]
-    fn linux_slug_helper_color_is_visible_through_instance_slice() {
+    fn slug_helper_color_is_visible_through_instance_slice() {
         let mut cx = Cx::new(Box::new(|_, _| {}));
         cx.with_vm(|vm| {
             crate::script_mod(vm);
-            register_draw_text_linux_slug(vm);
+            register_draw_text_slug(vm);
 
-            let mut slug_draw = DrawTextLinuxSlug::script_new_with_default(vm);
+            let mut slug_draw = DrawTextSlug::script_new_with_default(vm);
             slug_draw.color = vec4(0.15, 0.25, 0.35, 0.45);
 
             let packed = vm.with_cx_mut(|cx| {

--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -1632,6 +1632,9 @@ impl DrawText {
         for row in &text.rows {
             for glyph in &row.glyphs {
                 let font_size_in_dpxs = glyph.font_size_in_lpxs * dpi_factor;
+                if glyph.font.has_glyph_raster_image(glyph.id, font_size_in_dpxs) {
+                    continue;
+                }
                 if !cx.fonts.borrow().should_use_slug_glyph(font_size_in_dpxs) {
                     continue;
                 }
@@ -2684,7 +2687,8 @@ impl DrawText {
 
     fn resolve_glyph(&mut self, cx: &mut Cx2d, glyph: &LaidoutGlyph) -> Option<ResolvedGlyph> {
         let font_size_in_dpxs = glyph.font_size_in_lpxs * cx.current_dpi_factor() as f32;
-        if cx.fonts.borrow().should_use_slug_glyph(font_size_in_dpxs) {
+        let glyph_prefers_raster_image = glyph.font.has_glyph_raster_image(glyph.id, font_size_in_dpxs);
+        if !glyph_prefers_raster_image && cx.fonts.borrow().should_use_slug_glyph(font_size_in_dpxs) {
             let slug_lookup = {
                 let mut fonts = cx.fonts.borrow_mut();
                 fonts.get_or_cache_slug_glyph(cx.cx.redraw_id, glyph.font.as_ref(), glyph.id)

--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -237,6 +237,26 @@ script_mod! {
             return v.w
         }
 
+        slug_curve_offset: fn() -> float {
+            return self.t_min.x
+        }
+
+        slug_curve_count: fn() -> float {
+            return self.t_min.y
+        }
+
+        slug_band_offset: fn() -> float {
+            return self.t_max.x
+        }
+
+        slug_band_count: fn() -> float {
+            return self.t_max.y
+        }
+
+        slug_fill_flags: fn() -> float {
+            return self.atlas_plane
+        }
+
         calc_root_code: fn(y1: float, y2: float, y3: float) -> u32 {
             let i1 = asuint(y1) >> u32(31)
             let i2 = asuint(y2) >> u32(30)
@@ -359,7 +379,7 @@ script_mod! {
         }
 
         scan_horizontal_all: fn(sample: vec2, px_size: float) -> vec2 {
-            let limit = floor(self.curve_count + 0.5)
+            let limit = floor(self.slug_curve_count() + 0.5)
             var coverage = 0.0
             var weight = 0.0
 
@@ -367,7 +387,7 @@ script_mod! {
             loop {
                 if i >= limit { break }
 
-                let curve_idx = self.curve_offset + i
+                let curve_idx = self.slug_curve_offset() + i
                 let p12 = self.fetch_curve_texel(curve_idx * 2.0) - vec4(sample.x, sample.y, sample.x, sample.y)
                 let p3 = self.fetch_curve_texel(curve_idx * 2.0 + 1.0).xy - sample
                 let code = self.calc_root_code(p12.y, p12.w, p3.y)
@@ -390,7 +410,7 @@ script_mod! {
         }
 
         scan_vertical_all: fn(sample: vec2, px_size: float) -> vec2 {
-            let limit = floor(self.curve_count + 0.5)
+            let limit = floor(self.slug_curve_count() + 0.5)
             var coverage = 0.0
             var weight = 0.0
 
@@ -398,7 +418,7 @@ script_mod! {
             loop {
                 if i >= limit { break }
 
-                let curve_idx = self.curve_offset + i
+                let curve_idx = self.slug_curve_offset() + i
                 let p12 = self.fetch_curve_texel(curve_idx * 2.0) - vec4(sample.x, sample.y, sample.x, sample.y)
                 let p3 = self.fetch_curve_texel(curve_idx * 2.0 + 1.0).xy - sample
                 let code = self.calc_root_code(p12.x, p12.z, p3.x)
@@ -425,7 +445,7 @@ script_mod! {
                 abs(xcov * xwgt + ycov * ywgt) / max(xwgt + ywgt, 1.0 / 65536.0),
                 min(abs(xcov), abs(ycov))
             )
-            if self.fill_flags >= 4096.0 {
+            if self.slug_fill_flags() >= 4096.0 {
                 return 1.0 - abs(1.0 - fract(coverage * 0.5) * 2.0)
             }
             return self.saturate(coverage)
@@ -437,12 +457,12 @@ script_mod! {
             var weight_x = 0.0
             var weight_y = 0.0
 
-            if self.band_count > 0.5 {
-                let num_bands = max(floor(self.band_count + 0.5), 1.0)
+            if self.slug_band_count() > 0.5 {
+                let num_bands = max(floor(self.slug_band_count() + 0.5), 1.0)
                 let h_band_idx = clamp(floor(sample.y * num_bands), 0.0, num_bands - 1.0)
                 let v_band_idx = clamp(floor(sample.x * num_bands), 0.0, num_bands - 1.0)
 
-                let h_band_info = self.fetch_band_texel(self.band_offset + h_band_idx)
+                let h_band_info = self.fetch_band_texel(self.slug_band_offset() + h_band_idx)
                 let h_band = self.scan_horizontal_list(
                     floor(h_band_info.x + 0.5),
                     h_band_info.y,
@@ -452,7 +472,9 @@ script_mod! {
                 coverage_x = h_band.x
                 weight_x = h_band.y
 
-                let v_band_info = self.fetch_band_texel(self.band_offset + num_bands + v_band_idx)
+                let v_band_info = self.fetch_band_texel(
+                    self.slug_band_offset() + num_bands + v_band_idx
+                )
                 let v_band = self.scan_vertical_list(
                     floor(v_band_info.x + 0.5),
                     v_band_info.y,
@@ -475,7 +497,7 @@ script_mod! {
         }
 
         sample_slug_pixel: fn() {
-            if self.curve_count < 0.5 {
+            if self.slug_curve_count() < 0.5 {
                 return vec4(0.0, 0.0, 0.0, 0.0)
             }
 
@@ -649,16 +671,6 @@ pub struct DrawText {
     pub atlas_plane: f32,
     #[live]
     pub pad1: f32,
-    #[live]
-    pub curve_offset: f32,
-    #[live]
-    pub curve_count: f32,
-    #[live]
-    pub band_offset: f32,
-    #[live]
-    pub band_count: f32,
-    #[live(0.0)]
-    pub fill_flags: f32,
     #[live(0.0)]
     pub aa_2x2: f32,
     #[live(0.0)]
@@ -667,14 +679,6 @@ pub struct DrawText {
     pub stem_darken: f32,
     #[live(0.125)]
     pub stem_darken_max: f32,
-    // Keep the base DrawText instance payload 16-byte aligned so repr(C)
-    // subclasses with Vec4 fields don't pick up implicit Rust padding.
-    #[live(0.0)]
-    pub pad2: f32,
-    #[live(0.0)]
-    pub pad3: f32,
-    #[live(0.0)]
-    pub pad4: f32,
 }
 
 #[derive(Clone, Debug)]
@@ -1062,6 +1066,7 @@ impl DrawText {
                     &mut instances.instances,
                 );
             }
+            self.flush_slug_textures(cx);
             self.many_instances = Some(instances);
             return;
         }
@@ -1077,7 +1082,13 @@ impl DrawText {
                 &mut instances.instances,
             );
         }
+        self.flush_slug_textures(cx);
         self.finish_many_instances(cx, instances);
+    }
+
+    fn flush_slug_textures(&mut self, cx: &mut Cx2d) {
+        let fonts = cx.fonts.clone();
+        fonts.borrow_mut().flush_slug_textures(cx.cx);
     }
 
     fn finish_many_instances(&mut self, cx: &mut Cx2d, instances: ManyInstances) {
@@ -1264,14 +1275,9 @@ impl DrawText {
             ) / 255.0;
         }
         self.texture_index = 3.0;
-        self.atlas_plane = 0.0;
-        self.t_min = vec2(0.0, 0.0);
-        self.t_max = vec2(0.0, 0.0);
-        self.curve_offset = glyph.curve_offset as f32;
-        self.curve_count = glyph.curve_count as f32;
-        self.band_offset = glyph.band_offset as f32;
-        self.band_count = glyph.band_count as f32;
-        self.fill_flags = glyph.fill_flags as f32;
+        self.atlas_plane = glyph.fill_flags as f32;
+        self.t_min = vec2(glyph.curve_offset as f32, glyph.curve_count as f32);
+        self.t_max = vec2(glyph.band_offset as f32, glyph.band_count as f32);
         let slice = self.draw_vars.as_slice();
 
         output.extend_from_slice(slice);
@@ -1338,11 +1344,6 @@ impl DrawText {
         self.atlas_plane = glyph.atlas_plane as f32;
         self.t_min = vec2(t_min.x, t_min.y);
         self.t_max = vec2(t_max.x, t_max.y);
-        self.curve_offset = 0.0;
-        self.curve_count = 0.0;
-        self.band_offset = 0.0;
-        self.band_count = 0.0;
-        self.fill_flags = 0.0;
         let slice = self.draw_vars.as_slice();
 
         output.extend_from_slice(slice);
@@ -1669,5 +1670,15 @@ impl ScriptHook for FontFamily {
         // to hundreds of widgets.
 
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DrawText;
+
+    #[test]
+    fn draw_text_size_stays_16_byte_aligned() {
+        assert_eq!(std::mem::size_of::<DrawText>() % 16, 0);
     }
 }

--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -614,7 +614,7 @@ pub struct DrawText {
     #[rust]
     pending_slug_flush_generation: u64,
     #[rust]
-    pending_slug_flush_generation_pad: u64,
+    slug_flush_defer_depth: u64,
     #[live]
     pub text_style: TextStyle,
     #[live(1.0)]
@@ -718,9 +718,27 @@ impl DrawText {
 
     pub fn end_many_instances(&mut self, cx: &mut Cx2d) {
         if let Some(instances) = self.many_instances.take() {
-            self.flush_slug_textures_if_needed(cx);
+            self.flush_slug_textures_if_allowed(cx);
             self.finish_many_instances(cx, instances);
         }
+    }
+
+    /// Defers SLUG atlas uploads while preserving the original draw-call order.
+    ///
+    /// This is useful for composite text widgets like `TextFlow`, which issue
+    /// many separate `DrawText` runs interleaved with non-text draw calls. Those
+    /// widgets need the glyph uploads to be coalesced, but cannot safely hold a
+    /// single `many_instances` batch open across the whole widget.
+    pub fn begin_deferred_slug_flush(&mut self) {
+        self.slug_flush_defer_depth = self.slug_flush_defer_depth.saturating_add(1);
+    }
+
+    pub fn end_deferred_slug_flush(&mut self, cx: &mut Cx2d) {
+        if self.slug_flush_defer_depth == 0 {
+            return;
+        }
+        self.slug_flush_defer_depth -= 1;
+        self.flush_slug_textures_if_allowed(cx);
     }
 
     pub fn draw_rasterized_glyphs_abs(
@@ -1086,8 +1104,15 @@ impl DrawText {
                 &mut instances.instances,
             );
         }
-        self.flush_slug_textures_if_needed(cx);
+        self.flush_slug_textures_if_allowed(cx);
         self.finish_many_instances(cx, instances);
+    }
+
+    fn flush_slug_textures_if_allowed(&mut self, cx: &mut Cx2d) {
+        if self.slug_flush_defer_depth != 0 {
+            return;
+        }
+        self.flush_slug_textures_if_needed(cx);
     }
 
     fn flush_slug_textures_if_needed(&mut self, cx: &mut Cx2d) {

--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -1271,6 +1271,15 @@ pub struct DrawText {
     #[cfg(target_os = "linux")]
     #[rust]
     slug_draw: Option<DrawTextLinuxSlug>,
+    #[cfg(target_os = "linux")]
+    #[rust]
+    linux_slug_promotion: LinuxSlugPromotionState,
+    #[cfg(target_os = "linux")]
+    #[rust]
+    linux_slug_sync_plan: LinuxSlugDrawSyncPlan,
+    #[cfg(target_os = "linux")]
+    #[rust]
+    linux_slug_layout_pad: u64,
     #[live]
     pub text_style: TextStyle,
     #[live(1.0)]
@@ -1421,6 +1430,103 @@ struct LinuxSlugPromotionState {
 }
 
 #[cfg(target_os = "linux")]
+#[derive(Default)]
+struct LinuxSlugDrawSyncPlan {
+    source_shader_id: Option<usize>,
+    target_shader_id: Option<usize>,
+    instance_ids: Vec<LiveId>,
+    uniform_ids: Vec<LiveId>,
+    source_has_color_2: bool,
+}
+
+#[cfg(target_os = "linux")]
+impl LinuxSlugDrawSyncPlan {
+    fn ensure(
+        &mut self,
+        cx: &Cx,
+        source_shader_id: usize,
+        target_shader_id: usize,
+    ) {
+        if self.source_shader_id == Some(source_shader_id)
+            && self.target_shader_id == Some(target_shader_id)
+        {
+            return;
+        }
+
+        self.source_shader_id = Some(source_shader_id);
+        self.target_shader_id = Some(target_shader_id);
+        self.instance_ids.clear();
+        self.uniform_ids.clear();
+
+        let source_shader = &cx.draw_shaders.shaders[source_shader_id];
+        let target_shader = &cx.draw_shaders.shaders[target_shader_id];
+        let source_dyn_instances = &source_shader.mapping.dyn_instances.inputs;
+        let target_dyn_instances = &target_shader.mapping.dyn_instances.inputs;
+        let source_dyn_uniforms = &source_shader.mapping.dyn_uniforms.inputs;
+        let target_dyn_uniforms = &target_shader.mapping.dyn_uniforms.inputs;
+
+        let source_has_instance = |id| source_dyn_instances.iter().any(|input| input.id == id);
+        let target_has_instance = |id| target_dyn_instances.iter().any(|input| input.id == id);
+        let source_has_uniform = |id| source_dyn_uniforms.iter().any(|input| input.id == id);
+        let target_has_uniform = |id| target_dyn_uniforms.iter().any(|input| input.id == id);
+
+        for id in [
+            live_id!(hover),
+            live_id!(focus),
+            live_id!(down),
+            live_id!(disabled),
+            live_id!(empty),
+            live_id!(active),
+            live_id!(drag),
+            live_id!(pressed),
+            live_id!(opened),
+            live_id!(focussed),
+            live_id!(is_even),
+            live_id!(is_folder),
+            live_id!(scale),
+            live_id!(total_chars),
+        ] {
+            if source_has_instance(id) && target_has_instance(id) {
+                self.instance_ids.push(id);
+            }
+        }
+
+        for id in [
+            live_id!(aa_pad_px),
+            live_id!(color_hover),
+            live_id!(color_focus),
+            live_id!(color_down),
+            live_id!(color_disabled),
+            live_id!(color_empty),
+            live_id!(color_empty_hover),
+            live_id!(color_empty_focus),
+            live_id!(color_active),
+            live_id!(color_drag),
+            live_id!(color_pressed),
+            live_id!(color_2),
+            live_id!(color_2_hover),
+            live_id!(color_2_focus),
+            live_id!(color_2_down),
+            live_id!(color_2_disabled),
+            live_id!(color_2_empty),
+            live_id!(color_2_empty_hover),
+            live_id!(color_2_empty_focus),
+            live_id!(color_2_active),
+            live_id!(color_2_drag),
+            live_id!(color_2_pressed),
+            live_id!(color_dither),
+            live_id!(gradient_fill_horizontal),
+        ] {
+            if source_has_uniform(id) && target_has_uniform(id) {
+                self.uniform_ids.push(id);
+            }
+        }
+
+        self.source_has_color_2 = source_has_uniform(live_id!(color_2));
+    }
+}
+
+#[cfg(target_os = "linux")]
 fn linux_slug_try_consume_helper_build_budget(cx: &mut Cx) -> bool {
     let redraw_id = cx.redraw_id;
     let state = cx.global::<LinuxSlugHelperWarmupState>();
@@ -1513,16 +1619,14 @@ impl DrawText {
         let mut all_slug_candidates_ready = true;
         let mut pending_slug_generation = 0;
 
-        {
-            let state = cx.cx.global::<LinuxSlugPromotionState>();
-            if state.redraw_id != redraw_id {
-                state.allow_slug_this_redraw = state.redraw_id != 0
-                    && state.saw_slug_candidates_this_redraw
-                    && !state.saw_unready_this_redraw;
-                state.redraw_id = redraw_id;
-                state.saw_slug_candidates_this_redraw = false;
-                state.saw_unready_this_redraw = false;
-            }
+        if self.linux_slug_promotion.redraw_id != redraw_id {
+            self.linux_slug_promotion.allow_slug_this_redraw =
+                self.linux_slug_promotion.redraw_id != 0
+                    && self.linux_slug_promotion.saw_slug_candidates_this_redraw
+                    && !self.linux_slug_promotion.saw_unready_this_redraw;
+            self.linux_slug_promotion.redraw_id = redraw_id;
+            self.linux_slug_promotion.saw_slug_candidates_this_redraw = false;
+            self.linux_slug_promotion.saw_unready_this_redraw = false;
         }
 
         for row in &text.rows {
@@ -1564,37 +1668,28 @@ impl DrawText {
             return false;
         }
 
-        {
-            let state = cx.cx.global::<LinuxSlugPromotionState>();
-            state.saw_slug_candidates_this_redraw = true;
-        }
+        self.linux_slug_promotion.saw_slug_candidates_this_redraw = true;
 
         if !all_slug_candidates_ready {
-            let state = cx.cx.global::<LinuxSlugPromotionState>();
-            state.saw_unready_this_redraw = true;
+            self.linux_slug_promotion.saw_unready_this_redraw = true;
             cx.redraw_all();
             return false;
         }
 
         if !linux_slug_maybe_prewarm_helper(cx) {
-            let state = cx.cx.global::<LinuxSlugPromotionState>();
-            state.saw_unready_this_redraw = true;
+            self.linux_slug_promotion.saw_unready_this_redraw = true;
             return false;
         }
 
         if !self.ensure_linux_slug_draw(cx) {
-            let state = cx.cx.global::<LinuxSlugPromotionState>();
-            state.saw_unready_this_redraw = true;
+            self.linux_slug_promotion.saw_unready_this_redraw = true;
             cx.redraw_all();
             return false;
         }
 
-        {
-            let state = cx.cx.global::<LinuxSlugPromotionState>();
-            if !state.allow_slug_this_redraw {
-                cx.redraw_all();
-                return false;
-            }
+        if !self.linux_slug_promotion.allow_slug_this_redraw {
+            cx.redraw_all();
+            return false;
         }
 
         true
@@ -1612,6 +1707,8 @@ impl ScriptHook for DrawText {
     ) {
         if apply.is_from_script() {
             self.slug_draw = None;
+            self.linux_slug_promotion = Default::default();
+            self.linux_slug_sync_plan = Default::default();
         }
     }
 }
@@ -1846,110 +1943,27 @@ impl DrawText {
         else {
             return;
         };
-
-        let source_dyn_instances: Vec<_> = cx.cx.draw_shaders.shaders[source_shader_id.index]
-            .mapping
-            .dyn_instances
-            .inputs
-            .iter()
-            .map(|input| input.id)
-            .collect();
-        let target_dyn_instances: Vec<_> = cx.cx.draw_shaders.shaders[target_shader_id.index]
-            .mapping
-            .dyn_instances
-            .inputs
-            .iter()
-            .map(|input| input.id)
-            .collect();
-        let source_dyn_uniforms: Vec<_> = cx.cx.draw_shaders.shaders[source_shader_id.index]
-            .mapping
-            .dyn_uniforms
-            .inputs
-            .iter()
-            .map(|input| input.id)
-            .collect();
-        let target_dyn_uniforms: Vec<_> = cx.cx.draw_shaders.shaders[target_shader_id.index]
-            .mapping
-            .dyn_uniforms
-            .inputs
-            .iter()
-            .map(|input| input.id)
-            .collect();
+        self.linux_slug_sync_plan
+            .ensure(cx.cx, source_shader_id.index, target_shader_id.index);
         let Some(slug_draw) = self.slug_draw.as_mut() else {
             return;
         };
         slug_draw.draw_vars.options = self.draw_vars.options.clone();
 
-        let copy_instance =
-            |draw_vars: &DrawVars, slug_draw: &mut DrawTextLinuxSlug, cx: &mut Cx2d, id: LiveId| {
-                if !source_dyn_instances.contains(&id) || !target_dyn_instances.contains(&id) {
-                    return;
-                }
-                let mut value = [0.0; 4];
-                draw_vars.get_instance(cx.cx, id, &mut value);
-                slug_draw.draw_vars.set_dyn_instance(cx.cx, id, &value);
-            };
-
-        let copy_uniform =
-            |draw_vars: &DrawVars, slug_draw: &mut DrawTextLinuxSlug, cx: &mut Cx2d, id: LiveId| {
-                if !source_dyn_uniforms.contains(&id) || !target_dyn_uniforms.contains(&id) {
-                    return;
-                }
-                let mut value = [0.0; 4];
-                draw_vars.get_uniform(cx.cx, id, &mut value);
-                slug_draw.draw_vars.set_uniform(cx.cx, id, &value);
-            };
-
-        for id in [
-            live_id!(hover),
-            live_id!(focus),
-            live_id!(down),
-            live_id!(disabled),
-            live_id!(empty),
-            live_id!(active),
-            live_id!(drag),
-            live_id!(pressed),
-            live_id!(opened),
-            live_id!(focussed),
-            live_id!(is_even),
-            live_id!(is_folder),
-            live_id!(scale),
-            live_id!(total_chars),
-        ] {
-            copy_instance(&self.draw_vars, slug_draw, cx, id);
+        for &id in &self.linux_slug_sync_plan.instance_ids {
+            let mut value = [0.0; 4];
+            self.draw_vars.get_instance(cx.cx, id, &mut value);
+            slug_draw.draw_vars.set_dyn_instance(cx.cx, id, &value);
         }
 
-        for id in [
-            live_id!(aa_pad_px),
-            live_id!(color_hover),
-            live_id!(color_focus),
-            live_id!(color_down),
-            live_id!(color_disabled),
-            live_id!(color_empty),
-            live_id!(color_empty_hover),
-            live_id!(color_empty_focus),
-            live_id!(color_active),
-            live_id!(color_drag),
-            live_id!(color_pressed),
-            live_id!(color_2),
-            live_id!(color_2_hover),
-            live_id!(color_2_focus),
-            live_id!(color_2_down),
-            live_id!(color_2_disabled),
-            live_id!(color_2_empty),
-            live_id!(color_2_empty_hover),
-            live_id!(color_2_empty_focus),
-            live_id!(color_2_active),
-            live_id!(color_2_drag),
-            live_id!(color_2_pressed),
-            live_id!(color_dither),
-            live_id!(gradient_fill_horizontal),
-        ] {
-            copy_uniform(&self.draw_vars, slug_draw, cx, id);
+        for &id in &self.linux_slug_sync_plan.uniform_ids {
+            let mut value = [0.0; 4];
+            self.draw_vars.get_uniform(cx.cx, id, &mut value);
+            slug_draw.draw_vars.set_uniform(cx.cx, id, &value);
         }
 
         let mut color_2 = [-1.0; 4];
-        if source_dyn_uniforms.contains(&live_id!(color_2)) {
+        if self.linux_slug_sync_plan.source_has_color_2 {
             self.draw_vars.get_uniform(cx.cx, live_id!(color_2), &mut color_2);
         }
         slug_draw.draw_vars.set_uniform(
@@ -2383,6 +2397,7 @@ impl DrawText {
                     match self.resolve_glyph(cx, glyph) {
                         Some(ResolvedGlyph::Slug(slug_glyph)) => {
                             let mut drew_slug = false;
+                            let mut needs_raster_fallback = shadow_slug_this_frame;
                             if self.ensure_linux_slug_draw(cx) {
                                 if let Some(instances) = raster_instances.take() {
                                     self.finish_many_instances(cx, instances);
@@ -2409,22 +2424,11 @@ impl DrawText {
                                     self.slug_draw = Some(slug_draw);
                                 }
                             }
-                            if shadow_slug_this_frame {
-                                if raster_instances.is_none() {
-                                    raster_instances =
-                                        cx.begin_many_aligned_instances(&self.draw_vars);
-                                }
-                                if let Some(instances) = raster_instances.as_mut() {
-                                    drew_raster_this_frame |= self.draw_linux_raster_fallback_glyph(
-                                        cx,
-                                        glyph_origin,
-                                        glyph,
-                                        &mut instances.instances,
-                                    );
-                                }
-                            }
                             if !drew_slug {
+                                needs_raster_fallback = true;
                                 cx.redraw_all();
+                            }
+                            if needs_raster_fallback {
                                 if raster_instances.is_none() {
                                     raster_instances =
                                         cx.begin_many_aligned_instances(&self.draw_vars);

--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -27,6 +27,158 @@ use {
     },
 };
 
+#[cfg(target_os = "linux")]
+script_mod! {
+    use mod.pod.*
+    use mod.math.*
+    use mod.shader.*
+    use mod.draw
+    use mod.geom
+    use mod.res.*
+
+    mod.text = {
+        let text = me
+        FontFamily: mod.std.set_type_default() do #(FontFamily::script_component(vm))
+        FontMember: mod.std.set_type_default() do #(FontMember::script_api(vm))
+        TextOverflow: mod.std.set_type_default() do #(TextOverflow::script_api(vm)),
+        ..me.TextOverflow,
+        TextStyle: mod.std.set_type_default() do #(TextStyle::script_api(vm)){
+            font_size: 10
+            font_family: text.FontFamily{
+                latin := text.FontMember{res: crate_resource("self:../../widgets/resources/IBMPlexSans-Text.ttf") asc:-0.1 desc:0.0}
+            }
+            line_spacing: 1.2
+        }
+    }
+
+    use mod.text.*
+
+    mod.draw.DrawText = mod.std.set_type_default() do #(DrawText::script_shader(vm)){
+
+        vertex_pos: vertex_position(vec4f)
+        fb0: fragment_output(0, vec4f)
+
+        draw_call: uniform_buffer(draw.DrawCallUniforms)
+        draw_pass: uniform_buffer(draw.DrawPassUniforms)
+        draw_list: uniform_buffer(draw.DrawListUniforms)
+
+        geom: vertex_buffer(geom.QuadVertex, geom.QuadGeom)
+
+        color: #fff
+        sdf_sharpness: 1.0
+        sdf_luma_bias: 0.03
+
+        pos: varying(vec2f)
+        t: varying(vec2f)
+        world: varying(vec4f)
+
+        radius: uniform(float)
+        cutoff: uniform(float)
+        total_chars: instance(1000000.0)
+
+        grayscale_texture: texture_2d(float)
+        color_texture: texture_2d(float)
+        msdf_texture: texture_2d(float)
+
+        vertex: fn() {
+            let p = mix(self.rect_pos, self.rect_pos + self.rect_size, self.geom.pos)
+            let p_clipped = clamp(p, self.draw_clip.xy, self.draw_clip.zw)
+            let p_normalized = (p_clipped - self.rect_pos) / self.rect_size
+
+            self.pos = p_normalized
+            self.t = mix(self.t_min, self.t_max, p_normalized.xy)
+            self.world = self.draw_list.view_transform * vec4(
+                p_clipped.x,
+                p_clipped.y,
+                self.glyph_depth + self.draw_call.zbias,
+                1.
+            )
+            self.vertex_pos = self.draw_pass.camera_projection * (self.draw_pass.camera_view * (self.world))
+        }
+
+        sdf: fn(scale, p, color) {
+            let sampled = self.grayscale_texture.sample_as_bgra(p)
+            let s = if self.atlas_plane < 0.5 {
+                sampled.r
+            } else if self.atlas_plane < 1.5 {
+                sampled.g
+            } else if self.atlas_plane < 2.5 {
+                sampled.b
+            } else {
+                sampled.a
+            }
+            let safe_scale = max(scale, 0.0001)
+            let luma = dot(color.rgb, vec3(0.299, 0.587, 0.114))
+            var a = clamp(
+                (s - (1.0 - self.cutoff)) * self.radius / safe_scale * self.sdf_sharpness + 0.5,
+                0.0,
+                1.0,
+            )
+            let bias = (0.5 - luma) * self.sdf_luma_bias
+            a = clamp(a - bias, 0.0, 1.0)
+            return a
+        }
+
+        msdf: fn(scale, p, color) {
+            let s = self.msdf_texture.sample_as_bgra(p)
+            let dist = s.a
+            let safe_scale = max(scale, 0.0001)
+            let luma = dot(color.rgb, vec3(0.299, 0.587, 0.114))
+            var a = clamp(
+                (dist - (1.0 - self.cutoff)) * self.radius / safe_scale * self.sdf_sharpness + 0.5,
+                0.0,
+                1.0,
+            )
+            let bias = (0.5 - luma) * self.sdf_luma_bias
+            if a > self.sdf_luma_bias * 0.5 {
+                a = clamp(a - bias, 0.0, 1.0)
+            }
+            return a
+        }
+
+        get_color: fn() {
+            return self.color
+        }
+
+        fragment: fn() {
+            self.fb0 = depth_clip(self.world, self.pixel(), self.depth_clip)
+        }
+
+        sample_text_pixel: fn() {
+            let dxt = length(dFdx(self.t))
+            let dyt = length(dFdy(self.t))
+            if self.texture_index < 0.5 {
+                let c = self.get_color()
+                let scale = (dxt + dyt) * self.grayscale_texture.size().x * 0.5
+                let tex_size = self.grayscale_texture.size()
+                let half_texel = vec2(0.5 / tex_size.x, 0.5 / tex_size.y)
+                let p = clamp(self.t.xy, self.t_min + half_texel, self.t_max - half_texel)
+                let s = self.sdf(scale, p, c)
+                return s * vec4(c.rgb * c.a, c.a)
+            } else if self.texture_index < 1.5 {
+                let tex_size = self.color_texture.size()
+                let half_texel = vec2(0.5 / tex_size.x, 0.5 / tex_size.y)
+                let p = clamp(self.t.xy, self.t_min + half_texel, self.t_max - half_texel)
+                let c = self.color_texture.sample_as_bgra(p)
+                return vec4(c.rgb * c.a, c.a)
+            } else {
+                let c = self.get_color()
+                let scale = (dxt + dyt) * self.msdf_texture.size().x * 0.5
+                let tex_size = self.msdf_texture.size()
+                let half_texel = vec2(0.5 / tex_size.x, 0.5 / tex_size.y)
+                let p = clamp(self.t.xy, self.t_min + half_texel, self.t_max - half_texel)
+                let s = self.msdf(scale, p, c)
+                return s * vec4(c.rgb * c.a, c.a)
+            }
+        }
+
+        pixel: fn() {
+            return self.sample_text_pixel()
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
 script_mod! {
     use mod.pod.*
     use mod.math.*
@@ -1240,12 +1392,13 @@ impl DrawText {
         output: &mut Vec<f32>,
     ) {
         use crate::text::geom::Point;
+        let font_size_in_dpxs = glyph.font_size_in_lpxs * cx.current_dpi_factor() as f32;
         let glyph_origin = Point::new(
             origin_in_lpxs.x + glyph.offset_in_lpxs() * self.font_scale,
             origin_in_lpxs.y,
         );
 
-        let slug_glyph = {
+        let slug_glyph = if cx.fonts.borrow().should_use_slug_glyph(font_size_in_dpxs) {
             let mut fonts = cx.fonts.borrow_mut();
             let generation_before = fonts.slug_cache_generation();
             let slug_glyph = fonts.get_or_cache_slug_glyph(glyph.font.as_ref(), glyph.id);
@@ -1255,6 +1408,8 @@ impl DrawText {
                     self.pending_slug_flush_generation.max(generation_after);
             }
             slug_glyph
+        } else {
+            None
         };
         if let Some(slug_glyph) = slug_glyph {
             self.draw_slug_glyph(
@@ -1268,7 +1423,6 @@ impl DrawText {
             return;
         }
 
-        let font_size_in_dpxs = glyph.font_size_in_lpxs * cx.current_dpi_factor() as f32;
         if let Some(rasterized_glyph) = glyph.rasterize(font_size_in_dpxs) {
             self.draw_rasterized_glyph(
                 glyph_origin,

--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -611,6 +611,10 @@ pub enum TextOverflow {
 pub struct DrawText {
     #[rust]
     pub many_instances: Option<ManyInstances>,
+    #[rust]
+    pending_slug_flush_generation: u64,
+    #[rust]
+    pending_slug_flush_generation_pad: u64,
     #[live]
     pub text_style: TextStyle,
     #[live(1.0)]
@@ -714,6 +718,7 @@ impl DrawText {
 
     pub fn end_many_instances(&mut self, cx: &mut Cx2d) {
         if let Some(instances) = self.many_instances.take() {
+            self.flush_slug_textures_if_needed(cx);
             self.finish_many_instances(cx, instances);
         }
     }
@@ -1066,7 +1071,6 @@ impl DrawText {
                     &mut instances.instances,
                 );
             }
-            self.flush_slug_textures(cx);
             self.many_instances = Some(instances);
             return;
         }
@@ -1082,13 +1086,22 @@ impl DrawText {
                 &mut instances.instances,
             );
         }
-        self.flush_slug_textures(cx);
+        self.flush_slug_textures_if_needed(cx);
         self.finish_many_instances(cx, instances);
     }
 
-    fn flush_slug_textures(&mut self, cx: &mut Cx2d) {
+    fn flush_slug_textures_if_needed(&mut self, cx: &mut Cx2d) {
+        if self.pending_slug_flush_generation == 0 {
+            return;
+        }
         let fonts = cx.fonts.clone();
-        fonts.borrow_mut().flush_slug_textures(cx.cx);
+        let mut fonts = fonts.borrow_mut();
+        if fonts.slug_uploaded_generation() < self.pending_slug_flush_generation {
+            fonts.flush_slug_textures(cx.cx);
+        }
+        if fonts.slug_uploaded_generation() >= self.pending_slug_flush_generation {
+            self.pending_slug_flush_generation = 0;
+        }
     }
 
     fn finish_many_instances(&mut self, cx: &mut Cx2d, instances: ManyInstances) {
@@ -1208,9 +1221,15 @@ impl DrawText {
         );
 
         let slug_glyph = {
-            cx.fonts
-                .borrow_mut()
-                .get_or_cache_slug_glyph(glyph.font.as_ref(), glyph.id)
+            let mut fonts = cx.fonts.borrow_mut();
+            let generation_before = fonts.slug_cache_generation();
+            let slug_glyph = fonts.get_or_cache_slug_glyph(glyph.font.as_ref(), glyph.id);
+            let generation_after = fonts.slug_cache_generation();
+            if generation_after != generation_before {
+                self.pending_slug_flush_generation =
+                    self.pending_slug_flush_generation.max(generation_after);
+            }
+            slug_glyph
         };
         if let Some(slug_glyph) = slug_glyph {
             self.draw_slug_glyph(

--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -15,6 +15,7 @@ use {
             },
             loader::{FontDefinition, FontFamilyDefinition},
             rasterizer::{AtlasKind, RasterizedGlyph},
+            slug_atlas::SlugGlyphCacheResult,
         },
         turtle::*,
         turtle::{Align, Walk},
@@ -26,6 +27,505 @@ use {
         rc::Rc,
     },
 };
+
+#[cfg(target_os = "linux")]
+fn register_draw_text_linux_slug(vm: &mut ScriptVm) {
+    let slug_shader = DrawTextLinuxSlug::script_shader(vm);
+    let script_mod = script! {
+        use mod.pod.*
+        use mod.math.*
+        use mod.shader.*
+        use mod.draw
+        use mod.geom
+        use mod.res.*
+
+        mod.std.set_type_default() do #(slug_shader){
+            async_compile: true
+
+            vertex_pos: vertex_position(vec4f)
+            fb0: fragment_output(0, vec4f)
+
+            draw_call: uniform_buffer(draw.DrawCallUniforms)
+            draw_pass: uniform_buffer(draw.DrawPassUniforms)
+            draw_list: uniform_buffer(draw.DrawListUniforms)
+
+            geom: vertex_buffer(geom.QuadVertex, geom.QuadGeom)
+
+            curve_texture: texture_2d(float)
+            band_texture: texture_2d(float)
+
+            color: #fff
+            hover: instance(0.0)
+            focus: instance(0.0)
+            down: instance(0.0)
+            disabled: instance(0.0)
+            empty: instance(0.0)
+            active: instance(0.0)
+            drag: instance(0.0)
+            pressed: instance(0.0)
+            opened: instance(0.0)
+            focussed: instance(0.0)
+            is_even: instance(0.0)
+            is_folder: instance(0.0)
+            scale: instance(1.0)
+
+            color_hover: uniform(#fff)
+            color_focus: uniform(#fff)
+            color_down: uniform(#fff)
+            color_disabled: uniform(#fff)
+            color_empty: uniform(#fff)
+            color_empty_hover: uniform(#fff)
+            color_empty_focus: uniform(#fff)
+            color_active: uniform(#fff)
+            color_drag: uniform(#fff)
+            color_pressed: uniform(#fff)
+
+            color_2: uniform(vec4(-1.0, -1.0, -1.0, -1.0))
+            color_2_hover: uniform(#fff)
+            color_2_focus: uniform(#fff)
+            color_2_down: uniform(#fff)
+            color_2_disabled: uniform(#fff)
+            color_2_empty: uniform(#fff)
+            color_2_empty_hover: uniform(#fff)
+            color_2_empty_focus: uniform(#fff)
+            color_2_active: uniform(#fff)
+            color_2_drag: uniform(#fff)
+            color_2_pressed: uniform(#fff)
+            use_color_2: uniform(0.0)
+
+            color_dither: uniform(0.0)
+            gradient_fill_horizontal: uniform(0.0)
+            total_chars: instance(1000000.0)
+            aa_pad_px: uniform(float(1.0))
+            slug_visibility: uniform(1.0)
+            slug_matrix_0: uniform(vec4(1.0, 0.0, 0.0, 0.0))
+            slug_matrix_1: uniform(vec4(0.0, 1.0, 0.0, 0.0))
+            slug_matrix_3: uniform(vec4(0.0, 0.0, 0.0, 1.0))
+            slug_viewport_px: uniform(vec2(1.0, 1.0))
+
+            pos: varying(vec2f)
+            world: varying(vec4f)
+
+            saturate: fn(v: float) -> float {
+                return clamp(v, 0.0, 1.0)
+            }
+
+            slug_dilate: fn(pos: vec2, tex: vec2, jac: vec4, normal: vec2) -> vec4 {
+                let n = normalize(normal)
+                let s = dot(self.slug_matrix_3.xy, pos) + self.slug_matrix_3.w
+                let t = dot(self.slug_matrix_3.xy, n)
+
+                let u = (
+                    s * dot(self.slug_matrix_0.xy, n)
+                        - t * (dot(self.slug_matrix_0.xy, pos) + self.slug_matrix_0.w)
+                ) * self.slug_viewport_px.x
+                let v = (
+                    s * dot(self.slug_matrix_1.xy, n)
+                        - t * (dot(self.slug_matrix_1.xy, pos) + self.slug_matrix_1.w)
+                ) * self.slug_viewport_px.y
+
+                let s2 = s * s
+                let st = s * t
+                let uv = u * u + v * v
+                let d = normal * (
+                    s2 * (st + sqrt(uv)) / max(uv - st * st, 0.0000001)
+                ) * self.aa_pad_px
+
+                let vpos = pos + d
+                let vtex = vec2(tex.x + dot(d, jac.xy), tex.y + dot(d, jac.zw))
+                return vec4(vtex.x, vtex.y, vpos.x, vpos.y)
+            }
+
+            vertex: fn() {
+                let p = mix(self.rect_pos, self.rect_pos + self.rect_size, self.geom.pos)
+                let p_clipped = clamp(p, self.draw_clip.xy, self.draw_clip.zw)
+                let pad_lpx = self.aa_pad_px / max(self.draw_pass.dpi_factor, 0.0001)
+                let content_rect_pos = self.rect_pos + vec2(pad_lpx, pad_lpx)
+                let content_rect_size = vec2(
+                    max(self.rect_size.x - 2.0 * pad_lpx, 0.0001),
+                    max(self.rect_size.y - 2.0 * pad_lpx, 0.0001)
+                )
+                self.pos = vec2(
+                    (p_clipped.x - content_rect_pos.x) / content_rect_size.x,
+                    (p_clipped.y - content_rect_pos.y) / content_rect_size.y
+                )
+                self.world = self.draw_list.view_transform * vec4(
+                    p_clipped.x,
+                    p_clipped.y,
+                    self.glyph_depth + self.draw_call.zbias,
+                    1.
+                )
+                self.vertex_pos = self.draw_pass.camera_projection * (self.draw_pass.camera_view * self.world)
+            }
+
+            fetch_curve_texel: fn(texel_idx: float) -> vec4 {
+                let tex_size = self.curve_texture.size()
+                let row = floor(texel_idx / tex_size.x)
+                let col = texel_idx - row * tex_size.x
+                let uv = vec2(
+                    (col + 0.5) / tex_size.x,
+                    (row + 0.5) / tex_size.y
+                )
+                return self.curve_texture.sample_nearest(uv)
+            }
+
+            fetch_band_texel: fn(texel_idx: float) -> vec4 {
+                let tex_size = self.band_texture.size()
+                let row = floor(texel_idx / tex_size.x)
+                let col = texel_idx - row * tex_size.x
+                let uv = vec2(
+                    (col + 0.5) / tex_size.x,
+                    (row + 0.5) / tex_size.y
+                )
+                return self.band_texture.sample_nearest(uv)
+            }
+
+            pick_channel: fn(v: vec4, channel: float) -> float {
+                if channel < 0.5 {
+                    return v.x
+                }
+                if channel < 1.5 {
+                    return v.y
+                }
+                if channel < 2.5 {
+                    return v.z
+                }
+                return v.w
+            }
+
+            slug_curve_offset: fn() -> float {
+                return self.t_min.x
+            }
+
+            slug_curve_count: fn() -> float {
+                return self.t_min.y
+            }
+
+            slug_band_offset: fn() -> float {
+                return self.t_max.x
+            }
+
+            slug_band_count: fn() -> float {
+                return self.t_max.y
+            }
+
+            slug_fill_flags: fn() -> float {
+                return self.atlas_plane
+            }
+
+            calc_root_code: fn(y1: float, y2: float, y3: float) -> u32 {
+                let i1 = asuint(y1) >> u32(31)
+                let i2 = asuint(y2) >> u32(30)
+                let i3 = asuint(y3) >> u32(29)
+
+                let shift = (i1 & u32(1)) | (i2 & u32(2)) | (i3 & u32(4))
+                return (u32(11892) >> shift) & u32(257)
+            }
+
+            solve_horiz_poly: fn(p12: vec4, p3: vec2) -> vec2 {
+                let a = p12.xy - p12.zw * 2.0 + p3
+                let b = p12.xy - p12.zw
+                let ra = 1.0 / a.y
+                let rb = 0.5 / b.y
+
+                let d = sqrt(max(b.y * b.y - a.y * p12.y, 0.0))
+                let mut t1 = (b.y - d) * ra
+                let mut t2 = (b.y + d) * ra
+                if abs(a.y) < 1.0 / 65536.0 {
+                    t1 = p12.y * rb
+                    t2 = t1
+                }
+                return vec2(
+                    (a.x * t1 - b.x * 2.0) * t1 + p12.x,
+                    (a.x * t2 - b.x * 2.0) * t2 + p12.x
+                )
+            }
+
+            solve_vert_poly: fn(p12: vec4, p3: vec2) -> vec2 {
+                let a = p12.xy - p12.zw * 2.0 + p3
+                let b = p12.xy - p12.zw
+                let ra = 1.0 / a.x
+                let rb = 0.5 / b.x
+
+                let d = sqrt(max(b.x * b.x - a.x * p12.x, 0.0))
+                let mut t1 = (b.x - d) * ra
+                let mut t2 = (b.x + d) * ra
+                if abs(a.x) < 1.0 / 65536.0 {
+                    t1 = p12.x * rb
+                    t2 = t1
+                }
+                return vec2(
+                    (a.y * t1 - b.y * 2.0) * t1 + p12.y,
+                    (a.y * t2 - b.y * 2.0) * t2 + p12.y
+                )
+            }
+
+            scan_horizontal_list: fn(list_offset: float, list_count: float, sample: vec2, px_size: float) -> vec2 {
+                let limit = floor(list_count + 0.5)
+                var coverage = 0.0
+                var weight = 0.0
+
+                var j = 0.0
+                loop {
+                    if j >= limit { break }
+
+                    let packed_idx = floor(j * 0.25)
+                    let channel = j - packed_idx * 4.0
+                    let idx_data = self.fetch_band_texel(list_offset + packed_idx)
+                    let curve_idx = self.pick_channel(idx_data, channel)
+
+                    let p12 = self.fetch_curve_texel(curve_idx * 2.0) - vec4(sample.x, sample.y, sample.x, sample.y)
+                    let p3 = self.fetch_curve_texel(curve_idx * 2.0 + 1.0).xy - sample
+                    if max(max(p12.x, p12.z), p3.x) / px_size < -0.5 { break }
+
+                    let code = self.calc_root_code(p12.y, p12.w, p3.y)
+                    if code != u32(0) {
+                        let r = self.solve_horiz_poly(p12, p3) / px_size
+                        if (code & u32(1)) != u32(0) {
+                            coverage = coverage + self.saturate(r.x + 0.5)
+                            weight = max(weight, self.saturate(1.0 - abs(r.x) * 2.0))
+                        }
+                        if code > u32(1) {
+                            coverage = coverage - self.saturate(r.y + 0.5)
+                            weight = max(weight, self.saturate(1.0 - abs(r.y) * 2.0))
+                        }
+                    }
+
+                    j = j + 1.0
+                }
+
+                return vec2(coverage, weight)
+            }
+
+            scan_vertical_list: fn(list_offset: float, list_count: float, sample: vec2, px_size: float) -> vec2 {
+                let limit = floor(list_count + 0.5)
+                var coverage = 0.0
+                var weight = 0.0
+
+                var j = 0.0
+                loop {
+                    if j >= limit { break }
+
+                    let packed_idx = floor(j * 0.25)
+                    let channel = j - packed_idx * 4.0
+                    let idx_data = self.fetch_band_texel(list_offset + packed_idx)
+                    let curve_idx = self.pick_channel(idx_data, channel)
+
+                    let p12 = self.fetch_curve_texel(curve_idx * 2.0) - vec4(sample.x, sample.y, sample.x, sample.y)
+                    let p3 = self.fetch_curve_texel(curve_idx * 2.0 + 1.0).xy - sample
+                    if max(max(p12.y, p12.w), p3.y) / px_size < -0.5 { break }
+
+                    let code = self.calc_root_code(p12.x, p12.z, p3.x)
+                    if code != u32(0) {
+                        let r = self.solve_vert_poly(p12, p3) / px_size
+                        if (code & u32(1)) != u32(0) {
+                            coverage = coverage - self.saturate(r.x + 0.5)
+                            weight = max(weight, self.saturate(1.0 - abs(r.x) * 2.0))
+                        }
+                        if code > u32(1) {
+                            coverage = coverage + self.saturate(r.y + 0.5)
+                            weight = max(weight, self.saturate(1.0 - abs(r.y) * 2.0))
+                        }
+                    }
+
+                    j = j + 1.0
+                }
+
+                return vec2(coverage, weight)
+            }
+
+            scan_horizontal_all: fn(sample: vec2, px_size: float) -> vec2 {
+                let limit = floor(self.slug_curve_count() + 0.5)
+                var coverage = 0.0
+                var weight = 0.0
+
+                var i = 0.0
+                loop {
+                    if i >= limit { break }
+
+                    let curve_idx = self.slug_curve_offset() + i
+                    let p12 = self.fetch_curve_texel(curve_idx * 2.0) - vec4(sample.x, sample.y, sample.x, sample.y)
+                    let p3 = self.fetch_curve_texel(curve_idx * 2.0 + 1.0).xy - sample
+                    let code = self.calc_root_code(p12.y, p12.w, p3.y)
+                    if code != u32(0) {
+                        let r = self.solve_horiz_poly(p12, p3) / px_size
+                        if (code & u32(1)) != u32(0) {
+                            coverage = coverage + self.saturate(r.x + 0.5)
+                            weight = max(weight, self.saturate(1.0 - abs(r.x) * 2.0))
+                        }
+                        if code > u32(1) {
+                            coverage = coverage - self.saturate(r.y + 0.5)
+                            weight = max(weight, self.saturate(1.0 - abs(r.y) * 2.0))
+                        }
+                    }
+
+                    i = i + 1.0
+                }
+
+                return vec2(coverage, weight)
+            }
+
+            scan_vertical_all: fn(sample: vec2, px_size: float) -> vec2 {
+                let limit = floor(self.slug_curve_count() + 0.5)
+                var coverage = 0.0
+                var weight = 0.0
+
+                var i = 0.0
+                loop {
+                    if i >= limit { break }
+
+                    let curve_idx = self.slug_curve_offset() + i
+                    let p12 = self.fetch_curve_texel(curve_idx * 2.0) - vec4(sample.x, sample.y, sample.x, sample.y)
+                    let p3 = self.fetch_curve_texel(curve_idx * 2.0 + 1.0).xy - sample
+                    let code = self.calc_root_code(p12.x, p12.z, p3.x)
+                    if code != u32(0) {
+                        let r = self.solve_vert_poly(p12, p3) / px_size
+                        if (code & u32(1)) != u32(0) {
+                            coverage = coverage - self.saturate(r.x + 0.5)
+                            weight = max(weight, self.saturate(1.0 - abs(r.x) * 2.0))
+                        }
+                        if code > u32(1) {
+                            coverage = coverage + self.saturate(r.y + 0.5)
+                            weight = max(weight, self.saturate(1.0 - abs(r.y) * 2.0))
+                        }
+                    }
+
+                    i = i + 1.0
+                }
+
+                return vec2(coverage, weight)
+            }
+
+            calc_coverage: fn(xcov: float, ycov: float, xwgt: float, ywgt: float) -> float {
+                let coverage = max(
+                    abs(xcov * xwgt + ycov * ywgt) / max(xwgt + ywgt, 1.0 / 65536.0),
+                    min(abs(xcov), abs(ycov))
+                )
+                if self.slug_fill_flags() >= 4096.0 {
+                    return 1.0 - abs(1.0 - fract(coverage * 0.5) * 2.0)
+                }
+                return self.saturate(coverage)
+            }
+
+            alpha_at: fn(sample: vec2, px_x: float, px_y: float) -> float {
+                // Linux uses the shared helper shader for SLUG fallback promotion.
+                // Prefer the simpler full-curve scan here to avoid correctness issues
+                // in the helper's band-accelerated path for some glyph shapes.
+                let x_scan = self.scan_horizontal_all(sample, px_x)
+                let y_scan = self.scan_vertical_all(sample, px_y)
+                return self.calc_coverage(x_scan.x, y_scan.x, x_scan.y, y_scan.y)
+            }
+
+            fragment: fn() {
+                self.fb0 = depth_clip(self.world, self.pixel(), self.depth_clip)
+            }
+
+            get_color: fn() {
+                let mut color = self.color
+                let mut color_hover = self.color_hover
+                let mut color_focus = self.color_focus
+                let mut color_down = self.color_down
+                let mut color_disabled = self.color_disabled
+                let mut color_empty = self.color_empty
+                let mut color_empty_hover = self.color_empty_hover
+                let mut color_empty_focus = self.color_empty_focus
+                let mut color_active = self.color_active
+                let mut color_drag = self.color_drag
+                let mut color_pressed = self.color_pressed
+
+                if (self.use_color_2 > 0.5) {
+                    let mut gradient_fill_dir = self.pos.y
+                    if (self.gradient_fill_horizontal > 0.5) {
+                        gradient_fill_dir = self.pos.x
+                    }
+                    color = mix(self.color, self.color_2, gradient_fill_dir)
+                    color_hover = mix(self.color_hover, self.color_2_hover, gradient_fill_dir)
+                    color_focus = mix(self.color_focus, self.color_2_focus, gradient_fill_dir)
+                    color_down = mix(self.color_down, self.color_2_down, gradient_fill_dir)
+                    color_disabled = mix(self.color_disabled, self.color_2_disabled, gradient_fill_dir)
+                    color_empty = mix(self.color_empty, self.color_2_empty, gradient_fill_dir)
+                    color_empty_hover = mix(self.color_empty_hover, self.color_2_empty_hover, gradient_fill_dir)
+                    color_empty_focus = mix(self.color_empty_focus, self.color_2_empty_focus, gradient_fill_dir)
+                    color_active = mix(self.color_active, self.color_2_active, gradient_fill_dir)
+                    color_drag = mix(self.color_drag, self.color_2_drag, gradient_fill_dir)
+                    color_pressed = mix(self.color_pressed, self.color_2_pressed, gradient_fill_dir)
+                }
+
+                return color
+                    .mix(
+                        color_empty
+                            .mix(color_empty_hover, self.hover)
+                            .mix(color_empty_focus, max(self.focus, self.focussed)),
+                        self.empty
+                    )
+                    .mix(color_focus, max(self.focus, self.focussed) * (1.0 - self.empty))
+                    .mix(color_active, max(self.active, self.opened))
+                    .mix(color_hover, self.hover)
+                    .mix(color_down, self.down)
+                    .mix(color_drag, self.drag)
+                    .mix(color_pressed, self.pressed)
+                    .mix(color_disabled, self.disabled)
+            }
+
+            sample_slug_pixel: fn() {
+                if self.slug_curve_count() < 0.5 {
+                    return vec4(0.0, 0.0, 0.0, 0.0)
+                }
+
+                let sample = self.pos
+                let px_x = max(abs(dFdx(sample.x)) + abs(dFdy(sample.x)), 0.00001)
+                let px_y = max(abs(dFdx(sample.y)) + abs(dFdy(sample.y)), 0.00001)
+                let alpha_base = if self.aa_4x4 > 0.5 {
+                    let x0 = px_x * 0.125
+                    let x1 = px_x * 0.375
+                    let y0 = px_y * 0.125
+                    let y1 = px_y * 0.375
+                    let a0 = self.alpha_at(sample + vec2(-x1, -y1), px_x, px_y)
+                    let a1 = self.alpha_at(sample + vec2(-x0, -y1), px_x, px_y)
+                    let a2 = self.alpha_at(sample + vec2( x0, -y1), px_x, px_y)
+                    let a3 = self.alpha_at(sample + vec2( x1, -y1), px_x, px_y)
+                    let a4 = self.alpha_at(sample + vec2(-x1, -y0), px_x, px_y)
+                    let a5 = self.alpha_at(sample + vec2(-x0, -y0), px_x, px_y)
+                    let a6 = self.alpha_at(sample + vec2( x0, -y0), px_x, px_y)
+                    let a7 = self.alpha_at(sample + vec2( x1, -y0), px_x, px_y)
+                    let a8 = self.alpha_at(sample + vec2(-x1,  y0), px_x, px_y)
+                    let a9 = self.alpha_at(sample + vec2(-x0,  y0), px_x, px_y)
+                    let a10 = self.alpha_at(sample + vec2( x0,  y0), px_x, px_y)
+                    let a11 = self.alpha_at(sample + vec2( x1,  y0), px_x, px_y)
+                    let a12 = self.alpha_at(sample + vec2(-x1,  y1), px_x, px_y)
+                    let a13 = self.alpha_at(sample + vec2(-x0,  y1), px_x, px_y)
+                    let a14 = self.alpha_at(sample + vec2( x0,  y1), px_x, px_y)
+                    let a15 = self.alpha_at(sample + vec2( x1,  y1), px_x, px_y)
+                    clamp(
+                        (a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11 + a12 + a13 + a14 + a15)
+                            * 0.0625,
+                        0.0,
+                        1.0
+                    )
+                } else if self.aa_2x2 > 0.5 {
+                    let offset = vec2(px_x * 0.25, px_y * 0.25)
+                    let a0 = self.alpha_at(sample + vec2(-offset.x, -offset.y), px_x, px_y)
+                    let a1 = self.alpha_at(sample + vec2(offset.x, -offset.y), px_x, px_y)
+                    let a2 = self.alpha_at(sample + vec2(-offset.x, offset.y), px_x, px_y)
+                    let a3 = self.alpha_at(sample + vec2(offset.x, offset.y), px_x, px_y)
+                    clamp((a0 + a1 + a2 + a3) * 0.25, 0.0, 1.0)
+                } else {
+                    self.alpha_at(sample, px_x, px_y)
+                }
+                let darken = clamp(max(px_x, px_y) * self.stem_darken, 0.0, self.stem_darken_max)
+                let edge_weight = clamp(1.0 - abs(alpha_base * 2.0 - 1.0), 0.0, 1.0)
+                let alpha = clamp(alpha_base + darken * edge_weight, 0.0, 1.0)
+                let color = self.get_color()
+                return vec4(color.rgb * color.a * alpha, color.a * alpha)
+            }
+
+            pixel: fn() {
+                return self.sample_slug_pixel() * self.slug_visibility
+            }
+        }
+    };
+    vm.eval(script_mod);
+}
 
 #[cfg(target_os = "linux")]
 script_mod! {
@@ -52,6 +552,7 @@ script_mod! {
     }
 
     use mod.text.*
+
 
     mod.draw.DrawText = mod.std.set_type_default() do #(DrawText::script_shader(vm)){
 
@@ -758,7 +1259,7 @@ pub enum TextOverflow {
     Ellipsis,
 }
 
-#[derive(Script, ScriptHook)]
+#[derive(Script)]
 #[repr(C)]
 pub struct DrawText {
     #[rust]
@@ -767,6 +1268,9 @@ pub struct DrawText {
     pending_slug_flush_generation: u64,
     #[rust]
     slug_flush_defer_depth: u64,
+    #[cfg(target_os = "linux")]
+    #[rust]
+    slug_draw: Option<DrawTextLinuxSlug>,
     #[live]
     pub text_style: TextStyle,
     #[live(1.0)]
@@ -837,6 +1341,284 @@ pub struct DrawText {
     pub stem_darken_max: f32,
 }
 
+#[cfg(target_os = "linux")]
+#[derive(Script, ScriptHook)]
+#[repr(C)]
+struct DrawTextLinuxSlug {
+    #[rust]
+    many_instances: Option<ManyInstances>,
+    #[deref]
+    draw_vars: DrawVars,
+    #[live]
+    rect_pos: Vec2f,
+    #[live]
+    rect_size: Vec2f,
+    #[live]
+    draw_clip: Vec4f,
+    #[live(1.0)]
+    depth_clip: f32,
+    #[live]
+    glyph_depth: f32,
+    #[live]
+    texture_index: f32,
+    #[live]
+    char_index: f32,
+    #[live(vec4(1., 1., 1., 1.))]
+    color: Vec4f,
+    #[live(1.0)]
+    sdf_sharpness: f32,
+    #[live(0.03)]
+    sdf_luma_bias: f32,
+    #[live]
+    t_min: Vec2f,
+    #[live]
+    t_max: Vec2f,
+    #[live]
+    atlas_plane: f32,
+    #[live]
+    pad1: f32,
+    #[live(0.0)]
+    aa_2x2: f32,
+    #[live(0.0)]
+    aa_4x4: f32,
+    #[live(0.2)]
+    stem_darken: f32,
+    #[live(0.125)]
+    stem_darken_max: f32,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ResolvedGlyph {
+    Raster(RasterizedGlyph),
+    Slug(crate::text::slug_atlas::SlugGlyphInfo),
+}
+
+#[cfg(target_os = "linux")]
+const LINUX_SLUG_HELPER_BUILDS_PER_REDRAW: usize = 1;
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+struct LinuxSlugHelperWarmupState {
+    redraw_id: u64,
+    builds_this_redraw: usize,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+struct LinuxSlugHelperPrewarmState {
+    registered: bool,
+    initialized: bool,
+    requested_redraw_id: u64,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+struct LinuxSlugPromotionState {
+    redraw_id: u64,
+    saw_slug_candidates_this_redraw: bool,
+    saw_unready_this_redraw: bool,
+    allow_slug_this_redraw: bool,
+}
+
+#[cfg(target_os = "linux")]
+fn linux_slug_try_consume_helper_build_budget(cx: &mut Cx) -> bool {
+    let redraw_id = cx.redraw_id;
+    let state = cx.global::<LinuxSlugHelperWarmupState>();
+    if state.redraw_id != redraw_id {
+        state.redraw_id = redraw_id;
+        state.builds_this_redraw = 0;
+    }
+    if state.builds_this_redraw >= LINUX_SLUG_HELPER_BUILDS_PER_REDRAW {
+        return false;
+    }
+    state.builds_this_redraw += 1;
+    true
+}
+
+#[cfg(target_os = "linux")]
+fn linux_slug_register_helper_if_needed(cx: &mut Cx) {
+    let should_register = {
+        let state = cx.global::<LinuxSlugHelperPrewarmState>();
+        if state.registered {
+            false
+        } else {
+            state.registered = true;
+            true
+        }
+    };
+    if should_register {
+        cx.with_vm(register_draw_text_linux_slug);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_slug_maybe_prewarm_helper(cx: &mut Cx2d) -> bool {
+    enum PrewarmAction {
+        Ready,
+        RequestFollowupRedraw,
+        TryPrewarm,
+    }
+
+    let redraw_id = cx.cx.redraw_id;
+    let action = {
+        let state = cx.cx.global::<LinuxSlugHelperPrewarmState>();
+        if state.initialized {
+            PrewarmAction::Ready
+        } else if state.requested_redraw_id == 0 {
+            state.requested_redraw_id = redraw_id;
+            PrewarmAction::RequestFollowupRedraw
+        } else if state.requested_redraw_id == redraw_id {
+            PrewarmAction::RequestFollowupRedraw
+        } else {
+            PrewarmAction::TryPrewarm
+        }
+    };
+
+    match action {
+        PrewarmAction::Ready => true,
+        PrewarmAction::RequestFollowupRedraw => {
+            // A real SLUG glyph was requested; keep this frame on the raster
+            // fallback and start warming the shared helper on the next redraw.
+            cx.redraw_all();
+            false
+        }
+        PrewarmAction::TryPrewarm => {
+            if !linux_slug_try_consume_helper_build_budget(cx.cx) {
+                cx.redraw_all();
+                return false;
+            }
+            linux_slug_register_helper_if_needed(cx.cx);
+            {
+                let state = cx.cx.global::<LinuxSlugHelperPrewarmState>();
+                if state.initialized {
+                    return true;
+                }
+                state.initialized = true;
+            }
+            cx.cx.with_vm(|vm| {
+                let _ = DrawTextLinuxSlug::script_new_with_default(vm);
+            });
+            cx.redraw_all();
+            false
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl DrawText {
+    fn linux_slug_run_is_ready(&mut self, cx: &mut Cx2d, text: &LaidoutText) -> bool {
+        let dpi_factor = cx.current_dpi_factor() as f32;
+        let redraw_id = cx.cx.redraw_id;
+        let mut has_slug_candidates = false;
+        let mut all_slug_candidates_ready = true;
+        let mut pending_slug_generation = 0;
+
+        {
+            let state = cx.cx.global::<LinuxSlugPromotionState>();
+            if state.redraw_id != redraw_id {
+                state.allow_slug_this_redraw = state.redraw_id != 0
+                    && state.saw_slug_candidates_this_redraw
+                    && !state.saw_unready_this_redraw;
+                state.redraw_id = redraw_id;
+                state.saw_slug_candidates_this_redraw = false;
+                state.saw_unready_this_redraw = false;
+            }
+        }
+
+        for row in &text.rows {
+            for glyph in &row.glyphs {
+                let font_size_in_dpxs = glyph.font_size_in_lpxs * dpi_factor;
+                if !cx.fonts.borrow().should_use_slug_glyph(font_size_in_dpxs) {
+                    continue;
+                }
+
+                match cx.fonts.borrow_mut().get_or_cache_slug_glyph(
+                    redraw_id,
+                    glyph.font.as_ref(),
+                    glyph.id,
+                ) {
+                    SlugGlyphCacheResult::Ready(..) => {
+                        has_slug_candidates = true;
+                    }
+                    SlugGlyphCacheResult::NeedsUpload { generation, .. } => {
+                        has_slug_candidates = true;
+                        all_slug_candidates_ready = false;
+                        pending_slug_generation = pending_slug_generation.max(generation);
+                    }
+                    SlugGlyphCacheResult::Deferred => {
+                        has_slug_candidates = true;
+                        all_slug_candidates_ready = false;
+                    }
+                    SlugGlyphCacheResult::Unavailable => {}
+                }
+            }
+        }
+
+        if pending_slug_generation != 0 {
+            self.pending_slug_flush_generation = self
+                .pending_slug_flush_generation
+                .max(pending_slug_generation);
+        }
+
+        if !has_slug_candidates {
+            return false;
+        }
+
+        {
+            let state = cx.cx.global::<LinuxSlugPromotionState>();
+            state.saw_slug_candidates_this_redraw = true;
+        }
+
+        if !all_slug_candidates_ready {
+            let state = cx.cx.global::<LinuxSlugPromotionState>();
+            state.saw_unready_this_redraw = true;
+            cx.redraw_all();
+            return false;
+        }
+
+        if !linux_slug_maybe_prewarm_helper(cx) {
+            let state = cx.cx.global::<LinuxSlugPromotionState>();
+            state.saw_unready_this_redraw = true;
+            return false;
+        }
+
+        if !self.ensure_linux_slug_draw(cx) {
+            let state = cx.cx.global::<LinuxSlugPromotionState>();
+            state.saw_unready_this_redraw = true;
+            cx.redraw_all();
+            return false;
+        }
+
+        {
+            let state = cx.cx.global::<LinuxSlugPromotionState>();
+            if !state.allow_slug_this_redraw {
+                cx.redraw_all();
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl ScriptHook for DrawText {
+    fn on_after_apply(
+        &mut self,
+        _vm: &mut ScriptVm,
+        apply: &Apply,
+        _scope: &mut Scope,
+        _value: ScriptValue,
+    ) {
+        if apply.is_from_script() {
+            self.slug_draw = None;
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+impl ScriptHook for DrawText {}
+
 #[derive(Clone, Debug)]
 pub struct PreparedTextGlyph {
     pub pen_x_in_lpxs: f32,
@@ -854,7 +1636,329 @@ pub struct PreparedTextRun {
     pub glyphs: Vec<PreparedTextGlyph>,
 }
 
+#[cfg(target_os = "linux")]
+impl DrawTextLinuxSlug {
+    fn has_open_batch(&self) -> bool {
+        self.many_instances.is_some()
+    }
+
+    fn begin_many_instances(&mut self, cx: &mut Cx2d, visibility: f32) -> bool {
+        if self.many_instances.is_some() {
+            return true;
+        }
+        self.update_draw_vars(cx);
+        self.draw_vars
+            .set_uniform(cx.cx, live_id!(slug_visibility), &[visibility]);
+        self.many_instances = cx.begin_many_aligned_instances(&self.draw_vars);
+        self.many_instances.is_some()
+    }
+
+    fn end_many_instances(&mut self, cx: &mut Cx2d, extend_area: bool) {
+        if let Some(instances) = self.many_instances.take() {
+            self.finish_many_instances(cx, instances, extend_area);
+        }
+    }
+
+    fn finish_many_instances(
+        &mut self,
+        cx: &mut Cx2d,
+        instances: ManyInstances,
+        extend_area: bool,
+    ) {
+        let new_area = cx.end_many_instances(instances);
+        let old_area = self.draw_vars.area;
+        if extend_area {
+            let extended = old_area.extend_with(cx, new_area);
+            self.draw_vars.area = cx.update_area_refs(old_area, extended);
+        } else {
+            self.draw_vars.area = cx.update_area_refs(old_area, new_area);
+        }
+    }
+
+    fn update_draw_vars(&mut self, cx: &mut Cx2d) {
+        self.draw_vars.append_group_id = cx.draw_call_group_content().0;
+        let fonts = cx.fonts.borrow();
+        self.draw_vars.texture_slots[0] = Some(fonts.slug_curve_texture().clone());
+        self.draw_vars.texture_slots[1] = Some(fonts.slug_band_texture().clone());
+        for slot in self.draw_vars.texture_slots.iter_mut().skip(2) {
+            *slot = None;
+        }
+
+        let pass_id = cx.pass_stack.last().unwrap().pass_id;
+        let draw_list_id = *cx.draw_list_stack.last().unwrap();
+        let pass_uniforms = cx.passes[pass_id].pass_uniforms.clone();
+        let view_transform = cx.draw_lists[draw_list_id]
+            .draw_list_uniforms
+            .view_transform;
+        let model_view = Mat4f::mul(&pass_uniforms.camera_view, &view_transform);
+        let slug_matrix = Mat4f::mul(&pass_uniforms.camera_projection, &model_view);
+        let viewport = cx.current_pass_size();
+        let dpi_factor = cx.current_dpi_factor() as f32;
+        let viewport_px = [
+            (viewport.x as f32 * dpi_factor).max(1.0),
+            (viewport.y as f32 * dpi_factor).max(1.0),
+        ];
+
+        self.draw_vars
+            .set_uniform(cx.cx, live_id!(slug_matrix_0), &mat4_row(&slug_matrix, 0));
+        self.draw_vars
+            .set_uniform(cx.cx, live_id!(slug_matrix_1), &mat4_row(&slug_matrix, 1));
+        self.draw_vars
+            .set_uniform(cx.cx, live_id!(slug_matrix_3), &mat4_row(&slug_matrix, 3));
+        self.draw_vars
+            .set_uniform(cx.cx, live_id!(slug_viewport_px), &viewport_px);
+    }
+
+    fn draw_slug_glyph(
+        &mut self,
+        cx: &mut Cx2d,
+        draw_text: &DrawText,
+        origin_in_lpxs: Point<f32>,
+        font_size_in_lpxs: f32,
+        color: Option<Color>,
+        glyph: crate::text::slug_atlas::SlugGlyphInfo,
+    ) {
+        let Some(instances) = self.many_instances.as_mut() else {
+            return;
+        };
+
+        let bounds_in_lpxs = TextRect::new(
+            Point::new(
+                origin_in_lpxs.x + glyph.origin_in_ems.x * font_size_in_lpxs * draw_text.font_scale,
+                origin_in_lpxs.y
+                    + (-glyph.origin_in_ems.y - glyph.size_in_ems.height)
+                        * font_size_in_lpxs
+                        * draw_text.font_scale,
+            ),
+            Size::new(
+                glyph.size_in_ems.width * font_size_in_lpxs * draw_text.font_scale,
+                glyph.size_in_ems.height * font_size_in_lpxs * draw_text.font_scale,
+            ),
+        );
+
+        let pad = (draw_text.get_aa_pad_px(cx.cx) / cx.current_dpi_factor() as f32).max(0.0);
+        self.rect_pos = vec2(bounds_in_lpxs.origin.x - pad, bounds_in_lpxs.origin.y - pad)
+            + vec2(0.0, draw_text.temp_y_shift * font_size_in_lpxs);
+        self.rect_size = vec2(
+            bounds_in_lpxs.size.width + pad * 2.0,
+            bounds_in_lpxs.size.height + pad * 2.0,
+        );
+        self.draw_clip = draw_text.draw_clip;
+        self.depth_clip = draw_text.depth_clip;
+        self.glyph_depth = draw_text.glyph_depth;
+        self.texture_index = 3.0;
+        self.char_index = draw_text.char_index;
+        let mut source_color = [
+            draw_text.color.x,
+            draw_text.color.y,
+            draw_text.color.z,
+            draw_text.color.w,
+        ];
+        if !draw_text
+            .draw_vars
+            .get_instance_on_area(cx.cx, live_id!(color), &mut source_color)
+        {
+            draw_text
+                .draw_vars
+                .get_instance(cx.cx, live_id!(color), &mut source_color);
+        }
+        self.color = vec4(
+            source_color[0],
+            source_color[1],
+            source_color[2],
+            source_color[3],
+        );
+        self.sdf_sharpness = draw_text.sdf_sharpness;
+        self.sdf_luma_bias = draw_text.sdf_luma_bias;
+        if let Some(color) = color {
+            self.color = vec4(
+                color.r as f32,
+                color.g as f32,
+                color.b as f32,
+                color.a as f32,
+            ) / 255.0;
+        }
+        self.t_min = vec2(glyph.curve_offset as f32, glyph.curve_count as f32);
+        self.t_max = vec2(glyph.band_offset as f32, glyph.band_count as f32);
+        self.atlas_plane = glyph.fill_flags as f32;
+        self.pad1 = 0.0;
+        self.aa_2x2 = draw_text.aa_2x2;
+        self.aa_4x4 = draw_text.aa_4x4;
+        self.stem_darken = draw_text.stem_darken;
+        self.stem_darken_max = draw_text.stem_darken_max;
+        self.draw_vars
+            .set_dyn_instance(cx.cx, live_id!(scale), &[draw_text.font_scale]);
+
+        instances
+            .instances
+            .extend_from_slice(self.draw_vars.as_slice());
+    }
+}
+
 impl DrawText {
+    #[cfg(target_os = "linux")]
+    fn linux_slug_draw_is_ready(&self, cx: &mut Cx2d) -> bool {
+        let Some(shader_id) = self
+            .slug_draw
+            .as_ref()
+            .and_then(|slug_draw| slug_draw.draw_vars.draw_shader_id)
+        else {
+            return false;
+        };
+        cx.cx.is_draw_shader_window_ready(shader_id)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn ensure_linux_slug_draw(&mut self, cx: &mut Cx2d) -> bool {
+        if self.slug_draw.is_some() {
+            self.sync_linux_slug_draw_state(cx);
+            return self.linux_slug_draw_is_ready(cx);
+        }
+
+        linux_slug_register_helper_if_needed(cx.cx);
+        let mut created = None;
+
+        cx.cx.with_vm(|vm| {
+            let slug_draw = DrawTextLinuxSlug::script_new_with_default(vm);
+            created = Some(slug_draw);
+        });
+
+        self.slug_draw = created;
+        if self.slug_draw.is_some() {
+            if let Some(slug_draw) = self.slug_draw.as_mut() {
+                slug_draw.draw_vars.options = self.draw_vars.options.clone();
+            }
+            self.sync_linux_slug_draw_state(cx);
+            return self.linux_slug_draw_is_ready(cx);
+        }
+        false
+    }
+
+    #[cfg(target_os = "linux")]
+    fn sync_linux_slug_draw_state(&mut self, cx: &mut Cx2d) {
+        let Some(source_shader_id) = self.draw_vars.draw_shader_id else {
+            return;
+        };
+        let Some(target_shader_id) = self
+            .slug_draw
+            .as_ref()
+            .and_then(|slug_draw| slug_draw.draw_vars.draw_shader_id)
+        else {
+            return;
+        };
+
+        let source_dyn_instances: Vec<_> = cx.cx.draw_shaders.shaders[source_shader_id.index]
+            .mapping
+            .dyn_instances
+            .inputs
+            .iter()
+            .map(|input| input.id)
+            .collect();
+        let target_dyn_instances: Vec<_> = cx.cx.draw_shaders.shaders[target_shader_id.index]
+            .mapping
+            .dyn_instances
+            .inputs
+            .iter()
+            .map(|input| input.id)
+            .collect();
+        let source_dyn_uniforms: Vec<_> = cx.cx.draw_shaders.shaders[source_shader_id.index]
+            .mapping
+            .dyn_uniforms
+            .inputs
+            .iter()
+            .map(|input| input.id)
+            .collect();
+        let target_dyn_uniforms: Vec<_> = cx.cx.draw_shaders.shaders[target_shader_id.index]
+            .mapping
+            .dyn_uniforms
+            .inputs
+            .iter()
+            .map(|input| input.id)
+            .collect();
+        let Some(slug_draw) = self.slug_draw.as_mut() else {
+            return;
+        };
+        slug_draw.draw_vars.options = self.draw_vars.options.clone();
+
+        let copy_instance =
+            |draw_vars: &DrawVars, slug_draw: &mut DrawTextLinuxSlug, cx: &mut Cx2d, id: LiveId| {
+                if !source_dyn_instances.contains(&id) || !target_dyn_instances.contains(&id) {
+                    return;
+                }
+                let mut value = [0.0; 4];
+                draw_vars.get_instance(cx.cx, id, &mut value);
+                slug_draw.draw_vars.set_dyn_instance(cx.cx, id, &value);
+            };
+
+        let copy_uniform =
+            |draw_vars: &DrawVars, slug_draw: &mut DrawTextLinuxSlug, cx: &mut Cx2d, id: LiveId| {
+                if !source_dyn_uniforms.contains(&id) || !target_dyn_uniforms.contains(&id) {
+                    return;
+                }
+                let mut value = [0.0; 4];
+                draw_vars.get_uniform(cx.cx, id, &mut value);
+                slug_draw.draw_vars.set_uniform(cx.cx, id, &value);
+            };
+
+        for id in [
+            live_id!(hover),
+            live_id!(focus),
+            live_id!(down),
+            live_id!(disabled),
+            live_id!(empty),
+            live_id!(active),
+            live_id!(drag),
+            live_id!(pressed),
+            live_id!(opened),
+            live_id!(focussed),
+            live_id!(is_even),
+            live_id!(is_folder),
+            live_id!(scale),
+            live_id!(total_chars),
+        ] {
+            copy_instance(&self.draw_vars, slug_draw, cx, id);
+        }
+
+        for id in [
+            live_id!(aa_pad_px),
+            live_id!(color_hover),
+            live_id!(color_focus),
+            live_id!(color_down),
+            live_id!(color_disabled),
+            live_id!(color_empty),
+            live_id!(color_empty_hover),
+            live_id!(color_empty_focus),
+            live_id!(color_active),
+            live_id!(color_drag),
+            live_id!(color_pressed),
+            live_id!(color_2),
+            live_id!(color_2_hover),
+            live_id!(color_2_focus),
+            live_id!(color_2_down),
+            live_id!(color_2_disabled),
+            live_id!(color_2_empty),
+            live_id!(color_2_empty_hover),
+            live_id!(color_2_empty_focus),
+            live_id!(color_2_active),
+            live_id!(color_2_drag),
+            live_id!(color_2_pressed),
+            live_id!(color_dither),
+            live_id!(gradient_fill_horizontal),
+        ] {
+            copy_uniform(&self.draw_vars, slug_draw, cx, id);
+        }
+
+        let mut color_2 = [-1.0; 4];
+        if source_dyn_uniforms.contains(&live_id!(color_2)) {
+            self.draw_vars.get_uniform(cx.cx, live_id!(color_2), &mut color_2);
+        }
+        slug_draw.draw_vars.set_uniform(
+            cx.cx,
+            live_id!(use_color_2),
+            &[if color_2[0] > -0.5 { 1.0 } else { 0.0 }],
+        );
+    }
+
     pub fn draw_abs(&mut self, cx: &mut Cx2d, pos: Vec2d, text: &str) {
         let text = self.layout(cx, 0.0, 0.0, None, false, Align::default(), text);
         self.draw_text(cx, Point::new(pos.x as f32, pos.y as f32), &text);
@@ -872,6 +1976,11 @@ impl DrawText {
         if let Some(instances) = self.many_instances.take() {
             self.flush_slug_textures_if_allowed(cx);
             self.finish_many_instances(cx, instances);
+        }
+        #[cfg(target_os = "linux")]
+        if let Some(mut slug_draw) = self.slug_draw.take() {
+            slug_draw.end_many_instances(cx, self.extend_area);
+            self.slug_draw = Some(slug_draw);
         }
     }
 
@@ -1230,8 +2339,186 @@ impl DrawText {
     }
 
     fn draw_text(&mut self, cx: &mut Cx2d, origin_in_lpxs: Point<f32>, text: &LaidoutText) {
-        self.update_draw_vars(cx);
-        if let Some(mut instances) = self.many_instances.take() {
+        #[cfg(target_os = "linux")]
+        {
+            self.update_draw_vars(cx);
+            self.glyph_depth = self.draw_depth;
+            let use_linux_slug_this_frame = self.linux_slug_run_is_ready(cx, text);
+            let slug_area_was_empty = self
+                .slug_draw
+                .as_ref()
+                .map(|slug_draw| slug_draw.draw_vars.area.is_empty())
+                .unwrap_or(true);
+            let shadow_slug_this_frame = use_linux_slug_this_frame && slug_area_was_empty;
+
+            let mut raster_instances = None::<ManyInstances>;
+            let mut drew_raster_this_frame = false;
+            let mut drew_slug_this_frame = false;
+
+            for row in &text.rows {
+                let row_origin = origin_in_lpxs + Size::from(row.origin_in_lpxs) * self.font_scale;
+                for glyph in &row.glyphs {
+                    use crate::text::geom::Point;
+
+                    let glyph_origin = Point::new(
+                        row_origin.x
+                            + glyph.origin_in_lpxs.x * self.font_scale
+                            + glyph.offset_in_lpxs() * self.font_scale,
+                        row_origin.y + glyph.origin_in_lpxs.y * self.font_scale,
+                    );
+                    if !use_linux_slug_this_frame {
+                        if raster_instances.is_none() {
+                            raster_instances = cx.begin_many_aligned_instances(&self.draw_vars);
+                        }
+                        if let Some(instances) = raster_instances.as_mut() {
+                            drew_raster_this_frame |= self.draw_linux_raster_fallback_glyph(
+                                cx,
+                                glyph_origin,
+                                glyph,
+                                &mut instances.instances,
+                            );
+                        }
+                        continue;
+                    }
+                    match self.resolve_glyph(cx, glyph) {
+                        Some(ResolvedGlyph::Slug(slug_glyph)) => {
+                            let mut drew_slug = false;
+                            if self.ensure_linux_slug_draw(cx) {
+                                if let Some(instances) = raster_instances.take() {
+                                    self.finish_many_instances(cx, instances);
+                                }
+                                self.sync_linux_slug_draw_state(cx);
+                                if let Some(mut slug_draw) = self.slug_draw.take() {
+                                    if slug_draw.begin_many_instances(
+                                        cx,
+                                        if shadow_slug_this_frame { 0.0 } else { 1.0 },
+                                    ) {
+                                        slug_draw.draw_slug_glyph(
+                                            cx,
+                                            self,
+                                            glyph_origin,
+                                            glyph.font_size_in_lpxs,
+                                            glyph.color,
+                                            slug_glyph,
+                                        );
+                                        self.glyph_depth += 0.000001;
+                                        self.char_index += 1.0;
+                                        drew_slug = true;
+                                        drew_slug_this_frame = true;
+                                    }
+                                    self.slug_draw = Some(slug_draw);
+                                }
+                            }
+                            if shadow_slug_this_frame {
+                                if raster_instances.is_none() {
+                                    raster_instances =
+                                        cx.begin_many_aligned_instances(&self.draw_vars);
+                                }
+                                if let Some(instances) = raster_instances.as_mut() {
+                                    drew_raster_this_frame |= self.draw_linux_raster_fallback_glyph(
+                                        cx,
+                                        glyph_origin,
+                                        glyph,
+                                        &mut instances.instances,
+                                    );
+                                }
+                            }
+                            if !drew_slug {
+                                cx.redraw_all();
+                                if raster_instances.is_none() {
+                                    raster_instances =
+                                        cx.begin_many_aligned_instances(&self.draw_vars);
+                                }
+                                if let Some(instances) = raster_instances.as_mut() {
+                                    drew_raster_this_frame |= self.draw_linux_raster_fallback_glyph(
+                                        cx,
+                                        glyph_origin,
+                                        glyph,
+                                        &mut instances.instances,
+                                    );
+                                }
+                            }
+                        }
+                        Some(ResolvedGlyph::Raster(rasterized_glyph)) => {
+                            if let Some(mut slug_draw) = self.slug_draw.take() {
+                                if slug_draw.has_open_batch() {
+                                    slug_draw.end_many_instances(cx, self.extend_area);
+                                }
+                                self.slug_draw = Some(slug_draw);
+                            }
+
+                            if raster_instances.is_none() {
+                                raster_instances = cx.begin_many_aligned_instances(&self.draw_vars);
+                            }
+                            let Some(instances) = raster_instances.as_mut() else {
+                                continue;
+                            };
+                            self.draw_rasterized_glyph(
+                                glyph_origin,
+                                glyph.font_size_in_lpxs,
+                                glyph.color,
+                                rasterized_glyph,
+                                &mut instances.instances,
+                            );
+                            drew_raster_this_frame = true;
+                        }
+                        None => {}
+                    }
+                }
+
+                self.draw_debug_row_guides(cx, row_origin, row);
+            }
+
+            if shadow_slug_this_frame && drew_slug_this_frame {
+                cx.redraw_all();
+            }
+
+            self.flush_slug_textures_if_allowed(cx);
+            if let Some(instances) = raster_instances.take() {
+                self.finish_many_instances(cx, instances);
+            }
+            if let Some(mut slug_draw) = self.slug_draw.take() {
+                if slug_draw.has_open_batch() {
+                    slug_draw.end_many_instances(cx, self.extend_area);
+                }
+                if !drew_slug_this_frame {
+                    let old_area = slug_draw.draw_vars.area;
+                    if !old_area.is_empty() {
+                        cx.cx.redraw_area_in_draw(old_area);
+                    }
+                    slug_draw.draw_vars.area = cx.update_area_refs(old_area, Area::Empty);
+                }
+                self.slug_draw = Some(slug_draw);
+            }
+            if !drew_raster_this_frame {
+                let old_area = self.draw_vars.area;
+                if !old_area.is_empty() {
+                    cx.cx.redraw_area_in_draw(old_area);
+                }
+                self.draw_vars.area = cx.update_area_refs(old_area, Area::Empty);
+            }
+            return;
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            self.update_draw_vars(cx);
+            if let Some(mut instances) = self.many_instances.take() {
+                self.glyph_depth = self.draw_depth;
+                for row in &text.rows {
+                    self.draw_row(
+                        cx,
+                        origin_in_lpxs + Size::from(row.origin_in_lpxs) * self.font_scale,
+                        row,
+                        &mut instances.instances,
+                    );
+                }
+                self.many_instances = Some(instances);
+                return;
+            }
+            let Some(mut instances) = cx.begin_many_aligned_instances(&self.draw_vars) else {
+                return;
+            };
             self.glyph_depth = self.draw_depth;
             for row in &text.rows {
                 self.draw_row(
@@ -1241,32 +2528,25 @@ impl DrawText {
                     &mut instances.instances,
                 );
             }
-            self.many_instances = Some(instances);
-            return;
+            self.flush_slug_textures_if_allowed(cx);
+            self.finish_many_instances(cx, instances);
         }
-        let Some(mut instances) = cx.begin_many_aligned_instances(&self.draw_vars) else {
-            return;
-        };
-        self.glyph_depth = self.draw_depth;
-        for row in &text.rows {
-            self.draw_row(
-                cx,
-                origin_in_lpxs + Size::from(row.origin_in_lpxs) * self.font_scale,
-                row,
-                &mut instances.instances,
-            );
-        }
-        self.flush_slug_textures_if_allowed(cx);
-        self.finish_many_instances(cx, instances);
     }
 
     fn flush_slug_textures_if_allowed(&mut self, cx: &mut Cx2d) {
+        #[cfg(target_os = "linux")]
+        let _ = cx;
+        #[cfg(target_os = "linux")]
+        return;
+        #[cfg(not(target_os = "linux"))]
         if self.slug_flush_defer_depth != 0 {
             return;
         }
+        #[cfg(not(target_os = "linux"))]
         self.flush_slug_textures_if_needed(cx);
     }
 
+    #[cfg(not(target_os = "linux"))]
     fn flush_slug_textures_if_needed(&mut self, cx: &mut Cx2d) {
         if self.pending_slug_flush_generation == 0 {
             return;
@@ -1302,34 +2582,84 @@ impl DrawText {
         self.draw_vars.texture_slots[0] = Some(fonts.grayscale_texture().clone());
         self.draw_vars.texture_slots[1] = Some(fonts.color_texture().clone());
         self.draw_vars.texture_slots[2] = Some(fonts.msdf_texture().clone());
-        self.draw_vars.texture_slots[3] = Some(fonts.slug_curve_texture().clone());
-        self.draw_vars.texture_slots[4] = Some(fonts.slug_band_texture().clone());
+        #[cfg(not(target_os = "linux"))]
+        {
+            self.draw_vars.texture_slots[3] = Some(fonts.slug_curve_texture().clone());
+            self.draw_vars.texture_slots[4] = Some(fonts.slug_band_texture().clone());
 
-        let pass_id = cx.pass_stack.last().unwrap().pass_id;
-        let draw_list_id = *cx.draw_list_stack.last().unwrap();
-        let pass_uniforms = cx.passes[pass_id].pass_uniforms.clone();
-        let view_transform = cx.draw_lists[draw_list_id]
-            .draw_list_uniforms
-            .view_transform;
-        let model_view = Mat4f::mul(&pass_uniforms.camera_view, &view_transform);
-        let slug_matrix = Mat4f::mul(&pass_uniforms.camera_projection, &model_view);
-        let viewport = cx.current_pass_size();
-        let dpi_factor = cx.current_dpi_factor() as f32;
-        let viewport_px = [
-            (viewport.x as f32 * dpi_factor).max(1.0),
-            (viewport.y as f32 * dpi_factor).max(1.0),
-        ];
+            let pass_id = cx.pass_stack.last().unwrap().pass_id;
+            let draw_list_id = *cx.draw_list_stack.last().unwrap();
+            let pass_uniforms = cx.passes[pass_id].pass_uniforms.clone();
+            let view_transform = cx.draw_lists[draw_list_id]
+                .draw_list_uniforms
+                .view_transform;
+            let model_view = Mat4f::mul(&pass_uniforms.camera_view, &view_transform);
+            let slug_matrix = Mat4f::mul(&pass_uniforms.camera_projection, &model_view);
+            let viewport = cx.current_pass_size();
+            let dpi_factor = cx.current_dpi_factor() as f32;
+            let viewport_px = [
+                (viewport.x as f32 * dpi_factor).max(1.0),
+                (viewport.y as f32 * dpi_factor).max(1.0),
+            ];
 
-        self.draw_vars
-            .set_uniform(cx.cx, live_id!(slug_matrix_0), &mat4_row(&slug_matrix, 0));
-        self.draw_vars
-            .set_uniform(cx.cx, live_id!(slug_matrix_1), &mat4_row(&slug_matrix, 1));
-        self.draw_vars
-            .set_uniform(cx.cx, live_id!(slug_matrix_3), &mat4_row(&slug_matrix, 3));
-        self.draw_vars
-            .set_uniform(cx.cx, live_id!(slug_viewport_px), &viewport_px);
+            self.draw_vars
+                .set_uniform(cx.cx, live_id!(slug_matrix_0), &mat4_row(&slug_matrix, 0));
+            self.draw_vars
+                .set_uniform(cx.cx, live_id!(slug_matrix_1), &mat4_row(&slug_matrix, 1));
+            self.draw_vars
+                .set_uniform(cx.cx, live_id!(slug_matrix_3), &mat4_row(&slug_matrix, 3));
+            self.draw_vars
+                .set_uniform(cx.cx, live_id!(slug_viewport_px), &viewport_px);
+        }
     }
 
+    fn draw_debug_row_guides(
+        &mut self,
+        cx: &mut Cx2d,
+        origin_in_lpxs: Point<f32>,
+        row: &LaidoutRow,
+    ) {
+        if !self.debug {
+            return;
+        }
+
+        let width_in_lpxs = row.width_in_lpxs * self.font_scale;
+        let mut area = Area::Empty;
+        cx.add_aligned_rect_area(
+            &mut area,
+            rect(
+                origin_in_lpxs.x as f64,
+                (origin_in_lpxs.y - row.ascender_in_lpxs * self.font_scale) as f64,
+                width_in_lpxs as f64,
+                1.0,
+            ),
+        );
+        cx.cx.debug.area(area, vec4(1.0, 0.0, 0.0, 1.0));
+        let mut area = Area::Empty;
+        cx.add_aligned_rect_area(
+            &mut area,
+            rect(
+                origin_in_lpxs.x as f64,
+                origin_in_lpxs.y as f64,
+                width_in_lpxs as f64,
+                1.0,
+            ),
+        );
+        cx.cx.debug.area(area, vec4(0.0, 1.0, 0.0, 1.0));
+        let mut area = Area::Empty;
+        cx.add_aligned_rect_area(
+            &mut area,
+            rect(
+                origin_in_lpxs.x as f64,
+                (origin_in_lpxs.y - row.descender_in_lpxs * self.font_scale) as f64,
+                width_in_lpxs as f64,
+                1.0,
+            ),
+        );
+        cx.cx.debug.area(area, vec4(0.0, 0.0, 1.0, 1.0));
+    }
+
+    #[cfg(not(target_os = "linux"))]
     fn draw_row(
         &mut self,
         cx: &mut Cx2d,
@@ -1345,45 +2675,52 @@ impl DrawText {
                 out_instances,
             );
         }
-
-        let width_in_lpxs = row.width_in_lpxs * self.font_scale;
-        if self.debug {
-            let mut area = Area::Empty;
-            cx.add_aligned_rect_area(
-                &mut area,
-                rect(
-                    origin_in_lpxs.x as f64,
-                    (origin_in_lpxs.y - row.ascender_in_lpxs * self.font_scale) as f64,
-                    width_in_lpxs as f64,
-                    1.0,
-                ),
-            );
-            cx.cx.debug.area(area, vec4(1.0, 0.0, 0.0, 1.0));
-            let mut area = Area::Empty;
-            cx.add_aligned_rect_area(
-                &mut area,
-                rect(
-                    origin_in_lpxs.x as f64,
-                    origin_in_lpxs.y as f64,
-                    width_in_lpxs as f64,
-                    1.0,
-                ),
-            );
-            cx.cx.debug.area(area, vec4(0.0, 1.0, 0.0, 1.0));
-            let mut area = Area::Empty;
-            cx.add_aligned_rect_area(
-                &mut area,
-                rect(
-                    origin_in_lpxs.x as f64,
-                    (origin_in_lpxs.y - row.descender_in_lpxs * self.font_scale) as f64,
-                    width_in_lpxs as f64,
-                    1.0,
-                ),
-            );
-            cx.cx.debug.area(area, vec4(0.0, 0.0, 1.0, 1.0));
-        }
+        self.draw_debug_row_guides(cx, origin_in_lpxs, row);
     }
 
+    fn resolve_glyph(&mut self, cx: &mut Cx2d, glyph: &LaidoutGlyph) -> Option<ResolvedGlyph> {
+        let font_size_in_dpxs = glyph.font_size_in_lpxs * cx.current_dpi_factor() as f32;
+        if cx.fonts.borrow().should_use_slug_glyph(font_size_in_dpxs) {
+            let slug_lookup = {
+                let mut fonts = cx.fonts.borrow_mut();
+                fonts.get_or_cache_slug_glyph(cx.cx.redraw_id, glyph.font.as_ref(), glyph.id)
+            };
+
+            match slug_lookup {
+                SlugGlyphCacheResult::Ready(slug_glyph) => {
+                    return Some(ResolvedGlyph::Slug(slug_glyph));
+                }
+                #[cfg(target_os = "linux")]
+                SlugGlyphCacheResult::NeedsUpload {
+                    generation,
+                    glyph: _,
+                } => {
+                    self.pending_slug_flush_generation =
+                        self.pending_slug_flush_generation.max(generation);
+                    cx.redraw_all();
+                }
+                #[cfg(not(target_os = "linux"))]
+                SlugGlyphCacheResult::NeedsUpload {
+                    generation,
+                    glyph: slug_glyph,
+                } => {
+                    self.pending_slug_flush_generation =
+                        self.pending_slug_flush_generation.max(generation);
+                    return Some(ResolvedGlyph::Slug(slug_glyph));
+                }
+                SlugGlyphCacheResult::Deferred => {
+                    cx.redraw_all();
+                }
+                SlugGlyphCacheResult::Unavailable => {}
+            }
+        }
+
+        glyph
+            .rasterize(font_size_in_dpxs)
+            .map(ResolvedGlyph::Raster)
+    }
+
+    #[cfg(not(target_os = "linux"))]
     fn draw_glyph(
         &mut self,
         cx: &mut Cx2d,
@@ -1392,48 +2729,34 @@ impl DrawText {
         output: &mut Vec<f32>,
     ) {
         use crate::text::geom::Point;
-        let font_size_in_dpxs = glyph.font_size_in_lpxs * cx.current_dpi_factor() as f32;
         let glyph_origin = Point::new(
             origin_in_lpxs.x + glyph.offset_in_lpxs() * self.font_scale,
             origin_in_lpxs.y,
         );
 
-        let slug_glyph = if cx.fonts.borrow().should_use_slug_glyph(font_size_in_dpxs) {
-            let mut fonts = cx.fonts.borrow_mut();
-            let generation_before = fonts.slug_cache_generation();
-            let slug_glyph = fonts.get_or_cache_slug_glyph(glyph.font.as_ref(), glyph.id);
-            let generation_after = fonts.slug_cache_generation();
-            if generation_after != generation_before {
-                self.pending_slug_flush_generation =
-                    self.pending_slug_flush_generation.max(generation_after);
+        match self.resolve_glyph(cx, glyph) {
+            Some(ResolvedGlyph::Slug(slug_glyph)) => {
+                self.draw_slug_glyph(
+                    cx,
+                    glyph_origin,
+                    glyph.font_size_in_lpxs,
+                    glyph.color,
+                    slug_glyph,
+                    output,
+                );
             }
-            slug_glyph
-        } else {
-            None
-        };
-        if let Some(slug_glyph) = slug_glyph {
-            self.draw_slug_glyph(
-                cx,
-                glyph_origin,
-                glyph.font_size_in_lpxs,
-                glyph.color,
-                slug_glyph,
-                output,
-            );
-            return;
-        }
-
-        if let Some(rasterized_glyph) = glyph.rasterize(font_size_in_dpxs) {
-            self.draw_rasterized_glyph(
+            Some(ResolvedGlyph::Raster(rasterized_glyph)) => self.draw_rasterized_glyph(
                 glyph_origin,
                 glyph.font_size_in_lpxs,
                 glyph.color,
                 rasterized_glyph,
                 output,
-            );
+            ),
+            None => {}
         }
     }
 
+    #[cfg(not(target_os = "linux"))]
     fn draw_slug_glyph(
         &mut self,
         cx: &mut Cx2d,
@@ -1481,6 +2804,47 @@ impl DrawText {
         output.extend_from_slice(slice);
         self.glyph_depth += 0.000001;
         self.char_index += 1.0;
+    }
+
+    #[cfg(target_os = "linux")]
+    fn draw_linux_raster_fallback_glyph(
+        &mut self,
+        cx: &mut Cx2d,
+        origin_in_lpxs: Point<f32>,
+        glyph: &LaidoutGlyph,
+        output: &mut Vec<f32>,
+    ) -> bool {
+        let font_size_in_dpxs = glyph.font_size_in_lpxs * cx.current_dpi_factor() as f32;
+        let should_use_slug = cx.fonts.borrow().should_use_slug_glyph(font_size_in_dpxs);
+        let fallback_dpxs_per_em = if should_use_slug && font_size_in_dpxs > 0.0 {
+            cx.fonts
+                .borrow()
+                .max_rasterized_glyph_dpxs_per_em()
+        } else {
+            0.0
+        };
+        let rasterized_glyph = if should_use_slug {
+            let stable_dpxs_per_em = if fallback_dpxs_per_em > 0.0 {
+                fallback_dpxs_per_em.min(font_size_in_dpxs)
+            } else {
+                font_size_in_dpxs
+            };
+            glyph.font
+                .rasterize_glyph_stable_fallback(glyph.id, stable_dpxs_per_em)
+        } else {
+            glyph.rasterize(font_size_in_dpxs)
+        };
+        let Some(rasterized_glyph) = rasterized_glyph else {
+            return false;
+        };
+        self.draw_rasterized_glyph(
+            origin_in_lpxs,
+            glyph.font_size_in_lpxs,
+            glyph.color,
+            rasterized_glyph,
+            output,
+        );
+        true
     }
 
     fn draw_rasterized_glyph(
@@ -1561,6 +2925,24 @@ impl DrawText {
     pub fn set_total_chars(&mut self, cx: &mut Cx, total: f32) {
         self.draw_vars
             .set_instance_on_area(cx, live_id!(total_chars), &[total]);
+        #[cfg(target_os = "linux")]
+        if let Some(slug_draw) = self.slug_draw.as_mut() {
+            slug_draw
+                .draw_vars
+                .set_instance_on_area(cx, live_id!(total_chars), &[total]);
+        }
+    }
+
+    pub fn redraw_areas(&self, cx: &mut Cx) {
+        self.draw_vars.area.redraw(cx);
+        #[cfg(target_os = "linux")]
+        if let Some(slug_draw) = self.slug_draw.as_ref() {
+            slug_draw.draw_vars.area.redraw(cx);
+        }
+    }
+
+    pub fn redraw(&self, cx: &mut Cx) {
+        self.redraw_areas(cx);
     }
 
     pub fn new_draw_call(&mut self, cx: &mut Cx2d) {
@@ -1573,6 +2955,15 @@ impl DrawText {
     }
 
     pub fn get_aa_pad_px(&self, cx: &mut Cx) -> f32 {
+        #[cfg(target_os = "linux")]
+        if let Some(slug_draw) = self.slug_draw.as_ref() {
+            let mut value = [0.0];
+            slug_draw
+                .draw_vars
+                .get_uniform(cx, live_id!(aa_pad_px), &mut value);
+            return value[0];
+        }
+
         let mut value = [0.0];
         self.draw_vars
             .get_uniform(cx, live_id!(aa_pad_px), &mut value);
@@ -1874,9 +3265,58 @@ impl ScriptHook for FontFamily {
 #[cfg(test)]
 mod tests {
     use super::DrawText;
+    #[cfg(target_os = "linux")]
+    use super::{register_draw_text_linux_slug, DrawTextLinuxSlug};
+    #[cfg(target_os = "linux")]
+    use crate::makepad_platform::{live_id, LiveId, ScriptNew, ScriptVmCx};
+    #[cfg(target_os = "linux")]
+    use crate::makepad_platform::{vec4, Cx};
 
     #[test]
     fn draw_text_size_stays_16_byte_aligned() {
         assert_eq!(std::mem::size_of::<DrawText>() % 16, 0);
+    }
+
+    #[cfg(target_os = "linux")]
+    fn read_instance(draw_vars: &super::DrawVars, cx: &mut Cx, id: LiveId) -> [f32; 4] {
+        let mut value = [0.0; 4];
+        draw_vars.get_instance(cx, id, &mut value);
+        value
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn draw_text_color_is_visible_through_instance_slice() {
+        let mut cx = Cx::new(Box::new(|_, _| {}));
+        cx.with_vm(|vm| {
+            crate::script_mod(vm);
+            let mut draw_text = DrawText::script_new_with_default(vm);
+            draw_text.color = vec4(0.11, 0.22, 0.33, 0.44);
+
+            let packed = vm.with_cx_mut(|cx| {
+                read_instance(&draw_text.draw_vars, cx, live_id!(color))
+            });
+
+            assert_eq!(packed, [0.11, 0.22, 0.33, 0.44]);
+        });
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_slug_helper_color_is_visible_through_instance_slice() {
+        let mut cx = Cx::new(Box::new(|_, _| {}));
+        cx.with_vm(|vm| {
+            crate::script_mod(vm);
+            register_draw_text_linux_slug(vm);
+
+            let mut slug_draw = DrawTextLinuxSlug::script_new_with_default(vm);
+            slug_draw.color = vec4(0.15, 0.25, 0.35, 0.45);
+
+            let packed = vm.with_cx_mut(|cx| {
+                read_instance(&slug_draw.draw_vars, cx, live_id!(color))
+            });
+
+            assert_eq!(packed, [0.15, 0.25, 0.35, 0.45]);
+        });
     }
 }

--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -73,26 +73,87 @@ script_mod! {
 
         radius: uniform(float)
         cutoff: uniform(float)
+        aa_pad_px: uniform(float(1.0))
+        slug_matrix_0: uniform(vec4(1.0, 0.0, 0.0, 0.0))
+        slug_matrix_1: uniform(vec4(0.0, 1.0, 0.0, 0.0))
+        slug_matrix_3: uniform(vec4(0.0, 0.0, 0.0, 1.0))
+        slug_viewport_px: uniform(vec2(1.0, 1.0))
         total_chars: instance(1000000.0)
 
         grayscale_texture: texture_2d(float)
         color_texture: texture_2d(float)
         msdf_texture: texture_2d(float)
+        curve_texture: texture_2d(float)
+        band_texture: texture_2d(float)
+
+        saturate: fn(v: float) -> float {
+            return clamp(v, 0.0, 1.0)
+        }
+
+        slug_dilate: fn(pos: vec2, tex: vec2, jac: vec4, normal: vec2) -> vec4 {
+            let n = normalize(normal)
+            let s = dot(self.slug_matrix_3.xy, pos) + self.slug_matrix_3.w
+            let t = dot(self.slug_matrix_3.xy, n)
+
+            let u = (
+                s * dot(self.slug_matrix_0.xy, n)
+                    - t * (dot(self.slug_matrix_0.xy, pos) + self.slug_matrix_0.w)
+            ) * self.slug_viewport_px.x
+            let v = (
+                s * dot(self.slug_matrix_1.xy, n)
+                    - t * (dot(self.slug_matrix_1.xy, pos) + self.slug_matrix_1.w)
+            ) * self.slug_viewport_px.y
+
+            let s2 = s * s
+            let st = s * t
+            let uv = u * u + v * v
+            let d = normal * (
+                s2 * (st + sqrt(uv)) / max(uv - st * st, 0.0000001)
+            ) * self.aa_pad_px
+
+            let vpos = pos + d
+            let vtex = vec2(tex.x + dot(d, jac.xy), tex.y + dot(d, jac.zw))
+            return vec4(vtex.x, vtex.y, vpos.x, vpos.y)
+        }
 
         vertex: fn() {
-            let p = mix(self.rect_pos, self.rect_pos + self.rect_size, self.geom.pos)
-            let p_clipped = clamp(p, self.draw_clip.xy, self.draw_clip.zw)
-            let p_normalized = (p_clipped - self.rect_pos) / self.rect_size
+            let use_slug = if self.texture_index > 2.5 {1.0} else {0.0}
 
-            self.pos = p_normalized;
-            self.t = mix(self.t_min, self.t_max, p_normalized.xy)
+            let p_raster = mix(self.rect_pos, self.rect_pos + self.rect_size, self.geom.pos)
+            let p_clipped_raster = clamp(p_raster, self.draw_clip.xy, self.draw_clip.zw)
+            let p_normalized_raster = (p_clipped_raster - self.rect_pos) / self.rect_size
+
+            let pad_lpx = self.aa_pad_px / max(self.draw_pass.dpi_factor, 0.0001)
+            let content_rect_pos = self.rect_pos + vec2(pad_lpx, pad_lpx)
+            let content_rect_size = vec2(
+                max(self.rect_size.x - 2.0 * pad_lpx, 0.0001),
+                max(self.rect_size.y - 2.0 * pad_lpx, 0.0001)
+            )
+            let p_slug = mix(content_rect_pos, content_rect_pos + content_rect_size, self.geom.pos)
+            let jac = vec4(1.0 / content_rect_size.x, 0.0, 0.0, 1.0 / content_rect_size.y)
+            let corner = self.geom.pos * 2.0 - 1.0
+            let normal = if dot(corner, corner) > 0.000001 {
+                corner
+            } else {
+                vec2(1.0, 0.0)
+            }
+            let dilated = self.slug_dilate(p_slug, self.geom.pos, jac, normal)
+            let p_clipped_slug = clamp(dilated.zw, self.draw_clip.xy, self.draw_clip.zw)
+            let pos_slug = vec2(
+                dilated.x + (p_clipped_slug.x - dilated.z) * jac.x,
+                dilated.y + (p_clipped_slug.y - dilated.w) * jac.w
+            )
+
+            self.pos = mix(p_normalized_raster, pos_slug, use_slug)
+            self.t = mix(self.t_min, self.t_max, p_normalized_raster.xy)
+            let final_pos = mix(p_clipped_raster, p_clipped_slug, use_slug)
             self.world = self.draw_list.view_transform * vec4(
-                p_clipped.x,
-                p_clipped.y,
+                final_pos.x,
+                final_pos.y,
                 self.glyph_depth + self.draw_call.zbias,
                 1.
             )
-            self.vertex_pos = self.draw_pass.camera_projection * (self.draw_pass.camera_view * (self.world))
+            self.vertex_pos = self.draw_pass.camera_projection * (self.draw_pass.camera_view * self.world)
         }
 
         sdf: fn(scale, p, color) {
@@ -141,6 +202,330 @@ script_mod! {
             return a
         }
 
+        fetch_curve_texel: fn(texel_idx: float) -> vec4 {
+            let tex_size = self.curve_texture.size()
+            let row = floor(texel_idx / tex_size.x)
+            let col = texel_idx - row * tex_size.x
+            let uv = vec2(
+                (col + 0.5) / tex_size.x,
+                (row + 0.5) / tex_size.y
+            )
+            return self.curve_texture.sample_nearest(uv)
+        }
+
+        fetch_band_texel: fn(texel_idx: float) -> vec4 {
+            let tex_size = self.band_texture.size()
+            let row = floor(texel_idx / tex_size.x)
+            let col = texel_idx - row * tex_size.x
+            let uv = vec2(
+                (col + 0.5) / tex_size.x,
+                (row + 0.5) / tex_size.y
+            )
+            return self.band_texture.sample_nearest(uv)
+        }
+
+        pick_channel: fn(v: vec4, channel: float) -> float {
+            if channel < 0.5 {
+                return v.x
+            }
+            if channel < 1.5 {
+                return v.y
+            }
+            if channel < 2.5 {
+                return v.z
+            }
+            return v.w
+        }
+
+        calc_root_code: fn(y1: float, y2: float, y3: float) -> u32 {
+            let i1 = asuint(y1) >> u32(31)
+            let i2 = asuint(y2) >> u32(30)
+            let i3 = asuint(y3) >> u32(29)
+
+            let shift = (i1 & u32(1)) | (i2 & u32(2)) | (i3 & u32(4))
+            return (u32(11892) >> shift) & u32(257)
+        }
+
+        solve_horiz_poly: fn(p12: vec4, p3: vec2) -> vec2 {
+            let a = p12.xy - p12.zw * 2.0 + p3
+            let b = p12.xy - p12.zw
+            let ra = 1.0 / a.y
+            let rb = 0.5 / b.y
+
+            let d = sqrt(max(b.y * b.y - a.y * p12.y, 0.0))
+            let mut t1 = (b.y - d) * ra
+            let mut t2 = (b.y + d) * ra
+            if abs(a.y) < 1.0 / 65536.0 {
+                t1 = p12.y * rb
+                t2 = t1
+            }
+            return vec2(
+                (a.x * t1 - b.x * 2.0) * t1 + p12.x,
+                (a.x * t2 - b.x * 2.0) * t2 + p12.x
+            )
+        }
+
+        solve_vert_poly: fn(p12: vec4, p3: vec2) -> vec2 {
+            let a = p12.xy - p12.zw * 2.0 + p3
+            let b = p12.xy - p12.zw
+            let ra = 1.0 / a.x
+            let rb = 0.5 / b.x
+
+            let d = sqrt(max(b.x * b.x - a.x * p12.x, 0.0))
+            let mut t1 = (b.x - d) * ra
+            let mut t2 = (b.x + d) * ra
+            if abs(a.x) < 1.0 / 65536.0 {
+                t1 = p12.x * rb
+                t2 = t1
+            }
+            return vec2(
+                (a.y * t1 - b.y * 2.0) * t1 + p12.y,
+                (a.y * t2 - b.y * 2.0) * t2 + p12.y
+            )
+        }
+
+        scan_horizontal_list: fn(list_offset: float, list_count: float, sample: vec2, px_size: float) -> vec2 {
+            let limit = floor(list_count + 0.5)
+            var coverage = 0.0
+            var weight = 0.0
+
+            var j = 0.0
+            loop {
+                if j >= limit { break }
+
+                let packed_idx = floor(j * 0.25)
+                let channel = j - packed_idx * 4.0
+                let idx_data = self.fetch_band_texel(list_offset + packed_idx)
+                let curve_idx = self.pick_channel(idx_data, channel)
+
+                let p12 = self.fetch_curve_texel(curve_idx * 2.0) - vec4(sample.x, sample.y, sample.x, sample.y)
+                let p3 = self.fetch_curve_texel(curve_idx * 2.0 + 1.0).xy - sample
+                if max(max(p12.x, p12.z), p3.x) / px_size < -0.5 { break }
+
+                let code = self.calc_root_code(p12.y, p12.w, p3.y)
+                if code != u32(0) {
+                    let r = self.solve_horiz_poly(p12, p3) / px_size
+                    if (code & u32(1)) != u32(0) {
+                        coverage = coverage + self.saturate(r.x + 0.5)
+                        weight = max(weight, self.saturate(1.0 - abs(r.x) * 2.0))
+                    }
+                    if code > u32(1) {
+                        coverage = coverage - self.saturate(r.y + 0.5)
+                        weight = max(weight, self.saturate(1.0 - abs(r.y) * 2.0))
+                    }
+                }
+
+                j = j + 1.0
+            }
+
+            return vec2(coverage, weight)
+        }
+
+        scan_vertical_list: fn(list_offset: float, list_count: float, sample: vec2, px_size: float) -> vec2 {
+            let limit = floor(list_count + 0.5)
+            var coverage = 0.0
+            var weight = 0.0
+
+            var j = 0.0
+            loop {
+                if j >= limit { break }
+
+                let packed_idx = floor(j * 0.25)
+                let channel = j - packed_idx * 4.0
+                let idx_data = self.fetch_band_texel(list_offset + packed_idx)
+                let curve_idx = self.pick_channel(idx_data, channel)
+
+                let p12 = self.fetch_curve_texel(curve_idx * 2.0) - vec4(sample.x, sample.y, sample.x, sample.y)
+                let p3 = self.fetch_curve_texel(curve_idx * 2.0 + 1.0).xy - sample
+                if max(max(p12.y, p12.w), p3.y) / px_size < -0.5 { break }
+
+                let code = self.calc_root_code(p12.x, p12.z, p3.x)
+                if code != u32(0) {
+                    let r = self.solve_vert_poly(p12, p3) / px_size
+                    if (code & u32(1)) != u32(0) {
+                        coverage = coverage - self.saturate(r.x + 0.5)
+                        weight = max(weight, self.saturate(1.0 - abs(r.x) * 2.0))
+                    }
+                    if code > u32(1) {
+                        coverage = coverage + self.saturate(r.y + 0.5)
+                        weight = max(weight, self.saturate(1.0 - abs(r.y) * 2.0))
+                    }
+                }
+
+                j = j + 1.0
+            }
+
+            return vec2(coverage, weight)
+        }
+
+        scan_horizontal_all: fn(sample: vec2, px_size: float) -> vec2 {
+            let limit = floor(self.curve_count + 0.5)
+            var coverage = 0.0
+            var weight = 0.0
+
+            var i = 0.0
+            loop {
+                if i >= limit { break }
+
+                let curve_idx = self.curve_offset + i
+                let p12 = self.fetch_curve_texel(curve_idx * 2.0) - vec4(sample.x, sample.y, sample.x, sample.y)
+                let p3 = self.fetch_curve_texel(curve_idx * 2.0 + 1.0).xy - sample
+                let code = self.calc_root_code(p12.y, p12.w, p3.y)
+                if code != u32(0) {
+                    let r = self.solve_horiz_poly(p12, p3) / px_size
+                    if (code & u32(1)) != u32(0) {
+                        coverage = coverage + self.saturate(r.x + 0.5)
+                        weight = max(weight, self.saturate(1.0 - abs(r.x) * 2.0))
+                    }
+                    if code > u32(1) {
+                        coverage = coverage - self.saturate(r.y + 0.5)
+                        weight = max(weight, self.saturate(1.0 - abs(r.y) * 2.0))
+                    }
+                }
+
+                i = i + 1.0
+            }
+
+            return vec2(coverage, weight)
+        }
+
+        scan_vertical_all: fn(sample: vec2, px_size: float) -> vec2 {
+            let limit = floor(self.curve_count + 0.5)
+            var coverage = 0.0
+            var weight = 0.0
+
+            var i = 0.0
+            loop {
+                if i >= limit { break }
+
+                let curve_idx = self.curve_offset + i
+                let p12 = self.fetch_curve_texel(curve_idx * 2.0) - vec4(sample.x, sample.y, sample.x, sample.y)
+                let p3 = self.fetch_curve_texel(curve_idx * 2.0 + 1.0).xy - sample
+                let code = self.calc_root_code(p12.x, p12.z, p3.x)
+                if code != u32(0) {
+                    let r = self.solve_vert_poly(p12, p3) / px_size
+                    if (code & u32(1)) != u32(0) {
+                        coverage = coverage - self.saturate(r.x + 0.5)
+                        weight = max(weight, self.saturate(1.0 - abs(r.x) * 2.0))
+                    }
+                    if code > u32(1) {
+                        coverage = coverage + self.saturate(r.y + 0.5)
+                        weight = max(weight, self.saturate(1.0 - abs(r.y) * 2.0))
+                    }
+                }
+
+                i = i + 1.0
+            }
+
+            return vec2(coverage, weight)
+        }
+
+        calc_coverage: fn(xcov: float, ycov: float, xwgt: float, ywgt: float) -> float {
+            let coverage = max(
+                abs(xcov * xwgt + ycov * ywgt) / max(xwgt + ywgt, 1.0 / 65536.0),
+                min(abs(xcov), abs(ycov))
+            )
+            if self.fill_flags >= 4096.0 {
+                return 1.0 - abs(1.0 - fract(coverage * 0.5) * 2.0)
+            }
+            return self.saturate(coverage)
+        }
+
+        alpha_at: fn(sample: vec2, px_x: float, px_y: float) -> float {
+            var coverage_x = 0.0
+            var coverage_y = 0.0
+            var weight_x = 0.0
+            var weight_y = 0.0
+
+            if self.band_count > 0.5 {
+                let num_bands = max(floor(self.band_count + 0.5), 1.0)
+                let h_band_idx = clamp(floor(sample.y * num_bands), 0.0, num_bands - 1.0)
+                let v_band_idx = clamp(floor(sample.x * num_bands), 0.0, num_bands - 1.0)
+
+                let h_band_info = self.fetch_band_texel(self.band_offset + h_band_idx)
+                let h_band = self.scan_horizontal_list(
+                    floor(h_band_info.x + 0.5),
+                    h_band_info.y,
+                    sample,
+                    px_x,
+                )
+                coverage_x = h_band.x
+                weight_x = h_band.y
+
+                let v_band_info = self.fetch_band_texel(self.band_offset + num_bands + v_band_idx)
+                let v_band = self.scan_vertical_list(
+                    floor(v_band_info.x + 0.5),
+                    v_band_info.y,
+                    sample,
+                    px_y,
+                )
+                coverage_y = v_band.x
+                weight_y = v_band.y
+            } else {
+                let x_scan = self.scan_horizontal_all(sample, px_x)
+                coverage_x = x_scan.x
+                weight_x = x_scan.y
+
+                let y_scan = self.scan_vertical_all(sample, px_y)
+                coverage_y = y_scan.x
+                weight_y = y_scan.y
+            }
+
+            return self.calc_coverage(coverage_x, coverage_y, weight_x, weight_y)
+        }
+
+        sample_slug_pixel: fn() {
+            if self.curve_count < 0.5 {
+                return vec4(0.0, 0.0, 0.0, 0.0)
+            }
+
+            let sample = self.pos
+            let px_x = max(abs(dFdx(sample.x)) + abs(dFdy(sample.x)), 0.00001)
+            let px_y = max(abs(dFdx(sample.y)) + abs(dFdy(sample.y)), 0.00001)
+            let alpha_base = if self.aa_4x4 > 0.5 {
+                let x0 = px_x * 0.125
+                let x1 = px_x * 0.375
+                let y0 = px_y * 0.125
+                let y1 = px_y * 0.375
+                let a0 = self.alpha_at(sample + vec2(-x1, -y1), px_x, px_y)
+                let a1 = self.alpha_at(sample + vec2(-x0, -y1), px_x, px_y)
+                let a2 = self.alpha_at(sample + vec2( x0, -y1), px_x, px_y)
+                let a3 = self.alpha_at(sample + vec2( x1, -y1), px_x, px_y)
+                let a4 = self.alpha_at(sample + vec2(-x1, -y0), px_x, px_y)
+                let a5 = self.alpha_at(sample + vec2(-x0, -y0), px_x, px_y)
+                let a6 = self.alpha_at(sample + vec2( x0, -y0), px_x, px_y)
+                let a7 = self.alpha_at(sample + vec2( x1, -y0), px_x, px_y)
+                let a8 = self.alpha_at(sample + vec2(-x1,  y0), px_x, px_y)
+                let a9 = self.alpha_at(sample + vec2(-x0,  y0), px_x, px_y)
+                let a10 = self.alpha_at(sample + vec2( x0,  y0), px_x, px_y)
+                let a11 = self.alpha_at(sample + vec2( x1,  y0), px_x, px_y)
+                let a12 = self.alpha_at(sample + vec2(-x1,  y1), px_x, px_y)
+                let a13 = self.alpha_at(sample + vec2(-x0,  y1), px_x, px_y)
+                let a14 = self.alpha_at(sample + vec2( x0,  y1), px_x, px_y)
+                let a15 = self.alpha_at(sample + vec2( x1,  y1), px_x, px_y)
+                clamp(
+                    (a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11 + a12 + a13 + a14 + a15)
+                        * 0.0625,
+                    0.0,
+                    1.0
+                )
+            } else if self.aa_2x2 > 0.5 {
+                let offset = vec2(px_x * 0.25, px_y * 0.25)
+                let a0 = self.alpha_at(sample + vec2(-offset.x, -offset.y), px_x, px_y)
+                let a1 = self.alpha_at(sample + vec2(offset.x, -offset.y), px_x, px_y)
+                let a2 = self.alpha_at(sample + vec2(-offset.x, offset.y), px_x, px_y)
+                let a3 = self.alpha_at(sample + vec2(offset.x, offset.y), px_x, px_y)
+                clamp((a0 + a1 + a2 + a3) * 0.25, 0.0, 1.0)
+            } else {
+                self.alpha_at(sample, px_x, px_y)
+            }
+            let darken = clamp(max(px_x, px_y) * self.stem_darken, 0.0, self.stem_darken_max)
+            let edge_weight = clamp(1.0 - abs(alpha_base * 2.0 - 1.0), 0.0, 1.0)
+            let alpha = clamp(alpha_base + darken * edge_weight, 0.0, 1.0)
+            let color = self.get_color()
+            return vec4(color.rgb * color.a * alpha, color.a * alpha)
+        }
+
         get_color: fn() {
             return self.color
         }
@@ -150,9 +535,9 @@ script_mod! {
         }
 
         sample_text_pixel: fn() {
-            let dxt = length(dFdx(self.t))
-            let dyt = length(dFdy(self.t))
-            if self.texture_index == 0 {
+            if self.texture_index < 0.5 {
+                let dxt = length(dFdx(self.t))
+                let dyt = length(dFdy(self.t))
                 let c = self.get_color()
                 let scale = (dxt + dyt) * self.grayscale_texture.size().x * 0.5
                 let tex_size = self.grayscale_texture.size()
@@ -160,13 +545,15 @@ script_mod! {
                 let p = clamp(self.t.xy, self.t_min + half_texel, self.t_max - half_texel)
                 let s = self.sdf(scale, p, c)
                 return s * vec4(c.rgb * c.a, c.a)
-            } else if self.texture_index == 1 {
+            } else if self.texture_index < 1.5 {
                 let tex_size = self.color_texture.size()
                 let half_texel = vec2(0.5 / tex_size.x, 0.5 / tex_size.y)
                 let p = clamp(self.t.xy, self.t_min + half_texel, self.t_max - half_texel)
                 let c = self.color_texture.sample_as_bgra(p)
                 return vec4(c.rgb * c.a, c.a)
-            } else {
+            } else if self.texture_index < 2.5 {
+                let dxt = length(dFdx(self.t))
+                let dyt = length(dFdy(self.t))
                 let c = self.get_color()
                 let scale = (dxt + dyt) * self.msdf_texture.size().x * 0.5
                 let tex_size = self.msdf_texture.size()
@@ -174,6 +561,8 @@ script_mod! {
                 let p = clamp(self.t.xy, self.t_min + half_texel, self.t_max - half_texel)
                 let s = self.msdf(scale, p, c)
                 return s * vec4(c.rgb * c.a, c.a)
+            } else {
+                return self.sample_slug_pixel()
             }
         }
 
@@ -260,6 +649,32 @@ pub struct DrawText {
     pub atlas_plane: f32,
     #[live]
     pub pad1: f32,
+    #[live]
+    pub curve_offset: f32,
+    #[live]
+    pub curve_count: f32,
+    #[live]
+    pub band_offset: f32,
+    #[live]
+    pub band_count: f32,
+    #[live(0.0)]
+    pub fill_flags: f32,
+    #[live(0.0)]
+    pub aa_2x2: f32,
+    #[live(0.0)]
+    pub aa_4x4: f32,
+    #[live(0.2)]
+    pub stem_darken: f32,
+    #[live(0.125)]
+    pub stem_darken_max: f32,
+    // Keep the base DrawText instance payload 16-byte aligned so repr(C)
+    // subclasses with Vec4 fields don't pick up implicit Rust padding.
+    #[live(0.0)]
+    pub pad2: f32,
+    #[live(0.0)]
+    pub pad3: f32,
+    #[live(0.0)]
+    pub pad4: f32,
 }
 
 #[derive(Clone, Debug)]
@@ -408,7 +823,11 @@ impl DrawText {
         if max_width_in_lpxs.is_none()
             && (self.text_overflow == TextOverflow::Ellipsis || self.max_lines > 0)
         {
-            if let crate::turtle::Size::Fit { max: Some(max_bound), .. } = walk.width {
+            if let crate::turtle::Size::Fit {
+                max: Some(max_bound),
+                ..
+            } = walk.width
+            {
                 if let Some(resolved) = max_bound.eval_width(cx) {
                     let padding = cx.turtle().padding();
                     max_width_in_lpxs =
@@ -682,6 +1101,32 @@ impl DrawText {
         self.draw_vars.texture_slots[0] = Some(fonts.grayscale_texture().clone());
         self.draw_vars.texture_slots[1] = Some(fonts.color_texture().clone());
         self.draw_vars.texture_slots[2] = Some(fonts.msdf_texture().clone());
+        self.draw_vars.texture_slots[3] = Some(fonts.slug_curve_texture().clone());
+        self.draw_vars.texture_slots[4] = Some(fonts.slug_band_texture().clone());
+
+        let pass_id = cx.pass_stack.last().unwrap().pass_id;
+        let draw_list_id = *cx.draw_list_stack.last().unwrap();
+        let pass_uniforms = cx.passes[pass_id].pass_uniforms.clone();
+        let view_transform = cx.draw_lists[draw_list_id]
+            .draw_list_uniforms
+            .view_transform;
+        let model_view = Mat4f::mul(&pass_uniforms.camera_view, &view_transform);
+        let slug_matrix = Mat4f::mul(&pass_uniforms.camera_projection, &model_view);
+        let viewport = cx.current_pass_size();
+        let dpi_factor = cx.current_dpi_factor() as f32;
+        let viewport_px = [
+            (viewport.x as f32 * dpi_factor).max(1.0),
+            (viewport.y as f32 * dpi_factor).max(1.0),
+        ];
+
+        self.draw_vars
+            .set_uniform(cx.cx, live_id!(slug_matrix_0), &mat4_row(&slug_matrix, 0));
+        self.draw_vars
+            .set_uniform(cx.cx, live_id!(slug_matrix_1), &mat4_row(&slug_matrix, 1));
+        self.draw_vars
+            .set_uniform(cx.cx, live_id!(slug_matrix_3), &mat4_row(&slug_matrix, 3));
+        self.draw_vars
+            .set_uniform(cx.cx, live_id!(slug_viewport_px), &viewport_px);
     }
 
     fn draw_row(
@@ -746,19 +1191,92 @@ impl DrawText {
         output: &mut Vec<f32>,
     ) {
         use crate::text::geom::Point;
+        let glyph_origin = Point::new(
+            origin_in_lpxs.x + glyph.offset_in_lpxs() * self.font_scale,
+            origin_in_lpxs.y,
+        );
+
+        let slug_glyph = {
+            cx.fonts
+                .borrow_mut()
+                .get_or_cache_slug_glyph(glyph.font.as_ref(), glyph.id)
+        };
+        if let Some(slug_glyph) = slug_glyph {
+            self.draw_slug_glyph(
+                cx,
+                glyph_origin,
+                glyph.font_size_in_lpxs,
+                glyph.color,
+                slug_glyph,
+                output,
+            );
+            return;
+        }
+
         let font_size_in_dpxs = glyph.font_size_in_lpxs * cx.current_dpi_factor() as f32;
         if let Some(rasterized_glyph) = glyph.rasterize(font_size_in_dpxs) {
             self.draw_rasterized_glyph(
-                Point::new(
-                    origin_in_lpxs.x + glyph.offset_in_lpxs() * self.font_scale,
-                    origin_in_lpxs.y,
-                ),
+                glyph_origin,
                 glyph.font_size_in_lpxs,
                 glyph.color,
                 rasterized_glyph,
                 output,
             );
         }
+    }
+
+    fn draw_slug_glyph(
+        &mut self,
+        cx: &mut Cx2d,
+        origin_in_lpxs: Point<f32>,
+        font_size_in_lpxs: f32,
+        color: Option<Color>,
+        glyph: crate::text::slug_atlas::SlugGlyphInfo,
+        output: &mut Vec<f32>,
+    ) {
+        let bounds_in_lpxs = TextRect::new(
+            Point::new(
+                origin_in_lpxs.x + glyph.origin_in_ems.x * font_size_in_lpxs * self.font_scale,
+                origin_in_lpxs.y
+                    + (-glyph.origin_in_ems.y - glyph.size_in_ems.height)
+                        * font_size_in_lpxs
+                        * self.font_scale,
+            ),
+            Size::new(
+                glyph.size_in_ems.width * font_size_in_lpxs * self.font_scale,
+                glyph.size_in_ems.height * font_size_in_lpxs * self.font_scale,
+            ),
+        );
+
+        let pad = (self.get_aa_pad_px(cx.cx) / cx.current_dpi_factor() as f32).max(0.0);
+        self.rect_pos = vec2(bounds_in_lpxs.origin.x - pad, bounds_in_lpxs.origin.y - pad)
+            + vec2(0.0, self.temp_y_shift * font_size_in_lpxs);
+        self.rect_size = vec2(
+            bounds_in_lpxs.size.width + pad * 2.0,
+            bounds_in_lpxs.size.height + pad * 2.0,
+        );
+        if let Some(color) = color {
+            self.color = vec4(
+                color.r as f32,
+                color.g as f32,
+                color.b as f32,
+                color.a as f32,
+            ) / 255.0;
+        }
+        self.texture_index = 3.0;
+        self.atlas_plane = 0.0;
+        self.t_min = vec2(0.0, 0.0);
+        self.t_max = vec2(0.0, 0.0);
+        self.curve_offset = glyph.curve_offset as f32;
+        self.curve_count = glyph.curve_count as f32;
+        self.band_offset = glyph.band_offset as f32;
+        self.band_count = glyph.band_count as f32;
+        self.fill_flags = glyph.fill_flags as f32;
+        let slice = self.draw_vars.as_slice();
+
+        output.extend_from_slice(slice);
+        self.glyph_depth += 0.000001;
+        self.char_index += 1.0;
     }
 
     fn draw_rasterized_glyph(
@@ -820,6 +1338,11 @@ impl DrawText {
         self.atlas_plane = glyph.atlas_plane as f32;
         self.t_min = vec2(t_min.x, t_min.y);
         self.t_max = vec2(t_max.x, t_max.y);
+        self.curve_offset = 0.0;
+        self.curve_count = 0.0;
+        self.band_offset = 0.0;
+        self.band_count = 0.0;
+        self.fill_flags = 0.0;
         let slice = self.draw_vars.as_slice();
 
         output.extend_from_slice(slice);
@@ -849,6 +1372,17 @@ impl DrawText {
     pub fn append_to_draw_call(&self, cx: &mut Cx2d) {
         cx.append_to_draw_call(&self.draw_vars);
     }
+
+    pub fn get_aa_pad_px(&self, cx: &mut Cx) -> f32 {
+        let mut value = [0.0];
+        self.draw_vars
+            .get_uniform(cx, live_id!(aa_pad_px), &mut value);
+        value[0]
+    }
+}
+
+fn mat4_row(mat: &Mat4f, row: usize) -> [f32; 4] {
+    [mat.v[row], mat.v[row + 4], mat.v[row + 8], mat.v[row + 12]]
 }
 
 #[derive(Debug, Clone, Script, ScriptHook)]

--- a/draw/src/text/font.rs
+++ b/draw/src/text/font.rs
@@ -170,6 +170,17 @@ impl Font {
             .borrow_mut()
             .rasterize_glyph(self, glyph_id, dpxs_per_em)
     }
+
+    pub fn rasterize_glyph_stable_fallback(
+        &self,
+        glyph_id: GlyphId,
+        dpxs_per_em: f32,
+    ) -> Option<RasterizedGlyph> {
+        self.rasterizer
+            .borrow_mut()
+            .rasterize_glyph_stable_fallback(self, glyph_id, dpxs_per_em)
+    }
+
 }
 
 impl Eq for Font {}

--- a/draw/src/text/font.rs
+++ b/draw/src/text/font.rs
@@ -165,6 +165,13 @@ impl Font {
         })
     }
 
+    pub fn has_glyph_raster_image(&self, glyph_id: GlyphId, dpxs_per_em: f32) -> bool {
+        self.with_ttf_parser_face(|face| {
+            let glyph_id = ttf_parser::GlyphId(glyph_id);
+            face.glyph_raster_image(glyph_id, dpxs_per_em as u16).is_some()
+        })
+    }
+
     pub fn rasterize_glyph(&self, glyph_id: GlyphId, dpxs_per_em: f32) -> Option<RasterizedGlyph> {
         self.rasterizer
             .borrow_mut()
@@ -198,3 +205,57 @@ impl PartialEq for Font {
 }
 
 pub type GlyphId = u16;
+
+#[cfg(test)]
+mod tests {
+    use super::{Font, FontId};
+    use crate::{
+        makepad_platform::SharedBytes,
+        text::{
+            font_face::FontFace,
+            layouter,
+            loader::FontData,
+            rasterizer::{AtlasKind, Rasterizer},
+        },
+    };
+    use std::{cell::RefCell, path::PathBuf, rc::Rc};
+
+    fn bundled_emoji_font_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../widgets/resources/NotoColorEmoji.ttf")
+    }
+
+    fn load_font_data(path: PathBuf) -> FontData {
+        SharedBytes::from_file_mmap_or_read(path).expect("font bytes should load")
+    }
+
+    fn make_font(path: PathBuf) -> Font {
+        Font::new(
+            FontId::from(0xE0E1_u64),
+            Rc::new(RefCell::new(Rasterizer::new(
+                layouter::Settings::default().loader.rasterizer,
+            ))),
+            FontFace::from_data_and_index(load_font_data(path), 0).expect("font face should load"),
+            0.0,
+            0.0,
+        )
+    }
+
+    #[test]
+    fn noto_color_emoji_prefers_raster_images() {
+        let font = make_font(bundled_emoji_font_path());
+        let glyph_id = font
+            .with_ttf_parser_face(|face| face.glyph_index('😀').map(|glyph| glyph.0))
+            .expect("emoji glyph should exist");
+        let dpxs_per_em = 128.0;
+
+        assert!(
+            font.has_glyph_raster_image(glyph_id, dpxs_per_em),
+            "emoji glyph should expose a raster image"
+        );
+
+        let rasterized = font
+            .rasterize_glyph(glyph_id, dpxs_per_em)
+            .expect("emoji glyph should rasterize");
+        assert_eq!(rasterized.atlas_kind, AtlasKind::Color);
+    }
+}

--- a/draw/src/text/fonts.rs
+++ b/draw/src/text/fonts.rs
@@ -123,6 +123,12 @@ impl Fonts {
         self.slug_atlas.get_or_cache_glyph(font, glyph_id)
     }
 
+    /// Uploads any newly appended SLUG curve/band data immediately so draw calls
+    /// in the current frame can see glyphs cached during the draw loop.
+    pub fn flush_slug_textures(&mut self, cx: &mut Cx) -> bool {
+        self.slug_atlas.prepare_textures(cx)
+    }
+
     pub fn is_font_family_known(&self, id: FontFamilyId) -> bool {
         self.layouter.is_font_family_known(id)
     }
@@ -177,7 +183,7 @@ impl Fonts {
             cx.redraw_all();
         }
         self.dispatch_msdf_jobs();
-        let slug_changed = self.slug_atlas.prepare_textures(cx);
+        let slug_changed = self.flush_slug_textures(cx);
         if slug_changed {
             cx.redraw_all();
         }

--- a/draw/src/text/fonts.rs
+++ b/draw/src/text/fonts.rs
@@ -1,12 +1,13 @@
 use {
     super::{
-        font::FontId,
+        font::{Font, FontId, GlyphId},
         font_family::{FontFamily, FontFamilyId},
         image::{Bgra, Image},
         layouter::{self, LaidoutText, LayoutParams, Layouter},
         loader::{FontDefinition, FontFamilyDefinition},
         msdfer::Msdfer,
         rasterizer::{CompletedMsdfJob, OutlineRasterizationMode, QueuedMsdfJob, Rasterizer},
+        slug_atlas::{SlugAtlas, SlugGlyphInfo},
     },
     crate::makepad_platform::*,
     std::{cell::RefCell, mem::ManuallyDrop, rc::Rc},
@@ -16,6 +17,7 @@ pub struct Fonts {
     layouter: Layouter,
     needs_prepare_atlases: bool,
     atlas_texture: Texture,
+    slug_atlas: SlugAtlas,
     msdf_job_sender: FromUISender<QueuedMsdfJob>,
     msdf_result_receiver: ToUIReceiver<CompletedMsdfJob>,
 }
@@ -69,6 +71,7 @@ impl Fonts {
                     updated: TextureUpdated::Empty,
                 },
             ),
+            slug_atlas: SlugAtlas::new(cx),
             msdf_job_sender,
             msdf_result_receiver,
         }
@@ -102,6 +105,22 @@ impl Fonts {
 
     pub fn msdf_texture(&self) -> &Texture {
         &self.atlas_texture
+    }
+
+    pub fn slug_curve_texture(&self) -> &Texture {
+        self.slug_atlas.curve_texture()
+    }
+
+    pub fn slug_band_texture(&self) -> &Texture {
+        self.slug_atlas.band_texture()
+    }
+
+    pub fn get_or_cache_slug_glyph(
+        &mut self,
+        font: &Font,
+        glyph_id: GlyphId,
+    ) -> Option<SlugGlyphInfo> {
+        self.slug_atlas.get_or_cache_glyph(font, glyph_id)
     }
 
     pub fn is_font_family_known(&self, id: FontFamilyId) -> bool {
@@ -158,6 +177,10 @@ impl Fonts {
             cx.redraw_all();
         }
         self.dispatch_msdf_jobs();
+        let slug_changed = self.slug_atlas.prepare_textures(cx);
+        if slug_changed {
+            cx.redraw_all();
+        }
         self.prepare_atlas_texture(cx);
         self.needs_prepare_atlases = true;
         true

--- a/draw/src/text/fonts.rs
+++ b/draw/src/text/fonts.rs
@@ -15,14 +15,14 @@ use {
 
 fn default_slug_new_glyphs_per_redraw(cx: &Cx) -> usize {
     match cx.os_type() {
-        OsType::LinuxWindow(_) | OsType::LinuxDirect => 1,
+        OsType::LinuxWindow(_) | OsType::LinuxDirect | OsType::Windows => 1,
         _ => usize::MAX,
     }
 }
 
 fn default_slug_min_dpxs_per_em(cx: &Cx, rasterizer: &Rasterizer) -> f32 {
     match cx.os_type() {
-        OsType::LinuxWindow(_) | OsType::LinuxDirect => {
+        OsType::LinuxWindow(_) | OsType::LinuxDirect | OsType::Windows => {
             rasterizer.msdf_resolution().max_dpxs_per_em
         }
         _ => 0.0,

--- a/draw/src/text/fonts.rs
+++ b/draw/src/text/fonts.rs
@@ -123,6 +123,14 @@ impl Fonts {
         self.slug_atlas.get_or_cache_glyph(font, glyph_id)
     }
 
+    pub fn slug_cache_generation(&self) -> u64 {
+        self.slug_atlas.cache_generation()
+    }
+
+    pub fn slug_uploaded_generation(&self) -> u64 {
+        self.slug_atlas.uploaded_generation()
+    }
+
     /// Uploads any newly appended SLUG curve/band data immediately so draw calls
     /// in the current frame can see glyphs cached during the draw loop.
     pub fn flush_slug_textures(&mut self, cx: &mut Cx) -> bool {

--- a/draw/src/text/fonts.rs
+++ b/draw/src/text/fonts.rs
@@ -7,17 +7,24 @@ use {
         loader::{FontDefinition, FontFamilyDefinition},
         msdfer::Msdfer,
         rasterizer::{CompletedMsdfJob, OutlineRasterizationMode, QueuedMsdfJob, Rasterizer},
-        slug_atlas::{SlugAtlas, SlugGlyphInfo},
+        slug_atlas::{SlugAtlas, SlugGlyphCacheResult},
     },
     crate::makepad_platform::*,
     std::{cell::RefCell, mem::ManuallyDrop, rc::Rc},
 };
 
-fn default_slug_min_dpxs_per_em(cx: &Cx) -> f32 {
-    const LINUX_DESKTOP_DEFAULT: f32 = 1_000_000.0;
-
+fn default_slug_new_glyphs_per_redraw(cx: &Cx) -> usize {
     match cx.os_type() {
-        OsType::LinuxWindow(_) | OsType::LinuxDirect => LINUX_DESKTOP_DEFAULT,
+        OsType::LinuxWindow(_) | OsType::LinuxDirect => 1,
+        _ => usize::MAX,
+    }
+}
+
+fn default_slug_min_dpxs_per_em(cx: &Cx, rasterizer: &Rasterizer) -> f32 {
+    match cx.os_type() {
+        OsType::LinuxWindow(_) | OsType::LinuxDirect => {
+            rasterizer.msdf_resolution().max_dpxs_per_em
+        }
         _ => 0.0,
     }
 }
@@ -28,6 +35,9 @@ pub struct Fonts {
     atlas_texture: Texture,
     slug_atlas: SlugAtlas,
     slug_min_dpxs_per_em: f32,
+    slug_new_glyphs_per_redraw: usize,
+    slug_budget_redraw_id: u64,
+    slug_built_glyphs_this_redraw: usize,
     msdf_job_sender: FromUISender<QueuedMsdfJob>,
     msdf_result_receiver: ToUIReceiver<CompletedMsdfJob>,
 }
@@ -35,11 +45,12 @@ pub struct Fonts {
 impl Fonts {
     pub fn new(cx: &mut Cx, settings: layouter::Settings) -> Self {
         let layouter = Layouter::new(settings);
-        let (atlas_size, msdfer_settings) = {
+        let (atlas_size, msdfer_settings, slug_min_dpxs_per_em) = {
             let rasterizer = layouter.rasterizer().borrow();
             (
                 rasterizer.color_atlas().size(),
                 rasterizer.msdfer().settings(),
+                default_slug_min_dpxs_per_em(cx, &rasterizer),
             )
         };
 
@@ -82,7 +93,10 @@ impl Fonts {
                 },
             ),
             slug_atlas: SlugAtlas::new(cx),
-            slug_min_dpxs_per_em: default_slug_min_dpxs_per_em(cx),
+            slug_min_dpxs_per_em,
+            slug_new_glyphs_per_redraw: default_slug_new_glyphs_per_redraw(cx),
+            slug_budget_redraw_id: 0,
+            slug_built_glyphs_this_redraw: 0,
             msdf_job_sender,
             msdf_result_receiver,
         }
@@ -130,12 +144,37 @@ impl Fonts {
         dpxs_per_em >= self.slug_min_dpxs_per_em
     }
 
+    pub fn max_rasterized_glyph_dpxs_per_em(&self) -> f32 {
+        self.layouter
+            .rasterizer()
+            .borrow()
+            .msdf_resolution()
+            .max_dpxs_per_em
+    }
+
     pub fn get_or_cache_slug_glyph(
         &mut self,
+        redraw_id: u64,
         font: &Font,
         glyph_id: GlyphId,
-    ) -> Option<SlugGlyphInfo> {
-        self.slug_atlas.get_or_cache_glyph(font, glyph_id)
+    ) -> SlugGlyphCacheResult {
+        match self.slug_atlas.get_or_cache_glyph(font, glyph_id, false) {
+            SlugGlyphCacheResult::Deferred => {}
+            result => return result,
+        }
+
+        if self.slug_new_glyphs_per_redraw != usize::MAX {
+            if self.slug_budget_redraw_id != redraw_id {
+                self.slug_budget_redraw_id = redraw_id;
+                self.slug_built_glyphs_this_redraw = 0;
+            }
+            if self.slug_built_glyphs_this_redraw >= self.slug_new_glyphs_per_redraw {
+                return SlugGlyphCacheResult::Deferred;
+            }
+            self.slug_built_glyphs_this_redraw += 1;
+        }
+
+        self.slug_atlas.get_or_cache_glyph(font, glyph_id, true)
     }
 
     pub fn slug_cache_generation(&self) -> u64 {

--- a/draw/src/text/fonts.rs
+++ b/draw/src/text/fonts.rs
@@ -13,11 +13,21 @@ use {
     std::{cell::RefCell, mem::ManuallyDrop, rc::Rc},
 };
 
+fn default_slug_min_dpxs_per_em(cx: &Cx) -> f32 {
+    const LINUX_DESKTOP_DEFAULT: f32 = 1_000_000.0;
+
+    match cx.os_type() {
+        OsType::LinuxWindow(_) | OsType::LinuxDirect => LINUX_DESKTOP_DEFAULT,
+        _ => 0.0,
+    }
+}
+
 pub struct Fonts {
     layouter: Layouter,
     needs_prepare_atlases: bool,
     atlas_texture: Texture,
     slug_atlas: SlugAtlas,
+    slug_min_dpxs_per_em: f32,
     msdf_job_sender: FromUISender<QueuedMsdfJob>,
     msdf_result_receiver: ToUIReceiver<CompletedMsdfJob>,
 }
@@ -72,6 +82,7 @@ impl Fonts {
                 },
             ),
             slug_atlas: SlugAtlas::new(cx),
+            slug_min_dpxs_per_em: default_slug_min_dpxs_per_em(cx),
             msdf_job_sender,
             msdf_result_receiver,
         }
@@ -113,6 +124,10 @@ impl Fonts {
 
     pub fn slug_band_texture(&self) -> &Texture {
         self.slug_atlas.band_texture()
+    }
+
+    pub fn should_use_slug_glyph(&self, dpxs_per_em: f32) -> bool {
+        dpxs_per_em >= self.slug_min_dpxs_per_em
     }
 
     pub fn get_or_cache_slug_glyph(

--- a/draw/src/text/layouter.rs
+++ b/draw/src/text/layouter.rs
@@ -552,13 +552,12 @@ impl LayoutContext {
     /// Finishes any pending glyphs into a row (without a newline).
     /// Always ensures at least one row exists.
     fn finish_current_row_if_pending(&mut self) {
-        let has_pending_content = self.current_row_start != self.current_row_end
-            || !self.glyphs.is_empty();
+        let has_pending_content =
+            self.current_row_start != self.current_row_end || !self.glyphs.is_empty();
         if has_pending_content || self.rows.is_empty() {
             self.finish_current_row(false);
         }
     }
-
 }
 
 #[derive(Debug)]
@@ -952,8 +951,7 @@ impl PartialEq for LayoutOptions {
         self.first_row_indent_in_lpxs.to_bits() == other.first_row_indent_in_lpxs.to_bits()
             && self.first_row_min_line_spacing_below_in_lpxs.to_bits()
                 == other.first_row_min_line_spacing_below_in_lpxs.to_bits()
-            && self.max_width_in_lpxs.map(f32::to_bits)
-                == other.max_width_in_lpxs.map(f32::to_bits)
+            && self.max_width_in_lpxs.map(f32::to_bits) == other.max_width_in_lpxs.map(f32::to_bits)
             && self.wrap == other.wrap
             && self.align.to_bits() == other.align.to_bits()
             && self.line_spacing_scale.to_bits() == other.line_spacing_scale.to_bits()

--- a/draw/src/text/mod.rs
+++ b/draw/src/text/mod.rs
@@ -18,6 +18,7 @@ pub mod sdfer;
 pub mod selection;
 pub mod shaper;
 pub mod slice;
+pub mod slug_atlas;
 pub mod substr;
 
 // Debug test commented out - requires png encoder

--- a/draw/src/text/rasterizer.rs
+++ b/draw/src/text/rasterizer.rs
@@ -217,6 +217,26 @@ impl Rasterizer {
         }
         None
     }
+
+    pub fn rasterize_glyph_stable_fallback(
+        &mut self,
+        font: &Font,
+        glyph_id: GlyphId,
+        dpxs_per_em: f32,
+    ) -> Option<RasterizedGlyph> {
+        if let Some(rasterized_glyph) =
+            self.rasterize_glyph_outline_sdf(font, glyph_id, dpxs_per_em)
+        {
+            return Some(rasterized_glyph);
+        }
+        if let Some(rasterized_glyph) =
+            self.rasterize_glyph_raster_image(font, glyph_id, dpxs_per_em)
+        {
+            return Some(rasterized_glyph);
+        }
+        None
+    }
+
     /*
     pub fn save_to_png(item:&Image<R>, path: impl AsRef<Path>) {
         let file = File::create(path).unwrap();

--- a/draw/src/text/rasterizer.rs
+++ b/draw/src/text/rasterizer.rs
@@ -207,12 +207,12 @@ impl Rasterizer {
         glyph_id: GlyphId,
         dpxs_per_em: f32,
     ) -> Option<RasterizedGlyph> {
-        if let Some(rasterized_glyph) = self.rasterize_glyph_outline(font, glyph_id, dpxs_per_em) {
-            return Some(rasterized_glyph);
-        };
         if let Some(rasterized_glyph) =
             self.rasterize_glyph_raster_image(font, glyph_id, dpxs_per_em)
         {
+            return Some(rasterized_glyph);
+        }
+        if let Some(rasterized_glyph) = self.rasterize_glyph_outline(font, glyph_id, dpxs_per_em) {
             return Some(rasterized_glyph);
         }
         None
@@ -225,12 +225,12 @@ impl Rasterizer {
         dpxs_per_em: f32,
     ) -> Option<RasterizedGlyph> {
         if let Some(rasterized_glyph) =
-            self.rasterize_glyph_outline_sdf(font, glyph_id, dpxs_per_em)
+            self.rasterize_glyph_raster_image(font, glyph_id, dpxs_per_em)
         {
             return Some(rasterized_glyph);
         }
         if let Some(rasterized_glyph) =
-            self.rasterize_glyph_raster_image(font, glyph_id, dpxs_per_em)
+            self.rasterize_glyph_outline_sdf(font, glyph_id, dpxs_per_em)
         {
             return Some(rasterized_glyph);
         }

--- a/draw/src/text/slug_atlas.rs
+++ b/draw/src/text/slug_atlas.rs
@@ -14,6 +14,7 @@ const BAND_TEX_WIDTH: usize = 2048;
 const DEFAULT_NUM_BANDS: usize = 24;
 const CUBIC_TO_QUAD_TOLERANCE: f32 = 0.05;
 const MAX_CUBIC_SPLIT_DEPTH: usize = 12;
+const RGBA_F32_TEXEL_FLOATS: usize = 4;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct SlugGlyphKey {
@@ -39,6 +40,8 @@ pub struct SlugAtlas {
     band_texture: Texture,
     curve_dirty: bool,
     band_dirty: bool,
+    curve_uploaded_floats: usize,
+    band_uploaded_floats: usize,
     cache_generation: u64,
     uploaded_generation: u64,
     cached_glyphs: FxHashMap<SlugGlyphKey, SlugGlyphInfo>,
@@ -69,6 +72,8 @@ impl SlugAtlas {
             ),
             curve_dirty: false,
             band_dirty: false,
+            curve_uploaded_floats: 0,
+            band_uploaded_floats: 0,
             cache_generation: 0,
             uploaded_generation: 0,
             cached_glyphs: FxHashMap::default(),
@@ -110,51 +115,25 @@ impl SlugAtlas {
         let mut changed = false;
 
         if self.curve_dirty {
-            let width = if self.curve_data.is_empty() {
-                1
-            } else {
-                CURVE_TEX_WIDTH.max(1)
-            };
-            let texels = (self.curve_data.len() / 4).max(1);
-            let height = texels.div_ceil(width);
-            let mut data = if self.curve_data.is_empty() {
-                vec![0.0f32; width * height * 4]
-            } else {
-                self.curve_data.clone()
-            };
-            data.resize(width * height * 4, 0.0);
-            *self.curve_texture.get_format(cx) = TextureFormat::VecRGBAf32 {
-                width,
-                height,
-                data: Some(data),
-                updated: TextureUpdated::Full,
-            };
+            changed |= Self::prepare_append_only_rgba_f32_texture(
+                cx,
+                &self.curve_texture,
+                CURVE_TEX_WIDTH,
+                &self.curve_data,
+                &mut self.curve_uploaded_floats,
+            );
             self.curve_dirty = false;
-            changed = true;
         }
 
         if self.band_dirty {
-            let width = if self.band_data.is_empty() {
-                1
-            } else {
-                BAND_TEX_WIDTH.max(1)
-            };
-            let texels = (self.band_data.len() / 4).max(1);
-            let height = texels.div_ceil(width);
-            let mut data = if self.band_data.is_empty() {
-                vec![0.0f32; width * height * 4]
-            } else {
-                self.band_data.clone()
-            };
-            data.resize(width * height * 4, 0.0);
-            *self.band_texture.get_format(cx) = TextureFormat::VecRGBAf32 {
-                width,
-                height,
-                data: Some(data),
-                updated: TextureUpdated::Full,
-            };
+            changed |= Self::prepare_append_only_rgba_f32_texture(
+                cx,
+                &self.band_texture,
+                BAND_TEX_WIDTH,
+                &self.band_data,
+                &mut self.band_uploaded_floats,
+            );
             self.band_dirty = false;
-            changed = true;
         }
 
         if changed {
@@ -162,6 +141,85 @@ impl SlugAtlas {
         }
 
         changed
+    }
+
+    fn prepare_append_only_rgba_f32_texture(
+        cx: &mut Cx,
+        texture: &Texture,
+        preferred_width: usize,
+        source: &[f32],
+        uploaded_floats: &mut usize,
+    ) -> bool {
+        debug_assert_eq!(source.len() % RGBA_F32_TEXEL_FLOATS, 0);
+
+        let new_width = if source.is_empty() { 1 } else { preferred_width.max(1) };
+        let new_texels = (source.len() / RGBA_F32_TEXEL_FLOATS).max(1);
+        let new_height = new_texels.div_ceil(new_width);
+        let old_uploaded_floats = (*uploaded_floats).min(source.len());
+
+        let format = texture.get_format(cx);
+        let (width, height, data, updated) = match format {
+            TextureFormat::VecRGBAf32 {
+                width,
+                height,
+                data,
+                updated,
+            } => (width, height, data, updated),
+            _ => panic!("expected VecRGBAf32 texture format for SLUG atlas"),
+        };
+
+        let dims_changed = *width != new_width || *height != new_height;
+        let mut texture_data = data.take().unwrap_or_default();
+        let had_texture_data = !texture_data.is_empty();
+        let new_capacity = new_width * new_height * RGBA_F32_TEXEL_FLOATS;
+        texture_data.resize(new_capacity, 0.0);
+
+        if !had_texture_data || *width != new_width || old_uploaded_floats > source.len() {
+            texture_data.fill(0.0);
+            if !source.is_empty() {
+                texture_data[..source.len()].copy_from_slice(source);
+            }
+        } else if old_uploaded_floats < source.len() {
+            texture_data[old_uploaded_floats..source.len()]
+                .copy_from_slice(&source[old_uploaded_floats..]);
+        }
+
+        *width = new_width;
+        *height = new_height;
+        *data = Some(texture_data);
+        *updated = if !had_texture_data || dims_changed || old_uploaded_floats > source.len() {
+            TextureUpdated::Full
+        } else {
+            updated.update(Self::appended_dirty_rect(
+                new_width,
+                old_uploaded_floats / RGBA_F32_TEXEL_FLOATS,
+                source.len() / RGBA_F32_TEXEL_FLOATS,
+            ))
+        };
+        *uploaded_floats = source.len();
+        true
+    }
+
+    fn appended_dirty_rect(width: usize, old_texels: usize, new_texels: usize) -> Option<RectUsize> {
+        if width == 0 || new_texels <= old_texels {
+            return None;
+        }
+
+        let start_row = old_texels / width;
+        let start_col = old_texels % width;
+        let end_row = (new_texels - 1) / width;
+
+        if start_row == end_row {
+            return Some(RectUsize::new(
+                PointUsize::new(start_col, start_row),
+                SizeUsize::new(new_texels - old_texels, 1),
+            ));
+        }
+
+        Some(RectUsize::new(
+            PointUsize::new(0, start_row),
+            SizeUsize::new(width, end_row - start_row + 1),
+        ))
     }
 
     fn build_glyph(&mut self, font: &Font, outline: &GlyphOutline) -> Option<SlugGlyphInfo> {
@@ -511,4 +569,27 @@ fn cubic_to_quads_recursive(
 
     cubic_to_quads_recursive(p0, p01, p012, p0123, depth + 1, bounds, inv_w, inv_h, out);
     cubic_to_quads_recursive(p0123, p123, p23, p3, depth + 1, bounds, inv_w, inv_h, out);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SlugAtlas;
+
+    #[test]
+    fn appended_dirty_rect_stays_tight_within_one_row() {
+        let rect = SlugAtlas::appended_dirty_rect(8, 3, 6).expect("expected dirty rect");
+        assert_eq!(rect.origin.x, 3);
+        assert_eq!(rect.origin.y, 0);
+        assert_eq!(rect.size.width, 3);
+        assert_eq!(rect.size.height, 1);
+    }
+
+    #[test]
+    fn appended_dirty_rect_expands_to_full_rows_when_tail_crosses_rows() {
+        let rect = SlugAtlas::appended_dirty_rect(8, 6, 11).expect("expected dirty rect");
+        assert_eq!(rect.origin.x, 0);
+        assert_eq!(rect.origin.y, 0);
+        assert_eq!(rect.size.width, 8);
+        assert_eq!(rect.size.height, 2);
+    }
 }

--- a/draw/src/text/slug_atlas.rs
+++ b/draw/src/text/slug_atlas.rs
@@ -1,0 +1,497 @@
+use {
+    super::{
+        font::{Font, FontId, GlyphId},
+        geom::{Point, Rect, Size},
+        glyph_outline::{Command, GlyphOutline},
+    },
+    crate::makepad_platform::*,
+    fxhash::FxHashMap,
+    std::cmp::Ordering,
+};
+
+const CURVE_TEX_WIDTH: usize = 2048;
+const BAND_TEX_WIDTH: usize = 2048;
+const DEFAULT_NUM_BANDS: usize = 24;
+const CUBIC_TO_QUAD_TOLERANCE: f32 = 0.05;
+const MAX_CUBIC_SPLIT_DEPTH: usize = 12;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct SlugGlyphKey {
+    font_id: FontId,
+    glyph_id: GlyphId,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct SlugGlyphInfo {
+    pub origin_in_ems: Point<f32>,
+    pub size_in_ems: Size<f32>,
+    pub curve_offset: usize,
+    pub curve_count: usize,
+    pub band_offset: usize,
+    pub band_count: usize,
+    pub fill_flags: u32,
+}
+
+pub struct SlugAtlas {
+    curve_data: Vec<f32>,
+    band_data: Vec<f32>,
+    curve_texture: Texture,
+    band_texture: Texture,
+    curve_dirty: bool,
+    band_dirty: bool,
+    cached_glyphs: FxHashMap<SlugGlyphKey, SlugGlyphInfo>,
+}
+
+impl SlugAtlas {
+    pub fn new(cx: &mut Cx) -> Self {
+        Self {
+            curve_data: Vec::new(),
+            band_data: Vec::new(),
+            curve_texture: Texture::new_with_format(
+                cx,
+                TextureFormat::VecRGBAf32 {
+                    width: 1,
+                    height: 1,
+                    data: None,
+                    updated: TextureUpdated::Empty,
+                },
+            ),
+            band_texture: Texture::new_with_format(
+                cx,
+                TextureFormat::VecRGBAf32 {
+                    width: 1,
+                    height: 1,
+                    data: None,
+                    updated: TextureUpdated::Empty,
+                },
+            ),
+            curve_dirty: false,
+            band_dirty: false,
+            cached_glyphs: FxHashMap::default(),
+        }
+    }
+
+    pub fn curve_texture(&self) -> &Texture {
+        &self.curve_texture
+    }
+
+    pub fn band_texture(&self) -> &Texture {
+        &self.band_texture
+    }
+
+    pub fn get_or_cache_glyph(&mut self, font: &Font, glyph_id: GlyphId) -> Option<SlugGlyphInfo> {
+        let key = SlugGlyphKey {
+            font_id: font.id(),
+            glyph_id,
+        };
+        if let Some(info) = self.cached_glyphs.get(&key).copied() {
+            return Some(info);
+        }
+
+        let outline = font.glyph_outline(glyph_id)?;
+        let info = self.build_glyph(font, &outline)?;
+        self.cached_glyphs.insert(key, info);
+        Some(info)
+    }
+
+    pub fn prepare_textures(&mut self, cx: &mut Cx) -> bool {
+        let mut changed = false;
+
+        if self.curve_dirty {
+            let width = if self.curve_data.is_empty() {
+                1
+            } else {
+                CURVE_TEX_WIDTH.max(1)
+            };
+            let texels = (self.curve_data.len() / 4).max(1);
+            let height = texels.div_ceil(width);
+            let mut data = if self.curve_data.is_empty() {
+                vec![0.0f32; width * height * 4]
+            } else {
+                self.curve_data.clone()
+            };
+            data.resize(width * height * 4, 0.0);
+            *self.curve_texture.get_format(cx) = TextureFormat::VecRGBAf32 {
+                width,
+                height,
+                data: Some(data),
+                updated: TextureUpdated::Full,
+            };
+            self.curve_dirty = false;
+            changed = true;
+        }
+
+        if self.band_dirty {
+            let width = if self.band_data.is_empty() {
+                1
+            } else {
+                BAND_TEX_WIDTH.max(1)
+            };
+            let texels = (self.band_data.len() / 4).max(1);
+            let height = texels.div_ceil(width);
+            let mut data = if self.band_data.is_empty() {
+                vec![0.0f32; width * height * 4]
+            } else {
+                self.band_data.clone()
+            };
+            data.resize(width * height * 4, 0.0);
+            *self.band_texture.get_format(cx) = TextureFormat::VecRGBAf32 {
+                width,
+                height,
+                data: Some(data),
+                updated: TextureUpdated::Full,
+            };
+            self.band_dirty = false;
+            changed = true;
+        }
+
+        changed
+    }
+
+    fn build_glyph(&mut self, font: &Font, outline: &GlyphOutline) -> Option<SlugGlyphInfo> {
+        let bounds = outline.bounds_in_ems();
+        if bounds.size.width <= 0.000001 || bounds.size.height <= 0.000001 {
+            return None;
+        }
+
+        let curves = outline_to_normalized_quads(outline, bounds, font.units_per_em());
+        if curves.is_empty() {
+            return None;
+        }
+
+        let curve_offset = self.curve_data.len() / 8;
+        for curve in &curves {
+            self.curve_data.extend_from_slice(&[
+                curve.p0.x, curve.p0.y, curve.p1.x, curve.p1.y, curve.p2.x, curve.p2.y, 0.0, 0.0,
+            ]);
+        }
+
+        let (band_offset, band_count) = self.build_bands(curve_offset, &curves, DEFAULT_NUM_BANDS);
+        self.curve_dirty = true;
+        self.band_dirty = true;
+
+        Some(SlugGlyphInfo {
+            origin_in_ems: bounds.origin,
+            size_in_ems: bounds.size,
+            curve_offset,
+            curve_count: curves.len(),
+            band_offset,
+            band_count,
+            fill_flags: 0,
+        })
+    }
+
+    fn build_bands(
+        &mut self,
+        curve_offset: usize,
+        curves: &[QuadCurve],
+        num_bands: usize,
+    ) -> (usize, usize) {
+        if curves.is_empty() || num_bands == 0 {
+            return (0, 0);
+        }
+
+        let band_offset = self.band_data.len() / 4;
+        let metadata_floats = num_bands * 2 * 4;
+        self.band_data
+            .resize(self.band_data.len() + metadata_floats, 0.0);
+        let mut horizontal_bands = vec![Vec::<usize>::new(); num_bands];
+        let mut vertical_bands = vec![Vec::<usize>::new(); num_bands];
+        let bands_f = num_bands as f32;
+        let epsilon = 1.0 / 1024.0;
+
+        for (curve_index, curve) in curves.iter().enumerate() {
+            if !curve_is_horizontal(curve) {
+                if let Some((lo, hi)) = band_range(
+                    curve.p0.y.min(curve.p1.y).min(curve.p2.y) - epsilon,
+                    curve.p0.y.max(curve.p1.y).max(curve.p2.y) + epsilon,
+                    bands_f,
+                    num_bands,
+                ) {
+                    for band in lo..=hi {
+                        horizontal_bands[band].push(curve_index);
+                    }
+                }
+            }
+
+            if !curve_is_vertical(curve) {
+                if let Some((lo, hi)) = band_range(
+                    curve.p0.x.min(curve.p1.x).min(curve.p2.x) - epsilon,
+                    curve.p0.x.max(curve.p1.x).max(curve.p2.x) + epsilon,
+                    bands_f,
+                    num_bands,
+                ) {
+                    for band in lo..=hi {
+                        vertical_bands[band].push(curve_index);
+                    }
+                }
+            }
+        }
+
+        for list in &mut horizontal_bands {
+            list.sort_by(|a, b| {
+                curve_max_x(curves[*b])
+                    .partial_cmp(&curve_max_x(curves[*a]))
+                    .unwrap_or(Ordering::Equal)
+            });
+        }
+        for list in &mut vertical_bands {
+            list.sort_by(|a, b| {
+                curve_max_y(curves[*b])
+                    .partial_cmp(&curve_max_y(curves[*a]))
+                    .unwrap_or(Ordering::Equal)
+            });
+        }
+
+        let mut list_texel_offset = band_offset + num_bands * 2;
+        for (band, list) in horizontal_bands
+            .into_iter()
+            .chain(vertical_bands.into_iter())
+            .enumerate()
+        {
+            let meta = (band_offset + band) * 4;
+            self.band_data[meta] = list_texel_offset as f32;
+            self.band_data[meta + 1] = list.len() as f32;
+            self.band_data[meta + 2] = 0.0;
+            self.band_data[meta + 3] = 0.0;
+
+            for chunk in list.chunks(4) {
+                let mut texel = [0.0f32; 4];
+                for (i, value) in chunk.iter().enumerate() {
+                    texel[i] = (curve_offset + *value) as f32;
+                }
+                self.band_data.extend_from_slice(&texel);
+                list_texel_offset += 1;
+            }
+        }
+
+        (band_offset, num_bands)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct P2 {
+    x: f32,
+    y: f32,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct QuadCurve {
+    p0: P2,
+    p1: P2,
+    p2: P2,
+}
+
+fn outline_to_normalized_quads(
+    outline: &GlyphOutline,
+    bounds: Rect<f32>,
+    units_per_em: f32,
+) -> Vec<QuadCurve> {
+    let mut curves = Vec::new();
+    let inv_units = 1.0 / units_per_em.max(0.000001);
+    let inv_w = 1.0 / bounds.size.width.max(0.000001);
+    let inv_h = 1.0 / bounds.size.height.max(0.000001);
+    let mut current = None::<P2>;
+    let mut contour_start = None::<P2>;
+
+    for command in outline.commands().iter().copied() {
+        match command {
+            Command::MoveTo(p) => {
+                let point = scale_point(p, inv_units);
+                current = Some(point);
+                contour_start = Some(point);
+            }
+            Command::LineTo(p) => {
+                let Some(p0) = current else {
+                    continue;
+                };
+                let p2 = scale_point(p, inv_units);
+                let p1 = midpoint(p0, p2);
+                curves.push(QuadCurve {
+                    p0: normalize_point(p0, bounds, inv_w, inv_h),
+                    p1: normalize_point(p1, bounds, inv_w, inv_h),
+                    p2: normalize_point(p2, bounds, inv_w, inv_h),
+                });
+                current = Some(p2);
+            }
+            Command::QuadTo(c, p) => {
+                let Some(p0) = current else {
+                    continue;
+                };
+                let p1 = scale_point(c, inv_units);
+                let p2 = scale_point(p, inv_units);
+                curves.push(QuadCurve {
+                    p0: normalize_point(p0, bounds, inv_w, inv_h),
+                    p1: normalize_point(p1, bounds, inv_w, inv_h),
+                    p2: normalize_point(p2, bounds, inv_w, inv_h),
+                });
+                current = Some(p2);
+            }
+            Command::CurveTo(c1, c2, p) => {
+                let Some(p0) = current else {
+                    continue;
+                };
+                let p1 = scale_point(c1, inv_units);
+                let p2 = scale_point(c2, inv_units);
+                let p3 = scale_point(p, inv_units);
+                cubic_to_quads_recursive(p0, p1, p2, p3, 0, bounds, inv_w, inv_h, &mut curves);
+                current = Some(p3);
+            }
+            Command::Close => {
+                if let (Some(p0), Some(ps)) = (current, contour_start) {
+                    if !same_point(p0, ps) {
+                        let p1 = midpoint(p0, ps);
+                        curves.push(QuadCurve {
+                            p0: normalize_point(p0, bounds, inv_w, inv_h),
+                            p1: normalize_point(p1, bounds, inv_w, inv_h),
+                            p2: normalize_point(ps, bounds, inv_w, inv_h),
+                        });
+                    }
+                    current = Some(ps);
+                }
+            }
+        }
+    }
+
+    curves
+}
+
+fn scale_point(point: Point<f32>, inv_units: f32) -> P2 {
+    P2 {
+        x: point.x * inv_units,
+        y: point.y * inv_units,
+    }
+}
+
+fn normalize_point(point: P2, bounds: Rect<f32>, inv_w: f32, inv_h: f32) -> P2 {
+    P2 {
+        x: (point.x - bounds.origin.x) * inv_w,
+        // Font outlines are Y-up, but DrawGlyph normalized quad space is Y-down.
+        y: (bounds.origin.y + bounds.size.height - point.y) * inv_h,
+    }
+}
+
+fn band_range(
+    min_value: f32,
+    max_value: f32,
+    bands_f: f32,
+    num_bands: usize,
+) -> Option<(usize, usize)> {
+    if num_bands == 0 {
+        return None;
+    }
+    let max_band = (num_bands - 1) as isize;
+    let mut lo = (min_value.clamp(0.0, 1.0) * bands_f).floor() as isize;
+    let mut hi = (max_value.clamp(0.0, 1.0) * bands_f).floor() as isize;
+    lo = lo.clamp(0, max_band);
+    hi = hi.clamp(0, max_band);
+    if hi < lo {
+        std::mem::swap(&mut lo, &mut hi);
+    }
+    Some((lo as usize, hi as usize))
+}
+
+fn curve_is_horizontal(curve: &QuadCurve) -> bool {
+    (curve.p0.y - curve.p1.y).abs() <= 0.000001 && (curve.p0.y - curve.p2.y).abs() <= 0.000001
+}
+
+fn curve_is_vertical(curve: &QuadCurve) -> bool {
+    (curve.p0.x - curve.p1.x).abs() <= 0.000001 && (curve.p0.x - curve.p2.x).abs() <= 0.000001
+}
+
+fn curve_max_x(curve: QuadCurve) -> f32 {
+    curve.p0.x.max(curve.p1.x).max(curve.p2.x)
+}
+
+fn curve_max_y(curve: QuadCurve) -> f32 {
+    curve.p0.y.max(curve.p1.y).max(curve.p2.y)
+}
+
+fn same_point(a: P2, b: P2) -> bool {
+    (a.x - b.x).abs() <= 0.000001 && (a.y - b.y).abs() <= 0.000001
+}
+
+fn midpoint(a: P2, b: P2) -> P2 {
+    P2 {
+        x: (a.x + b.x) * 0.5,
+        y: (a.y + b.y) * 0.5,
+    }
+}
+
+fn eval_quad(p0: P2, p1: P2, p2: P2, t: f32) -> P2 {
+    let s = 1.0 - t;
+    P2 {
+        x: s * s * p0.x + 2.0 * s * t * p1.x + t * t * p2.x,
+        y: s * s * p0.y + 2.0 * s * t * p1.y + t * t * p2.y,
+    }
+}
+
+fn eval_cubic(p0: P2, p1: P2, p2: P2, p3: P2, t: f32) -> P2 {
+    let s = 1.0 - t;
+    let s2 = s * s;
+    let t2 = t * t;
+    P2 {
+        x: p0.x * s2 * s + 3.0 * p1.x * s2 * t + 3.0 * p2.x * s * t2 + p3.x * t2 * t,
+        y: p0.y * s2 * s + 3.0 * p1.y * s2 * t + 3.0 * p2.y * s * t2 + p3.y * t2 * t,
+    }
+}
+
+fn distance(a: P2, b: P2) -> f32 {
+    let dx = a.x - b.x;
+    let dy = a.y - b.y;
+    (dx * dx + dy * dy).sqrt()
+}
+
+fn cubic_to_quad_control(p0: P2, p1: P2, p2: P2, p3: P2) -> P2 {
+    P2 {
+        x: (3.0 * (p1.x + p2.x) - p0.x - p3.x) * 0.25,
+        y: (3.0 * (p1.y + p2.y) - p0.y - p3.y) * 0.25,
+    }
+}
+
+fn cubic_to_quads_recursive(
+    p0: P2,
+    p1: P2,
+    p2: P2,
+    p3: P2,
+    depth: usize,
+    bounds: Rect<f32>,
+    inv_w: f32,
+    inv_h: f32,
+    out: &mut Vec<QuadCurve>,
+) {
+    let qc = cubic_to_quad_control(p0, p1, p2, p3);
+    let q = QuadCurve { p0, p1: qc, p2: p3 };
+    let e25 = distance(
+        eval_cubic(p0, p1, p2, p3, 0.25),
+        eval_quad(q.p0, q.p1, q.p2, 0.25),
+    );
+    let e50 = distance(
+        eval_cubic(p0, p1, p2, p3, 0.50),
+        eval_quad(q.p0, q.p1, q.p2, 0.50),
+    );
+    let e75 = distance(
+        eval_cubic(p0, p1, p2, p3, 0.75),
+        eval_quad(q.p0, q.p1, q.p2, 0.75),
+    );
+    let max_err = e25.max(e50).max(e75);
+
+    if max_err <= CUBIC_TO_QUAD_TOLERANCE || depth >= MAX_CUBIC_SPLIT_DEPTH {
+        out.push(QuadCurve {
+            p0: normalize_point(q.p0, bounds, inv_w, inv_h),
+            p1: normalize_point(q.p1, bounds, inv_w, inv_h),
+            p2: normalize_point(q.p2, bounds, inv_w, inv_h),
+        });
+        return;
+    }
+
+    let p01 = midpoint(p0, p1);
+    let p12 = midpoint(p1, p2);
+    let p23 = midpoint(p2, p3);
+    let p012 = midpoint(p01, p12);
+    let p123 = midpoint(p12, p23);
+    let p0123 = midpoint(p012, p123);
+
+    cubic_to_quads_recursive(p0, p01, p012, p0123, depth + 1, bounds, inv_w, inv_h, out);
+    cubic_to_quads_recursive(p0123, p123, p23, p3, depth + 1, bounds, inv_w, inv_h, out);
+}

--- a/draw/src/text/slug_atlas.rs
+++ b/draw/src/text/slug_atlas.rs
@@ -5,7 +5,7 @@ use {
         glyph_outline::{Command, GlyphOutline},
     },
     crate::makepad_platform::*,
-    fxhash::FxHashMap,
+    fxhash::{FxHashMap, FxHashSet},
     std::cmp::Ordering,
 };
 
@@ -33,6 +33,20 @@ pub struct SlugGlyphInfo {
     pub fill_flags: u32,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct CachedSlugGlyphInfo {
+    generation: u64,
+    info: SlugGlyphInfo,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum SlugGlyphCacheResult {
+    Ready(SlugGlyphInfo),
+    NeedsUpload { generation: u64, glyph: SlugGlyphInfo },
+    Deferred,
+    Unavailable,
+}
+
 pub struct SlugAtlas {
     curve_data: Vec<f32>,
     band_data: Vec<f32>,
@@ -44,7 +58,8 @@ pub struct SlugAtlas {
     band_uploaded_floats: usize,
     cache_generation: u64,
     uploaded_generation: u64,
-    cached_glyphs: FxHashMap<SlugGlyphKey, SlugGlyphInfo>,
+    cached_glyphs: FxHashMap<SlugGlyphKey, CachedSlugGlyphInfo>,
+    missing_glyphs: FxHashSet<SlugGlyphKey>,
 }
 
 impl SlugAtlas {
@@ -77,6 +92,7 @@ impl SlugAtlas {
             cache_generation: 0,
             uploaded_generation: 0,
             cached_glyphs: FxHashMap::default(),
+            missing_glyphs: FxHashSet::default(),
         }
     }
 
@@ -96,19 +112,47 @@ impl SlugAtlas {
         self.uploaded_generation
     }
 
-    pub fn get_or_cache_glyph(&mut self, font: &Font, glyph_id: GlyphId) -> Option<SlugGlyphInfo> {
+    pub fn get_or_cache_glyph(
+        &mut self,
+        font: &Font,
+        glyph_id: GlyphId,
+        can_build: bool,
+    ) -> SlugGlyphCacheResult {
         let key = SlugGlyphKey {
             font_id: font.id(),
             glyph_id,
         };
-        if let Some(info) = self.cached_glyphs.get(&key).copied() {
-            return Some(info);
+        if let Some(cached) = self.cached_glyphs.get(&key).copied() {
+            if cached.generation <= self.uploaded_generation {
+                return SlugGlyphCacheResult::Ready(cached.info);
+            }
+            return SlugGlyphCacheResult::NeedsUpload {
+                generation: cached.generation,
+                glyph: cached.info,
+            };
+        }
+        if self.missing_glyphs.contains(&key) {
+            return SlugGlyphCacheResult::Unavailable;
+        }
+        if !can_build {
+            return SlugGlyphCacheResult::Deferred;
         }
 
-        let outline = font.glyph_outline(glyph_id)?;
-        let info = self.build_glyph(font, &outline)?;
-        self.cached_glyphs.insert(key, info);
-        Some(info)
+        let Some(outline) = font.glyph_outline(glyph_id) else {
+            self.missing_glyphs.insert(key);
+            return SlugGlyphCacheResult::Unavailable;
+        };
+        let Some(info) = self.build_glyph(font, &outline) else {
+            self.missing_glyphs.insert(key);
+            return SlugGlyphCacheResult::Unavailable;
+        };
+        let generation = self.cache_generation;
+        self.cached_glyphs
+            .insert(key, CachedSlugGlyphInfo { generation, info });
+        SlugGlyphCacheResult::NeedsUpload {
+            generation,
+            glyph: info,
+        }
     }
 
     pub fn prepare_textures(&mut self, cx: &mut Cx) -> bool {
@@ -152,7 +196,11 @@ impl SlugAtlas {
     ) -> bool {
         debug_assert_eq!(source.len() % RGBA_F32_TEXEL_FLOATS, 0);
 
-        let new_width = if source.is_empty() { 1 } else { preferred_width.max(1) };
+        let new_width = if source.is_empty() {
+            1
+        } else {
+            preferred_width.max(1)
+        };
         let new_texels = (source.len() / RGBA_F32_TEXEL_FLOATS).max(1);
         let new_height = new_texels.div_ceil(new_width);
         let old_uploaded_floats = (*uploaded_floats).min(source.len());
@@ -200,7 +248,11 @@ impl SlugAtlas {
         true
     }
 
-    fn appended_dirty_rect(width: usize, old_texels: usize, new_texels: usize) -> Option<RectUsize> {
+    fn appended_dirty_rect(
+        width: usize,
+        old_texels: usize,
+        new_texels: usize,
+    ) -> Option<RectUsize> {
         if width == 0 || new_texels <= old_texels {
             return None;
         }
@@ -573,7 +625,160 @@ fn cubic_to_quads_recursive(
 
 #[cfg(test)]
 mod tests {
-    use super::SlugAtlas;
+    use super::{SlugAtlas, SlugGlyphCacheResult};
+    use crate::{
+        makepad_platform::{Cx, SharedBytes},
+        text::{
+            font::FontId,
+            layouter,
+            loader::{FontDefinition, Loader},
+        },
+    };
+    use std::path::PathBuf;
+
+    #[derive(Clone, Copy, Debug)]
+    struct TestCurve {
+        p0: (f32, f32),
+        p1: (f32, f32),
+        p2: (f32, f32),
+    }
+
+    fn calc_root_code(y1: f32, y2: f32, y3: f32) -> u32 {
+        let i1 = y1.to_bits() >> 31;
+        let i2 = y2.to_bits() >> 30;
+        let i3 = y3.to_bits() >> 29;
+        let shift = (i1 & 1) | (i2 & 2) | (i3 & 4);
+        (11892u32 >> shift) & 257
+    }
+
+    fn solve_horiz_poly(p12: [f32; 4], p3: [f32; 2]) -> (f32, f32) {
+        let a = [p12[0] - p12[2] * 2.0 + p3[0], p12[1] - p12[3] * 2.0 + p3[1]];
+        let b = [p12[0] - p12[2], p12[1] - p12[3]];
+        let ra = 1.0 / a[1];
+        let rb = 0.5 / b[1];
+        let d = (b[1] * b[1] - a[1] * p12[1]).max(0.0).sqrt();
+        let (mut t1, mut t2) = ((b[1] - d) * ra, (b[1] + d) * ra);
+        if a[1].abs() < 1.0 / 65536.0 {
+            t1 = p12[1] * rb;
+            t2 = t1;
+        }
+        (
+            (a[0] * t1 - b[0] * 2.0) * t1 + p12[0],
+            (a[0] * t2 - b[0] * 2.0) * t2 + p12[0],
+        )
+    }
+
+    fn solve_vert_poly(p12: [f32; 4], p3: [f32; 2]) -> (f32, f32) {
+        let a = [p12[0] - p12[2] * 2.0 + p3[0], p12[1] - p12[3] * 2.0 + p3[1]];
+        let b = [p12[0] - p12[2], p12[1] - p12[3]];
+        let ra = 1.0 / a[0];
+        let rb = 0.5 / b[0];
+        let d = (b[0] * b[0] - a[0] * p12[0]).max(0.0).sqrt();
+        let (mut t1, mut t2) = ((b[0] - d) * ra, (b[0] + d) * ra);
+        if a[0].abs() < 1.0 / 65536.0 {
+            t1 = p12[0] * rb;
+            t2 = t1;
+        }
+        (
+            (a[1] * t1 - b[1] * 2.0) * t1 + p12[1],
+            (a[1] * t2 - b[1] * 2.0) * t2 + p12[1],
+        )
+    }
+
+    fn saturate(v: f32) -> f32 {
+        v.clamp(0.0, 1.0)
+    }
+
+    fn calc_coverage(xcov: f32, ycov: f32, xwgt: f32, ywgt: f32) -> f32 {
+        let coverage = ((xcov * xwgt + ycov * ywgt).abs() / (xwgt + ywgt).max(1.0 / 65536.0))
+            .max(xcov.abs().min(ycov.abs()));
+        saturate(coverage)
+    }
+
+    fn alpha_at_full_scan(curves: &[TestCurve], sample: (f32, f32), px_x: f32, px_y: f32) -> f32 {
+        let mut coverage_x = 0.0;
+        let mut weight_x: f32 = 0.0;
+        let mut coverage_y = 0.0;
+        let mut weight_y: f32 = 0.0;
+
+        for curve in curves {
+            let p12 = [
+                curve.p0.0 - sample.0,
+                curve.p0.1 - sample.1,
+                curve.p1.0 - sample.0,
+                curve.p1.1 - sample.1,
+            ];
+            let p3 = [curve.p2.0 - sample.0, curve.p2.1 - sample.1];
+
+            let h_code = calc_root_code(p12[1], p12[3], p3[1]);
+            if h_code != 0 {
+                let (r0, r1) = solve_horiz_poly(p12, p3);
+                let r0 = r0 / px_x;
+                let r1 = r1 / px_x;
+                if (h_code & 1) != 0 {
+                    coverage_x += saturate(r0 + 0.5);
+                    weight_x = weight_x.max(saturate(1.0 - r0.abs() * 2.0));
+                }
+                if h_code > 1 {
+                    coverage_x -= saturate(r1 + 0.5);
+                    weight_x = weight_x.max(saturate(1.0 - r1.abs() * 2.0));
+                }
+            }
+
+            let v_code = calc_root_code(p12[0], p12[2], p3[0]);
+            if v_code != 0 {
+                let (r0, r1) = solve_vert_poly(p12, p3);
+                let r0 = r0 / px_y;
+                let r1 = r1 / px_y;
+                if (v_code & 1) != 0 {
+                    coverage_y -= saturate(r0 + 0.5);
+                    weight_y = weight_y.max(saturate(1.0 - r0.abs() * 2.0));
+                }
+                if v_code > 1 {
+                    coverage_y += saturate(r1 + 0.5);
+                    weight_y = weight_y.max(saturate(1.0 - r1.abs() * 2.0));
+                }
+            }
+        }
+
+        calc_coverage(coverage_x, coverage_y, weight_x, weight_y)
+    }
+
+    fn curves_for_glyph(atlas: &SlugAtlas, curve_offset: usize, curve_count: usize) -> Vec<TestCurve> {
+        let mut curves = Vec::with_capacity(curve_count);
+        for i in 0..curve_count {
+            let base = (curve_offset + i) * 8;
+            curves.push(TestCurve {
+                p0: (atlas.curve_data[base], atlas.curve_data[base + 1]),
+                p1: (atlas.curve_data[base + 2], atlas.curve_data[base + 3]),
+                p2: (atlas.curve_data[base + 4], atlas.curve_data[base + 5]),
+            });
+        }
+        curves
+    }
+
+    fn bundled_font_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../widgets/resources/IBMPlexSans-Text.ttf")
+    }
+
+    fn load_test_font() -> std::rc::Rc<crate::text::font::Font> {
+        let mut loader = Loader::new(layouter::Settings::default().loader);
+        let font_id: FontId = 0x5151_0001_u64.into();
+        let font_data =
+            SharedBytes::from_file_mmap_or_read(bundled_font_path()).expect("font bytes should load");
+        loader.define_font(
+            font_id,
+            FontDefinition {
+                data: font_data,
+                index: 0,
+                ascender_fudge_in_ems: -0.1,
+                descender_fudge_in_ems: 0.0,
+                weight: None,
+                variations: Vec::new(),
+            },
+        );
+        loader.get_or_load_font(font_id).clone()
+    }
 
     #[test]
     fn appended_dirty_rect_stays_tight_within_one_row() {
@@ -591,5 +796,66 @@ mod tests {
         assert_eq!(rect.origin.y, 0);
         assert_eq!(rect.size.width, 8);
         assert_eq!(rect.size.height, 2);
+    }
+
+    #[test]
+    fn builds_slug_glyphs_for_uizoo_demo_letters() {
+        let font = load_test_font();
+        let face = rustybuzz::ttf_parser::Face::parse(font.data().as_slice(), 0)
+            .expect("font face should parse");
+        let mut cx = Cx::new(Box::new(|_, _| {}));
+        let mut atlas = SlugAtlas::new(&mut cx);
+
+        for ch in ['A', 'g', 'W', 'S', 'L'] {
+            let glyph_id = face
+                .glyph_index(ch)
+                .unwrap_or_else(|| panic!("missing glyph for {ch:?}"))
+                .0;
+            let result = atlas.get_or_cache_glyph(font.as_ref(), glyph_id, true);
+            match result {
+                SlugGlyphCacheResult::NeedsUpload { glyph, .. }
+                | SlugGlyphCacheResult::Ready(glyph) => {
+                    assert!(glyph.curve_count > 0, "expected curves for {ch:?}");
+                    assert!(glyph.size_in_ems.width > 0.0, "expected width for {ch:?}");
+                    assert!(glyph.size_in_ems.height > 0.0, "expected height for {ch:?}");
+                }
+                SlugGlyphCacheResult::Deferred => {
+                    panic!("unexpected deferred result for {ch:?}");
+                }
+                SlugGlyphCacheResult::Unavailable => {
+                    panic!("unexpected unavailable result for {ch:?}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn uizoo_demo_letters_produce_nonzero_slug_coverage() {
+        let font = load_test_font();
+        let face = rustybuzz::ttf_parser::Face::parse(font.data().as_slice(), 0)
+            .expect("font face should parse");
+        let mut cx = Cx::new(Box::new(|_, _| {}));
+        let mut atlas = SlugAtlas::new(&mut cx);
+
+        for ch in ['A', 'g', 'W', 'S', 'L'] {
+            let glyph_id = face
+                .glyph_index(ch)
+                .unwrap_or_else(|| panic!("missing glyph for {ch:?}"))
+                .0;
+            let glyph = match atlas.get_or_cache_glyph(font.as_ref(), glyph_id, true) {
+                SlugGlyphCacheResult::NeedsUpload { glyph, .. }
+                | SlugGlyphCacheResult::Ready(glyph) => glyph,
+                other => panic!("unexpected glyph build result for {ch:?}: {other:?}"),
+            };
+            let curves = curves_for_glyph(&atlas, glyph.curve_offset, glyph.curve_count);
+            let mut max_alpha: f32 = 0.0;
+            for y in 0..33 {
+                for x in 0..33 {
+                    let sample = (x as f32 / 32.0, y as f32 / 32.0);
+                    max_alpha = max_alpha.max(alpha_at_full_scan(&curves, sample, 1.0 / 192.0, 1.0 / 192.0));
+                }
+            }
+            assert!(max_alpha > 0.2, "expected visible SLUG coverage for {ch:?}, got {max_alpha}");
+        }
     }
 }

--- a/draw/src/text/slug_atlas.rs
+++ b/draw/src/text/slug_atlas.rs
@@ -39,6 +39,8 @@ pub struct SlugAtlas {
     band_texture: Texture,
     curve_dirty: bool,
     band_dirty: bool,
+    cache_generation: u64,
+    uploaded_generation: u64,
     cached_glyphs: FxHashMap<SlugGlyphKey, SlugGlyphInfo>,
 }
 
@@ -67,6 +69,8 @@ impl SlugAtlas {
             ),
             curve_dirty: false,
             band_dirty: false,
+            cache_generation: 0,
+            uploaded_generation: 0,
             cached_glyphs: FxHashMap::default(),
         }
     }
@@ -77,6 +81,14 @@ impl SlugAtlas {
 
     pub fn band_texture(&self) -> &Texture {
         &self.band_texture
+    }
+
+    pub fn cache_generation(&self) -> u64 {
+        self.cache_generation
+    }
+
+    pub fn uploaded_generation(&self) -> u64 {
+        self.uploaded_generation
     }
 
     pub fn get_or_cache_glyph(&mut self, font: &Font, glyph_id: GlyphId) -> Option<SlugGlyphInfo> {
@@ -145,6 +157,10 @@ impl SlugAtlas {
             changed = true;
         }
 
+        if changed {
+            self.uploaded_generation = self.cache_generation;
+        }
+
         changed
     }
 
@@ -169,6 +185,7 @@ impl SlugAtlas {
         let (band_offset, band_count) = self.build_bands(curve_offset, &curves, DEFAULT_NUM_BANDS);
         self.curve_dirty = true;
         self.band_dirty = true;
+        self.cache_generation = self.cache_generation.wrapping_add(1);
 
         Some(SlugGlyphInfo {
             origin_in_ems: bounds.origin,

--- a/examples/uizoo/src/app.rs
+++ b/examples/uizoo/src/app.rs
@@ -45,6 +45,7 @@ script_mod! {
                 @tImageBlend
                 @tGlassPanel
                 @tLabel
+                @tSlug
                 @tLinkLabel
                 @tMarkdown
                 @tPageFlip
@@ -86,6 +87,7 @@ script_mod! {
         tImageBlend := DockTab{name: "ImageBlend" template: @PermanentTab kind: @TabImageBlend}
         tGlassPanel := DockTab{name: "GlassPanel" template: @PermanentTab kind: @TabGlassPanel}
         tLabel := DockTab{name: "Label" template: @PermanentTab kind: @TabLabel}
+        tSlug := DockTab{name: "SLUG" template: @PermanentTab kind: @TabSlug}
         tLinkLabel := DockTab{name: "LinkLabel" template: @PermanentTab kind: @TabLinkLabel}
         tMarkdown := DockTab{name: "Markdown" template: @PermanentTab kind: @TabMarkdown}
         tPageFlip := DockTab{name: "PageFlip" template: @PermanentTab kind: @TabPageFlip}
@@ -117,6 +119,7 @@ script_mod! {
         TabImageBlend := UIZooTab{DemoImageBlend{}}
         TabGlassPanel := UIZooTab{DemoGlassPanel{}}
         TabLabel := UIZooTab{DemoLabel{}}
+        TabSlug := UIZooTab{DemoSlug{}}
         TabLinkLabel := UIZooTab{DemoLinkLabel{}}
         TabMarkdown := UIZooTab{DemoMarkdown{}}
         TabPageFlip := UIZooTab{DemoPageFlip{}}
@@ -383,6 +386,7 @@ impl AppMain for App {
         crate::tab_rotatedimage::script_mod(vm);
         crate::tab_scrollbar::script_mod(vm);
         crate::tab_slider::script_mod(vm);
+        crate::tab_slug::script_mod(vm);
         crate::tab_slidesview::script_mod(vm);
         crate::tab_stacknavigation::script_mod(vm);
         crate::tab_adaptiveview::script_mod(vm);

--- a/examples/uizoo/src/demofiletree.rs
+++ b/examples/uizoo/src/demofiletree.rs
@@ -293,8 +293,20 @@ impl Widget for DemoFileTree {
                 #[cfg(not(target_arch = "wasm32"))]
                 {
                     let root_path: PathBuf = PathBuf::from(".");
-                    let root = FileNodeData::Directory {
-                        entries: get_directory_entries(&root_path, false).unwrap(),
+                    let root = match get_directory_entries(&root_path, false) {
+                        Ok(entries) => FileNodeData::Directory { entries },
+                        Err(err) => {
+                            let message = match err {
+                                FileError::Unknown(s) | FileError::CannotOpen(s) => s,
+                            };
+                            log!("DemoFileTree: cannot read `{}`: {}", root_path.display(), message);
+                            FileNodeData::Directory {
+                                entries: vec![DirectoryEntry {
+                                    name: format!("<cannot access filesystem: {}>", message),
+                                    node: FileNodeData::File { data: None },
+                                }],
+                            }
+                        }
                     };
                     let file_tree_data = FileTreeData {
                         root_path: "".into(),

--- a/examples/uizoo/src/layout_templates.rs
+++ b/examples/uizoo/src/layout_templates.rs
@@ -21,7 +21,10 @@ script_mod! {
 
             flow: Down
             spacing: theme.space_2
-            scroll_bars: ScrollBars{show_scroll_x: false show_scroll_y: true}
+            scroll_bars: ScrollBars{
+                show_scroll_x: false show_scroll_y: true
+                scroll_bar_y.drag_scrolling: true
+            }
         }
 
         demos := View{
@@ -30,7 +33,10 @@ script_mod! {
             spacing: theme.space_2
             padding: theme.mspace_3{right: (theme.space_2 * 3.0)}
             margin: theme.mspace_v_2
-            scroll_bars: ScrollBars{show_scroll_x: false show_scroll_y: true}
+            scroll_bars: ScrollBars{
+                show_scroll_x: false show_scroll_y: true
+                scroll_bar_y.drag_scrolling: true
+            }
         }
     }
 

--- a/examples/uizoo/src/lib.rs
+++ b/examples/uizoo/src/lib.rs
@@ -27,6 +27,7 @@ pub mod tab_rotatedimage;
 pub mod tab_scrollbar;
 pub mod tab_slider;
 pub mod tab_slidesview;
+pub mod tab_slug;
 pub mod tab_spinner;
 pub mod tab_stacknavigation;
 pub mod tab_textinput;

--- a/examples/uizoo/src/tab_align_scroll.rs
+++ b/examples/uizoo/src/tab_align_scroll.rs
@@ -34,7 +34,10 @@ script_mod! {
                 width: Fill height: 200.
                 flow: Down
                 align: Align{x: 0.5 y: 0.5}
-                scroll_bars: ScrollBars{show_scroll_x: false show_scroll_y: true}
+                scroll_bars: ScrollBars{
+                    show_scroll_x: false show_scroll_y: true
+                    scroll_bar_y.drag_scrolling: true
+                }
                 AlignScrollBox{width: 120. height: 80. P{width: Fit text: "Box 1"}}
                 AlignScrollBox{width: 120. height: 80. P{width: Fit text: "Box 2"}}
                 AlignScrollBox{width: 120. height: 80. P{width: Fit text: "Box 3"}}
@@ -51,7 +54,10 @@ script_mod! {
                 width: 250. height: Fit
                 flow: Down
                 align: Align{x: 0.5 y: 0.0}
-                scroll_bars: ScrollBars{show_scroll_x: true show_scroll_y: false}
+                scroll_bars: ScrollBars{
+                    show_scroll_x: true show_scroll_y: false
+                    scroll_bar_x.drag_scrolling: true
+                }
                 AlignScrollBox{width: 400. height: 40. P{width: Fit text: "Wide box 1 — 400px in a 250px container"}}
                 AlignScrollBox{width: 150. height: 40. P{width: Fit text: "Narrow box 2"}}
                 AlignScrollBox{width: 400. height: 40. P{width: Fit text: "Wide box 3 — also 400px wide"}}
@@ -66,7 +72,10 @@ script_mod! {
                 width: Fill height: 150.
                 flow: Right
                 align: Align{x: 0.0 y: 0.5}
-                scroll_bars: ScrollBars{show_scroll_x: false show_scroll_y: true}
+                scroll_bars: ScrollBars{
+                    show_scroll_x: false show_scroll_y: true
+                    scroll_bar_y.drag_scrolling: true
+                }
                 AlignScrollBox{width: 100. height: 50. P{width: Fit text: "Short"}}
                 AlignScrollBox{width: 100. height: 250. P{width: Fit text: "Tall (250px)"}}
                 AlignScrollBox{width: 100. height: 50. P{width: Fit text: "Short"}}
@@ -81,7 +90,10 @@ script_mod! {
                 width: 300. height: Fit
                 flow: Right
                 align: Align{x: 0.5 y: 0.5}
-                scroll_bars: ScrollBars{show_scroll_x: true show_scroll_y: false}
+                scroll_bars: ScrollBars{
+                    show_scroll_x: true show_scroll_y: false
+                    scroll_bar_x.drag_scrolling: true
+                }
                 AlignScrollBox{width: 100. height: 60. P{width: Fit text: "A"}}
                 AlignScrollBox{width: 100. height: 60. P{width: Fit text: "B"}}
                 AlignScrollBox{width: 100. height: 60. P{width: Fit text: "C"}}
@@ -98,7 +110,11 @@ script_mod! {
                 width: 250. height: 150.
                 flow: Overlay
                 align: Align{x: 0.5 y: 0.5}
-                scroll_bars: ScrollBars{show_scroll_x: true show_scroll_y: true}
+                scroll_bars: ScrollBars{
+                    show_scroll_x: true show_scroll_y: true
+                    scroll_bar_x.drag_scrolling: true
+                    scroll_bar_y.drag_scrolling: true
+                }
                 AlignScrollBox{
                     width: 400. height: 300.
                     P{width: Fit text: "400x300 box in a 250x150 container.\nScroll both directions to see all content."}
@@ -114,7 +130,10 @@ script_mod! {
                 width: Fill height: 150.
                 flow: Down
                 align: Align{x: 0.5 y: 0.5}
-                scroll_bars: ScrollBars{show_scroll_x: false show_scroll_y: true}
+                scroll_bars: ScrollBars{
+                    show_scroll_x: false show_scroll_y: true
+                    scroll_bar_y.drag_scrolling: true
+                }
                 AlignScrollBox{width: 120. height: 40. P{width: Fit text: "Centered"}}
             }
         }

--- a/examples/uizoo/src/tab_scrollbar.rs
+++ b/examples/uizoo/src/tab_scrollbar.rs
@@ -16,7 +16,10 @@ script_mod! {
                     color_2: uniform(#f00)
                 }
             }
-            scroll_bars: ScrollBars{}
+            scroll_bars: ScrollBars{
+                scroll_bar_x.drag_scrolling: true
+                scroll_bar_y.drag_scrolling: true
+            }
         }
     }
 }

--- a/examples/uizoo/src/tab_slug.rs
+++ b/examples/uizoo/src/tab_slug.rs
@@ -1,0 +1,379 @@
+use crate::makepad_widgets::*;
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use mod.widgets.*
+
+    let SlugDemoCard = RoundedView{
+        width: Fill
+        height: Fit
+        flow: Down
+        spacing: theme.space_2
+        padding: theme.mspace_2
+        show_bg: true
+        draw_bg +: {
+            color: uniform(theme.color_inset)
+            border_radius: uniform(theme.corner_radius)
+            border_size: uniform(1.0)
+            border_color: uniform(#fff2)
+        }
+    }
+
+    let SlugDemoTitle = Pbold{
+        width: Fill
+        margin: 0.
+    }
+
+    let SlugDemoNote = P{
+        width: Fill
+        margin: 0.
+    }
+
+    let SlugProbeGrid = View{
+        width: Fill
+        height: Fit
+        flow: Flow.Right{wrap: true}
+        spacing: theme.space_2
+    }
+
+    let SlugProbeCard = RoundedView{
+        width: 200.
+        height: Fit
+        flow: Down
+        spacing: theme.space_2
+        padding: theme.mspace_2
+        show_bg: true
+        draw_bg +: {
+            color: uniform(theme.color_inset_1)
+            border_radius: uniform(theme.corner_radius)
+            border_size: uniform(1.0)
+            border_color: uniform(#fff1)
+        }
+    }
+
+    let SlugLargeDefaultLabel = Label{
+        draw_text +: {
+            text_style +: {
+                font_size: 160.
+            }
+        }
+    }
+
+    let SlugLargeLiteralLabel = Label{
+        draw_text +: {
+            color: #fff
+            text_style +: {
+                font_size: 160.
+            }
+        }
+    }
+
+    let SlugLargeThemeLabel = Label{
+        draw_text +: {
+            color: theme.color_text
+            text_style +: {
+                font_size: 160.
+            }
+        }
+    }
+
+    let SlugLargeAccentLabel = Label{
+        draw_text +: {
+            color: theme.color_makepad
+            text_style +: {
+                font_size: 160.
+            }
+        }
+    }
+
+    let SlugLargeGradientLabel = Label{
+        draw_text +: {
+            color: #x6CF
+            color_2: #xFD6
+            gradient_fill_horizontal: 1.0
+            text_style +: {
+                font_size: 160.
+            }
+        }
+    }
+
+    let SlugLargeCustomLiteralLabel = Label{
+        draw_text +: {
+            color: #xF75
+            text_style +: {
+                font_size: 160.
+            }
+            get_color: fn() -> vec4 {
+                return mix(#xF75 #0000 self.pos.x)
+            }
+        }
+    }
+
+    let SlugLargeCustomThemeLabel = Label{
+        draw_text +: {
+            color: theme.color_makepad
+            text_style +: {
+                font_size: 160.
+            }
+            get_color: fn() -> vec4 {
+                return mix(theme.color_makepad #0000 self.pos.x)
+            }
+        }
+    }
+
+    mod.widgets.DemoSlug = UIZooTabLayout_B{
+        desc +: {
+            Markdown{
+                body: "# SLUG\n\nThese demos compare the same text widget below and above the current Linux SLUG cutoff.\n\nOnly the text size changes between the left and right columns. On Linux, the left column should stay on the raster/MSDF text path while the right column should switch to SLUG. On other platforms, both columns may already use SLUG.\n\nThe lower diagnostic section intentionally adds redundant large-text probes so we can tell whether Linux SLUG failures are tied to glyph shape, color source, or custom `get_color()` logic."
+            }
+        }
+        demos +: {
+            H4{text: "Plain Label"}
+            P{text: "Same Label widget, same text, different font sizes."}
+            UIZooRowH{
+                align: Align{x: 0. y: 0.}
+                SlugDemoCard{
+                    SlugDemoTitle{text: "Below Linux cutoff"}
+                    SlugDemoNote{text: "32 px Label text. Expected to stay on the normal text path on Linux."}
+                    Label{
+                        draw_text +: {
+                            text_style +: {
+                                font_size: 32.
+                            }
+                        }
+                        text: "Ag"
+                    }
+                }
+                SlugDemoCard{
+                    SlugDemoTitle{text: "Above Linux cutoff"}
+                    SlugDemoNote{text: "192 px Label text. Expected to use SLUG on Linux."}
+                    Label{
+                        draw_text +: {
+                            text_style +: {
+                                font_size: 192.
+                            }
+                        }
+                        text: "Ag"
+                    }
+                }
+            }
+
+            Hr{}
+            H4{text: "Gradient Label"}
+            P{text: "Same gradient Label widget, so this is useful for checking that text styling still matches across both render paths."}
+            UIZooRowH{
+                align: Align{x: 0. y: 0.}
+                SlugDemoCard{
+                    SlugDemoTitle{text: "Gradient below cutoff"}
+                    SlugDemoNote{text: "32 px LabelGradientX text."}
+                    LabelGradientX{
+                        draw_text +: {
+                            color: #x6CF
+                            color_2: #xFD6
+                            text_style +: {
+                                font_size: 32.
+                            }
+                        }
+                        text: "SLUG"
+                    }
+                }
+                SlugDemoCard{
+                    SlugDemoTitle{text: "Gradient above cutoff"}
+                    SlugDemoNote{text: "192 px LabelGradientX text."}
+                    LabelGradientX{
+                        draw_text +: {
+                            color: #x6CF
+                            color_2: #xFD6
+                            text_style +: {
+                                font_size: 192.
+                            }
+                        }
+                        text: "SL"
+                    }
+                }
+            }
+
+            Hr{}
+            H4{text: "Custom Text Shader"}
+            P{text: "Both sides use the same Label shader override. This makes it easy to compare custom get_color logic across non-SLUG and SLUG rendering on Linux."}
+            UIZooRowH{
+                align: Align{x: 0. y: 0.}
+                SlugDemoCard{
+                    SlugDemoTitle{text: "Custom shader below cutoff"}
+                    SlugDemoNote{text: "32 px Label with a custom get_color function."}
+                    Label{
+                        draw_text +: {
+                            color: theme.color_makepad
+                            text_style +: {
+                                font_size: 32.
+                            }
+                            get_color: fn() -> vec4 {
+                                return mix(theme.color_makepad #0000 self.pos.x)
+                            }
+                        }
+                        text: "WAVE"
+                    }
+                }
+                SlugDemoCard{
+                    SlugDemoTitle{text: "Custom shader above cutoff"}
+                    SlugDemoNote{text: "192 px Label with the same custom get_color function."}
+                    Label{
+                        draw_text +: {
+                            color: theme.color_makepad
+                            text_style +: {
+                                font_size: 192.
+                            }
+                            get_color: fn() -> vec4 {
+                                return mix(theme.color_makepad #0000 self.pos.x)
+                            }
+                        }
+                        text: "W"
+                    }
+                }
+            }
+
+            Hr{}
+            H4{text: "LinkLabel"}
+            P{text: "This row uses the same interactive text widget at two sizes so you can compare the path switch on Linux with built-in link styling."}
+            UIZooRowH{
+                align: Align{x: 0. y: 0.}
+                SlugDemoCard{
+                    SlugDemoTitle{text: "LinkLabel below cutoff"}
+                    SlugDemoNote{text: "28 px LinkLabel text."}
+                    LinkLabel{
+                        draw_text +: {
+                            gradient_fill_horizontal: 1.0
+                            color: #x8CF
+                            color_2: #xFB8
+                            text_style +: {
+                                font_size: 28.
+                            }
+                        }
+                        text: "Open docs"
+                    }
+                }
+                SlugDemoCard{
+                    SlugDemoTitle{text: "LinkLabel above cutoff"}
+                    SlugDemoNote{text: "144 px LinkLabel text."}
+                    LinkLabel{
+                        draw_text +: {
+                            gradient_fill_horizontal: 1.0
+                            color: #x8CF
+                            color_2: #xFB8
+                            text_style +: {
+                                font_size: 144.
+                            }
+                        }
+                        text: "Go"
+                    }
+                }
+            }
+
+            Hr{}
+            H4{text: "Diagnostic Matrix"}
+            P{text: "These extra probes all stay above the Linux SLUG cutoff. They are meant to help isolate whether the disappearing text is tied to plain single-color Labels, inherited theme colors, custom get_color logic, or specific glyph shapes."}
+
+            H4{text: "Color Source Probes"}
+            P{text: "Same large Label widget, same text, different color sources. If only some of these disappear after SLUG promotion, that narrows the bug quickly."}
+            SlugProbeGrid{
+                SlugProbeCard{
+                    SlugDemoTitle{text: "Default Label"}
+                    SlugDemoNote{text: "No explicit color override."}
+                    SlugLargeDefaultLabel{text: "Ag"}
+                }
+                SlugProbeCard{
+                    SlugDemoTitle{text: "Literal White"}
+                    SlugDemoNote{text: "Plain Label with color: #fff."}
+                    SlugLargeLiteralLabel{text: "Ag"}
+                }
+                SlugProbeCard{
+                    SlugDemoTitle{text: "Theme Text"}
+                    SlugDemoNote{text: "Plain Label with theme.color_text."}
+                    SlugLargeThemeLabel{text: "Ag"}
+                }
+                SlugProbeCard{
+                    SlugDemoTitle{text: "Theme Accent"}
+                    SlugDemoNote{text: "Plain Label with theme.color_makepad."}
+                    SlugLargeAccentLabel{text: "Ag"}
+                }
+                SlugProbeCard{
+                    SlugDemoTitle{text: "Plain Gradient"}
+                    SlugDemoNote{text: "Plain Label using color and color_2."}
+                    SlugLargeGradientLabel{text: "Ag"}
+                }
+            }
+
+            Hr{}
+            H4{text: "Glyph Shape Probes"}
+            P{text: "All of these use the same large plain Label with a literal white color. This helps separate geometry-specific failures from color/state-specific failures."}
+            SlugProbeGrid{
+                SlugProbeCard{
+                    SlugDemoTitle{text: "A"}
+                    SlugDemoNote{text: "Uppercase with counters."}
+                    SlugLargeLiteralLabel{text: "A"}
+                }
+                SlugProbeCard{
+                    SlugDemoTitle{text: "g"}
+                    SlugDemoNote{text: "Lowercase descender."}
+                    SlugLargeLiteralLabel{text: "g"}
+                }
+                SlugProbeCard{
+                    SlugDemoTitle{text: "W"}
+                    SlugDemoNote{text: "Wide uppercase."}
+                    SlugLargeLiteralLabel{text: "W"}
+                }
+                SlugProbeCard{
+                    SlugDemoTitle{text: "S"}
+                    SlugDemoNote{text: "Curved single glyph."}
+                    SlugLargeLiteralLabel{text: "S"}
+                }
+                SlugProbeCard{
+                    SlugDemoTitle{text: "L"}
+                    SlugDemoNote{text: "Simple cornered glyph."}
+                    SlugLargeLiteralLabel{text: "L"}
+                }
+                SlugProbeCard{
+                    SlugDemoTitle{text: "O"}
+                    SlugDemoNote{text: "Closed loop counter."}
+                    SlugLargeLiteralLabel{text: "O"}
+                }
+                SlugProbeCard{
+                    SlugDemoTitle{text: "8"}
+                    SlugDemoNote{text: "Double counter."}
+                    SlugLargeLiteralLabel{text: "8"}
+                }
+                SlugProbeCard{
+                    SlugDemoTitle{text: "y"}
+                    SlugDemoNote{text: "Descender with simpler shape."}
+                    SlugLargeLiteralLabel{text: "y"}
+                }
+            }
+
+            Hr{}
+            H4{text: "Custom Shader Probes"}
+            P{text: "These all use the same basic fade-out get_color idea, but vary whether the base color is literal or theme-driven and whether the text is Ag or W."}
+            SlugProbeGrid{
+                SlugProbeCard{
+                    SlugDemoTitle{text: "Custom Literal Ag"}
+                    SlugDemoNote{text: "Literal base color, Ag text."}
+                    SlugLargeCustomLiteralLabel{text: "Ag"}
+                }
+                SlugProbeCard{
+                    SlugDemoTitle{text: "Custom Theme Ag"}
+                    SlugDemoNote{text: "Theme base color, Ag text."}
+                    SlugLargeCustomThemeLabel{text: "Ag"}
+                }
+                SlugProbeCard{
+                    SlugDemoTitle{text: "Custom Literal W"}
+                    SlugDemoNote{text: "Literal base color, W text."}
+                    SlugLargeCustomLiteralLabel{text: "W"}
+                }
+                SlugProbeCard{
+                    SlugDemoTitle{text: "Custom Theme W"}
+                    SlugDemoNote{text: "Theme base color, W text."}
+                    SlugLargeCustomThemeLabel{text: "W"}
+                }
+            }
+        }
+    }
+}

--- a/platform/script/src/shader_calls.rs
+++ b/platform/script/src/shader_calls.rs
@@ -1480,12 +1480,14 @@ impl ShaderFnCompiler {
                     s,
                 );
             }
-            id!(sample) | id!(sample_as_bgra) | id!(sample_lod) => {
+            id!(sample) | id!(sample_as_bgra) | id!(sample_lod) | id!(sample_nearest) => {
                 // sample(coord) samples the texture at normalized coordinates.
                 // sample_as_bgra(coord) is identical except on WebGL GLSL, where it
                 // applies a BGRA->RGBA swizzle in the sampler helper.
                 let method_name = if method_id == id!(sample_as_bgra) {
                     "sample_as_bgra"
+                } else if method_id == id!(sample_nearest) {
+                    "sample_nearest"
                 } else if method_id == id!(sample_lod) {
                     "sample_lod"
                 } else {
@@ -1511,8 +1513,14 @@ impl ShaderFnCompiler {
                     let lod = args.get(1);
                     let mut s = self.stack.new_string();
 
-                    // Get or create the default sampler (linear, clamp_to_edge, normalized)
-                    let sampler = ShaderSampler::default();
+                    let sampler = if method_id == id!(sample_nearest) {
+                        ShaderSampler {
+                            filter: SamplerFilter::Nearest,
+                            ..ShaderSampler::default()
+                        }
+                    } else {
+                        ShaderSampler::default()
+                    };
                     let sampler_idx = output.get_or_create_sampler(sampler);
 
                     match output.backend {

--- a/platform/src/draw_shader.rs
+++ b/platform/src/draw_shader.rs
@@ -347,6 +347,7 @@ pub struct DrawShaderFlags {
     pub debug_code: bool,
     pub draw_call_nocompare: bool,
     pub draw_call_always: bool,
+    pub async_compile: bool,
 }
 
 #[derive(Clone, Hash, PartialEq, Eq)]
@@ -498,6 +499,10 @@ impl CxDrawShaderMapping {
             == Some(true);
         let debug_code = heap
             .value(source.as_object(), id!(debug_code).into(), NoTrap)
+            .as_bool()
+            == Some(true);
+        let async_compile = heap
+            .value(source.as_object(), id!(async_compile).into(), NoTrap)
             .as_bool()
             == Some(true);
         // Use attribute packing for instances (they're vertex attributes)
@@ -801,6 +806,7 @@ impl CxDrawShaderMapping {
                 debug_draw,
                 debug_layout,
                 debug_code,
+                async_compile,
                 ..DrawShaderFlags::default()
             },
             instances,

--- a/platform/src/os/linux/gl_sys.rs
+++ b/platform/src/os/linux/gl_sys.rs
@@ -120,6 +120,8 @@ pub const TEXTURE_WRAP_R: GLenum = 0x8072;
 pub const CLAMP_TO_EDGE: GLenum = 0x812F;
 pub const CLAMP_TO_BORDER: GLenum = 0x812D;
 pub const PROGRAM_BINARY_LENGTH: GLenum = 0x8741;
+pub const MAX_SHADER_COMPILER_THREADS_KHR: GLenum = 0x91B0;
+pub const COMPLETION_STATUS_KHR: GLenum = 0x91B1;
 pub const NO_ERROR: GLenum = 0x0;
 pub const UNPACK_ALIGNMENT: GLenum = 0x0CF5;
 pub const UNPACK_ROW_LENGTH: GLenum = 0x0CF2;
@@ -240,7 +242,9 @@ pub type TglCompileShader = unsafe extern "C" fn(shader: GLuint) -> ();
 pub type TglCreateProgram = unsafe extern "C" fn() -> GLuint;
 pub type TglAttachShader = unsafe extern "C" fn(program: GLuint, shader: GLuint) -> ();
 pub type TglLinkProgram = unsafe extern "C" fn(program: GLuint) -> ();
+pub type TglDeleteProgram = unsafe extern "C" fn(program: GLuint) -> ();
 pub type TglDeleteShader = unsafe extern "C" fn(shader: GLuint) -> ();
+pub type TglMaxShaderCompilerThreadsKHR = unsafe extern "C" fn(count: GLuint) -> ();
 pub type TglUniform1fv =
     unsafe extern "C" fn(location: GLint, count: GLsizei, value: *const GLfloat) -> ();
 pub type TglGenTextures = unsafe extern "C" fn(n: GLsizei, textures: *mut GLuint) -> ();
@@ -432,7 +436,9 @@ pub struct LibGl {
     pub glCreateProgram: TglCreateProgram,
     pub glAttachShader: TglAttachShader,
     pub glLinkProgram: TglLinkProgram,
+    pub glDeleteProgram: TglDeleteProgram,
     pub glDeleteShader: TglDeleteShader,
+    pub glMaxShaderCompilerThreadsKHR: Option<TglMaxShaderCompilerThreadsKHR>,
     pub glUniform1fv: TglUniform1fv,
     pub glGenTextures: TglGenTextures,
     pub glTexParameteri: TglTexParameteri,
@@ -690,7 +696,20 @@ impl LibGl {
                 "glAttachObjectARB"
             )?,
             glLinkProgram: load!(loadfn, TglLinkProgram, "glLinkProgram", "glLinkProgramARB")?,
+            glDeleteProgram: load!(
+                loadfn,
+                TglDeleteProgram,
+                "glDeleteProgram",
+                "glDeleteProgramARB"
+            )?,
             glDeleteShader: load!(loadfn, TglDeleteShader, "glDeleteShader")?,
+            glMaxShaderCompilerThreadsKHR: load!(
+                loadfn,
+                TglMaxShaderCompilerThreadsKHR,
+                "glMaxShaderCompilerThreadsKHR",
+                "glMaxShaderCompilerThreadsARB"
+            )
+            .ok(),
             glUniform1fv: load!(loadfn, TglUniform1fv, "glUniform1fv", "glUniform1fvARB")?,
             glGenTextures: load!(loadfn, TglGenTextures, "glGenTextures")?,
             glTexParameteri: load!(loadfn, TglTexParameteri, "glTexParameteri")?,

--- a/platform/src/os/linux/gl_sys.rs
+++ b/platform/src/os/linux/gl_sys.rs
@@ -100,8 +100,10 @@ pub const TEXTURE_BORDER_COLOR: GLenum = 0x1004;
 pub const DEBUG_OUTPUT: GLenum = 0x92E0;
 
 pub const RGBA: GLenum = 0x1908;
+pub const RGBA32F: GLenum = 0x8814;
 pub const BGRA: GLenum = 0x80E1;
 pub const RED: GLenum = 0x1903;
+pub const R32F: GLenum = 0x822E;
 pub const RG: GLenum = 0x8227;
 pub const R8: GLenum = 0x8229;
 pub const UNSIGNED_BYTE: GLenum = 0x1401;

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -2047,6 +2047,18 @@ impl CxTexture {
     /// Note: This method assumes that the texture format doesn't change between updates.
     /// This is safe because when allocating textures at the Cx level, there are compatibility checks.
     pub fn update_vec_texture(&mut self, gl: &LibGl, _os_type: &OsType) {
+        fn gl_unpack_alignment(bytes_per_pixel: usize) -> i32 {
+            if bytes_per_pixel % 8 == 0 {
+                8
+            } else if bytes_per_pixel % 4 == 0 {
+                4
+            } else if bytes_per_pixel % 2 == 0 {
+                2
+            } else {
+                1
+            }
+        }
+
         let mut needs_realloc = false;
         if self.alloc_vec() {
             if let Some(previous) = self.previous_platform_resource.take() {
@@ -2283,10 +2295,11 @@ impl CxTexture {
                 _ => panic!("Unsupported texture format"),
             };
 
-            // Partial texture updates don't (yet) work on OHOS simulators/emulators.
-
-            // DISABLE PARTIAL TEXTURE UPDATES ENTIRELY. Its broken.
-            const DO_PARTIAL_TEXTURE_UPDATES: bool = false; //cfg!(not(ohos_sim));
+            // Partial texture uploads are critical for append-only SLUG float atlases on
+            // Linux desktop. OHOS simulators/emulators still need the conservative full
+            // upload path.
+            const DO_PARTIAL_TEXTURE_UPDATES: bool = cfg!(not(ohos_sim));
+            let unpack_alignment = gl_unpack_alignment(bytes_per_pixel);
 
             match updated {
                 TextureUpdated::Partial(rect) if DO_PARTIAL_TEXTURE_UPDATES => {
@@ -2304,7 +2317,7 @@ impl CxTexture {
                         );
                     }
 
-                    (gl.glPixelStorei)(gl_sys::UNPACK_ALIGNMENT, bytes_per_pixel);
+                    (gl.glPixelStorei)(gl_sys::UNPACK_ALIGNMENT, unpack_alignment);
                     (gl.glPixelStorei)(gl_sys::UNPACK_ROW_LENGTH, width as _);
                     (gl.glPixelStorei)(gl_sys::UNPACK_SKIP_PIXELS, rect.origin.x as i32);
                     (gl.glPixelStorei)(gl_sys::UNPACK_SKIP_ROWS, rect.origin.y as i32);
@@ -2322,7 +2335,7 @@ impl CxTexture {
                 }
                 // Note: this `Partial(_)` case will only match if `DO_PARTIAL_TEXTURE_UPDATES` is false.
                 TextureUpdated::Partial(_) | TextureUpdated::Full => {
-                    (gl.glPixelStorei)(gl_sys::UNPACK_ALIGNMENT, bytes_per_pixel);
+                    (gl.glPixelStorei)(gl_sys::UNPACK_ALIGNMENT, unpack_alignment);
                     (gl.glPixelStorei)(gl_sys::UNPACK_ROW_LENGTH, width as _);
                     (gl.glPixelStorei)(gl_sys::UNPACK_SKIP_PIXELS, 0);
                     (gl.glPixelStorei)(gl_sys::UNPACK_SKIP_ROWS, 0);
@@ -2340,6 +2353,11 @@ impl CxTexture {
                 }
                 TextureUpdated::Empty => panic!("already asserted that updated is not empty"),
             };
+
+            (gl.glPixelStorei)(gl_sys::UNPACK_ALIGNMENT, 4);
+            (gl.glPixelStorei)(gl_sys::UNPACK_ROW_LENGTH, 0);
+            (gl.glPixelStorei)(gl_sys::UNPACK_SKIP_PIXELS, 0);
+            (gl.glPixelStorei)(gl_sys::UNPACK_SKIP_ROWS, 0);
 
             (gl.glTexParameteri)(
                 gl_sys::TEXTURE_2D,

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -34,6 +34,7 @@ use {
         fs::{remove_file, File},
         io::prelude::*,
         mem, ptr,
+        sync::Once,
     },
 };
 
@@ -341,16 +342,43 @@ impl Cx {
 
                 let shader_variant = self.passes[draw_pass_id].os.shader_variant;
 
-                if shp.gl_shader[shader_variant].is_none() {
-                    shp.gl_shader[shader_variant] = Some(GlShader::new(
+                let shgl = if sh.mapping.flags.async_compile {
+                    shp.ensure_gl_shader_started(
                         self.os.gl(),
-                        &shp.vertex[shader_variant],
-                        &shp.pixel[shader_variant],
+                        shader_variant,
                         &sh.mapping,
                         &self.os_type,
-                    ));
-                }
-                let shgl = shp.gl_shader[shader_variant].as_ref().unwrap();
+                    );
+                    shp.poll_gl_shader_ready(
+                        self.os.gl(),
+                        shader_variant,
+                        &sh.mapping,
+                        &self.os_type,
+                    );
+                    let Some(shgl) = shp
+                        .gl_shader[shader_variant]
+                        .as_ref()
+                        .and_then(GlShaderState::as_ready)
+                    else {
+                        self.demo_time_repaint = true;
+                        continue;
+                    };
+                    shgl
+                } else {
+                    if shp.gl_shader[shader_variant].is_none() {
+                        shp.gl_shader[shader_variant] = Some(GlShaderState::Ready(GlShader::new(
+                            self.os.gl(),
+                            &shp.vertex[shader_variant],
+                            &shp.pixel[shader_variant],
+                            &sh.mapping,
+                            &self.os_type,
+                        )));
+                    }
+                    shp.gl_shader[shader_variant]
+                        .as_ref()
+                        .and_then(GlShaderState::as_ready)
+                        .unwrap()
+                };
                 let trace_draw = std::env::var_os("MAKEPAD_GL_DRAW_TRACE").is_some();
 
                 if draw_call.instance_dirty || draw_item.os.inst_vb.gl_buffer.is_none() {
@@ -933,35 +961,100 @@ impl Cx {
         let compile_set = std::mem::take(&mut self.draw_shaders.compile_set);
 
         for shader_index in compile_set {
-            let cx_shader = &mut self.draw_shaders.shaders[shader_index];
-            if cx_shader.os_shader_id.is_some() {
-                continue;
-            }
+            let mapping = self.draw_shaders.shaders[shader_index].mapping.clone();
+            let os_shader_id = {
+                let cx_shader = &mut self.draw_shaders.shaders[shader_index];
+                if cx_shader.os_shader_id.is_none() {
+                    let (vertex, pixel) = match &cx_shader.mapping.code {
+                        CxDrawShaderCode::Separate { vertex, fragment } => {
+                            (vertex.clone(), fragment.clone())
+                        }
+                        CxDrawShaderCode::Combined { code } => (code.clone(), code.clone()),
+                    };
 
-            let (vertex, pixel) = match &cx_shader.mapping.code {
-                CxDrawShaderCode::Separate { vertex, fragment } => {
-                    (vertex.clone(), fragment.clone())
+                    if cx_shader.mapping.flags.debug_code {
+                        crate::log!("{}\n{}", vertex, pixel);
+                    }
+
+                    for (index, ds) in self.draw_shaders.os_shaders.iter().enumerate() {
+                        if ds.in_vertex == vertex && ds.in_pixel == pixel {
+                            cx_shader.os_shader_id = Some(index);
+                            break;
+                        }
+                    }
+
+                    if cx_shader.os_shader_id.is_none() {
+                        let shp = CxOsDrawShader::new(self.os.gl(), &vertex, &pixel, &self.os_type);
+                        cx_shader.os_shader_id = Some(self.draw_shaders.os_shaders.len());
+                        self.draw_shaders.os_shaders.push(shp);
+                    }
                 }
-                CxDrawShaderCode::Combined { code } => (code.clone(), code.clone()),
+                cx_shader.os_shader_id
             };
 
-            if cx_shader.mapping.flags.debug_code {
-                crate::log!("{}\n{}", vertex, pixel);
-            }
-
-            for (index, ds) in self.draw_shaders.os_shaders.iter().enumerate() {
-                if ds.in_vertex == vertex && ds.in_pixel == pixel {
-                    cx_shader.os_shader_id = Some(index);
-                    break;
+            if let Some(os_shader_id) = os_shader_id {
+                if !mapping.flags.async_compile {
+                    continue;
+                }
+                let os_shader = &mut self.draw_shaders.os_shaders[os_shader_id];
+                os_shader.ensure_gl_shader_started(
+                    self.os.gl(),
+                    SHADER_VARIANT_WINDOW,
+                    &mapping,
+                    &self.os_type,
+                );
+                os_shader.poll_gl_shader_ready(
+                    self.os.gl(),
+                    SHADER_VARIANT_WINDOW,
+                    &mapping,
+                    &self.os_type,
+                );
+                if matches!(
+                    os_shader.gl_shader[SHADER_VARIANT_WINDOW],
+                    Some(GlShaderState::Pending(_))
+                ) {
+                    self.demo_time_repaint = true;
                 }
             }
+        }
 
-            if cx_shader.os_shader_id.is_none() {
-                let shp = CxOsDrawShader::new(self.os.gl(), &vertex, &pixel, &self.os_type);
-                cx_shader.os_shader_id = Some(self.draw_shaders.os_shaders.len());
-                self.draw_shaders.os_shaders.push(shp);
+        for shader_index in 0..self.draw_shaders.shaders.len() {
+            let (mapping, os_shader_id) = {
+                let cx_shader = &self.draw_shaders.shaders[shader_index];
+                (cx_shader.mapping.clone(), cx_shader.os_shader_id)
+            };
+            if !mapping.flags.async_compile {
+                continue;
+            }
+            let Some(os_shader_id) = os_shader_id else {
+                continue;
+            };
+            let os_shader = &mut self.draw_shaders.os_shaders[os_shader_id];
+            if matches!(
+                os_shader.gl_shader[SHADER_VARIANT_WINDOW],
+                Some(GlShaderState::Pending(_))
+            ) {
+                os_shader.poll_gl_shader_ready(
+                    self.os.gl(),
+                    SHADER_VARIANT_WINDOW,
+                    &mapping,
+                    &self.os_type,
+                );
+                if matches!(
+                    os_shader.gl_shader[SHADER_VARIANT_WINDOW],
+                    Some(GlShaderState::Pending(_))
+                ) {
+                    self.demo_time_repaint = true;
+                }
             }
         }
+    }
+
+    pub fn is_draw_shader_window_ready(&self, shader_id: DrawShaderId) -> bool {
+        let Some(os_shader_id) = self.draw_shaders.shaders[shader_id.index].os_shader_id else {
+            return false;
+        };
+        self.draw_shaders.os_shaders[os_shader_id].is_window_gl_shader_ready()
     }
     /*
     pub fn maybe_warn_hardware_support(&self) {
@@ -994,7 +1087,7 @@ pub const SHADER_VARIANT_XR: usize = 1;
 const NUM_SHADER_VARIANTS: usize = 2;
 
 pub struct CxOsDrawShader {
-    pub gl_shader: [Option<GlShader>; NUM_SHADER_VARIANTS],
+    pub gl_shader: [Option<GlShaderState>; NUM_SHADER_VARIANTS],
     pub in_vertex: String,
     pub in_pixel: String,
     pub vertex: [String; NUM_SHADER_VARIANTS],
@@ -1014,6 +1107,55 @@ pub struct GlShaderUniforms {
     pub live_uniforms_binding: OpenglUniformBlockBinding,
     pub const_table_uniform: OpenglUniform,
     pub live_uniforms: OpenglBuffer,
+}
+
+pub enum GlShaderState {
+    Ready(GlShader),
+    Pending(PendingGlShader),
+}
+
+impl GlShaderState {
+    fn as_ready(&self) -> Option<&GlShader> {
+        match self {
+            Self::Ready(shader) => Some(shader),
+            Self::Pending(_) => None,
+        }
+    }
+
+    fn free_resources(self, gl: &LibGl) {
+        match self {
+            Self::Ready(shader) => shader.free_resources(gl),
+            Self::Pending(shader) => shader.free_resources(gl),
+        }
+    }
+}
+
+pub struct PendingGlShader {
+    pub program: u32,
+    pub vertex_shader: u32,
+    pub fragment_shader: u32,
+}
+
+impl PendingGlShader {
+    fn is_complete(&self, gl: &LibGl) -> bool {
+        unsafe {
+            let mut complete = 0;
+            (gl.glGetProgramiv)(
+                self.program,
+                gl_sys::COMPLETION_STATUS_KHR,
+                &mut complete,
+            );
+            complete == gl_sys::TRUE as i32
+        }
+    }
+
+    fn free_resources(self, gl: &LibGl) {
+        unsafe {
+            (gl.glDeleteShader)(self.vertex_shader);
+            (gl.glDeleteShader)(self.fragment_shader);
+            (gl.glDeleteProgram)(self.program);
+        }
+    }
 }
 impl GlShaderUniforms {
     fn new(gl: &LibGl, program: u32, mapping: &CxDrawShaderMapping) -> Self {
@@ -1094,77 +1236,71 @@ impl GlShader {
             .collect()
     }
 
-    pub fn new(
-        gl: &LibGl,
-        vertex: &str,
-        pixel: &str,
-        mapping: &CxDrawShaderMapping,
-        os_type: &OsType,
-    ) -> Self {
-        // On OpenHarmony, re-using cached shaders doesn't work properly yet.
-        #[cfg(ohos_sim)]
-        unsafe fn read_cache(
-            _gl: &LibOpenGl,
-            _vertex: &str,
-            _pixel: &str,
-            _os_type: &OsType,
-        ) -> Option<gl_sys::GLuint> {
-            None
+    fn supports_parallel_compile(gl: &LibGl) -> bool {
+        let supported = get_gl_string(gl, gl_sys::EXTENSIONS)
+            .split_whitespace()
+            .any(|ext| {
+                ext == "GL_KHR_parallel_shader_compile"
+                    || ext == "GL_ARB_parallel_shader_compile"
+            });
+        if supported {
+            static CONFIGURE_PARALLEL_COMPILE: Once = Once::new();
+            CONFIGURE_PARALLEL_COMPILE.call_once(|| unsafe {
+                if let Some(set_threads) = gl.glMaxShaderCompilerThreadsKHR {
+                    // Ask the driver to use as many background compiler threads as it supports.
+                    set_threads(u32::MAX);
+                }
+            });
         }
+        supported
+    }
 
-        #[cfg(not(ohos_sim))]
-        unsafe fn read_cache(
-            gl: &LibGl,
-            vertex: &str,
-            pixel: &str,
-            os_type: &OsType,
-        ) -> Option<gl_sys::GLuint> {
-            if let Some(cache_dir) = os_type.get_cache_dir() {
-                let shader_hash = live_id!(shader).str_append(&vertex).str_append(&pixel);
-                let mut base_filename = format!("{}/shader_{:08x}", cache_dir, shader_hash.0);
+    #[cfg(ohos_sim)]
+    fn read_program_cache(_gl: &LibGl, _vertex: &str, _pixel: &str, _os_type: &OsType) -> Option<u32> {
+        None
+    }
 
-                match os_type {
-                    OsType::Android(params) => {
-                        base_filename = format!(
-                            "{}_av{}_bn{}_kv{}",
-                            base_filename,
-                            params.android_version,
-                            params.build_number,
-                            params.kernel_version
-                        );
-                    }
-                    _ => (),
-                };
+    #[cfg(not(ohos_sim))]
+    fn read_program_cache(gl: &LibGl, vertex: &str, pixel: &str, os_type: &OsType) -> Option<u32> {
+        if let Some(cache_dir) = os_type.get_cache_dir() {
+            let shader_hash = live_id!(shader).str_append(&vertex).str_append(&pixel);
+            let mut base_filename = format!("{}/shader_{:08x}", cache_dir, shader_hash.0);
 
-                let filename = format!("{}.bin", base_filename);
+            if let OsType::Android(params) = os_type {
+                base_filename = format!(
+                    "{}_av{}_bn{}_kv{}",
+                    base_filename,
+                    params.android_version,
+                    params.build_number,
+                    params.kernel_version
+                );
+            }
 
-                if let Ok(mut cache_file) = File::open(&filename) {
-                    let mut binary = Vec::new();
-                    let mut format_bytes = [0u8; 4];
-                    match cache_file.read(&mut format_bytes) {
-                        Ok(_bytes_read) => {
-                            let binary_format = u32::from_be_bytes(format_bytes);
-                            match cache_file.read_to_end(&mut binary) {
-                                Ok(_full_bytes) => {
-                                    let mut version_consistency_conflict = false;
-                                    // On Android, invalidate the cached file if there have been significant system updates
-                                    match os_type {
-                                        OsType::Android(params) => {
-                                            let current_filename = format!(
-                                                "{}/shader_{:08x}_av{}_bn{}_kv{}.bin",
-                                                cache_dir,
-                                                shader_hash.0,
-                                                params.android_version,
-                                                params.build_number,
-                                                params.kernel_version
-                                            );
-                                            version_consistency_conflict =
-                                                filename != current_filename;
-                                        }
-                                        _ => (),
-                                    };
+            let filename = format!("{}.bin", base_filename);
 
-                                    if !version_consistency_conflict {
+            if let Ok(mut cache_file) = File::open(&filename) {
+                let mut binary = Vec::new();
+                let mut format_bytes = [0u8; 4];
+                match cache_file.read(&mut format_bytes) {
+                    Ok(_bytes_read) => {
+                        let binary_format = u32::from_be_bytes(format_bytes);
+                        match cache_file.read_to_end(&mut binary) {
+                            Ok(_full_bytes) => {
+                                let mut version_consistency_conflict = false;
+                                if let OsType::Android(params) = os_type {
+                                    let current_filename = format!(
+                                        "{}/shader_{:08x}_av{}_bn{}_kv{}.bin",
+                                        cache_dir,
+                                        shader_hash.0,
+                                        params.android_version,
+                                        params.build_number,
+                                        params.kernel_version
+                                    );
+                                    version_consistency_conflict = filename != current_filename;
+                                }
+
+                                if !version_consistency_conflict {
+                                    unsafe {
                                         let program = (gl.glCreateProgram)();
                                         (gl.glProgramBinary)(
                                             program,
@@ -1185,184 +1321,240 @@ impl GlShader {
                                             return None;
                                         }
                                         return Some(program);
-                                    } else {
-                                        // Version mismatch, delete the old cache file
-                                        let _ = remove_file(&filename);
                                     }
-                                }
-                                Err(e) => {
-                                    crate::warning!("Failed to read the full shader cache file {filename}, error: {e}");
+                                } else {
+                                    let _ = remove_file(&filename);
                                 }
                             }
-                        }
-                        Err(e) => {
-                            crate::warning!("Failed to read format bytes from shader cache file {filename}, error: {e}");
+                            Err(e) => {
+                                crate::warning!(
+                                    "Failed to read the full shader cache file {filename}, error: {e}"
+                                );
+                            }
                         }
                     }
-                } else {
-                    // crate::debug!("File was not in shader cache: {filename}");
+                    Err(e) => {
+                        crate::warning!(
+                            "Failed to read format bytes from shader cache file {filename}, error: {e}"
+                        );
+                    }
                 }
-            } else {
-                //crate::warning!("No cache directory available for shader cache");
             }
-            None
+        }
+        None
+    }
+
+    fn start_pending_program_compile(
+        gl: &LibGl,
+        vertex: &str,
+        pixel: &str,
+        _os_type: &OsType,
+    ) -> PendingGlShader {
+        let vertex_len = Self::shader_source_len(vertex);
+        let pixel_len = Self::shader_source_len(pixel);
+        #[cfg(target_os = "android")]
+        let vertex_hash = Self::shader_source_hash(vertex);
+        #[cfg(target_os = "android")]
+        let pixel_hash = Self::shader_source_hash(pixel);
+
+        #[cfg(target_os = "android")]
+        let log_shader_builds = matches!(_os_type, OsType::Android(_))
+            && std::env::var_os("MAKEPAD_LOG_GL_SHADER_BUILDS").is_some();
+
+        #[cfg(target_os = "android")]
+        if log_shader_builds {
+            crate::log!(
+                "GL shader build start renderer={} vertex_hash={:016x} vertex_len={} fragment_hash={:016x} fragment_len={} vertex_preview={:?} fragment_preview={:?}",
+                get_gl_string(gl, gl_sys::RENDERER),
+                vertex_hash.0,
+                vertex_len,
+                pixel_hash.0,
+                pixel_len,
+                Self::shader_source_preview(vertex),
+                Self::shader_source_preview(pixel)
+            );
         }
 
         unsafe {
-            let program = if let Some(program) = read_cache(gl, &vertex, &pixel, os_type) {
-                program
-            } else {
-                let vertex_len = Self::shader_source_len(vertex);
-                let pixel_len = Self::shader_source_len(pixel);
-                #[cfg(target_os = "android")]
-                let vertex_hash = Self::shader_source_hash(vertex);
-                #[cfg(target_os = "android")]
-                let pixel_hash = Self::shader_source_hash(pixel);
+            let vs = (gl.glCreateShader)(gl_sys::VERTEX_SHADER);
+            let vertex_ptr = vertex.as_ptr() as *const _;
+            let vertex_ptrs = [vertex_ptr];
+            let vertex_lengths = [vertex_len];
+            #[cfg(target_os = "android")]
+            if log_shader_builds {
+                crate::log!(
+                    "GL shader upload vertex shader={} hash={:016x} len={}",
+                    vs,
+                    vertex_hash.0,
+                    vertex_len
+                );
+            }
+            (gl.glShaderSource)(vs, 1, vertex_ptrs.as_ptr(), vertex_lengths.as_ptr());
+            #[cfg(target_os = "android")]
+            if log_shader_builds {
+                crate::log!(
+                    "GL shader compile vertex shader={} hash={:016x}",
+                    vs,
+                    vertex_hash.0
+                );
+            }
+            (gl.glCompileShader)(vs);
 
-                #[cfg(target_os = "android")]
-                let log_shader_builds = matches!(os_type, OsType::Android(_))
-                    && std::env::var_os("MAKEPAD_LOG_GL_SHADER_BUILDS").is_some();
+            let fs = (gl.glCreateShader)(gl_sys::FRAGMENT_SHADER);
+            let pixel_ptr = pixel.as_ptr() as *const _;
+            let pixel_ptrs = [pixel_ptr];
+            let pixel_lengths = [pixel_len];
+            #[cfg(target_os = "android")]
+            if log_shader_builds {
+                crate::log!(
+                    "GL shader upload fragment shader={} hash={:016x} len={}",
+                    fs,
+                    pixel_hash.0,
+                    pixel_len
+                );
+            }
+            (gl.glShaderSource)(fs, 1, pixel_ptrs.as_ptr(), pixel_lengths.as_ptr());
+            #[cfg(target_os = "android")]
+            if log_shader_builds {
+                crate::log!(
+                    "GL shader compile fragment shader={} hash={:016x}",
+                    fs,
+                    pixel_hash.0
+                );
+            }
+            (gl.glCompileShader)(fs);
 
-                #[cfg(target_os = "android")]
-                if log_shader_builds {
-                    crate::log!(
-                        "GL shader build start renderer={} vertex_hash={:016x} vertex_len={} fragment_hash={:016x} fragment_len={} vertex_preview={:?} fragment_preview={:?}",
-                        get_gl_string(gl, gl_sys::RENDERER),
-                        vertex_hash.0,
-                        vertex_len,
-                        pixel_hash.0,
-                        pixel_len,
-                        Self::shader_source_preview(vertex),
-                        Self::shader_source_preview(pixel)
+            let program = (gl.glCreateProgram)();
+            (gl.glAttachShader)(program, vs);
+            (gl.glAttachShader)(program, fs);
+            (gl.glLinkProgram)(program);
+
+            PendingGlShader {
+                program,
+                vertex_shader: vs,
+                fragment_shader: fs,
+            }
+        }
+    }
+
+    #[cfg(not(ohos_sim))]
+    fn write_program_cache(
+        gl: &LibGl,
+        program: u32,
+        vertex: &str,
+        pixel: &str,
+        os_type: &OsType,
+    ) {
+        if let Some(cache_dir) = os_type.get_cache_dir() {
+            unsafe {
+                let mut binary = Vec::new();
+                let mut binary_len = 0;
+                (gl.glGetProgramiv)(program, gl_sys::PROGRAM_BINARY_LENGTH, &mut binary_len);
+                if binary_len != 0 {
+                    binary.resize(binary_len as usize, 0u8);
+                    let mut return_size = 0i32;
+                    let mut binary_format = 0u32;
+                    (gl.glGetProgramBinary)(
+                        program,
+                        binary.len() as i32,
+                        &mut return_size as *mut _,
+                        &mut binary_format as *mut _,
+                        binary.as_mut_ptr() as *mut _,
                     );
-                }
+                    if return_size != 0 {
+                        let shader_hash =
+                            live_id!(shader).str_append(&vertex).str_append(&pixel);
+                        let mut filename =
+                            format!("{}/shader_{:08x}", cache_dir, shader_hash.0);
 
-                let vs = (gl.glCreateShader)(gl_sys::VERTEX_SHADER);
-                let vertex_ptr = vertex.as_ptr() as *const _;
-                let vertex_ptrs = [vertex_ptr];
-                let vertex_lengths = [vertex_len];
-                #[cfg(target_os = "android")]
-                if log_shader_builds {
-                    crate::log!(
-                        "GL shader upload vertex shader={} hash={:016x} len={}",
-                        vs,
-                        vertex_hash.0,
-                        vertex_len
-                    );
-                }
-                (gl.glShaderSource)(vs, 1, vertex_ptrs.as_ptr(), vertex_lengths.as_ptr());
-                #[cfg(target_os = "android")]
-                if log_shader_builds {
-                    crate::log!(
-                        "GL shader compile vertex shader={} hash={:016x}",
-                        vs,
-                        vertex_hash.0
-                    );
-                }
-                (gl.glCompileShader)(vs);
-                Self::opengl_log_shader_info(gl, true, vs as usize, "vertex", vertex);
-                if let Some(error) = Self::opengl_has_shader_error(gl, true, vs as usize, &vertex) {
-                    panic!("ERROR::SHADER::VERTEX::COMPILATION_FAILED\n{}", error);
-                }
-                let fs = (gl.glCreateShader)(gl_sys::FRAGMENT_SHADER);
-                let pixel_ptr = pixel.as_ptr() as *const _;
-                let pixel_ptrs = [pixel_ptr];
-                let pixel_lengths = [pixel_len];
-                #[cfg(target_os = "android")]
-                if log_shader_builds {
-                    crate::log!(
-                        "GL shader upload fragment shader={} hash={:016x} len={}",
-                        fs,
-                        pixel_hash.0,
-                        pixel_len
-                    );
-                }
-                (gl.glShaderSource)(fs, 1, pixel_ptrs.as_ptr(), pixel_lengths.as_ptr());
-                #[cfg(target_os = "android")]
-                if log_shader_builds {
-                    crate::log!(
-                        "GL shader compile fragment shader={} hash={:016x}",
-                        fs,
-                        pixel_hash.0
-                    );
-                }
-                (gl.glCompileShader)(fs);
-                Self::opengl_log_shader_info(gl, true, fs as usize, "fragment", pixel);
-                if let Some(error) = Self::opengl_has_shader_error(gl, true, fs as usize, &pixel) {
-                    panic!("ERROR::SHADER::FRAGMENT::COMPILATION_FAILED\n{}", error);
-                }
+                        if let OsType::Android(params) = os_type {
+                            filename = format!(
+                                "{}_av{}_bn{}_kv{}",
+                                filename,
+                                params.android_version,
+                                params.build_number,
+                                params.kernel_version
+                            );
+                        }
 
-                let program = (gl.glCreateProgram)();
-                (gl.glAttachShader)(program, vs);
-                (gl.glAttachShader)(program, fs);
-                (gl.glLinkProgram)(program);
-                Self::opengl_log_shader_info(gl, false, program as usize, "program", "");
-                if let Some(error) = Self::opengl_has_shader_error(gl, false, program as usize, "")
-                {
-                    panic!("ERROR::SHADER::LINK::COMPILATION_FAILED\n{}", error);
-                }
-                (gl.glDeleteShader)(vs);
-                (gl.glDeleteShader)(fs);
+                        filename = format!("{}.bin", filename);
 
-                #[cfg(not(ohos_sim))] // caching doesn't work properly on OpenHarmony
-                if let Some(cache_dir) = os_type.get_cache_dir() {
-                    let mut binary = Vec::new();
-                    let mut binary_len = 0;
-                    (gl.glGetProgramiv)(program, gl_sys::PROGRAM_BINARY_LENGTH, &mut binary_len);
-                    if binary_len != 0 {
-                        binary.resize(binary_len as usize, 0u8);
-                        let mut return_size = 0i32;
-                        let mut binary_format = 0u32;
-                        (gl.glGetProgramBinary)(
-                            program,
-                            binary.len() as i32,
-                            &mut return_size as *mut _,
-                            &mut binary_format as *mut _,
-                            binary.as_mut_ptr() as *mut _,
-                        );
-                        if return_size != 0 {
-                            // crate::log!("GOT FORMAT {}", format);
-                            let shader_hash =
-                                live_id!(shader).str_append(&vertex).str_append(&pixel);
-                            let mut filename =
-                                format!("{}/shader_{:08x}", cache_dir, shader_hash.0);
-
-                            match os_type {
-                                OsType::Android(params) => {
-                                    filename = format!(
-                                        "{}_av{}_bn{}_kv{}",
-                                        filename,
-                                        params.android_version,
-                                        params.build_number,
-                                        params.kernel_version
-                                    );
-                                }
-                                _ => (),
-                            };
-
-                            filename = format!("{}.bin", filename);
-
-                            binary.resize(return_size as usize, 0u8);
-                            match File::create(&filename) {
-                                Ok(mut cache) => {
-                                    let _res1 = cache.write_all(&binary_format.to_be_bytes());
-                                    let _res2 = cache.write_all(&binary);
-                                    if _res1.is_err() || _res2.is_err() {
-                                        crate::error!("Failed to write shader binary to shader cache {filename}");
-                                    }
-                                }
-                                Err(e) => {
+                        binary.resize(return_size as usize, 0u8);
+                        match File::create(&filename) {
+                            Ok(mut cache) => {
+                                let res1 = cache.write_all(&binary_format.to_be_bytes());
+                                let res2 = cache.write_all(&binary);
+                                if res1.is_err() || res2.is_err() {
                                     crate::error!(
-                                        "Failed to write shader cache to {filename}, error: {e}"
+                                        "Failed to write shader binary to shader cache {filename}"
                                     );
                                 }
+                            }
+                            Err(e) => {
+                                crate::error!(
+                                    "Failed to write shader cache to {filename}, error: {e}"
+                                );
                             }
                         }
                     }
                 }
-                program
-            };
+            }
+        }
+    }
 
+    #[cfg(ohos_sim)]
+    fn write_program_cache(
+        _gl: &LibGl,
+        _program: u32,
+        _vertex: &str,
+        _pixel: &str,
+        _os_type: &OsType,
+    ) {
+    }
+
+    fn finish_pending_program_compile(
+        gl: &LibGl,
+        pending: PendingGlShader,
+        vertex: &str,
+        pixel: &str,
+        os_type: &OsType,
+    ) -> u32 {
+        Self::opengl_log_shader_info(gl, true, pending.vertex_shader as usize, "vertex", vertex);
+        if let Some(error) =
+            Self::opengl_has_shader_error(gl, true, pending.vertex_shader as usize, vertex)
+        {
+            panic!("ERROR::SHADER::VERTEX::COMPILATION_FAILED\n{}", error);
+        }
+
+        Self::opengl_log_shader_info(
+            gl,
+            true,
+            pending.fragment_shader as usize,
+            "fragment",
+            pixel,
+        );
+        if let Some(error) =
+            Self::opengl_has_shader_error(gl, true, pending.fragment_shader as usize, pixel)
+        {
+            panic!("ERROR::SHADER::FRAGMENT::COMPILATION_FAILED\n{}", error);
+        }
+
+        Self::opengl_log_shader_info(gl, false, pending.program as usize, "program", "");
+        if let Some(error) = Self::opengl_has_shader_error(gl, false, pending.program as usize, "")
+        {
+            panic!("ERROR::SHADER::LINK::COMPILATION_FAILED\n{}", error);
+        }
+
+        unsafe {
+            (gl.glDeleteShader)(pending.vertex_shader);
+            (gl.glDeleteShader)(pending.fragment_shader);
+        }
+        Self::write_program_cache(gl, pending.program, vertex, pixel, os_type);
+        pending.program
+    }
+
+    fn build_from_program(gl: &LibGl, program: u32, mapping: &CxDrawShaderMapping) -> Self {
+        unsafe {
             (gl.glUseProgram)(program);
 
             let uniforms = GlShaderUniforms::new(gl, program, mapping);
@@ -1378,7 +1570,7 @@ impl GlShader {
 
             (gl.glUseProgram)(0);
 
-            let t = Self {
+            Self {
                 program,
                 geometries: Self::opengl_get_attributes(
                     gl,
@@ -1398,9 +1590,44 @@ impl GlShader {
                 samplers: Self::opengl_create_samplers(gl, mapping),
                 xr_depth_texture: Self::opengl_get_uniform(gl, program, "xr_depth_texture"),
                 uniforms,
-            };
-            t
+            }
         }
+    }
+
+    fn begin_state(
+        gl: &LibGl,
+        vertex: &str,
+        pixel: &str,
+        mapping: &CxDrawShaderMapping,
+        os_type: &OsType,
+    ) -> GlShaderState {
+        if let Some(program) = Self::read_program_cache(gl, vertex, pixel, os_type) {
+            return GlShaderState::Ready(Self::build_from_program(gl, program, mapping));
+        }
+
+        if Self::supports_parallel_compile(gl) {
+            return GlShaderState::Pending(Self::start_pending_program_compile(
+                gl, vertex, pixel, os_type,
+            ));
+        }
+
+        GlShaderState::Ready(Self::new(gl, vertex, pixel, mapping, os_type))
+    }
+
+    pub fn new(
+        gl: &LibGl,
+        vertex: &str,
+        pixel: &str,
+        mapping: &CxDrawShaderMapping,
+        os_type: &OsType,
+    ) -> Self {
+        if let Some(program) = Self::read_program_cache(gl, vertex, pixel, os_type) {
+            return Self::build_from_program(gl, program, mapping);
+        }
+
+        let pending = Self::start_pending_program_compile(gl, vertex, pixel, os_type);
+        let program = Self::finish_pending_program_compile(gl, pending, vertex, pixel, os_type);
+        Self::build_from_program(gl, program, mapping)
     }
 
     pub fn set_uniform_array(gl: &LibGl, loc: &OpenglUniform, array: &[f32]) {
@@ -1690,7 +1917,7 @@ impl GlShader {
             }
         }
         unsafe {
-            (gl.glDeleteShader)(self.program);
+            (gl.glDeleteProgram)(self.program);
         }
     }
 }
@@ -1717,6 +1944,60 @@ impl CxOsDrawShader {
         hydrated.gl_shader = std::mem::take(&mut self.gl_shader);
         hydrated.live_uniforms = std::mem::take(&mut self.live_uniforms);
         *self = hydrated;
+    }
+
+    fn ensure_gl_shader_started(
+        &mut self,
+        gl: &LibGl,
+        shader_variant: usize,
+        mapping: &CxDrawShaderMapping,
+        os_type: &OsType,
+    ) {
+        self.ensure_gl_shader_sources(gl, os_type);
+        if self.gl_shader[shader_variant].is_none() {
+            self.gl_shader[shader_variant] = Some(GlShader::begin_state(
+                gl,
+                &self.vertex[shader_variant],
+                &self.pixel[shader_variant],
+                mapping,
+                os_type,
+            ));
+        }
+    }
+
+    fn poll_gl_shader_ready(
+        &mut self,
+        gl: &LibGl,
+        shader_variant: usize,
+        mapping: &CxDrawShaderMapping,
+        os_type: &OsType,
+    ) {
+        let Some(GlShaderState::Pending(pending)) = self.gl_shader[shader_variant].take() else {
+            return;
+        };
+
+        if !pending.is_complete(gl) {
+            self.gl_shader[shader_variant] = Some(GlShaderState::Pending(pending));
+            return;
+        }
+
+        let program = GlShader::finish_pending_program_compile(
+            gl,
+            pending,
+            &self.vertex[shader_variant],
+            &self.pixel[shader_variant],
+            os_type,
+        );
+        self.gl_shader[shader_variant] = Some(GlShaderState::Ready(
+            GlShader::build_from_program(gl, program, mapping),
+        ));
+    }
+
+    pub fn is_window_gl_shader_ready(&self) -> bool {
+        self.gl_shader[SHADER_VARIANT_WINDOW]
+            .as_ref()
+            .and_then(GlShaderState::as_ready)
+            .is_some()
     }
 
     #[cfg(use_vulkan)]
@@ -2299,10 +2580,12 @@ impl CxTexture {
             // Linux desktop. OHOS simulators/emulators still need the conservative full
             // upload path.
             const DO_PARTIAL_TEXTURE_UPDATES: bool = cfg!(not(ohos_sim));
+            let allow_partial_texture_updates = DO_PARTIAL_TEXTURE_UPDATES
+                && !matches!(self.format, TextureFormat::VecRGBAf32 { .. });
             let unpack_alignment = gl_unpack_alignment(bytes_per_pixel);
 
             match updated {
-                TextureUpdated::Partial(rect) if DO_PARTIAL_TEXTURE_UPDATES => {
+                TextureUpdated::Partial(rect) if allow_partial_texture_updates => {
                     if needs_realloc {
                         (gl.glTexImage2D)(
                             gl_sys::TEXTURE_2D,

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -2088,11 +2088,13 @@ impl CxOsDrawShader {
             vec4 depth_clip(vec4 w, vec4 c, float clip);
             vec4 sample2d(sampler2D sampler, vec2 pos){return texture(sampler, vec2(pos.x, pos.y));}
             vec4 sample2d_lod(sampler2D sampler, vec2 pos, float lod){return textureLod(sampler, vec2(pos.x, pos.y), lod);}
-            vec4 sample2d_bgra(sampler2D sampler, vec2 pos){return texture(sampler, vec2(pos.x, pos.y));}
+            // GLES drivers are inconsistent about BGRA texture upload support.
+            // Upload BGRA-backed textures as RGBA on Android and swizzle them back here.
+            vec4 sample2d_bgra(sampler2D sampler, vec2 pos){return texture(sampler, vec2(pos.x, pos.y)).bgra;}
             vec4 sample2d_rt(sampler2D sampler, vec2 pos){return texture(sampler, vec2(pos.x, 1.0 - pos.y));}
             vec4 samplecube(samplerCube sampler, vec3 dir){return texture(sampler, dir);}
             vec4 samplecube_lod(samplerCube sampler, vec3 dir, float lod){return textureLod(sampler, dir, lod);}
-            vec4 samplecube_bgra(samplerCube sampler, vec3 dir){return texture(sampler, dir);}
+            vec4 samplecube_bgra(samplerCube sampler, vec3 dir){return texture(sampler, dir).bgra;}
             ";
         #[cfg(not(target_os = "android"))]
         let sampler_helpers = "
@@ -2464,6 +2466,9 @@ impl CxTexture {
                     data,
                     ..
                 } => {
+                    #[cfg(target_os = "android")]
+                    let (internal_format, format) = (gl_sys::RGBA, gl_sys::RGBA);
+                    #[cfg(not(target_os = "android"))]
                     let (internal_format, format) = (gl_sys::BGRA, gl_sys::BGRA);
 
                     (
@@ -2484,17 +2489,24 @@ impl CxTexture {
                     data,
                     max_level: _,
                     ..
-                } => (
-                    *width,
-                    *height,
-                    gl_sys::BGRA,
-                    gl_sys::BGRA,
-                    gl_sys::UNSIGNED_BYTE,
-                    data.as_ref().unwrap().as_ptr() as *const std::ffi::c_void,
-                    4,
-                    true,
-                    false,
-                ),
+                } => {
+                    #[cfg(target_os = "android")]
+                    let (internal_format, format) = (gl_sys::RGBA, gl_sys::RGBA);
+                    #[cfg(not(target_os = "android"))]
+                    let (internal_format, format) = (gl_sys::BGRA, gl_sys::BGRA);
+
+                    (
+                        *width,
+                        *height,
+                        internal_format,
+                        format,
+                        gl_sys::UNSIGNED_BYTE,
+                        data.as_ref().unwrap().as_ptr() as *const std::ffi::c_void,
+                        4,
+                        true,
+                        false,
+                    )
+                }
                 TextureFormat::VecRGBAf32 {
                     width,
                     height,

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -2083,20 +2083,6 @@ impl CxOsDrawShader {
         let nop_depth_clip = "
             vec4 depth_clip(vec4 w, vec4 c, float clip){return c;}
         ";
-        #[cfg(target_os = "android")]
-        let sampler_helpers = "
-            vec4 depth_clip(vec4 w, vec4 c, float clip);
-            vec4 sample2d(sampler2D sampler, vec2 pos){return texture(sampler, vec2(pos.x, pos.y));}
-            vec4 sample2d_lod(sampler2D sampler, vec2 pos, float lod){return textureLod(sampler, vec2(pos.x, pos.y), lod);}
-            // GLES drivers are inconsistent about BGRA texture upload support.
-            // Upload BGRA-backed textures as RGBA on Android and swizzle them back here.
-            vec4 sample2d_bgra(sampler2D sampler, vec2 pos){return texture(sampler, vec2(pos.x, pos.y)).bgra;}
-            vec4 sample2d_rt(sampler2D sampler, vec2 pos){return texture(sampler, vec2(pos.x, 1.0 - pos.y));}
-            vec4 samplecube(samplerCube sampler, vec3 dir){return texture(sampler, dir);}
-            vec4 samplecube_lod(samplerCube sampler, vec3 dir, float lod){return textureLod(sampler, dir, lod);}
-            vec4 samplecube_bgra(samplerCube sampler, vec3 dir){return texture(sampler, dir).bgra;}
-            ";
-        #[cfg(not(target_os = "android"))]
         let sampler_helpers = "
             vec4 depth_clip(vec4 w, vec4 c, float clip);
             vec4 sample2d(sampler2D sampler, vec2 pos){return texture(sampler, vec2(pos.x, pos.y));}
@@ -2342,6 +2328,21 @@ impl CxTexture {
             }
         }
 
+        // Check for pending updates BEFORE calling alloc_vec(). alloc_vec() has
+        // the side effect of marking the texture as allocated (self.alloc = Some)
+        // and generating a GL texture name. If we bail out early on an empty
+        // update after alloc_vec(), the next non-empty update sees the texture
+        // as already allocated (needs_realloc = false) and takes the partial
+        // update path, which calls glTexSubImage2D on GL storage that was never
+        // allocated via glTexImage2D. On Android GLES this silently fails and
+        // leaves the texture sampling as opaque black — e.g. emoji renders as
+        // black boxes because on Android-with-SLUG the color atlas's very first
+        // dirty rect is zero-sized (text goes through SLUG, not the atlas).
+        let updated = self.take_updated();
+        if updated.is_empty() {
+            return;
+        }
+
         let mut needs_realloc = false;
         if self.alloc_vec() {
             if let Some(previous) = self.previous_platform_resource.take() {
@@ -2356,11 +2357,6 @@ impl CxTexture {
                 }
             }
             needs_realloc = true;
-        }
-
-        let updated = self.take_updated();
-        if updated.is_empty() {
-            return;
         }
 
         if let TextureFormat::VecCubeBGRAu8_32 {
@@ -2465,48 +2461,34 @@ impl CxTexture {
                     height,
                     data,
                     ..
-                } => {
-                    #[cfg(target_os = "android")]
-                    let (internal_format, format) = (gl_sys::RGBA, gl_sys::RGBA);
-                    #[cfg(not(target_os = "android"))]
-                    let (internal_format, format) = (gl_sys::BGRA, gl_sys::BGRA);
-
-                    (
-                        *width,
-                        *height,
-                        internal_format,
-                        format,
-                        gl_sys::UNSIGNED_BYTE,
-                        data.as_ref().unwrap().as_ptr() as *const std::ffi::c_void,
-                        4,
-                        false,
-                        false,
-                    )
-                }
+                } => (
+                    *width,
+                    *height,
+                    gl_sys::BGRA,
+                    gl_sys::BGRA,
+                    gl_sys::UNSIGNED_BYTE,
+                    data.as_ref().unwrap().as_ptr() as *const std::ffi::c_void,
+                    4,
+                    false,
+                    false,
+                ),
                 TextureFormat::VecMipBGRAu8_32 {
                     width,
                     height,
                     data,
                     max_level: _,
                     ..
-                } => {
-                    #[cfg(target_os = "android")]
-                    let (internal_format, format) = (gl_sys::RGBA, gl_sys::RGBA);
-                    #[cfg(not(target_os = "android"))]
-                    let (internal_format, format) = (gl_sys::BGRA, gl_sys::BGRA);
-
-                    (
-                        *width,
-                        *height,
-                        internal_format,
-                        format,
-                        gl_sys::UNSIGNED_BYTE,
-                        data.as_ref().unwrap().as_ptr() as *const std::ffi::c_void,
-                        4,
-                        true,
-                        false,
-                    )
-                }
+                } => (
+                    *width,
+                    *height,
+                    gl_sys::BGRA,
+                    gl_sys::BGRA,
+                    gl_sys::UNSIGNED_BYTE,
+                    data.as_ref().unwrap().as_ptr() as *const std::ffi::c_void,
+                    4,
+                    true,
+                    false,
+                ),
                 TextureFormat::VecRGBAf32 {
                     width,
                     height,

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -1220,7 +1220,11 @@ impl GlShader {
                 let pixel_hash = Self::shader_source_hash(pixel);
 
                 #[cfg(target_os = "android")]
-                if matches!(os_type, OsType::Android(_)) {
+                let log_shader_builds = matches!(os_type, OsType::Android(_))
+                    && std::env::var_os("MAKEPAD_LOG_GL_SHADER_BUILDS").is_some();
+
+                #[cfg(target_os = "android")]
+                if log_shader_builds {
                     crate::log!(
                         "GL shader build start renderer={} vertex_hash={:016x} vertex_len={} fragment_hash={:016x} fragment_len={} vertex_preview={:?} fragment_preview={:?}",
                         get_gl_string(gl, gl_sys::RENDERER),
@@ -1238,7 +1242,7 @@ impl GlShader {
                 let vertex_ptrs = [vertex_ptr];
                 let vertex_lengths = [vertex_len];
                 #[cfg(target_os = "android")]
-                if matches!(os_type, OsType::Android(_)) {
+                if log_shader_builds {
                     crate::log!(
                         "GL shader upload vertex shader={} hash={:016x} len={}",
                         vs,
@@ -1248,7 +1252,7 @@ impl GlShader {
                 }
                 (gl.glShaderSource)(vs, 1, vertex_ptrs.as_ptr(), vertex_lengths.as_ptr());
                 #[cfg(target_os = "android")]
-                if matches!(os_type, OsType::Android(_)) {
+                if log_shader_builds {
                     crate::log!(
                         "GL shader compile vertex shader={} hash={:016x}",
                         vs,
@@ -1265,7 +1269,7 @@ impl GlShader {
                 let pixel_ptrs = [pixel_ptr];
                 let pixel_lengths = [pixel_len];
                 #[cfg(target_os = "android")]
-                if matches!(os_type, OsType::Android(_)) {
+                if log_shader_builds {
                     crate::log!(
                         "GL shader upload fragment shader={} hash={:016x} len={}",
                         fs,
@@ -1275,7 +1279,7 @@ impl GlShader {
                 }
                 (gl.glShaderSource)(fs, 1, pixel_ptrs.as_ptr(), pixel_lengths.as_ptr());
                 #[cfg(target_os = "android")]
-                if matches!(os_type, OsType::Android(_)) {
+                if log_shader_builds {
                     crate::log!(
                         "GL shader compile fragment shader={} hash={:016x}",
                         fs,
@@ -2159,6 +2163,7 @@ impl CxTexture {
                 data,
                 bytes_per_pixel,
                 use_mipmaps,
+                use_nearest_filter,
             ) = match &mut self.format {
                 TextureFormat::VecBGRAu8_32 {
                     width,
@@ -2177,6 +2182,7 @@ impl CxTexture {
                         data.as_ref().unwrap().as_ptr() as *const std::ffi::c_void,
                         4,
                         false,
+                        false,
                     )
                 }
                 TextureFormat::VecMipBGRAu8_32 {
@@ -2194,6 +2200,7 @@ impl CxTexture {
                     data.as_ref().unwrap().as_ptr() as *const std::ffi::c_void,
                     4,
                     true,
+                    false,
                 ),
                 TextureFormat::VecRGBAf32 {
                     width,
@@ -2203,12 +2210,13 @@ impl CxTexture {
                 } => (
                     *width,
                     *height,
-                    gl_sys::RGBA,
+                    gl_sys::RGBA32F,
                     gl_sys::RGBA,
                     gl_sys::FLOAT,
                     data.as_ref().unwrap().as_ptr() as *const std::ffi::c_void,
                     16,
                     false,
+                    true,
                 ),
                 TextureFormat::VecRu8 {
                     width,
@@ -2229,6 +2237,7 @@ impl CxTexture {
                         gl_sys::UNSIGNED_BYTE,
                         data.as_ref().unwrap().as_ptr() as *const std::ffi::c_void,
                         1,
+                        false,
                         false,
                     )
                 }
@@ -2252,6 +2261,7 @@ impl CxTexture {
                         data.as_ref().unwrap().as_ptr() as *const std::ffi::c_void,
                         2,
                         false,
+                        false,
                     )
                 }
                 TextureFormat::VecRf32 {
@@ -2262,12 +2272,13 @@ impl CxTexture {
                 } => (
                     *width,
                     *height,
-                    gl_sys::RED,
+                    gl_sys::R32F,
                     gl_sys::RED,
                     gl_sys::FLOAT,
                     data.as_ref().unwrap().as_ptr() as *const std::ffi::c_void,
                     4,
                     false,
+                    true,
                 ),
                 _ => panic!("Unsupported texture format"),
             };
@@ -2333,7 +2344,9 @@ impl CxTexture {
             (gl.glTexParameteri)(
                 gl_sys::TEXTURE_2D,
                 gl_sys::TEXTURE_MIN_FILTER,
-                if use_mipmaps {
+                if use_nearest_filter {
+                    gl_sys::NEAREST
+                } else if use_mipmaps {
                     gl_sys::LINEAR_MIPMAP_LINEAR
                 } else {
                     gl_sys::LINEAR
@@ -2342,7 +2355,11 @@ impl CxTexture {
             (gl.glTexParameteri)(
                 gl_sys::TEXTURE_2D,
                 gl_sys::TEXTURE_MAG_FILTER,
-                gl_sys::LINEAR as i32,
+                if use_nearest_filter {
+                    gl_sys::NEAREST
+                } else {
+                    gl_sys::LINEAR
+                } as i32,
             );
 
             if use_mipmaps {

--- a/platform/src/os/windows/d3d11.rs
+++ b/platform/src/os/windows/d3d11.rs
@@ -593,12 +593,116 @@ impl Cx {
     }
 
     pub(crate) fn hlsl_compile_shaders(&mut self, d3d11_cx: &D3d11Cx) {
+        let cache_dir = shader_cache_dir();
+
+        // Step 1: adopt any background compiles that finished since the last
+        // call. The worker thread writes the DXBC into the on-disk cache
+        // before sending the completion, so CxOsDrawShader::new takes the
+        // cache-hit path (disk read + D3D11 object creation — a few ms).
+        // The scoped block below keeps the immutable borrow of
+        // draw_shaders.shaders short so we can mutate it afterwards to set
+        // os_shader_id; that avoids the explicit mapping/bindings clones
+        // an earlier revision used.
+        let ready_async = self.os.async_hlsl_compile.drain_ready();
+        let mut any_async_ready = false;
+        for result in ready_async {
+            any_async_ready = true;
+            if let Err(msg) = &result.vs_status {
+                crate::error!(
+                    "Background vertex-shader compile failed for shader id {}: {}",
+                    result.shader_id, msg
+                );
+                continue;
+            }
+            if let Err(msg) = &result.ps_status {
+                crate::error!(
+                    "Background pixel-shader compile failed for shader id {}: {}",
+                    result.shader_id, msg
+                );
+                continue;
+            }
+            let shader_id = result.shader_id;
+            let shp = {
+                let cx_shader = &self.draw_shaders.shaders[shader_id];
+                let CxDrawShaderCode::Combined { code } = &cx_shader.mapping.code else {
+                    continue;
+                };
+                CxOsDrawShader::new(
+                    d3d11_cx,
+                    code,
+                    cache_dir,
+                    &cx_shader.mapping,
+                    &cx_shader.mapping.uniform_buffer_bindings,
+                )
+            };
+            if let Some(shp) = shp {
+                let cx_shader = &mut self.draw_shaders.shaders[shader_id];
+                cx_shader.os_shader_id = Some(self.draw_shaders.os_shaders.len());
+                self.draw_shaders.os_shaders.push(shp);
+            }
+        }
+        if any_async_ready {
+            // Widgets that skipped their draw call because the shader wasn't
+            // ready need one more redraw to materialize now that it is.
+            self.redraw_all();
+        }
+
         if self.draw_shaders.compile_set.is_empty() {
             return;
         }
         let compile_set = std::mem::take(&mut self.draw_shaders.compile_set);
-        let cache_dir = shader_cache_dir();
-        for draw_shader_id in compile_set {
+
+        // Step 2: partition by cache state, computing the cache key once.
+        //
+        // Cache hit  → sync path: disk read + D3D11 object creation, a few
+        //              ms total. Faster than thread/channel overhead.
+        // Cache miss → async path: D3DCompile can burn 100ms-multiple
+        //              seconds per shader, so it must not block the frame.
+        // `async_compile: true` (the SLUG helper) still forces async even
+        // on a cache hit, matching the Linux flag semantics — the one-frame
+        // latency on warm cache is acceptable, and this keeps behavior
+        // consistent across platforms.
+        let mut async_items: Vec<(usize, u64)> = Vec::new();
+        let mut sync_ids: Vec<usize> = Vec::new();
+        for id in compile_set {
+            let sh = &self.draw_shaders.shaders[id];
+            let code = match &sh.mapping.code {
+                CxDrawShaderCode::Combined { code } => code,
+                CxDrawShaderCode::Separate { .. } => {
+                    crate::error!("D3D11 does not support separate vertex/fragment sources");
+                    continue;
+                }
+            };
+            let cache_key = hlsl_cache_key(code);
+            let cached = shader_bytes_cached(cache_dir, cache_key);
+            let force_async = sh.mapping.flags.async_compile;
+            if force_async || !cached {
+                async_items.push((id, cache_key));
+            } else {
+                sync_ids.push(id);
+            }
+        }
+
+        // Step 3: dispatch background compiles. The window presents this
+        // frame without waiting; widgets whose shader isn't ready skip
+        // their draw call via the `sh.os_shader_id.is_none()` guard in
+        // render_view. When workers finish, the next hlsl_compile_shaders
+        // call drains them and triggers a redraw.
+        for (id, cache_key) in async_items {
+            let hlsl = {
+                let sh = &self.draw_shaders.shaders[id];
+                let CxDrawShaderCode::Combined { code } = &sh.mapping.code else {
+                    continue;
+                };
+                code.clone()
+            };
+            self.os
+                .async_hlsl_compile
+                .spawn(id, hlsl, cache_key, cache_dir);
+        }
+
+        // Step 4: serial D3D11 object creation for the cache-hit shaders.
+        for draw_shader_id in sync_ids {
             let shp = {
                 let cx_shader = &self.draw_shaders.shaders[draw_shader_id];
                 if cx_shader.mapping.flags.debug_code {
@@ -606,19 +710,16 @@ impl Cx {
                         crate::log!("{}", code);
                     }
                 }
-                match &cx_shader.mapping.code {
-                    CxDrawShaderCode::Separate { .. } => {
-                        crate::error!("D3D11 does not support separate vertex/fragment sources");
-                        None
-                    }
-                    CxDrawShaderCode::Combined { code } => CxOsDrawShader::new(
-                        d3d11_cx,
-                        code,
-                        cache_dir,
-                        &cx_shader.mapping,
-                        &cx_shader.mapping.uniform_buffer_bindings,
-                    ),
-                }
+                let CxDrawShaderCode::Combined { code } = &cx_shader.mapping.code else {
+                    continue;
+                };
+                CxOsDrawShader::new(
+                    d3d11_cx,
+                    code,
+                    cache_dir,
+                    &cx_shader.mapping,
+                    &cx_shader.mapping.uniform_buffer_bindings,
+                )
             };
             if let Some(shp) = shp {
                 let cx_shader = &mut self.draw_shaders.shaders[draw_shader_id];
@@ -632,6 +733,14 @@ impl Cx {
         let cxtexture = &mut self.textures[texture.texture_id()];
         cxtexture.update_shared_texture(self.os.d3d11_device.as_ref().unwrap());
         cxtexture.os.shared_handle.0 as u64
+    }
+
+    // HLSL shaders compile synchronously via `hlsl_compile_shaders`, so a shader
+    // is "window-ready" iff its OS-level shader entry has been allocated.
+    // Used by the shared SLUG helper path that also runs on Linux (where GL may
+    // async-compile) to decide whether to draw or fall back to raster.
+    pub fn is_draw_shader_window_ready(&self, shader_id: DrawShaderId) -> bool {
+        self.draw_shaders.shaders[shader_id.index].os_shader_id.is_some()
     }
 }
 
@@ -1892,6 +2001,221 @@ fn shader_cache_dir() -> Option<&'static std::path::Path> {
     .as_deref()
 }
 
+// FNV-1a 64-bit hash of the HLSL source — used as the on-disk cache key.
+// The leading seed byte lets us invalidate every cache entry by bumping
+// CACHE_KEY_VERSION whenever the compile flags or entry points change, which
+// would otherwise leave stale bytecode on disk that no longer matches what
+// the runtime expects.
+fn hlsl_cache_key(hlsl: &str) -> u64 {
+    const CACHE_KEY_VERSION: u8 = 2;
+    let mut hash: u64 = 0xcbf29ce484222325;
+    hash ^= CACHE_KEY_VERSION as u64;
+    hash = hash.wrapping_mul(0x100000001b3);
+    for byte in hlsl.bytes() {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+// Invoke D3DCompile (fxcompiler) on one stage. Thread-safe (pure CPU work)
+// so can be called from a background thread to parallelize startup compile.
+//
+// We pass D3DCOMPILE_SKIP_OPTIMIZATION because FXC's optimizer is what makes
+// shader compile times explode — it can spend many seconds on a single text
+// shader with loops. UI shaders are short-lived per frame and the win from
+// FXC-level optimization is tiny for this workload, while the cold-cache
+// startup cost is huge. If a specific shader is later shown to be a runtime
+// hotspot, it should be recompiled with optimizations on a background thread
+// and hot-swapped — that's a cleaner solution than paying the cost upfront
+// for every shader in the app.
+fn d3d_compile_hlsl(target: &str, entry: &str, shader: &str) -> Result<Vec<u8>, String> {
+    const D3DCOMPILE_SKIP_OPTIMIZATION: u32 = 1 << 2;
+    const D3DCOMPILE_ENABLE_BACKWARDS_COMPATIBILITY: u32 = 1 << 12;
+    const FLAGS: u32 = D3DCOMPILE_SKIP_OPTIMIZATION | D3DCOMPILE_ENABLE_BACKWARDS_COMPATIBILITY;
+    unsafe {
+        let shader_bytes = shader.as_bytes();
+        let mut blob = None;
+        let mut errors = None;
+        if D3DCompile(
+            shader_bytes.as_ptr() as *const _,
+            shader_bytes.len(),
+            PCSTR("makepad_shader\0".as_ptr()),
+            None,
+            None,
+            PCSTR(entry.as_ptr()),
+            PCSTR(target.as_ptr()),
+            FLAGS,
+            0,
+            &mut blob,
+            Some(&mut errors),
+        )
+        .is_ok()
+        {
+            let blob = blob.unwrap();
+            let ptr = blob.GetBufferPointer() as *const u8;
+            let len = blob.GetBufferSize();
+            return Ok(std::slice::from_raw_parts(ptr, len).to_vec());
+        }
+        let error = errors.unwrap();
+        let pointer = error.GetBufferPointer();
+        let size = error.GetBufferSize();
+        let slice = std::slice::from_raw_parts(pointer as *const u8, size as usize);
+        Err(String::from_utf8_lossy(slice).into_owned())
+    }
+}
+
+// Cheap existence check used to decide whether a shader can go through the
+// synchronous fast path (disk reads only) or needs the async background
+// compile path. We only check existence, not contents — if the files are
+// present but corrupt/short, the subsequent read path will catch that.
+fn shader_bytes_cached(cache_dir: Option<&std::path::Path>, cache_key: u64) -> bool {
+    let Some(dir) = cache_dir else {
+        return false;
+    };
+    let vs = dir.join(format!("{:016x}_vs.dxbc", cache_key));
+    let ps = dir.join(format!("{:016x}_ps.dxbc", cache_key));
+    vs.exists() && ps.exists()
+}
+
+// Read the DXBC blob from the on-disk cache if present, otherwise compile and
+// write it. Disk I/O and D3DCompile are both thread-safe so this can run on a
+// worker thread.
+fn get_or_compile_shader_bytes(
+    cache_dir: Option<&std::path::Path>,
+    cache_key: u64,
+    suffix: &str,
+    target: &str,
+    entry: &str,
+    hlsl: &str,
+) -> Result<Vec<u8>, String> {
+    if let Some(dir) = cache_dir {
+        let path = dir.join(format!("{:016x}{}.dxbc", cache_key, suffix));
+        if let Ok(bytes) = std::fs::read(&path) {
+            return Ok(bytes);
+        }
+        let bytes = d3d_compile_hlsl(target, entry, hlsl)?;
+        let _ = std::fs::write(&path, &bytes);
+        return Ok(bytes);
+    }
+    d3d_compile_hlsl(target, entry, hlsl)
+}
+
+/// Result of a background D3DCompile for one shader.
+///
+/// The worker writes the compiled bytes to the on-disk cache before sending
+/// this result, so the main thread picks them back up via the disk cache in
+/// `CxOsDrawShader::new`. We only carry status (not the bytes themselves) so
+/// the channel doesn't ferry hundreds of KB of DXBC — the SLUG helper alone
+/// is ~240 KB. Error strings are kept for diagnostic output when a compile
+/// fails.
+struct AsyncCompileResult {
+    shader_id: usize,
+    vs_status: Result<(), String>,
+    ps_status: Result<(), String>,
+}
+
+/// Background HLSL compile queue used for `async_compile: true` shaders.
+///
+/// The DrawTextSlug helper is by far the most expensive shader to compile on
+/// Windows (hundreds of KB of DXBC, multiple seconds with the default FXC
+/// settings) and it is the primary motivation for this path — without it the
+/// SLUG helper blocks the main thread the first time a SLUG glyph is needed.
+/// Other shaders stay on the synchronous parallel-precompile path so the app
+/// still renders its widgets immediately on the first frame.
+///
+/// The worker threads call `D3DCompile`, write the resulting bytecode into
+/// the on-disk shader cache, then send a lightweight result to the main
+/// thread via an mpsc channel. The main thread drains completed results
+/// each paint tick, creates the D3D11 shader objects, and requests a redraw
+/// so the now-ready widgets get a chance to render.
+pub struct AsyncHlslCompile {
+    inner: std::sync::Mutex<AsyncHlslCompileInner>,
+}
+
+struct AsyncHlslCompileInner {
+    tx: std::sync::mpsc::Sender<AsyncCompileResult>,
+    rx: std::sync::mpsc::Receiver<AsyncCompileResult>,
+    pending: std::collections::HashSet<usize>,
+}
+
+impl Default for AsyncHlslCompile {
+    fn default() -> Self {
+        let (tx, rx) = std::sync::mpsc::channel();
+        Self {
+            inner: std::sync::Mutex::new(AsyncHlslCompileInner {
+                tx,
+                rx,
+                pending: std::collections::HashSet::new(),
+            }),
+        }
+    }
+}
+
+impl AsyncHlslCompile {
+    /// Start a background compile for `shader_id`. No-op if that shader is
+    /// already being compiled. Returns true if a new worker was spawned.
+    fn spawn(
+        &self,
+        shader_id: usize,
+        hlsl: String,
+        cache_key: u64,
+        cache_dir: Option<&'static std::path::Path>,
+    ) -> bool {
+        let tx = {
+            let mut inner = self.inner.lock().unwrap();
+            if !inner.pending.insert(shader_id) {
+                return false;
+            }
+            inner.tx.clone()
+        };
+        std::thread::Builder::new()
+            .name(format!("hlsl-compile-{}", shader_id))
+            .spawn(move || {
+                // Discard the bytes once they hit the disk cache — the main
+                // thread re-reads them via CxOsDrawShader::new, and keeping
+                // them here would pin hundreds of KB per shader until the
+                // result is drained.
+                let vs_status = get_or_compile_shader_bytes(
+                    cache_dir,
+                    cache_key,
+                    "_vs",
+                    "vs_5_0\0",
+                    "vertex_main\0",
+                    &hlsl,
+                )
+                .map(drop);
+                let ps_status = get_or_compile_shader_bytes(
+                    cache_dir,
+                    cache_key,
+                    "_ps",
+                    "ps_5_0\0",
+                    "pixel_main\0",
+                    &hlsl,
+                )
+                .map(drop);
+                let _ = tx.send(AsyncCompileResult {
+                    shader_id,
+                    vs_status,
+                    ps_status,
+                });
+            })
+            .expect("failed to spawn HLSL compile worker");
+        true
+    }
+
+    /// Drain any workers that have finished since the last call.
+    fn drain_ready(&self) -> Vec<AsyncCompileResult> {
+        let mut inner = self.inner.lock().unwrap();
+        let mut out = Vec::new();
+        while let Ok(result) = inner.rx.try_recv() {
+            inner.pending.remove(&result.shader_id);
+            out.push(result);
+        }
+        out
+    }
+}
+
 #[derive(Clone)]
 pub struct CxOsDrawShader {
     pub const_table_uniforms: D3d11Buffer,
@@ -1919,69 +2243,6 @@ impl CxOsDrawShader {
         mapping: &CxDrawShaderMapping,
         bindings: &UniformBufferBindings,
     ) -> Option<Self> {
-        fn compile_shader(target: &str, entry: &str, shader: &str) -> Result<Vec<u8>, String> {
-            const D3DCOMPILE_ENABLE_BACKWARDS_COMPATIBILITY: u32 = 1 << 12;
-            unsafe {
-                let shader_bytes = shader.as_bytes();
-                let mut blob = None;
-                let mut errors = None;
-                if D3DCompile(
-                    shader_bytes.as_ptr() as *const _,
-                    shader_bytes.len(),
-                    PCSTR("makepad_shader\0".as_ptr()), // sourcename
-                    None,                               // defines
-                    None,                               // include
-                    PCSTR(entry.as_ptr()),              // entry point
-                    PCSTR(target.as_ptr()),             // target
-                    D3DCOMPILE_ENABLE_BACKWARDS_COMPATIBILITY,
-                    0, // flags2
-                    &mut blob,
-                    Some(&mut errors),
-                )
-                .is_ok()
-                {
-                    let blob = blob.unwrap();
-                    let ptr = blob.GetBufferPointer() as *const u8;
-                    let len = blob.GetBufferSize();
-                    return Ok(std::slice::from_raw_parts(ptr, len).to_vec());
-                };
-                let error = errors.unwrap();
-                let pointer = error.GetBufferPointer();
-                let size = error.GetBufferSize();
-                let slice = std::slice::from_raw_parts(pointer as *const u8, size as usize);
-                return Err(String::from_utf8_lossy(slice).into_owned());
-            }
-        }
-
-        fn hlsl_cache_key(hlsl: &str) -> u64 {
-            // FNV-1a 64-bit hash — stable across Rust versions
-            let mut hash: u64 = 0xcbf29ce484222325;
-            for byte in hlsl.bytes() {
-                hash ^= byte as u64;
-                hash = hash.wrapping_mul(0x100000001b3);
-            }
-            hash
-        }
-
-        fn get_shader_bytes(
-            cache_dir: Option<&std::path::Path>,
-            cache_key: u64,
-            suffix: &str,
-            target: &str,
-            entry: &str,
-            hlsl: &str,
-        ) -> Result<Vec<u8>, String> {
-            if let Some(dir) = cache_dir {
-                let path = dir.join(format!("{:016x}{}.dxbc", cache_key, suffix));
-                if let Ok(bytes) = std::fs::read(&path) {
-                    return Ok(bytes);
-                }
-                let bytes = compile_shader(target, entry, hlsl)?;
-                let _ = std::fs::write(&path, &bytes);
-                return Ok(bytes);
-            }
-            compile_shader(target, entry, hlsl)
-        }
         fn split_source(src: &str) -> String {
             let mut r = String::new();
             let split = src.split("\n");
@@ -2037,13 +2298,19 @@ impl CxOsDrawShader {
                 }
             }
         }
-        fn index_to_char(index: usize) -> char {
-            std::char::from_u32(index as u32 + 65).unwrap_or('?')
-        }
+        // Use the same semantic suffix scheme as the HLSL generator so the
+        // InputLayout semantic names match what the compiled vertex shader
+        // declares. Single-char `A`..`Z` for the first 26 inputs, then
+        // `AA`..`AZ`, `BA`..., which is valid HLSL and keeps names aligned
+        // across any number of inputs. Naive `index + 'A'` produces invalid
+        // chars (`[`, `\\`, ...) past Z and fails CreateInputLayout with
+        // E_INVALIDARG — surfaced by text helpers that have many instance
+        // slots.
+        use makepad_script::shader_hlsl::index_to_semantic;
 
         let cache_key = hlsl_cache_key(hlsl);
 
-        let vs_bytes = match get_shader_bytes(
+        let vs_bytes = match get_or_compile_shader_bytes(
             cache_dir,
             cache_key,
             "_vs",
@@ -2062,7 +2329,7 @@ impl CxOsDrawShader {
             Ok(bytes) => bytes,
         };
 
-        let ps_bytes = match get_shader_bytes(
+        let ps_bytes = match get_or_compile_shader_bytes(
             cache_dir,
             cache_key,
             "_ps",
@@ -2118,7 +2385,7 @@ impl CxOsDrawShader {
 
         let mut geom_sem_index = 0usize;
         for geom in &mapping.geometries.inputs {
-            strings.push(format!("GEOM{}\0", index_to_char(geom_sem_index)));
+            strings.push(format!("GEOM{}\0", index_to_semantic(geom_sem_index)));
             let semantic_name = PCSTR(strings.last().unwrap().as_ptr());
             let mut slot_offset = 0usize;
             for (semantic_chunk_index, chunk_slots) in
@@ -2148,7 +2415,7 @@ impl CxOsDrawShader {
 
         let mut inst_sem_index = 0usize;
         for inst in &mapping.instances.inputs {
-            strings.push(format!("INST{}\0", index_to_char(inst_sem_index)));
+            strings.push(format!("INST{}\0", index_to_semantic(inst_sem_index)));
             let semantic_name = PCSTR(strings.last().unwrap().as_ptr());
             let mut slot_offset = 0usize;
             for (semantic_chunk_index, chunk_slots) in

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -835,4 +835,5 @@ pub struct CxOs {
     pub(crate) game_input_events: GameInputEventChannel,
     pub(crate) windows_game_input: Option<WindowsGameInput>,
     pub(crate) video_players: HashMap<LiveId, WindowsUnifiedVideoPlayer>,
+    pub(crate) async_hlsl_compile: crate::os::windows::d3d11::AsyncHlslCompile,
 }

--- a/widgets/src/label.rs
+++ b/widgets/src/label.rs
@@ -1,6 +1,5 @@
 use crate::{
-    makepad_derive_widget::*, makepad_draw::*,
-    makepad_draw::shader::draw_text::TextOverflow,
+    makepad_derive_widget::*, makepad_draw::shader::draw_text::TextOverflow, makepad_draw::*,
     widget::*, widget_async::ScriptAsyncResult,
 };
 

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -4,9 +4,8 @@ use crate::makepad_draw::text::{
     selection::{Cursor, Selection},
 };
 use crate::{
-    animator::*, makepad_derive_widget::*, makepad_draw::*,
-    makepad_draw::shader::draw_text::TextOverflow,
-    widget::*, widget_tree::CxWidgetExt,
+    animator::*, makepad_derive_widget::*, makepad_draw::shader::draw_text::TextOverflow,
+    makepad_draw::*, widget::*, widget_tree::CxWidgetExt,
 };
 use std::rc::Rc;
 
@@ -928,7 +927,7 @@ impl Widget for TextFlow {
                 }
                 // Update shader directly and request redraw for the area
                 self.draw_text.set_total_chars(cx, self.animated_chars);
-                self.draw_text.draw_vars.area.redraw(cx);
+                self.draw_text.redraw_areas(cx);
             }
 
             // Keep animation alive if streaming or not done fading

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -1021,7 +1021,7 @@ impl TextFlow {
         cx.begin_turtle(walk, self.layout);
         self.draw_state.set(DrawState::Drawing);
         self.draw_block.append_to_draw_call(cx);
-        self.draw_text.begin_many_instances(cx);
+        self.draw_text.begin_deferred_slug_flush();
         self.clear_stacks();
         self.lines_drawn = 0;
         self.content_truncated = false;
@@ -1076,7 +1076,7 @@ impl TextFlow {
     }
 
     pub fn end(&mut self, cx: &mut Cx2d) {
-        self.draw_text.end_many_instances(cx);
+        self.draw_text.end_deferred_slug_flush(cx);
 
         // Draw selection highlight before finishing the turtle
         self.draw_selection_rects(cx);

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -1021,6 +1021,7 @@ impl TextFlow {
         cx.begin_turtle(walk, self.layout);
         self.draw_state.set(DrawState::Drawing);
         self.draw_block.append_to_draw_call(cx);
+        self.draw_text.begin_many_instances(cx);
         self.clear_stacks();
         self.lines_drawn = 0;
         self.content_truncated = false;
@@ -1075,6 +1076,8 @@ impl TextFlow {
     }
 
     pub fn end(&mut self, cx: &mut Cx2d) {
+        self.draw_text.end_many_instances(cx);
+
         // Draw selection highlight before finishing the turtle
         self.draw_selection_rects(cx);
 


### PR DESCRIPTION
On Linux & Windows, because compiling the SLUG shaders can be incredibly slow, we currently use a hybrid approach that first uses SDF (very fast shader compilation, e.g., <200ms) to show text in a low-latency manner, and then switch to SLUG once the shaders are compiled asynchronously. Currently SLUG isn't actually used on Linux/Windows unless the font is quite large (where it makes the biggest difference). Hopefully in the future we can cut down on that SLUG shader compilation delay and then start to use SLUG for all non-bitmap fonts.

I did a shit-ton of thorough platform testing.
 - [x] Android ~~(TODO: emoji are black boxes currently. Fixed by claude but needs verif)~~ working
 - [x] macOS
 - [x] iOS
 - [x] Windows
 - [x] Linux X11
 - [x] Linux Wayland
 