### PR TITLE
Ensure .notdef glyph for unsupported characters is visibly drawn

### DIFF
--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -603,7 +603,7 @@ impl DrawText {
     ) -> Rc<LaidoutText> {
         self.text_style
             .font_family
-            .ensure_fonts_loaded_for_text(cx, Some(text));
+            .ensure_fonts_loaded(cx);
         let fonts = cx.get_global::<Rc<RefCell<Fonts>>>().clone();
         let mut fonts = fonts.borrow_mut();
 
@@ -900,13 +900,10 @@ impl FontFamily {
         (self.id.0).into()
     }
 
-    fn update_font_definitions(&self, cx: &mut Cx, fonts: &mut Fonts, text: Option<&str>) {
+    fn update_font_definitions(&self, cx: &mut Cx, fonts: &mut Fonts) {
         let mut font_ids = Vec::new();
 
         for member in &self.members {
-            if !font_member_is_needed_for_text(cx, member.handle, text) {
-                continue;
-            }
             let font_id = font_member_font_id(member);
 
             if !fonts.is_font_known(font_id) {
@@ -941,7 +938,7 @@ impl FontFamily {
         );
     }
 
-    fn ensure_fonts_loaded_for_text(&self, cx: &mut Cx, text: Option<&str>) {
+    fn ensure_fonts_loaded(&self, cx: &mut Cx) {
         CxDraw::lazy_construct_fonts(cx);
 
         let family_id = self.to_font_family_id();
@@ -954,11 +951,7 @@ impl FontFamily {
             }
         }
 
-        // Slow path: request only the resources needed by this family, then re-check.
         for member in &self.members {
-            if !font_member_is_needed_for_text(cx, member.handle, text) {
-                continue;
-            }
             cx.load_script_resource(member.handle);
         }
         {
@@ -969,49 +962,8 @@ impl FontFamily {
         }
 
         let mut fonts_ref = fonts.borrow_mut();
-        self.update_font_definitions(cx, &mut fonts_ref, text);
+        self.update_font_definitions(cx, &mut fonts_ref);
     }
-
-    fn ensure_fonts_loaded(&self, cx: &mut Cx) {
-        self.ensure_fonts_loaded_for_text(cx, None);
-    }
-}
-
-fn font_member_is_needed_for_text(cx: &Cx, handle: ScriptHandle, text: Option<&str>) -> bool {
-    let Some(text) = text else {
-        return true;
-    };
-    let Some(path) = cx.get_resource_abs_path(handle) else {
-        return true;
-    };
-
-    if is_cjk_fallback_font_path(&path) {
-        return text_has_cjk(text);
-    }
-    if is_emoji_fallback_font_path(&path) {
-        return text_has_emoji(text);
-    }
-    true
-}
-
-fn is_cjk_fallback_font_path(path: &str) -> bool {
-    matches!(
-        resource_basename(path),
-        Some(name)
-            if name.eq_ignore_ascii_case("LXGWWenKaiRegular.ttf")
-                || name.eq_ignore_ascii_case("LXGWWenKaiBold.ttf")
-    )
-}
-
-fn is_emoji_fallback_font_path(path: &str) -> bool {
-    matches!(
-        resource_basename(path),
-        Some(name) if name.eq_ignore_ascii_case("NotoColorEmoji.ttf")
-    )
-}
-
-fn resource_basename(path: &str) -> Option<&str> {
-    path.rsplit(['/', '\\']).next()
 }
 
 fn font_member_weight(member: &FontMemberDef) -> Option<f32> {
@@ -1029,42 +981,6 @@ fn font_member_font_id(member: &FontMemberDef) -> FontId {
     member.desc.to_bits().hash(&mut hasher);
     member.weight.to_bits().hash(&mut hasher);
     FontId::from(hasher.finish())
-}
-
-fn text_has_cjk(text: &str) -> bool {
-    text.chars().any(is_cjk_char)
-}
-
-fn is_cjk_char(ch: char) -> bool {
-    matches!(
-        ch as u32,
-        0x2E80..=0x2FFF
-            | 0x3000..=0x303F
-            | 0x3040..=0x30FF
-            | 0x3100..=0x312F
-            | 0x31A0..=0x31EF
-            | 0x1100..=0x11FF
-            | 0x3130..=0x318F
-            | 0xAC00..=0xD7AF
-            | 0x3400..=0x4DBF
-            | 0x4E00..=0x9FFF
-            | 0xF900..=0xFAFF
-            | 0xFE30..=0xFE4F
-            | 0xFF00..=0xFFEF
-            | 0x20000..=0x2EE5F
-            | 0x2F800..=0x2FA1F
-    )
-}
-
-fn text_has_emoji(text: &str) -> bool {
-    text.chars().any(is_emoji_char)
-}
-
-fn is_emoji_char(ch: char) -> bool {
-    matches!(
-        ch as u32,
-        0x2600..=0x27BF | 0x200D | 0xFE0F | 0x1F000..=0x1FAFF | 0x1FB00..=0x1FBFF
-    )
 }
 
 fn row_span_x_bounds_in_lpxs(
@@ -1091,11 +1007,6 @@ impl TextStyle {
 
     pub fn ensure_fonts_loaded(&self, cx: &mut Cx) {
         self.font_family.ensure_fonts_loaded(cx);
-    }
-
-    pub fn ensure_fonts_loaded_for_text(&self, cx: &mut Cx, text: &str) {
-        self.font_family
-            .ensure_fonts_loaded_for_text(cx, Some(text));
     }
 }
 

--- a/draw/src/text/shaper.rs
+++ b/draw/src/text/shaper.rs
@@ -96,6 +96,7 @@ impl Shaper {
         } else {
             self.shape_recursive(
                 &params.text,
+                &params.fonts[0],
                 &params.fonts,
                 &params.features,
                 params.direction,
@@ -129,6 +130,7 @@ impl Shaper {
     fn shape_recursive(
         &mut self,
         text: &str,
+        primary_font: &Rc<Font>,
         fonts: &[Rc<Font>],
         features: &[(u32, u32)],
         direction: Direction,
@@ -136,14 +138,14 @@ impl Shaper {
         end: usize,
         out_glyphs: &mut Vec<ShapedGlyph>,
     ) {
-        let (font, fonts) = fonts.split_first().unwrap();
+        let (font, remaining_fonts) = fonts.split_first().unwrap();
         let mut glyphs = self.reusable_glyphs.pop().unwrap_or_default();
         self.shape_step(text, font, features, direction, start, end, &mut glyphs);
         let mut glyph_groups = glyphs
             .group_by(|glyph_0, glyph_1| glyph_0.cluster == glyph_1.cluster)
             .peekable();
         while let Some(glyph_group) = glyph_groups.next() {
-            if glyph_group.iter().any(|glyph| glyph.id == 0) && !fonts.is_empty() {
+            if glyph_group.iter().any(|glyph| glyph.id == 0) && !remaining_fonts.is_empty() {
                 let missing_start = glyph_group[0].cluster;
                 while glyph_groups
                     .peek()
@@ -156,7 +158,8 @@ impl Shaper {
                     .map_or(end, |next_glyph_group| next_glyph_group[0].cluster);
                 self.shape_recursive(
                     text,
-                    fonts,
+                    primary_font,
+                    remaining_fonts,
                     features,
                     direction,
                     missing_start,
@@ -164,7 +167,22 @@ impl Shaper {
                     out_glyphs,
                 );
             } else {
-                out_glyphs.extend(glyph_group.iter().cloned());
+                // If we've exhausted all fallback fonts and still have
+                // unmapped glyphs (id == 0), use the primary font's .notdef
+                // so a visible placeholder is rendered instead of nothing.
+                if glyph_group.iter().any(|glyph| glyph.id == 0)
+                    && !Rc::ptr_eq(font, primary_font)
+                {
+                    out_glyphs.extend(glyph_group.iter().map(|glyph| {
+                        let mut g = glyph.clone();
+                        if g.id == 0 {
+                            g.font = primary_font.clone();
+                        }
+                        g
+                    }));
+                } else {
+                    out_glyphs.extend(glyph_group.iter().cloned());
+                }
             }
         }
         drop(glyph_groups);


### PR DESCRIPTION
When a character isn't in any font in the family (e.g., 🫪 U+1FAEA not in
the bundled NotoColorEmoji), the shaper exhausts all fallback fonts and
emits glyph id 0 (.notdef) from the last font tried. For bitmap-only fonts
like NotoColorEmoji (no glyf table), the .notdef has no outline, so the
rasterizer returns None and draw_glyph silently skips it — leaving
invisible blank space.

Fix: in shape_recursive, when all fallback fonts are exhausted and glyphs
remain unmapped (id == 0), reassign them to the primary font (IBM Plex
Sans), whose .notdef has visible contours (the standard "tofu" rectangle).
This is done at the point of emission rather than as a post-processing
scan, so the common case (all glyphs found) has zero overhead.