### PR TITLE
Fix iOS touch hit-test and window geometry source

### DIFF
--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -970,19 +970,16 @@ impl Event {
                             }
 
                             let rect = area.clipped_rect(&cx);
-                            // Add touch radius to the margin to account for finger size
-                            let margin_with_radius = if t.radius.x > 0.0 || t.radius.y > 0.0 {
-                                let base_margin = options.margin.unwrap_or_default();
-                                Some(Inset {
-                                    left: base_margin.left + t.radius.x,
-                                    top: base_margin.top + t.radius.y,
-                                    right: base_margin.right + t.radius.x,
-                                    bottom: base_margin.bottom + t.radius.y,
-                                })
-                            } else {
-                                options.margin
-                            };
-                            if !hit_test(t.abs, &rect, &margin_with_radius) {
+                            // Hit-test against the touch centroid only — do NOT inflate the
+                            // widget rect by `t.radius`. UITouch.majorRadius (and the Android
+                            // equivalent) is the contact area's radius, not a "give me extra
+                            // hit padding" instruction, and inflating by it leads to surprising
+                            // captures: the iOS Simulator reports a `majorRadius` of ~25-40pt
+                            // for mouse-as-touch, which makes every button capture clicks ~30pt
+                            // outside its visible bounds. UIKit/AppKit hit-test on the centroid;
+                            // we match that. Apps that genuinely need a larger hit zone should
+                            // pass it explicitly via `HitOptions::margin`.
+                            if !hit_test(t.abs, &rect, &options.margin) {
                                 continue;
                             }
 
@@ -1010,18 +1007,9 @@ impl Event {
                             let tap_count = cx.fingers.tap_count();
                             let rect = area.clipped_rect(&cx);
                             if let Some(capture) = cx.fingers.find_area_capture(area) {
-                                // Check if finger is over the widget using touch radius if available
-                                let rect_check = if t.radius.x > 0.0 || t.radius.y > 0.0 {
-                                    let margin = Inset {
-                                        left: t.radius.x,
-                                        top: t.radius.y,
-                                        right: t.radius.x,
-                                        bottom: t.radius.y,
-                                    };
-                                    Inset::rect_contains_with_inset(t.abs, &rect, &Some(margin))
-                                } else {
-                                    rect.contains(t.abs)
-                                };
+                                // See the note in TouchState::Start above: hit-test on the
+                                // touch centroid only, without inflating by `t.radius`.
+                                let rect_check = rect.contains(t.abs);
 
                                 // Layout shift fallback: also treat as "over" if finger didn't move
                                 // significantly from start (handles keyboard dismissal moving widgets)

--- a/platform/src/os/apple/ios/ios_app.rs
+++ b/platform/src/os/apple/ios/ios_app.rs
@@ -433,10 +433,10 @@ impl IosApp {
         }
     }
 
-    pub fn draw_size_will_change(_view: ObjcId, _size: NSSize) {
+    pub fn draw_size_will_change(view: ObjcId, size: NSSize) {
         // Avoid re-entrant calls by checking if we're already in a with_ios_app call.
-        // We must drop the borrow *before* calling check_window_geom, because
-        // check_window_geom calls with_ios_app which tries to borrow_mut again.
+        // We must drop the borrow *before* calling apply_new_window_geom, because
+        // it calls with_ios_app which tries to borrow_mut again.
         let should_call = IOS_APP
             .try_with(|app| {
                 match app.try_borrow_mut() {
@@ -445,45 +445,104 @@ impl IosApp {
                 }
             })
             .unwrap_or(false);
-        if should_call {
-            Self::check_window_geom();
+        if !should_call {
+            return;
+        }
+
+        // `size` is the authoritative new drawable size in physical pixels, delivered
+        // by UIKit at the exact moment the view is resizing. Using it (rather than
+        // re-reading UIScreen.bounds or even the view's own bounds) is the only way
+        // to be race-free across device rotation, iPad Split View / Slide Over /
+        // Stage Manager resizes, and multi-scene transitions, where other sources can
+        // briefly lag the actual geometry by one layout pass.
+        //
+        // We pull scale and safeAreaInsets from the same `view` pointer so they are
+        // guaranteed consistent with the size we just received.
+        unsafe {
+            let scale: f64 = msg_send![view, contentScaleFactor];
+            let inner_size = if scale > 0.0 {
+                dvec2(size.width / scale, size.height / scale)
+            } else {
+                // `contentScaleFactor` should never be 0 in practice, but don't
+                // divide by zero if it somehow is — fall through to raw pixels.
+                dvec2(size.width, size.height)
+            };
+            let insets: UIEdgeInsets = msg_send![view, safeAreaInsets];
+            let safe_area_insets = crate::event::SafeAreaInsets {
+                top: insets.top,
+                right: insets.right,
+                bottom: insets.bottom,
+                left: insets.left,
+            };
+            Self::apply_new_window_geom(inner_size, scale, safe_area_insets);
         }
     }
 
     pub fn check_window_geom() {
-        let main_screen: ObjcId = unsafe { msg_send![class!(UIScreen), mainScreen] };
-        let screen_rect: NSRect = unsafe { msg_send![main_screen, bounds] };
-        let dpi_factor: f64 = unsafe { msg_send![main_screen, scale] };
-        let new_size = dvec2(
-            screen_rect.size.width as f64,
-            screen_rect.size.height as f64,
-        );
-
-        // Query safe area insets from the MTKView (accounts for notch/Dynamic Island,
-        // home indicator, rounded corners, etc.)
-        let safe_area_insets = with_ios_app(|app| {
-            if let Some(mtk_view) = app.mtk_view {
-                unsafe {
-                    let insets: UIEdgeInsets = msg_send![mtk_view, safeAreaInsets];
+        // Read geometry from the MTKView: its `bounds` are in logical points and
+        // share the exact coordinate space that UITouch `locationInView:` returns,
+        // so touches and layout cannot drift.
+        //
+        // Reading from `UIScreen.mainScreen.bounds` here would be wrong: UIScreen
+        // describes the *physical screen*, not the app's drawing surface. On iPad
+        // with Split View / Slide Over / Stage Manager, and on multi-scene apps,
+        // the window is a fraction of the screen — using UIScreen would introduce
+        // a constant offset between where we draw and where touches land.
+        let read = with_ios_app(|app| {
+            app.mtk_view.map(|mtk_view| unsafe {
+                let bounds: NSRect = msg_send![mtk_view, bounds];
+                let scale: f64 = msg_send![mtk_view, contentScaleFactor];
+                let insets: UIEdgeInsets = msg_send![mtk_view, safeAreaInsets];
+                (
+                    dvec2(bounds.size.width as f64, bounds.size.height as f64),
+                    scale,
                     crate::event::SafeAreaInsets {
                         top: insets.top,
                         right: insets.right,
                         bottom: insets.bottom,
                         left: insets.left,
-                    }
-                }
-            } else {
-                crate::event::SafeAreaInsets::default()
-            }
+                    },
+                )
+            })
         });
+        let (inner_size, dpi_factor, safe_area_insets) = match read {
+            Some(v) => v,
+            None => {
+                // MTKView has not been created yet — this is only reachable during
+                // early init, before `create_window` wires up `app.mtk_view`. Fall
+                // back to UIScreen so callers can still get a sensible initial geom;
+                // the first real MTKView callback will replace it with the correct
+                // values.
+                unsafe {
+                    let main_screen: ObjcId = msg_send![class!(UIScreen), mainScreen];
+                    let screen_rect: NSRect = msg_send![main_screen, bounds];
+                    let scale: f64 = msg_send![main_screen, scale];
+                    (
+                        dvec2(
+                            screen_rect.size.width as f64,
+                            screen_rect.size.height as f64,
+                        ),
+                        scale,
+                        crate::event::SafeAreaInsets::default(),
+                    )
+                }
+            }
+        };
+        Self::apply_new_window_geom(inner_size, dpi_factor, safe_area_insets);
+    }
 
+    fn apply_new_window_geom(
+        inner_size: DVec2,
+        dpi_factor: f64,
+        safe_area_insets: crate::event::SafeAreaInsets,
+    ) {
         let new_geom = WindowGeom {
             xr_is_presenting: false,
             is_topmost: false,
             is_fullscreen: true,
             can_fullscreen: false,
-            inner_size: new_size,
-            outer_size: new_size,
+            inner_size,
+            outer_size: inner_size,
             dpi_factor,
             position: dvec2(0.0, 0.0),
             safe_area_insets,


### PR DESCRIPTION
Two independent iOS touch-input correctness fixes.

1. Hit-test: stop inflating widget bounds by touch radius

   `Cx::hits_with_options_and_test` was inflating every widget's
   clickable rect outward by `touch.radius` on all four sides, where
   `radius` comes from `UITouch.majorRadius` on iOS (and the Android
   equivalent). On real fingers this is 5-15pt, but the iOS Simulator
   synthesizes mouse clicks as touches with `majorRadius` ~25-40pt, so
   every button in the simulator captured clicks ~30pt outside its
   visible bounds — a click well above or below the Upload Avatar
   button still activated it.

   Remove the inflation in both TouchState::Start and TouchState::Stop
   and hit-test against the touch centroid only. This matches UIKit/
   AppKit native behavior; Apple's HIG and Material Design already
   require touch targets large enough that hidden inflation isn't
   needed. Apps that want explicit hit padding can still pass it via
   `HitOptions::margin`. `touch.radius` is still populated and
   delivered to apps that want it for visual feedback.

   Affected platforms: iOS, Android, web touch. Desktop mouse paths
   (MouseDown/Up) never touched this code.

2. Window geometry: read from MTKView, not UIScreen

   `IosApp::check_window_geom` was reading `inner_size` from
   `UIScreen.mainScreen.bounds`, which describes the *physical screen*
   rather than the app's drawing surface. On iPad Split View, Slide
   Over, Stage Manager, and multi-scene apps the window is a fraction
   of the screen, so `inner_size` could disagree with the MTKView's
   actual bounds — introducing a constant offset between layout and
   the touch coordinate space (UITouch `locationInView:` is always
   view-local).

   Read `bounds`, `contentScaleFactor`, and `safeAreaInsets` from the
   MTKView itself, falling back to UIScreen only during the early-init
   window before the view exists.

   Also use the `size` parameter delivered to
   `mtkView:drawableSizeWillChange:` directly (converting pixels→points
   via `contentScaleFactor` from the same view) rather than re-querying.
   UIKit gives us the authoritative new size synchronously with the
   resize callback; re-reading any other source can race by one layout
   pass during rotation or multitasking transitions.

   Extract the common WindowGeom construction / first-draw / update_geom
   / callback-dispatch tail into `apply_new_window_geom`.