### PR TITLE
fix(code_editor): honour East Asian Wide width in column_count

### DIFF
--- a/code_editor/src/char.rs
+++ b/code_editor/src/char.rs
@@ -21,7 +21,30 @@ impl CharExt for char {
     }
 
     fn column_count(self) -> usize {
-        1
+        // Unicode East Asian Width: characters in East Asian Wide or Fullwidth
+        // categories occupy two display columns in a monospace grid. Without
+        // this, CJK text in the code editor overlaps because each glyph draws
+        // at 2× advance but the layouter only reserves 1 column.
+        match self as u32 {
+            // CJK Symbols and Punctuation, Hiragana, Katakana
+            0x3000..=0x30FF
+            // CJK Unified Ideographs Extension A
+            | 0x3400..=0x4DBF
+            // CJK Unified Ideographs (main block)
+            | 0x4E00..=0x9FFF
+            // Hangul Syllables
+            | 0xAC00..=0xD7AF
+            // CJK Compatibility Ideographs
+            | 0xF900..=0xFAFF
+            // Fullwidth forms + Halfwidth/Fullwidth punctuation
+            | 0xFF00..=0xFF60
+            | 0xFFE0..=0xFFE6
+            // CJK Unified Ideographs Extensions B..F
+            | 0x20000..=0x2FFFF
+            // Emoticons, misc symbols & pictographs, transport, supplemental symbols
+            | 0x1F300..=0x1F9FF => 2,
+            _ => 1,
+        }
     }
 
     fn opposite_delimiter(&self) -> Option<char> {


### PR DESCRIPTION
## Summary

`CharExt::column_count` in `code_editor/src/char.rs` returns `1` for every `char`, regardless of width. The layouter advances x-position by this value per grapheme — see `code_editor.rs:1217` (`column_index += grapheme.column_count()`) — so CJK / emoji glyphs, which the shaper draws at ~2× Latin monospace advance, **overlap one another** inside CodeView. Cursor movement, selection rectangles, and soft-wrap points all read the same broken value.

## Repro (before)

Render any Rust file with Chinese/Japanese/Korean in comments inside a Makepad `CodeView`. Characters collapse onto each other:

```
//! 消戭尝 定义 Actor 可的慕约作    (expected: 消息类型：定义 Actor 可接收的操作)
```

Same pattern with emoji. Non-CJK code is unaffected.

## Fix

Honour Unicode East Asian Width: `Wide` and `Fullwidth` characters (plus the common emoji ranges that render double-width) report 2 columns. Kept as an inline match table rather than pulling in the `unicode-width` crate — this is a hot-path function called per-grapheme in `draw_text_layer`, and only the broad blocks are needed.

Ranges covered:

| Range | Block |
|---|---|
| U+3000..U+30FF | CJK punctuation / Hiragana / Katakana |
| U+3400..U+4DBF | CJK Unified Ideographs Extension A |
| U+4E00..U+9FFF | CJK Unified Ideographs (main) |
| U+AC00..U+D7AF | Hangul Syllables |
| U+F900..U+FAFF | CJK Compatibility Ideographs |
| U+FF00..U+FF60 | Fullwidth forms |
| U+FFE0..U+FFE6 | Fullwidth sign forms |
| U+20000..U+2FFFF | CJK Unified Ideographs Extensions B..F |
| U+1F300..U+1F9FF | Emoticons / symbols / transport / supplemental |

## Effect

- CJK and emoji glyphs now render with correct spacing inside `CodeView` and any other widget layouting via `CodeSession`.
- Cursor keystrokes and mouse selection hit the visually-expected columns.
- Latin-only code is untouched (the `match` falls through to `_ => 1`).

## Test plan

- [x] `cargo check -p makepad-code-editor` passes
- [x] Manually verified in a Makepad 2.0 chat app streaming Kimi output with Chinese comments — before: overlapping glyphs; after: correctly spaced
- [ ] No automated tests added (the file has no existing unit test scaffolding — happy to add one if you'd prefer)

## Notes / follow-ups

- The ranges are conservative. If you'd rather depend on `unicode-width` for full Unicode correctness (including lesser-used scripts), say the word — I can swap the implementation.
- Same bug likely exists for column-based measurements used by soft-wrap heuristics when long CJK lines hit the edge — the fix trickles through since those paths also route through `column_count`.

## Before

<img width="780" height="739" alt="截屏2026-04-17 03 45 45" src="https://github.com/user-attachments/assets/eb20c14b-9b89-4727-ab08-348aa47e620e" />

## After

<img width="509" height="576" alt="截屏2026-04-17 03 50 05" src="https://github.com/user-attachments/assets/2af5609a-44c2-4933-8565-e174117ccfa5" />
