### PR TITLE
Fully proper fix for black screen on Android start/resume

### DIFF
--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -441,6 +441,26 @@ impl Cx {
         self.redraw_all();
     }
 
+    fn hide_android_surface_cover_after_first_present_if_needed(&mut self) {
+        if !self.os.hide_surface_cover_after_first_present || self.os.in_xr_mode {
+            return;
+        }
+        self.os.hide_surface_cover_after_first_present = false;
+        unsafe {
+            android_jni::to_java_set_surface_cover_visible(false);
+        }
+    }
+
+    fn request_android_surface_snapshot_refresh_after_present_if_needed(&mut self) {
+        if !self.os.refresh_surface_snapshot_after_first_present || self.os.in_xr_mode {
+            return;
+        }
+        self.os.refresh_surface_snapshot_after_first_present = false;
+        unsafe {
+            android_jni::to_java_request_surface_snapshot_refresh();
+        }
+    }
+
     pub(crate) fn handle_message(&mut self, msg: FromJavaMessage) {
         match msg {
             FromJavaMessage::SwitchedActivity(activity_handle, activity_thread_id) => {
@@ -510,6 +530,11 @@ impl Cx {
                 // Ensure the next time the surface becomes drawable, we force
                 // a full redraw to avoid a black screen.
                 self.os.needs_first_draw = true;
+                // The Java host shows its placeholder cover before sending
+                // SurfaceDestroyed, so only arm the hide-on-present path for
+                // genuine surface teardown/rebuild cycles, not cold start.
+                self.os.hide_surface_cover_after_first_present = true;
+                self.os.refresh_surface_snapshot_after_first_present = true;
 
                 #[cfg(not(use_vulkan))]
                 unsafe {
@@ -1121,6 +1146,12 @@ impl Cx {
                         android_jni::to_java_set_full_screen(env, true);
                     }
                 }
+                // Java may keep a cached snapshot overlay visible across any
+                // pause/resume transition, even when Android never tears down
+                // the underlying SurfaceView. Always hide that overlay on the
+                // first successful present after resume.
+                self.os.hide_surface_cover_after_first_present = true;
+                self.os.refresh_surface_snapshot_after_first_present = true;
                 self.redraw_all();
                 self.reinitialise_media();
                 self.call_event_handler(&Event::Resume);
@@ -1336,8 +1367,16 @@ impl Cx {
                 let mut vulkan = self.os.vulkan.take().unwrap();
                 let result = vulkan.draw_pass_and_present(self, draw_pass_id);
                 self.os.vulkan = Some(vulkan);
-                if let Err(err) = result {
-                    crate::error!("Android Vulkan draw/present failed: {err}");
+                match result {
+                    Ok(presented) => {
+                        if presented {
+                            self.hide_android_surface_cover_after_first_present_if_needed();
+                            self.request_android_surface_snapshot_refresh_after_present_if_needed();
+                        }
+                    }
+                    Err(err) => {
+                        crate::error!("Android Vulkan draw/present failed: {err}");
+                    }
                 }
             } else {
                 self.draw_pass_to_fullscreen(draw_pass_id);
@@ -1388,10 +1427,14 @@ impl Cx {
                         // implementation when the underlying buffer queue is
                         // already gone.
                         if display.is_surface_alive() {
-                            (display.libegl.eglSwapBuffers.unwrap())(
+                            let swapped = (display.libegl.eglSwapBuffers.unwrap())(
                                 display.egl_display,
                                 display.surface,
                             );
+                            if swapped != 0 {
+                                self.hide_android_surface_cover_after_first_present_if_needed();
+                                self.request_android_surface_snapshot_refresh_after_present_if_needed();
+                            }
                         }
                     }
                 }
@@ -1403,10 +1446,14 @@ impl Cx {
         unsafe {
             if let Some(display) = &mut self.os.display {
                 if display.is_surface_alive() {
-                    (display.libegl.eglSwapBuffers.unwrap())(
+                    let swapped = (display.libegl.eglSwapBuffers.unwrap())(
                         display.egl_display,
                         display.surface,
                     );
+                    if swapped != 0 {
+                        self.hide_android_surface_cover_after_first_present_if_needed();
+                        self.request_android_surface_snapshot_refresh_after_present_if_needed();
+                    }
                 }
             }
         }
@@ -3006,6 +3053,8 @@ impl Default for CxOs {
             start_time: Instant::now(),
             first_after_resize: true,
             needs_first_draw: true,
+            hide_surface_cover_after_first_present: false,
+            refresh_surface_snapshot_after_first_present: true,
             frame_time: 0,
             display_size: dvec2(100., 100.),
             dpi_factor: 1.5,
@@ -3078,6 +3127,14 @@ pub struct CxOs {
     /// can start up showing a black screen if the initial redraw request was
     /// consumed before the surface was available.
     pub needs_first_draw: bool,
+    /// Tracks whether the Java-side surface cover overlay should remain visible
+    /// until the next successful present reaches the rebuilt Android surface.
+    pub hide_surface_cover_after_first_present: bool,
+    /// Tracks whether Java should refresh its cached `SurfaceView` snapshot
+    /// after the next successful present. This keeps the task snapshot path
+    /// from falling back to black when Android backgrounds/resumes the app
+    /// without destroying the surface.
+    pub refresh_surface_snapshot_after_first_present: bool,
     pub display_size: Vec2d,
     pub dpi_factor: f64,
     pub safe_area_insets: crate::event::SafeAreaInsets,

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -25,7 +25,7 @@ use {
         ndk_sys,
     },
     crate::{
-        cx::{Cx, OsType},
+        cx::{AndroidParams, Cx, OsType},
         cx_api::{CxOsApi, CxOsOp, OpenUrlInPlace, XrFrameCpuBreakdown},
         draw_pass::CxDrawPassParent,
         draw_pass::{DrawPassClearColor, DrawPassClearDepth, DrawPassId},
@@ -283,9 +283,15 @@ impl Cx {
     /// It handles all incoming messages, processes other events, and manages drawing operations.
     pub fn main_loop(&mut self, from_java_rx: mpsc::Receiver<FromJavaMessage>) {
         self.gpu_info.performance = GpuPerformance::Tier1;
-        // Populate display_context and script heap with safe area insets
-        // BEFORE Startup, so app script_mod! definitions can use them.
+        // Populate display_context and script heap with the initial display
+        // metrics BEFORE Startup, so app script_mod! definitions can use them.
         let insets = self.os.safe_area_insets;
+        let dpi_factor = if self.os.dpi_factor > 0.0 {
+            self.os.dpi_factor
+        } else {
+            1.0
+        };
+        self.display_context.screen_size = self.os.display_size / dpi_factor;
         self.display_context.safe_area_insets = insets;
         self.update_safe_inset_script_values(insets);
         self.call_event_handler(&Event::Startup);
@@ -402,6 +408,39 @@ impl Cx {
         from_java_messages_clear()
     }
 
+    fn sync_android_surface_alive_from_backend(&mut self) {
+        #[cfg(not(use_vulkan))]
+        {
+            self.os.surface_alive = self
+                .os
+                .display
+                .as_ref()
+                .map(|d| d.is_surface_alive())
+                .unwrap_or(false);
+        }
+
+        #[cfg(use_vulkan)]
+        {
+            self.os.surface_alive = if self.os.in_xr_mode && self.os.openxr.session.is_some() {
+                self.os.vulkan.is_some()
+            } else {
+                self.os
+                    .vulkan
+                    .as_ref()
+                    .map(|vulkan| vulkan.has_drawable_surface())
+                    .unwrap_or(false)
+            };
+        }
+    }
+
+    fn request_android_surface_redraw(&mut self) {
+        // A newly created/recreated surface starts with undefined contents.
+        // Always re-arm the first full redraw instead of relying on a later
+        // size-change callback to do it for us.
+        self.os.needs_first_draw = true;
+        self.redraw_all();
+    }
+
     pub(crate) fn handle_message(&mut self, msg: FromJavaMessage) {
         match msg {
             FromJavaMessage::SwitchedActivity(activity_handle, activity_thread_id) => {
@@ -430,15 +469,6 @@ impl Cx {
                     unsafe {
                         self.os.display.as_mut().unwrap().update_surface(window);
                     }
-                    // Only mark the surface alive if `update_surface` actually
-                    // succeeded — otherwise we'd lie to the renderer and it
-                    // would try to draw against a null EGL surface.
-                    self.os.surface_alive = self
-                        .os
-                        .display
-                        .as_ref()
-                        .map(|d| d.is_surface_alive())
-                        .unwrap_or(false);
                 }
 
                 #[cfg(use_vulkan)]
@@ -457,10 +487,15 @@ impl Cx {
                             let height = self.os.display_size.y.max(1.0) as u32;
                             if let Err(err) = vulkan.update_surface(window, width, height) {
                                 crate::error!("Android Vulkan surface create/update failed: {err}");
-                            } else {
-                                self.os.surface_alive = true;
                             }
                         }
+                    }
+                }
+
+                if !self.os.in_xr_mode {
+                    self.sync_android_surface_alive_from_backend();
+                    if self.os.surface_alive {
+                        self.request_android_surface_redraw();
                     }
                 }
             }
@@ -564,16 +599,6 @@ impl Cx {
                     unsafe {
                         self.os.display.as_mut().unwrap().update_surface(window);
                     }
-                    // SurfaceChanged is the canonical "surface is good now"
-                    // signal — it's also how the very first surface is
-                    // delivered. Mark the surface alive only if the EGL window
-                    // surface actually got created.
-                    self.os.surface_alive = self
-                        .os
-                        .display
-                        .as_ref()
-                        .map(|d| d.is_surface_alive())
-                        .unwrap_or(false);
                 }
 
                 #[cfg(use_vulkan)]
@@ -596,14 +621,11 @@ impl Cx {
                         if let Some(vulkan) = self.os.vulkan.as_mut() {
                             if let Err(err) = vulkan.update_surface(window, width_u32, height_u32) {
                                 crate::error!("Android Vulkan surface update failed: {err}");
-                            } else {
-                                self.os.surface_alive = true;
                             }
                         } else {
                             match CxVulkan::new(window, width_u32, height_u32) {
                                 Ok(vulkan) => {
                                     self.os.vulkan = Some(vulkan);
-                                    self.os.surface_alive = true;
                                 }
                                 Err(err) => {
                                     crate::error!(
@@ -612,6 +634,13 @@ impl Cx {
                                 }
                             }
                         }
+                    }
+                }
+
+                if !self.os.in_xr_mode {
+                    self.sync_android_surface_alive_from_backend();
+                    if self.os.surface_alive {
+                        self.request_android_surface_redraw();
                     }
                 }
 
@@ -1692,24 +1721,62 @@ impl Cx {
             cx.os.render_thread_id =
                 Some(unsafe { libc_sys::syscall(libc_sys::SYS_GETTID) as u64 });
 
-            let window = loop {
+            let mut initial_params: Option<AndroidParams> = None;
+            let mut initial_surface: Option<(*mut ndk_sys::ANativeWindow, i32, i32)> = None;
+
+            let (window, width, height, android_params) = loop {
                 // Here use blocking method `recv` to reduce CPU usage during cold start.
                 match from_java_rx.recv() {
                     Ok(FromJavaMessage::Init(params)) => {
-                        cx.os.dpi_factor = params.density;
-                        cx.os_type = OsType::Android(params);
+                        initial_params = Some(params);
+                    }
+                    Ok(FromJavaMessage::SurfaceCreated { window }) => {
+                        // Bootstrap off the first SurfaceChanged so we have a
+                        // real size. SurfaceCreated still hands us an acquired
+                        // ANativeWindow ref, so release it immediately here to
+                        // avoid leaking the unused bootstrap callback.
+                        unsafe {
+                            if !window.is_null() {
+                                ndk_sys::ANativeWindow_release(window);
+                            }
+                        }
                     }
                     Ok(FromJavaMessage::SurfaceChanged {
                         window,
                         width,
                         height,
                     }) => {
-                        cx.os.display_size = dvec2(width as f64, height as f64);
-                        break window;
+                        if let Some((old_window, _, _)) = initial_surface.replace((window, width, height)) {
+                            unsafe {
+                                if !old_window.is_null() {
+                                    ndk_sys::ANativeWindow_release(old_window);
+                                }
+                            }
+                        }
+                    }
+                    Ok(FromJavaMessage::SurfaceDestroyed { ack }) => {
+                        if let Some((old_window, _, _)) = initial_surface.take() {
+                            unsafe {
+                                if !old_window.is_null() {
+                                    ndk_sys::ANativeWindow_release(old_window);
+                                }
+                            }
+                        }
+                        signal_surface_ack(&ack);
                     }
                     _ => (),
                 }
+
+                if initial_params.is_some() && initial_surface.is_some() {
+                    let android_params = initial_params.take().unwrap();
+                    let (window, width, height) = initial_surface.take().unwrap();
+                    break (window, width, height, android_params);
+                }
             };
+
+            cx.os.dpi_factor = android_params.density;
+            cx.os_type = OsType::Android(android_params);
+            cx.os.display_size = dvec2(width as f64, height as f64);
 
             // SAFETY:
             // The LibEgl instance (libegl) has been properly loaded and initialized earlier.
@@ -1811,6 +1878,11 @@ impl Cx {
                     }
                 }
             }
+
+            // The initial SurfaceChanged was consumed during bootstrap so the
+            // regular lifecycle handler will not get a second chance to seed
+            // drawable-surface state for the first frame. Do it explicitly here.
+            cx.sync_android_surface_alive_from_backend();
 
             cx.main_loop(from_java_rx);
             cx.stop_studio_websocket();
@@ -3114,13 +3186,11 @@ impl CxOs {
         {
             // Non-XR Vulkan: the EGL surface is a 1x1 pbuffer kept alive only
             // for GL interop, so the relevant question is whether the Vulkan
-            // backend has a usable native window.
-            self.vulkan.is_some()
-                && self
-                    .display
-                    .as_ref()
-                    .map(|d| !d.window.is_null())
-                    .unwrap_or(false)
+            // backend still has a live Android window surface + swapchain.
+            self.vulkan
+                .as_ref()
+                .map(|vulkan| vulkan.has_drawable_surface())
+                .unwrap_or(false)
         }
     }
 }

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -1309,6 +1309,27 @@ pub unsafe fn to_java_set_full_screen(env: *mut jni_sys::JNIEnv, fullscreen: boo
     );
 }
 
+pub unsafe fn to_java_set_surface_cover_visible(visible: bool) {
+    let env = attach_jni_env();
+    ndk_utils::call_void_method!(
+        env,
+        get_activity(),
+        "setSurfaceCoverVisible",
+        "(Z)V",
+        visible as i32
+    );
+}
+
+pub unsafe fn to_java_request_surface_snapshot_refresh() {
+    let env = attach_jni_env();
+    ndk_utils::call_void_method!(
+        env,
+        get_activity(),
+        "requestSurfaceSnapshotRefresh",
+        "()V"
+    );
+}
+
 pub unsafe fn to_java_switch_activity(env: *mut jni_sys::JNIEnv) {
     ndk_utils::call_void_method!(env, get_activity(), "switchActivity", "()V");
 }

--- a/platform/src/os/linux/vulkan.rs
+++ b/platform/src/os/linux/vulkan.rs
@@ -330,6 +330,12 @@ pub struct CxVulkan {
 }
 
 impl CxVulkan {
+    pub(crate) fn has_drawable_surface(&self) -> bool {
+        !self.window.is_null()
+            && self.surface != vk::SurfaceKHR::null()
+            && self.swapchain != vk::SwapchainKHR::null()
+    }
+
     fn geometry_id_is_live(cx: &Cx, geometry_id: GeometryId) -> bool {
         let slot_index = geometry_id.slot_index();
         cx.geometries

--- a/platform/src/os/linux/vulkan.rs
+++ b/platform/src/os/linux/vulkan.rs
@@ -2539,24 +2539,24 @@ impl CxVulkan {
         &mut self,
         cx: &mut Cx,
         draw_pass_id: DrawPassId,
-    ) -> Result<(), String> {
+    ) -> Result<bool, String> {
         if self.surface == vk::SurfaceKHR::null() || self.swapchain == vk::SwapchainKHR::null() {
-            return Ok(());
+            return Ok(false);
         }
 
         let draw_list_id = if let Some(id) = cx.passes[draw_pass_id].main_draw_list_id {
             id
         } else {
-            return Ok(());
+            return Ok(false);
         };
 
         let dpi_factor = cx.passes[draw_pass_id].dpi_factor.unwrap_or(1.0);
         let pass_rect = match cx.get_pass_rect(draw_pass_id, dpi_factor) {
             Some(rect) => rect,
-            None => return Ok(()),
+            None => return Ok(false),
         };
         if pass_rect.size.x < 0.5 || pass_rect.size.y < 0.5 {
-            return Ok(());
+            return Ok(false);
         }
 
         {
@@ -2599,11 +2599,11 @@ impl CxVulkan {
             Ok(v) => v,
             Err(vk::Result::ERROR_OUT_OF_DATE_KHR) => {
                 self.recreate_swapchain()?;
-                return Ok(());
+                return Ok(false);
             }
             Err(vk::Result::ERROR_SURFACE_LOST_KHR) => {
                 self.suspend_surface();
-                return Ok(());
+                return Ok(false);
             }
             Err(err) => {
                 return Err(format!("acquire_next_image failed: {err:?}"));
@@ -2860,11 +2860,11 @@ impl CxVulkan {
             Ok(suboptimal) => suboptimal,
             Err(vk::Result::ERROR_OUT_OF_DATE_KHR) => {
                 self.recreate_swapchain()?;
-                return Ok(());
+                return Ok(false);
             }
             Err(vk::Result::ERROR_SURFACE_LOST_KHR) => {
                 self.suspend_surface();
-                return Ok(());
+                return Ok(false);
             }
             Err(err) => {
                 return Err(format!("queue_present failed: {err:?}"));
@@ -2875,7 +2875,7 @@ impl CxVulkan {
             self.recreate_swapchain()?;
         }
 
-        Ok(())
+        Ok(true)
     }
 
     fn ensure_pass_color_target(

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -178,9 +178,6 @@ class MakepadSurface
     public void surfaceCreated(SurfaceHolder holder) {
         Surface surface = holder.getSurface();
         //surface.setFrameRate(120f,0);
-        Log.i("Makepad", "[" + SystemClock.uptimeMillis() + "] surfaceCreated"
-            + " size=" + getWidth() + "x" + getHeight()
-            + " surfaceValid=" + (surface != null && surface.isValid()));
         MakepadNative.surfaceOnSurfaceCreated(surface);
     }
 
@@ -194,9 +191,6 @@ class MakepadSurface
             }
         }
         Surface surface = holder.getSurface();
-        Log.i("Makepad", "[" + SystemClock.uptimeMillis() + "] surfaceDestroyed"
-            + " size=" + getWidth() + "x" + getHeight()
-            + " surfaceValid=" + (surface != null && surface.isValid()));
         MakepadNative.surfaceOnSurfaceDestroyed(surface);
     }
 
@@ -207,10 +201,6 @@ class MakepadSurface
                                int height) {
         Surface surface = holder.getSurface();
         //surface.setFrameRate(120f,0);
-        Log.i("Makepad", "[" + SystemClock.uptimeMillis() + "] surfaceChanged"
-            + " size=" + width + "x" + height
-            + " format=" + format
-            + " surfaceValid=" + (surface != null && surface.isValid()));
         MakepadNative.surfaceOnSurfaceChanged(surface, width, height);
 
     }
@@ -722,52 +712,6 @@ public class MakepadActivity
         System.loadLibrary("makepad");
     }
 
-    private String orientationSummary() {
-        int orientation = getResources().getConfiguration().orientation;
-        if (orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE) {
-            return "landscape";
-        }
-        if (orientation == android.content.res.Configuration.ORIENTATION_PORTRAIT) {
-            return "portrait";
-        }
-        return "undefined";
-    }
-
-    private String visibilitySummary(int visibility) {
-        if (visibility == View.VISIBLE) {
-            return "VISIBLE";
-        }
-        if (visibility == View.INVISIBLE) {
-            return "INVISIBLE";
-        }
-        if (visibility == View.GONE) {
-            return "GONE";
-        }
-        return Integer.toString(visibility);
-    }
-
-    private void logLifecycle(String message) {
-        Surface surface = null;
-        if (view != null && view.getHolder() != null) {
-            surface = view.getHolder().getSurface();
-        }
-        String surfaceSummary = view == null
-            ? "view=null"
-            : "view="
-                + view.getWidth() + "x" + view.getHeight()
-                + " vis=" + visibilitySummary(view.getVisibility())
-                + " surfaceValid=" + (surface != null && surface.isValid());
-        Log.i(LOG_TAG,
-            "[" + SystemClock.uptimeMillis() + "] "
-                + message
-                + " orient=" + orientationSummary()
-                + " focus=" + hasWindowFocus()
-                + " recovery=" + mSurfaceRecoveryOverlayVisible
-                + " snapshot=" + (mLatestSurfaceSnapshot != null)
-                + " " + surfaceSummary
-        );
-    }
-
     private void cacheWarmResumeSurfaceSnapshot(Bitmap snapshot) {
         if (snapshot == null) {
             return;
@@ -816,12 +760,10 @@ public class MakepadActivity
         mLatestSurfaceSnapshotOrientation = getResources().getConfiguration().orientation;
         updateSurfaceSnapshotBackdrop();
         clearWarmResumeSurfaceSnapshot();
-        logLifecycle("restoreWarmResumeSurfaceSnapshotIfAvailable success");
     }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        logLifecycle("onCreate begin");
         if (mWebSocketsThread == null || !mWebSocketsThread.isAlive()) {
             mWebSocketsThread = new HandlerThread("WebSocketsThread");
             mWebSocketsThread.start();
@@ -836,7 +778,6 @@ public class MakepadActivity
         }
         
         super.onCreate(savedInstanceState);
-        logLifecycle("onCreate after super");
         
         this.requestWindowFeature(Window.FEATURE_NO_TITLE);
 
@@ -926,9 +867,7 @@ public class MakepadActivity
         restoreWarmResumeSurfaceSnapshotIfAvailable();
         updateTaskDescription();
 
-        logLifecycle("calling MakepadNative.activityOnCreate");
         MakepadNative.activityOnCreate(this);
-        logLifecycle("returned from MakepadNative.activityOnCreate");
 
         mVideoPlaybackThread = new HandlerThread("VideoPlayerThread");
         mVideoPlaybackThread.start(); // TODO: only start this if its needed.
@@ -953,7 +892,6 @@ public class MakepadActivity
 
         float refreshRate = getDeviceRefreshRate();
         MakepadNative.initChoreographer(refreshRate, sdkVersion);
-        logLifecycle("onCreate complete");
         //% MAIN_ACTIVITY_ON_CREATE
         
     }
@@ -962,7 +900,6 @@ public class MakepadActivity
     protected void onStart() {
         super.onStart();
         restoreSurfaceViewForWarmResumeIfNeeded();
-        logLifecycle("onStart");
         MakepadNative.activityOnStart();
     }
 
@@ -970,7 +907,6 @@ public class MakepadActivity
     protected void onResume() {
         super.onResume();
         restoreSurfaceViewForWarmResumeIfNeeded();
-        logLifecycle("onResume");
         updateTaskDescription();
         MakepadNative.activityOnResume();
 
@@ -980,7 +916,6 @@ public class MakepadActivity
     protected void onPause() {
         prepareSurfaceSnapshotOverlayForPause();
         super.onPause();
-        logLifecycle("onPause");
         MakepadNative.activityOnPause();
 
         //% MAIN_ACTIVITY_ON_PAUSE
@@ -989,13 +924,11 @@ public class MakepadActivity
     @Override
     protected void onStop() {
         super.onStop();
-        logLifecycle("onStop");
         MakepadNative.activityOnStop();
     }
 
     @Override
     protected void onDestroy() {
-        logLifecycle("onDestroy begin switching=" + mIsSwitchingActivity);
         if (mCameraPreviewOverlay != null) {
             for (Long videoId : mCameraPreviewViews.keySet()) {
                 MakepadNative.onCameraPreviewSurfaceDestroyed(videoId);
@@ -1032,7 +965,6 @@ public class MakepadActivity
         }
         super.onDestroy();
         MakepadNative.activityOnDestroy();
-        logLifecycle("onDestroy complete");
     }
 
     @Override
@@ -1059,7 +991,6 @@ public class MakepadActivity
         super.onNewIntent(intent);
         setIntent(intent);
         restoreSurfaceViewForWarmResumeIfNeeded();
-        logLifecycle("onNewIntent");
     }
 
     @Override
@@ -1148,7 +1079,6 @@ public class MakepadActivity
 
     private void refreshSurfaceSnapshotCache() {
         if (!canCaptureSurfaceSnapshot()) {
-            logLifecycle("refreshSurfaceSnapshotCache skipped");
             return;
         }
 
@@ -1159,13 +1089,11 @@ public class MakepadActivity
         );
         PixelCopy.request(view, snapshot, copyResult -> {
             if (copyResult != PixelCopy.SUCCESS) {
-                logLifecycle("refreshSurfaceSnapshotCache failed result=" + copyResult);
                 return;
             }
             mLatestSurfaceSnapshot = snapshot;
             mLatestSurfaceSnapshotOrientation = getResources().getConfiguration().orientation;
             cacheWarmResumeSurfaceSnapshot(snapshot);
-            logLifecycle("refreshSurfaceSnapshotCache success");
             updateSurfaceSnapshotBackdrop();
             if (mSurfaceRecoveryOverlayVisible) {
                 showSurfaceRecoverySnapshotIfAvailable();
@@ -1174,10 +1102,8 @@ public class MakepadActivity
     }
 
     private void prepareSurfaceSnapshotOverlayForPause() {
-        logLifecycle("prepareSurfaceSnapshotOverlayForPause begin");
         if (!hasRecoverySnapshotAvailable()) {
             refreshSurfaceSnapshotCache();
-            logLifecycle("prepareSurfaceSnapshotOverlayForPause no snapshot");
             return;
         }
         mSurfaceRecoveryOverlayVisible = true;
@@ -1188,7 +1114,6 @@ public class MakepadActivity
         }
         showSurfaceRecoverySnapshotIfAvailable();
         refreshSurfaceSnapshotCache();
-        logLifecycle("prepareSurfaceSnapshotOverlayForPause end");
     }
 
     private void restoreSurfaceViewForWarmResumeIfNeeded() {
@@ -1211,7 +1136,6 @@ public class MakepadActivity
             mSurfaceCoverOverlay.bringToFront();
         }
         updateSurfaceSnapshotBackdrop();
-        logLifecycle("restoreSurfaceViewForWarmResumeIfNeeded");
     }
 
     private Bitmap createTaskDescriptionIconBitmap() {
@@ -1307,7 +1231,6 @@ public class MakepadActivity
             return;
         }
 
-        logLifecycle("applySurfaceCoverVisibility visible=" + visible);
         if (visible && !hasRecoverySnapshotAvailable()) {
             mSurfaceRecoveryOverlayVisible = false;
             if (view != null) {

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -1,6 +1,7 @@
 package dev.makepad.android;
 
 import android.app.Activity;
+import android.app.ActivityManager;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothManager;
@@ -11,9 +12,12 @@ import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.Manifest;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Insets;
 import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
@@ -37,6 +41,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
+import android.view.PixelCopy;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
@@ -59,6 +64,7 @@ import android.text.InputType;
 import android.text.Selection;
 import android.text.SpannableStringBuilder;
 import android.widget.FrameLayout;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 
 import java.io.BufferedReader;
@@ -172,12 +178,25 @@ class MakepadSurface
     public void surfaceCreated(SurfaceHolder holder) {
         Surface surface = holder.getSurface();
         //surface.setFrameRate(120f,0);
+        Log.i("Makepad", "[" + SystemClock.uptimeMillis() + "] surfaceCreated"
+            + " size=" + getWidth() + "x" + getHeight()
+            + " surfaceValid=" + (surface != null && surface.isValid()));
         MakepadNative.surfaceOnSurfaceCreated(surface);
     }
 
     @Override
     public void surfaceDestroyed(SurfaceHolder holder) {
+        Context context = getContext();
+        if (context instanceof MakepadActivity) {
+            MakepadActivity activity = (MakepadActivity) context;
+            if (activity.hasRecoverySnapshotAvailable()) {
+                activity.setSurfaceCoverVisible(true);
+            }
+        }
         Surface surface = holder.getSurface();
+        Log.i("Makepad", "[" + SystemClock.uptimeMillis() + "] surfaceDestroyed"
+            + " size=" + getWidth() + "x" + getHeight()
+            + " surfaceValid=" + (surface != null && surface.isValid()));
         MakepadNative.surfaceOnSurfaceDestroyed(surface);
     }
 
@@ -188,6 +207,10 @@ class MakepadSurface
                                int height) {
         Surface surface = holder.getSurface();
         //surface.setFrameRate(120f,0);
+        Log.i("Makepad", "[" + SystemClock.uptimeMillis() + "] surfaceChanged"
+            + " size=" + width + "x" + height
+            + " format=" + format
+            + " surfaceValid=" + (surface != null && surface.isValid()));
         MakepadNative.surfaceOnSurfaceChanged(surface, width, height);
 
     }
@@ -610,9 +633,9 @@ class ResizingLayout
 
     public ResizingLayout(Context context){
         super(context);
-        // When viewing in landscape mode with keyboard shown, there are
-        // gaps on both sides so we fill the negative space with black.
-        setBackgroundColor(Color.BLACK);
+        // Keep a stable non-black fallback behind the SurfaceView for task snapshots
+        // and system transition frames that cannot capture the separate surface layer.
+        setBackgroundResource(R.drawable.makepad_launch_background);
         setOnApplyWindowInsetsListener(this);
     }
 
@@ -643,6 +666,12 @@ public class MakepadActivity
     implements MidiManager.OnDeviceOpenedListener
 {
     private static final String LOG_TAG = "Makepad";
+    private static final long SURFACE_COVER_FADE_OUT_MS = 100;
+    private static final long WARM_RESUME_SNAPSHOT_MAX_AGE_MS = 10000;
+    private static final int TASK_DESCRIPTION_BACKGROUND_COLOR = 0xFFF5F7FA;
+    private static Bitmap sWarmResumeSurfaceSnapshot;
+    private static long sWarmResumeSurfaceSnapshotUptimeMs;
+    private static int sWarmResumeSurfaceSnapshotOrientation = android.content.res.Configuration.ORIENTATION_UNDEFINED;
     //% MAIN_ACTIVITY_BODY
 
     private MakepadSurface view;
@@ -669,8 +698,14 @@ public class MakepadActivity
 
     // native camera preview overlays
     private FrameLayout mRootLayout;
+    private FrameLayout mSurfaceCoverOverlay;
+    private ImageView mSurfaceSnapshotBackdrop;
+    private ImageView mSurfaceSnapshotOverlay;
     private FrameLayout mCameraPreviewOverlay;
     private HashMap<Long, CameraPreviewSurface> mCameraPreviewViews = new HashMap<>();
+    private Bitmap mLatestSurfaceSnapshot;
+    private int mLatestSurfaceSnapshotOrientation = android.content.res.Configuration.ORIENTATION_UNDEFINED;
+    private boolean mSurfaceRecoveryOverlayVisible = false;
 
     // selection handles overlay
     private static final int SELECTION_HANDLE_START = 0;
@@ -687,7 +722,101 @@ public class MakepadActivity
         System.loadLibrary("makepad");
     }
 
+    private String orientationSummary() {
+        int orientation = getResources().getConfiguration().orientation;
+        if (orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE) {
+            return "landscape";
+        }
+        if (orientation == android.content.res.Configuration.ORIENTATION_PORTRAIT) {
+            return "portrait";
+        }
+        return "undefined";
+    }
+
+    private String visibilitySummary(int visibility) {
+        if (visibility == View.VISIBLE) {
+            return "VISIBLE";
+        }
+        if (visibility == View.INVISIBLE) {
+            return "INVISIBLE";
+        }
+        if (visibility == View.GONE) {
+            return "GONE";
+        }
+        return Integer.toString(visibility);
+    }
+
     private void logLifecycle(String message) {
+        Surface surface = null;
+        if (view != null && view.getHolder() != null) {
+            surface = view.getHolder().getSurface();
+        }
+        String surfaceSummary = view == null
+            ? "view=null"
+            : "view="
+                + view.getWidth() + "x" + view.getHeight()
+                + " vis=" + visibilitySummary(view.getVisibility())
+                + " surfaceValid=" + (surface != null && surface.isValid());
+        Log.i(LOG_TAG,
+            "[" + SystemClock.uptimeMillis() + "] "
+                + message
+                + " orient=" + orientationSummary()
+                + " focus=" + hasWindowFocus()
+                + " recovery=" + mSurfaceRecoveryOverlayVisible
+                + " snapshot=" + (mLatestSurfaceSnapshot != null)
+                + " " + surfaceSummary
+        );
+    }
+
+    private void cacheWarmResumeSurfaceSnapshot(Bitmap snapshot) {
+        if (snapshot == null) {
+            return;
+        }
+        sWarmResumeSurfaceSnapshot = snapshot;
+        sWarmResumeSurfaceSnapshotUptimeMs = SystemClock.uptimeMillis();
+        sWarmResumeSurfaceSnapshotOrientation = getResources().getConfiguration().orientation;
+    }
+
+    private boolean canRestoreWarmResumeSurfaceSnapshot() {
+        if (sWarmResumeSurfaceSnapshot == null) {
+            return false;
+        }
+        if (SystemClock.uptimeMillis() - sWarmResumeSurfaceSnapshotUptimeMs > WARM_RESUME_SNAPSHOT_MAX_AGE_MS) {
+            return false;
+        }
+        int orientation = getResources().getConfiguration().orientation;
+        return sWarmResumeSurfaceSnapshotOrientation == android.content.res.Configuration.ORIENTATION_UNDEFINED
+            || sWarmResumeSurfaceSnapshotOrientation == orientation;
+    }
+
+    private void clearWarmResumeSurfaceSnapshot() {
+        sWarmResumeSurfaceSnapshot = null;
+        sWarmResumeSurfaceSnapshotUptimeMs = 0;
+        sWarmResumeSurfaceSnapshotOrientation = android.content.res.Configuration.ORIENTATION_UNDEFINED;
+    }
+
+    boolean hasRecoverySnapshotAvailable() {
+        return mLatestSurfaceSnapshot != null;
+    }
+
+    private boolean hasCurrentOrientationRecoverySnapshot() {
+        if (mLatestSurfaceSnapshot == null) {
+            return false;
+        }
+        int orientation = getResources().getConfiguration().orientation;
+        return mLatestSurfaceSnapshotOrientation == android.content.res.Configuration.ORIENTATION_UNDEFINED
+            || mLatestSurfaceSnapshotOrientation == orientation;
+    }
+
+    private void restoreWarmResumeSurfaceSnapshotIfAvailable() {
+        if (!canRestoreWarmResumeSurfaceSnapshot()) {
+            return;
+        }
+        mLatestSurfaceSnapshot = sWarmResumeSurfaceSnapshot;
+        mLatestSurfaceSnapshotOrientation = getResources().getConfiguration().orientation;
+        updateSurfaceSnapshotBackdrop();
+        clearWarmResumeSurfaceSnapshot();
+        logLifecycle("restoreWarmResumeSurfaceSnapshotIfAvailable success");
     }
 
     @Override
@@ -701,9 +830,9 @@ public class MakepadActivity
 
         // On API 30+, Theme.NoTitleBar.Fullscreen sets FLAG_FULLSCREEN which positions
         // the window below the status bar, conflicting with the modern WindowInsetsController.
-        // Switch to a non-fullscreen theme and handle fullscreen programmatically.
+        // Switch from the launch theme to the app theme and handle fullscreen programmatically.
         if (Build.VERSION.SDK_INT >= 30) {
-            setTheme(android.R.style.Theme_DeviceDefault_NoActionBar);
+            setTheme(R.style.MakepadAppTheme);
         }
         
         super.onCreate(savedInstanceState);
@@ -718,10 +847,59 @@ public class MakepadActivity
         view = new MakepadSurface(this);
         // Put it inside a parent layout which can resize it using padding
         ResizingLayout layout = new ResizingLayout(this);
-        layout.addView(view);
+        FrameLayout surfaceContentLayout = new FrameLayout(this);
+        surfaceContentLayout.setLayoutParams(new LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT
+        ));
+        surfaceContentLayout.setBackgroundResource(R.drawable.makepad_launch_background);
+
+        mSurfaceSnapshotBackdrop = new ImageView(this);
+        mSurfaceSnapshotBackdrop.setLayoutParams(new FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT
+        ));
+        mSurfaceSnapshotBackdrop.setBackgroundResource(R.drawable.makepad_launch_background);
+        mSurfaceSnapshotBackdrop.setScaleType(ImageView.ScaleType.FIT_CENTER);
+        mSurfaceSnapshotBackdrop.setClickable(false);
+        mSurfaceSnapshotBackdrop.setFocusable(false);
+        mSurfaceSnapshotBackdrop.setVisibility(View.GONE);
+        surfaceContentLayout.addView(mSurfaceSnapshotBackdrop);
+
+        view.setLayoutParams(new FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT
+        ));
+        surfaceContentLayout.addView(view);
+        layout.addView(surfaceContentLayout);
 
         mRootLayout = new FrameLayout(this);
         mRootLayout.addView(layout);
+
+        mSurfaceCoverOverlay = new FrameLayout(this);
+        mSurfaceCoverOverlay.setLayoutParams(new FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT
+        ));
+        mSurfaceCoverOverlay.setBackgroundResource(R.drawable.makepad_launch_background);
+        mSurfaceCoverOverlay.setClickable(false);
+        mSurfaceCoverOverlay.setFocusable(false);
+        mSurfaceCoverOverlay.setAlpha(1.0f);
+        mSurfaceCoverOverlay.setVisibility(View.GONE);
+        mRootLayout.addView(mSurfaceCoverOverlay);
+
+        mSurfaceSnapshotOverlay = new ImageView(this);
+        mSurfaceSnapshotOverlay.setLayoutParams(new FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT
+        ));
+        mSurfaceSnapshotOverlay.setBackgroundResource(R.drawable.makepad_launch_background);
+        mSurfaceSnapshotOverlay.setScaleType(ImageView.ScaleType.FIT_CENTER);
+        mSurfaceSnapshotOverlay.setClickable(false);
+        mSurfaceSnapshotOverlay.setFocusable(false);
+        mSurfaceSnapshotOverlay.setAlpha(1.0f);
+        mSurfaceSnapshotOverlay.setVisibility(View.GONE);
+        mRootLayout.addView(mSurfaceSnapshotOverlay);
 
         mCameraPreviewOverlay = new FrameLayout(this);
         mRootLayout.addView(mCameraPreviewOverlay);
@@ -745,6 +923,8 @@ public class MakepadActivity
         mSelectionHandleOverlay.addView(mSelectionHandleEnd);
 
         setContentView(mRootLayout);
+        restoreWarmResumeSurfaceSnapshotIfAvailable();
+        updateTaskDescription();
 
         logLifecycle("calling MakepadNative.activityOnCreate");
         MakepadNative.activityOnCreate(this);
@@ -781,6 +961,7 @@ public class MakepadActivity
     @Override
     protected void onStart() {
         super.onStart();
+        restoreSurfaceViewForWarmResumeIfNeeded();
         logLifecycle("onStart");
         MakepadNative.activityOnStart();
     }
@@ -788,13 +969,16 @@ public class MakepadActivity
     @Override
     protected void onResume() {
         super.onResume();
+        restoreSurfaceViewForWarmResumeIfNeeded();
         logLifecycle("onResume");
+        updateTaskDescription();
         MakepadNative.activityOnResume();
 
         //% MAIN_ACTIVITY_ON_RESUME
     }
     @Override
     protected void onPause() {
+        prepareSurfaceSnapshotOverlayForPause();
         super.onPause();
         logLifecycle("onPause");
         MakepadNative.activityOnPause();
@@ -825,6 +1009,21 @@ public class MakepadActivity
             mSelectionHandleStart = null;
             mSelectionHandleEnd = null;
         }
+        if (mSurfaceCoverOverlay != null) {
+            mRootLayout.removeView(mSurfaceCoverOverlay);
+            mSurfaceCoverOverlay = null;
+        }
+        if (mSurfaceSnapshotBackdrop != null) {
+            mSurfaceSnapshotBackdrop.setImageBitmap(null);
+            mSurfaceSnapshotBackdrop = null;
+        }
+        if (mSurfaceSnapshotOverlay != null) {
+            mSurfaceSnapshotOverlay.setImageBitmap(null);
+            mRootLayout.removeView(mSurfaceSnapshotOverlay);
+            mSurfaceSnapshotOverlay = null;
+        }
+        mLatestSurfaceSnapshot = null;
+        mLatestSurfaceSnapshotOrientation = android.content.res.Configuration.ORIENTATION_UNDEFINED;
         cleanupVideoPlaybackState();
         shutdownVideoPlaybackThread();
         if (!mIsSwitchingActivity) {
@@ -847,6 +1046,20 @@ public class MakepadActivity
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
         MakepadNative.activityOnWindowFocusChanged(hasFocus);
+    }
+
+    @Override
+    protected void onUserLeaveHint() {
+        prepareSurfaceSnapshotOverlayForPause();
+        super.onUserLeaveHint();
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        restoreSurfaceViewForWarmResumeIfNeeded();
+        logLifecycle("onNewIntent");
     }
 
     @Override
@@ -920,6 +1133,288 @@ public class MakepadActivity
                     applyFullScreen(fullscreen);
                 }
             });
+    }
+
+    private boolean canCaptureSurfaceSnapshot() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return false;
+        }
+        if (view == null || view.getWidth() <= 0 || view.getHeight() <= 0) {
+            return false;
+        }
+        Surface surface = view.getHolder().getSurface();
+        return surface != null && surface.isValid();
+    }
+
+    private void refreshSurfaceSnapshotCache() {
+        if (!canCaptureSurfaceSnapshot()) {
+            logLifecycle("refreshSurfaceSnapshotCache skipped");
+            return;
+        }
+
+        final Bitmap snapshot = Bitmap.createBitmap(
+            view.getWidth(),
+            view.getHeight(),
+            Bitmap.Config.ARGB_8888
+        );
+        PixelCopy.request(view, snapshot, copyResult -> {
+            if (copyResult != PixelCopy.SUCCESS) {
+                logLifecycle("refreshSurfaceSnapshotCache failed result=" + copyResult);
+                return;
+            }
+            mLatestSurfaceSnapshot = snapshot;
+            mLatestSurfaceSnapshotOrientation = getResources().getConfiguration().orientation;
+            cacheWarmResumeSurfaceSnapshot(snapshot);
+            logLifecycle("refreshSurfaceSnapshotCache success");
+            updateSurfaceSnapshotBackdrop();
+            if (mSurfaceRecoveryOverlayVisible) {
+                showSurfaceRecoverySnapshotIfAvailable();
+            }
+        }, new Handler(Looper.getMainLooper()));
+    }
+
+    private void prepareSurfaceSnapshotOverlayForPause() {
+        logLifecycle("prepareSurfaceSnapshotOverlayForPause begin");
+        if (!hasRecoverySnapshotAvailable()) {
+            refreshSurfaceSnapshotCache();
+            logLifecycle("prepareSurfaceSnapshotOverlayForPause no snapshot");
+            return;
+        }
+        mSurfaceRecoveryOverlayVisible = true;
+        cacheWarmResumeSurfaceSnapshot(mLatestSurfaceSnapshot);
+        updateSurfaceSnapshotBackdrop();
+        if (view != null) {
+            view.setVisibility(View.INVISIBLE);
+        }
+        showSurfaceRecoverySnapshotIfAvailable();
+        refreshSurfaceSnapshotCache();
+        logLifecycle("prepareSurfaceSnapshotOverlayForPause end");
+    }
+
+    private void restoreSurfaceViewForWarmResumeIfNeeded() {
+        if (!mSurfaceRecoveryOverlayVisible || view == null) {
+            return;
+        }
+
+        Surface surface = view.getHolder().getSurface();
+        boolean surfaceValid = surface != null && surface.isValid();
+        if (view.getVisibility() == View.VISIBLE && surfaceValid) {
+            return;
+        }
+
+        // Keep the recovery overlay visible, but restore the SurfaceView itself
+        // so Android can recreate its surface on same-activity warm resumes.
+        view.setVisibility(View.VISIBLE);
+        if (!showSurfaceRecoverySnapshotIfAvailable() && mSurfaceCoverOverlay != null) {
+            mSurfaceCoverOverlay.setAlpha(1.0f);
+            mSurfaceCoverOverlay.setVisibility(View.VISIBLE);
+            mSurfaceCoverOverlay.bringToFront();
+        }
+        updateSurfaceSnapshotBackdrop();
+        logLifecycle("restoreSurfaceViewForWarmResumeIfNeeded");
+    }
+
+    private Bitmap createTaskDescriptionIconBitmap() {
+        int iconResId = getApplicationIconResId();
+        if (iconResId == 0) {
+            return null;
+        }
+        Drawable drawable = getDrawable(iconResId);
+        if (drawable == null) {
+            return null;
+        }
+        int width = Math.max(1, drawable.getIntrinsicWidth());
+        int height = Math.max(1, drawable.getIntrinsicHeight());
+        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        drawable.setBounds(0, 0, width, height);
+        drawable.draw(canvas);
+        return bitmap;
+    }
+
+    @SuppressWarnings("deprecation")
+    private void updateTaskDescription() {
+        try {
+            String label = getApplicationName();
+            int iconResId = getApplicationIconResId();
+            ActivityManager.TaskDescription taskDescription;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                taskDescription = new ActivityManager.TaskDescription.Builder()
+                    .setLabel(label)
+                    .setIcon(iconResId)
+                    .setPrimaryColor(TASK_DESCRIPTION_BACKGROUND_COLOR)
+                    .setBackgroundColor(TASK_DESCRIPTION_BACKGROUND_COLOR)
+                    .build();
+            }
+            else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                taskDescription = new ActivityManager.TaskDescription(
+                    label,
+                    iconResId,
+                    TASK_DESCRIPTION_BACKGROUND_COLOR
+                );
+            }
+            else {
+                taskDescription = new ActivityManager.TaskDescription(
+                    label,
+                    createTaskDescriptionIconBitmap(),
+                    TASK_DESCRIPTION_BACKGROUND_COLOR
+                );
+            }
+            setTaskDescription(taskDescription);
+        }
+        catch (Throwable throwable) {
+            Log.w(LOG_TAG, "Failed to update task description", throwable);
+        }
+    }
+
+    private void updateSurfaceSnapshotBackdrop() {
+        if (mSurfaceSnapshotBackdrop == null) {
+            return;
+        }
+
+        if (hasCurrentOrientationRecoverySnapshot()) {
+            mSurfaceSnapshotBackdrop.setImageBitmap(mLatestSurfaceSnapshot);
+            mSurfaceSnapshotBackdrop.setVisibility(View.VISIBLE);
+            return;
+        }
+
+        mSurfaceSnapshotBackdrop.setImageBitmap(null);
+        mSurfaceSnapshotBackdrop.setVisibility(View.GONE);
+    }
+
+    private boolean showSurfaceRecoverySnapshotIfAvailable() {
+        if (mSurfaceSnapshotOverlay == null || mSurfaceCoverOverlay == null) {
+            return false;
+        }
+
+        if (hasCurrentOrientationRecoverySnapshot()) {
+            mSurfaceSnapshotOverlay.setImageBitmap(mLatestSurfaceSnapshot);
+            mSurfaceSnapshotOverlay.setAlpha(1.0f);
+            mSurfaceSnapshotOverlay.setVisibility(View.VISIBLE);
+            mSurfaceSnapshotOverlay.bringToFront();
+            mSurfaceCoverOverlay.setVisibility(View.GONE);
+            mSurfaceCoverOverlay.setAlpha(1.0f);
+            return true;
+        }
+
+        mSurfaceSnapshotOverlay.setImageBitmap(null);
+        mSurfaceSnapshotOverlay.setVisibility(View.GONE);
+        return false;
+    }
+
+    private void applySurfaceCoverVisibility(boolean visible) {
+        if (mSurfaceCoverOverlay == null || mSurfaceSnapshotOverlay == null) {
+            return;
+        }
+
+        logLifecycle("applySurfaceCoverVisibility visible=" + visible);
+        if (visible && !hasRecoverySnapshotAvailable()) {
+            mSurfaceRecoveryOverlayVisible = false;
+            if (view != null) {
+                view.setVisibility(View.VISIBLE);
+            }
+            return;
+        }
+        mSurfaceRecoveryOverlayVisible = visible;
+        if (view != null) {
+            view.setVisibility(visible ? View.INVISIBLE : view.getVisibility());
+        }
+        if (visible) {
+            refreshSurfaceSnapshotCache();
+        }
+
+        mSurfaceCoverOverlay.animate().cancel();
+        mSurfaceSnapshotOverlay.animate().cancel();
+        if (visible) {
+            if (showSurfaceRecoverySnapshotIfAvailable()) {
+                return;
+            }
+            mSurfaceCoverOverlay.setAlpha(1.0f);
+            mSurfaceCoverOverlay.setVisibility(View.VISIBLE);
+            mSurfaceCoverOverlay.bringToFront();
+            return;
+        }
+
+        if (mSurfaceCoverOverlay.getVisibility() != View.VISIBLE
+            && mSurfaceSnapshotOverlay.getVisibility() != View.VISIBLE) {
+            mSurfaceCoverOverlay.setAlpha(1.0f);
+            mSurfaceSnapshotOverlay.setAlpha(1.0f);
+            if (view != null) {
+                view.setVisibility(View.VISIBLE);
+            }
+            clearWarmResumeSurfaceSnapshot();
+            return;
+        }
+
+        final FrameLayout surfaceCoverOverlay = mSurfaceCoverOverlay;
+        final ImageView surfaceSnapshotOverlay = mSurfaceSnapshotOverlay;
+        if (surfaceSnapshotOverlay.getVisibility() == View.VISIBLE) {
+            surfaceCoverOverlay.setVisibility(View.GONE);
+            surfaceCoverOverlay.setAlpha(1.0f);
+            surfaceSnapshotOverlay.animate()
+                .alpha(0.0f)
+                .setDuration(SURFACE_COVER_FADE_OUT_MS)
+                .withEndAction(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (mSurfaceCoverOverlay != surfaceCoverOverlay
+                            || mSurfaceSnapshotOverlay != surfaceSnapshotOverlay) {
+                            return;
+                        }
+                        surfaceSnapshotOverlay.setVisibility(View.GONE);
+                        surfaceSnapshotOverlay.setAlpha(1.0f);
+                        if (view != null) {
+                            view.setVisibility(View.VISIBLE);
+                        }
+                        clearWarmResumeSurfaceSnapshot();
+                    }
+                });
+            return;
+        }
+
+        surfaceCoverOverlay.animate()
+            .alpha(0.0f)
+            .setDuration(SURFACE_COVER_FADE_OUT_MS)
+            .withEndAction(new Runnable() {
+                @Override
+                public void run() {
+                    if (mSurfaceCoverOverlay != surfaceCoverOverlay) {
+                        return;
+                    }
+                    surfaceCoverOverlay.setVisibility(View.GONE);
+                    surfaceCoverOverlay.setAlpha(1.0f);
+                    if (view != null) {
+                        view.setVisibility(View.VISIBLE);
+                    }
+                    clearWarmResumeSurfaceSnapshot();
+                }
+            });
+    }
+
+    public void setSurfaceCoverVisible(final boolean visible) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            applySurfaceCoverVisibility(visible);
+            return;
+        }
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                applySurfaceCoverVisibility(visible);
+            }
+        });
+    }
+
+    public void requestSurfaceSnapshotRefresh() {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            refreshSurfaceSnapshotCache();
+            return;
+        }
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                refreshSurfaceSnapshotCache();
+            }
+        });
     }
 
     @SuppressWarnings("deprecation")
@@ -1112,6 +1607,11 @@ public class MakepadActivity
         ApplicationInfo applicationInfo = getApplicationContext().getApplicationInfo();
         CharSequence appName = applicationInfo.loadLabel(getPackageManager());
         return appName.toString();
+    }
+
+    private int getApplicationIconResId() {
+        ApplicationInfo applicationInfo = getApplicationContext().getApplicationInfo();
+        return applicationInfo.icon;
     }
 
     public void showClipboardActions(final boolean hasSelection, final int left, final int top, final int right, final int bottom, final int keyboardShift) {

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -7,6 +7,7 @@ import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothManager;
 import android.content.ClipData;
 import android.content.ClipboardManager;
+import android.content.ComponentCallbacks2;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
@@ -665,7 +666,7 @@ public class MakepadActivity
     //% MAIN_ACTIVITY_BODY
 
     private MakepadSurface view;
-    Handler mHandler;
+    private final Handler mHandler = new Handler(Looper.getMainLooper());
 
     // video playback
     Handler mVideoPlaybackHandler;
@@ -695,6 +696,7 @@ public class MakepadActivity
     private HashMap<Long, CameraPreviewSurface> mCameraPreviewViews = new HashMap<>();
     private Bitmap mLatestSurfaceSnapshot;
     private int mLatestSurfaceSnapshotOrientation = android.content.res.Configuration.ORIENTATION_UNDEFINED;
+    private boolean mSurfaceSnapshotCopyInFlight = false;
     private boolean mSurfaceRecoveryOverlayVisible = false;
 
     // selection handles overlay
@@ -726,6 +728,7 @@ public class MakepadActivity
             return false;
         }
         if (SystemClock.uptimeMillis() - sWarmResumeSurfaceSnapshotUptimeMs > WARM_RESUME_SNAPSHOT_MAX_AGE_MS) {
+            clearWarmResumeSurfaceSnapshot();
             return false;
         }
         int orientation = getResources().getConfiguration().orientation;
@@ -737,6 +740,33 @@ public class MakepadActivity
         sWarmResumeSurfaceSnapshot = null;
         sWarmResumeSurfaceSnapshotUptimeMs = 0;
         sWarmResumeSurfaceSnapshotOrientation = android.content.res.Configuration.ORIENTATION_UNDEFINED;
+    }
+
+    private void clearLatestSurfaceSnapshot() {
+        mLatestSurfaceSnapshot = null;
+        mLatestSurfaceSnapshotOrientation = android.content.res.Configuration.ORIENTATION_UNDEFINED;
+    }
+
+    private void trimSurfaceSnapshotCaches() {
+        clearWarmResumeSurfaceSnapshot();
+        clearLatestSurfaceSnapshot();
+
+        if (mSurfaceSnapshotBackdrop != null) {
+            mSurfaceSnapshotBackdrop.setImageBitmap(null);
+            mSurfaceSnapshotBackdrop.setVisibility(View.GONE);
+        }
+        if (mSurfaceSnapshotOverlay != null) {
+            mSurfaceSnapshotOverlay.animate().cancel();
+            mSurfaceSnapshotOverlay.setImageBitmap(null);
+            mSurfaceSnapshotOverlay.setAlpha(1.0f);
+            mSurfaceSnapshotOverlay.setVisibility(View.GONE);
+        }
+        if (mSurfaceRecoveryOverlayVisible && mSurfaceCoverOverlay != null) {
+            mSurfaceCoverOverlay.animate().cancel();
+            mSurfaceCoverOverlay.setAlpha(1.0f);
+            mSurfaceCoverOverlay.setVisibility(View.VISIBLE);
+            mSurfaceCoverOverlay.bringToFront();
+        }
     }
 
     boolean hasRecoverySnapshotAvailable() {
@@ -955,8 +985,8 @@ public class MakepadActivity
             mRootLayout.removeView(mSurfaceSnapshotOverlay);
             mSurfaceSnapshotOverlay = null;
         }
-        mLatestSurfaceSnapshot = null;
-        mLatestSurfaceSnapshotOrientation = android.content.res.Configuration.ORIENTATION_UNDEFINED;
+        clearLatestSurfaceSnapshot();
+        mSurfaceSnapshotCopyInFlight = false;
         cleanupVideoPlaybackState();
         shutdownVideoPlaybackThread();
         if (!mIsSwitchingActivity) {
@@ -965,6 +995,29 @@ public class MakepadActivity
         }
         super.onDestroy();
         MakepadNative.activityOnDestroy();
+    }
+
+    @Override
+    public void onTrimMemory(int level) {
+        super.onTrimMemory(level);
+        switch (level) {
+            case ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE:
+            case ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW:
+            case ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL:
+            case ComponentCallbacks2.TRIM_MEMORY_BACKGROUND:
+            case ComponentCallbacks2.TRIM_MEMORY_MODERATE:
+            case ComponentCallbacks2.TRIM_MEMORY_COMPLETE:
+                trimSurfaceSnapshotCaches();
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    public void onLowMemory() {
+        super.onLowMemory();
+        trimSurfaceSnapshotCaches();
     }
 
     @Override
@@ -1078,9 +1131,10 @@ public class MakepadActivity
     }
 
     private void refreshSurfaceSnapshotCache() {
-        if (!canCaptureSurfaceSnapshot()) {
+        if (!canCaptureSurfaceSnapshot() || mSurfaceSnapshotCopyInFlight) {
             return;
         }
+        mSurfaceSnapshotCopyInFlight = true;
 
         final Bitmap snapshot = Bitmap.createBitmap(
             view.getWidth(),
@@ -1088,6 +1142,7 @@ public class MakepadActivity
             Bitmap.Config.ARGB_8888
         );
         PixelCopy.request(view, snapshot, copyResult -> {
+            mSurfaceSnapshotCopyInFlight = false;
             if (copyResult != PixelCopy.SUCCESS) {
                 return;
             }
@@ -1098,10 +1153,13 @@ public class MakepadActivity
             if (mSurfaceRecoveryOverlayVisible) {
                 showSurfaceRecoverySnapshotIfAvailable();
             }
-        }, new Handler(Looper.getMainLooper()));
+        }, mHandler);
     }
 
     private void prepareSurfaceSnapshotOverlayForPause() {
+        if (mSurfaceRecoveryOverlayVisible && view != null && view.getVisibility() != View.VISIBLE) {
+            return;
+        }
         if (!hasRecoverySnapshotAvailable()) {
             refreshSurfaceSnapshotCache();
             return;
@@ -1231,10 +1289,22 @@ public class MakepadActivity
             return;
         }
 
+        boolean wasRecoveryOverlayVisible = mSurfaceRecoveryOverlayVisible;
         if (visible && !hasRecoverySnapshotAvailable()) {
-            mSurfaceRecoveryOverlayVisible = false;
+            mSurfaceRecoveryOverlayVisible = true;
             if (view != null) {
-                view.setVisibility(View.VISIBLE);
+                view.setVisibility(View.INVISIBLE);
+            }
+            mSurfaceCoverOverlay.animate().cancel();
+            mSurfaceSnapshotOverlay.animate().cancel();
+            mSurfaceSnapshotOverlay.setImageBitmap(null);
+            mSurfaceSnapshotOverlay.setVisibility(View.GONE);
+            mSurfaceSnapshotOverlay.setAlpha(1.0f);
+            mSurfaceCoverOverlay.setAlpha(1.0f);
+            mSurfaceCoverOverlay.setVisibility(View.VISIBLE);
+            mSurfaceCoverOverlay.bringToFront();
+            if (!wasRecoveryOverlayVisible) {
+                refreshSurfaceSnapshotCache();
             }
             return;
         }
@@ -1242,7 +1312,7 @@ public class MakepadActivity
         if (view != null) {
             view.setVisibility(visible ? View.INVISIBLE : view.getVisibility());
         }
-        if (visible) {
+        if (visible && !wasRecoveryOverlayVisible) {
             refreshSurfaceSnapshotCache();
         }
 
@@ -1939,7 +2009,7 @@ public class MakepadActivity
                     if(device.getType() == BluetoothDevice.DEVICE_TYPE_LE){
                         String name =device.getName();
                         bt_names.add(name);
-                        mm.openBluetoothDevice(device, this, new Handler(Looper.getMainLooper()));
+                        mm.openBluetoothDevice(device, this, mHandler);
                     }
                 }
                 // this appears to give you nonworking BLE midi devices. So we skip those by name (not perfect but ok)
@@ -1953,7 +2023,7 @@ public class MakepadActivity
                         }
                     }
                     if(!found){
-                        mm.openDevice(info, this, new Handler(Looper.getMainLooper()));
+                        mm.openDevice(info, this, mHandler);
                     }
                 }
             }

--- a/tools/cargo_makepad/src/android/mod.rs
+++ b/tools/cargo_makepad/src/android/mod.rs
@@ -68,6 +68,7 @@ impl AndroidVariant {
                     android:name=".{class_name}"
                     android:configChanges="orientation|screenSize|keyboardHidden"
                     android:exported="true"
+                    android:launchMode="singleTask"
                     android:theme="@style/MakepadLaunchTheme">
                     <intent-filter>
                         <action android:name="android.intent.action.MAIN" />
@@ -598,6 +599,7 @@ mod tests {
             AndroidVariant::Default.manifest_xml("App", "MakepadApp", "dev.makepad.app", 33, true);
         assert!(xml.contains("android:theme=\"@style/MakepadAppTheme\""));
         assert!(xml.contains("android:theme=\"@style/MakepadLaunchTheme\""));
+        assert!(xml.contains("android:launchMode=\"singleTask\""));
     }
 
     #[test]

--- a/tools/cargo_makepad/src/android/res/drawable/makepad_launch_background.xml
+++ b/tools/cargo_makepad/src/android/res/drawable/makepad_launch_background.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@android:color/white" />
-    <item>
-        <bitmap
-            android:src="@android:drawable/sym_def_app_icon"
-            android:gravity="center" />
-    </item>
-</layer-list>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#FFF5F7FA" />
+</shape>

--- a/tools/cargo_makepad/src/android/res/values-v31/styles.xml
+++ b/tools/cargo_makepad/src/android/res/values-v31/styles.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="MakepadLaunchTheme" parent="@style/MakepadAppTheme">
-        <item name="android:windowSplashScreenBackground">#FFFFFF</item>
-        <item name="android:windowSplashScreenAnimatedIcon">@android:drawable/sym_def_app_icon</item>
+        <item name="android:windowSplashScreenBackground">#FFF5F7FA</item>
         <item name="android:windowSplashScreenAnimationDuration">0</item>
     </style>
 </resources>


### PR DESCRIPTION
pretty much a full rework of Android surface lifecycle handling.
Should eliminate black frames on start, black frame flicker on resume,
weird visual artifacts where the splash screen shows for a split second, etc.

Details of all changes:

- bootstrap Android startup from the first sized surface and seed the
  initial display metrics before app startup
- track drawable-surface state more accurately for EGL and Vulkan and
  force the first redraw after surface creation/recreation
- coordinate Java and Rust surface-cover behavior through new JNI hooks
  so the cover is hidden only after the first successful present
- add Java-side snapshot-backed recovery overlays for pause/resume,
  including same-activity warm resumes and orientation-aware snapshot use
- avoid stale launcher/task artifacts by using a neutral launch
  background and singleTask activity launch mode
- refresh cached snapshots after the first present so backgrounding does
  not fall back to black
- coalesce duplicate snapshot refresh work, reuse the main-thread
  handler, and clear cached snapshots on memory pressure
- remove temporary Java lifecycle tracing after the recovery path was
  stabilized
