### PR TITLE
draw_text: adopt outer many_instances batch on linux/windows

### DIFF
--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -2368,7 +2368,13 @@ impl DrawText {
                 .unwrap_or(true);
             let shadow_slug_this_frame = use_slug_this_frame && slug_area_was_empty;
 
-            let mut raster_instances = None::<ManyInstances>;
+            // If the caller opened an outer raster batch via
+            // DrawText::begin_many_instances, adopt it here. A nested
+            // cx.begin_many_aligned_instances on the same draw_item would
+            // otherwise panic, because the outer open already swapped the
+            // draw_item's `instances` Vec into its ManyInstances.
+            let mut raster_instances = self.many_instances.take();
+            let mut raster_instances_is_outer = raster_instances.is_some();
             let mut drew_raster_this_frame = false;
             let mut drew_slug_this_frame = false;
 
@@ -2386,6 +2392,7 @@ impl DrawText {
                     if !use_slug_this_frame {
                         if raster_instances.is_none() {
                             raster_instances = cx.begin_many_aligned_instances(&self.draw_vars);
+                            raster_instances_is_outer = false;
                         }
                         if let Some(instances) = raster_instances.as_mut() {
                             drew_raster_this_frame |= self.draw_slug_raster_fallback_glyph(
@@ -2404,6 +2411,7 @@ impl DrawText {
                             if self.ensure_slug_draw(cx) {
                                 if let Some(instances) = raster_instances.take() {
                                     self.finish_many_instances(cx, instances);
+                                    raster_instances_is_outer = false;
                                 }
                                 self.sync_slug_draw_state(cx);
                                 if let Some(mut slug_draw) = self.slug_draw.take() {
@@ -2435,6 +2443,7 @@ impl DrawText {
                                 if raster_instances.is_none() {
                                     raster_instances =
                                         cx.begin_many_aligned_instances(&self.draw_vars);
+                                    raster_instances_is_outer = false;
                                 }
                                 if let Some(instances) = raster_instances.as_mut() {
                                     drew_raster_this_frame |= self.draw_slug_raster_fallback_glyph(
@@ -2456,6 +2465,7 @@ impl DrawText {
 
                             if raster_instances.is_none() {
                                 raster_instances = cx.begin_many_aligned_instances(&self.draw_vars);
+                                raster_instances_is_outer = false;
                             }
                             let Some(instances) = raster_instances.as_mut() else {
                                 continue;
@@ -2482,7 +2492,13 @@ impl DrawText {
 
             self.flush_slug_textures_if_allowed(cx);
             if let Some(instances) = raster_instances.take() {
-                self.finish_many_instances(cx, instances);
+                if raster_instances_is_outer {
+                    // Hand the outer batch back so the caller's eventual
+                    // end_many_instances can finalize it.
+                    self.many_instances = Some(instances);
+                } else {
+                    self.finish_many_instances(cx, instances);
+                }
             }
             if let Some(mut slug_draw) = self.slug_draw.take() {
                 if slug_draw.has_open_batch() {
@@ -2497,7 +2513,8 @@ impl DrawText {
                 }
                 self.slug_draw = Some(slug_draw);
             }
-            if !drew_raster_this_frame {
+            // Don't clobber the outer batch's area if we've handed it back.
+            if !drew_raster_this_frame && self.many_instances.is_none() {
                 let old_area = self.draw_vars.area;
                 if !old_area.is_empty() {
                     cx.cx.redraw_area_in_draw(old_area);


### PR DESCRIPTION
CodeEditor opens an outer raster batch via DrawText::begin_many_instances before its glyph loop. The linux/windows branch of DrawText::draw_text ignored self.many_instances and opened its own nested batch, which resolved (via find_appendable_drawcall) to the same draw_item whose `instances` Vec was already swapped out by the outer open, panicking on unwrap in Cx2d::begin_many_instances.

Mirror what the other platform branch (and draw_rasterized_glyphs_abs) already do: take self.many_instances on entry, track whether the active raster batch is the outer one, and hand it back on exit so the caller's end_many_instances finalizes it. Skip the !drew_raster_this_frame area clear when the outer batch is still live.