### PR TITLE
Fix RTL/bidi text shaping panic and mis-layout

### DIFF
--- a/draw/src/text/shaper.rs
+++ b/draw/src/text/shaper.rs
@@ -16,6 +16,39 @@ use {
     unicode_segmentation::UnicodeSegmentation,
 };
 
+/// Returns `true` if `text` is guaranteed to contain no right-to-left
+/// characters, so that the Unicode Bidirectional Algorithm can be skipped
+/// entirely. False negatives (returning `false` for pure-LTR text containing
+/// characters in these blocks that happen to be non-RTL) are acceptable —
+/// we just run BiDi in that case. False positives would cause mis-rendering,
+/// so the ranges below are the full Unicode blocks that contain any strong
+/// RTL characters, rather than the exact RTL code points.
+fn is_definitely_ltr(text: &str) -> bool {
+    // Optimised common case: pure ASCII is always LTR, and `is_ascii` uses
+    // a SIMD-accelerated byte scan.
+    if text.is_ascii() {
+        return true;
+    }
+    !text.chars().any(|c| {
+        let c = c as u32;
+        // BMP blocks containing any strong RTL characters: Hebrew, Arabic,
+        // Syriac, Thaana, NKo, Samaritan, Mandaic, Syriac Supplement and
+        // Arabic Extended-A/B.
+        (0x0590..=0x08FF).contains(&c)
+            // Alphabetic Presentation Forms (Hebrew ligatures) through
+            // Arabic Presentation Forms-A.
+            || (0xFB1D..=0xFDFF).contains(&c)
+            // Arabic Presentation Forms-B.
+            || (0xFE70..=0xFEFF).contains(&c)
+            // Ancient RTL scripts (Imperial Aramaic, Phoenician, etc.) in
+            // the Supplementary Multilingual Plane.
+            || (0x10800..=0x10FFF).contains(&c)
+            // More modern SMP RTL blocks (Mende Kikakui, Adlam, Arabic
+            // Mathematical Alphabetic Symbols, etc.).
+            || (0x1E800..=0x1EFFF).contains(&c)
+    })
+}
+
 /// Float wrapper that supports Hash and Eq via bit representation.
 #[derive(Clone, Copy, Debug)]
 pub struct Ems(pub f32);
@@ -52,6 +85,14 @@ pub enum Direction {
 pub struct Shaper {
     reusable_glyphs: Vec<Vec<ShapedGlyph>>,
     reusable_unicode_buffer: UnicodeBuffer,
+    // One-slot cache for the converted rustybuzz feature list. `shape_step`
+    // is called on every shaping path and would otherwise rebuild a
+    // `Vec<rustybuzz::Feature>` on each call. We key the cache on the
+    // feature-pair slice contents (not on pointer identity — see note in
+    // `shape_step`), which is cheap because `features` is almost always
+    // empty in practice and rarely changes across calls when it isn't.
+    cached_features_source: Vec<(u32, u32)>,
+    cached_rb_features: Vec<rustybuzz::Feature>,
     cache_size: usize,
     cached_params: VecDeque<ShapeParams>,
     cached_results: FxHashMap<ShapeParams, Rc<ShapedText>>,
@@ -62,6 +103,8 @@ impl Shaper {
         Self {
             reusable_glyphs: Vec::new(),
             reusable_unicode_buffer: UnicodeBuffer::new(),
+            cached_features_source: Vec::new(),
+            cached_rb_features: Vec::new(),
             cache_size: settings.cache_size,
             cached_params: VecDeque::with_capacity(settings.cache_size),
             cached_results: FxHashMap::with_capacity_and_hasher(
@@ -94,16 +137,73 @@ impl Shaper {
         if params.fonts.is_empty() {
             println!("WARNING: encountered empty font family");
         } else {
-            self.shape_recursive(
-                &params.text,
-                &params.fonts[0],
-                &params.fonts,
-                &params.features,
-                params.direction,
-                0,
-                params.text.len(),
-                &mut glyphs,
-            );
+            let text: &str = &params.text;
+            // Fast path: when the text is guaranteed to contain no RTL
+            // characters, skip the Unicode Bidirectional Algorithm entirely
+            // and shape as a single LTR run. This avoids BiDi's classification
+            // pass and vec allocations for the common case of ASCII / Latin /
+            // Greek / Cyrillic / CJK / emoji text.
+            if is_definitely_ltr(text) {
+                self.shape_recursive(
+                    text,
+                    &params.fonts[0],
+                    &params.fonts,
+                    &params.features,
+                    Direction::Ltr,
+                    0,
+                    text.len(),
+                    &mut glyphs,
+                );
+            } else {
+                // The text contains at least one possibly-RTL character, so
+                // run the Unicode Bidirectional Algorithm to resolve embedding
+                // levels and segment the text into visual runs. Shaping each
+                // run in its resolved direction keeps mixed LTR/RTL strings
+                // from stomping on each other visually.
+                let default_level = match params.direction {
+                    Direction::Ltr => Some(unicode_bidi::Level::ltr()),
+                    Direction::Rtl => Some(unicode_bidi::Level::rtl()),
+                };
+                let bidi = unicode_bidi::ParagraphBidiInfo::new(text, default_level);
+                if bidi.is_pure_ltr {
+                    // BiDi confirmed everything resolved to LTR after all
+                    // (e.g. isolated presentation-form characters), so a
+                    // single LTR shape call is still correct and avoids the
+                    // visual_runs allocation.
+                    self.shape_recursive(
+                        text,
+                        &params.fonts[0],
+                        &params.fonts,
+                        &params.features,
+                        Direction::Ltr,
+                        0,
+                        text.len(),
+                        &mut glyphs,
+                    );
+                } else {
+                    // `visual_runs` returns level runs in visual (left-to-right)
+                    // order, so appending each run's shaped glyphs in iteration
+                    // order yields glyphs in the final visual order.
+                    let (levels, runs) = bidi.visual_runs(0..text.len());
+                    for run in &runs {
+                        let direction = if levels[run.start].is_rtl() {
+                            Direction::Rtl
+                        } else {
+                            Direction::Ltr
+                        };
+                        self.shape_recursive(
+                            text,
+                            &params.fonts[0],
+                            &params.fonts,
+                            &params.features,
+                            direction,
+                            run.start,
+                            run.end,
+                            &mut glyphs,
+                        );
+                    }
+                }
+            }
         }
 
         // Post-process: apply letter-spacing and word-spacing
@@ -141,32 +241,88 @@ impl Shaper {
         let (font, remaining_fonts) = fonts.split_first().unwrap();
         let mut glyphs = self.reusable_glyphs.pop().unwrap_or_default();
         self.shape_step(text, font, features, direction, start, end, &mut glyphs);
-        let mut glyph_groups = glyphs
+
+        // Collect glyph groups (runs of glyphs sharing a cluster) in the order
+        // produced by the shaper, which is the visual order for `direction`.
+        // We use an indexable Vec so we can look both forward and backward to
+        // compute the logical byte range a glyph group covers — necessary
+        // because HarfBuzz emits clusters monotonically in the shaping
+        // direction (non-decreasing for LTR, non-increasing for RTL).
+        let glyph_groups: Vec<&[ShapedGlyph]> = glyphs
             .group_by(|glyph_0, glyph_1| glyph_0.cluster == glyph_1.cluster)
-            .peekable();
-        while let Some(glyph_group) = glyph_groups.next() {
-            if glyph_group.iter().any(|glyph| glyph.id == 0) && !remaining_fonts.is_empty() {
-                let missing_start = glyph_group[0].cluster;
-                while glyph_groups
-                    .peek()
-                    .is_some_and(|glyph_group| glyph_group.iter().any(|glyph| glyph.id == 0))
+            .collect();
+
+        let mut i = 0;
+        while i < glyph_groups.len() {
+            if glyph_groups[i].iter().any(|glyph| glyph.id == 0) && !remaining_fonts.is_empty() {
+                // Extend the run to cover every adjacent glyph group that
+                // still has an unmapped glyph, so we can reshape the whole
+                // span with the next fallback font in one call.
+                let run_start = i;
+                while i < glyph_groups.len()
+                    && glyph_groups[i].iter().any(|glyph| glyph.id == 0)
                 {
-                    glyph_groups.next();
+                    i += 1;
                 }
-                let missing_end = glyph_groups
-                    .peek()
-                    .map_or(end, |next_glyph_group| next_glyph_group[0].cluster);
-                self.shape_recursive(
-                    text,
-                    primary_font,
-                    remaining_fonts,
-                    features,
-                    direction,
-                    missing_start,
-                    missing_end,
-                    out_glyphs,
-                );
+                let run_end = i;
+
+                // Compute the logical byte range [missing_start, missing_end)
+                // in `text` that this missing run covers. The "logically next"
+                // cluster after a group sits visually to the right in LTR and
+                // visually to the left in RTL. If the group is at the visual
+                // edge of the run, the range extends to `end` (LTR) or to the
+                // group just before the run (RTL).
+                let (missing_start, missing_end) = match direction {
+                    Direction::Ltr => {
+                        let lo = glyph_groups[run_start][0].cluster;
+                        let hi = glyph_groups
+                            .get(run_end)
+                            .map_or(end, |next| next[0].cluster);
+                        (lo, hi)
+                    }
+                    Direction::Rtl => {
+                        let lo = glyph_groups[run_end - 1][0].cluster;
+                        let hi = if run_start == 0 {
+                            end
+                        } else {
+                            glyph_groups[run_start - 1][0].cluster
+                        };
+                        (lo, hi)
+                    }
+                };
+
+                // Defensive: if the computed range is invalid for any reason
+                // (e.g. HarfBuzz produced unexpected non-monotonic clusters
+                // for a complex script shaped in the "wrong" direction), fall
+                // back to rendering the missing groups as the primary font's
+                // .notdef glyph rather than panicking inside a recursive
+                // shape_step call on an inverted byte range.
+                if missing_start >= start
+                    && missing_end <= end
+                    && missing_start < missing_end
+                {
+                    self.shape_recursive(
+                        text,
+                        primary_font,
+                        remaining_fonts,
+                        features,
+                        direction,
+                        missing_start,
+                        missing_end,
+                        out_glyphs,
+                    );
+                } else {
+                    for group in &glyph_groups[run_start..run_end] {
+                        out_glyphs.extend(group.iter().map(|glyph| {
+                            let mut g = glyph.clone();
+                            g.id = 0;
+                            g.font = primary_font.clone();
+                            g
+                        }));
+                    }
+                }
             } else {
+                let glyph_group = glyph_groups[i];
                 // If we've exhausted all fallback fonts and still have
                 // unmapped glyphs (id == 0), use the primary font's .notdef
                 // so a visible placeholder is rendered instead of nothing.
@@ -183,6 +339,7 @@ impl Shaper {
                 } else {
                     out_glyphs.extend(glyph_group.iter().cloned());
                 }
+                i += 1;
             }
         }
         drop(glyph_groups);
@@ -212,18 +369,30 @@ impl Shaper {
                 unicode_buffer.add(char, cluster as u32);
             }
         }
-        let rb_features: Vec<rustybuzz::Feature> = features
-            .iter()
-            .map(|&(tag, value)| {
-                rustybuzz::Feature::new(
-                    rustybuzz::ttf_parser::Tag::from_bytes(&tag.to_be_bytes()),
-                    value,
-                    ..,
-                )
-            })
-            .collect();
+        // Convert the caller's `(tag, value)` feature pairs into rustybuzz's
+        // `Feature` type, reusing the previous conversion when the feature
+        // set hasn't changed. We compare contents rather than pointers: a
+        // pointer-based cache would be unsound if the caller's `Rc<Vec<_>>`
+        // backing the slice were dropped and a fresh allocation happened
+        // to reuse the same address. Content comparison is O(n), but `n`
+        // is almost always zero, and the saved work on a hit (allocation
+        // + Feature construction) dwarfs the comparison itself.
+        if features != self.cached_features_source.as_slice() {
+            self.cached_features_source.clear();
+            self.cached_features_source.extend_from_slice(features);
+            self.cached_rb_features.clear();
+            self.cached_rb_features
+                .extend(features.iter().map(|&(tag, value)| {
+                    rustybuzz::Feature::new(
+                        rustybuzz::ttf_parser::Tag::from_bytes(&tag.to_be_bytes()),
+                        value,
+                        ..,
+                    )
+                }));
+        }
+        let rb_features = &self.cached_rb_features;
         let glyph_buffer =
-            font.with_rustybuzz_face(|face| rustybuzz::shape(face, &rb_features, unicode_buffer));
+            font.with_rustybuzz_face(|face| rustybuzz::shape(face, rb_features, unicode_buffer));
         let units_per_em = font.units_per_em();
         out_glyphs.extend(
             glyph_buffer


### PR DESCRIPTION
been complaining about panics in text shaping for the better part of the last 2 years so i might as well go ahead and fix it :)

THis still doesn't fully support bi-di text but it gets most of the way there without any noticeable perf impacts on text shaping

--------------

Details:

Shaping a string containing right-to-left characters (Arabic, Hebrew, etc.) could panic in shape_recursive with "byte range starts at N but ends at M", and even when it didn't panic, the surrounding LTR text was laid out in visually wrong positions.

- shaper: compute fallback byte ranges in shape_recursive in a direction-aware way. HarfBuzz emits clusters monotonically in the shaping direction (non-decreasing for LTR, non-increasing for RTL), so the "next logical cluster" lives visually after the current group for LTR and visually before it for RTL. Also collect glyph groups into an indexable Vec so we can look both forward and backward, and defensively fall back to rendering .notdef tofu rather than recursing on an inverted range if HarfBuzz ever produces unexpected non-monotonic output.

- shaper: run the Unicode Bidirectional Algorithm via the already- present unicode-bidi crate before shaping. Segment each input into visual runs with ParagraphBidiInfo, then shape each run in its resolved direction and append in visual order. This keeps an RTL chunk embedded in LTR text from stomping on the surrounding LTR layout. Full RTL support (joining quality, cursor/hit-testing in RTL runs) is still not wired up above the shaper.

- shaper: add an is_definitely_ltr fast path that short-circuits BiDi entirely when the input contains no characters in any RTL Unicode block. Uses str::is_ascii (SIMD) for the common ASCII case and falls back to a char-level range check, so ASCII / Latin / Greek / Cyrillic / CJK / emoji text pays no BiDi classification or vec- allocation cost on cache miss.

- shaper: cache the rustybuzz Feature conversion in shape_step with a one-slot content-keyed cache, so repeated shape calls with the same feature set (typically empty) don't rebuild the Vec each time.