### PR TITLE
Html/Markdown fixes: sub/superscript, table outlines/alignment, etc

### DIFF
--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -1292,6 +1292,13 @@ pub struct DrawText {
     #[live]
     pub temp_y_shift: f32,
 
+    /// Per-row horizontal alignment applied by the text layouter when the
+    /// text does not fill the full `max_width_in_lpxs`. `x: 0.0` = left,
+    /// `0.5` = center, `1.0` = right. `y` is currently unused by the
+    /// layouter. Reset to `Align::default()` per draw by callers that care.
+    #[rust]
+    pub layout_align: Align,
+
     /// Maximum number of lines to display. 0 means unlimited (default).
     /// When text exceeds this many lines, excess lines are hidden.
     /// Combined with `text_overflow: Ellipsis`, an ellipsis is appended
@@ -2230,7 +2237,7 @@ impl DrawText {
             row_height as f32,
             max_width_in_lpxs,
             wrap,
-            Align::default(),
+            self.layout_align,
             text_str,
         );
         self.draw_text(cx, origin_in_lpxs, &text);

--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -2368,7 +2368,13 @@ impl DrawText {
                 .unwrap_or(true);
             let shadow_slug_this_frame = use_slug_this_frame && slug_area_was_empty;
 
-            let mut raster_instances = None::<ManyInstances>;
+            // If the caller opened an outer raster batch via
+            // DrawText::begin_many_instances, adopt it here. A nested
+            // cx.begin_many_aligned_instances on the same draw_item would
+            // otherwise panic, because the outer open already swapped the
+            // draw_item's `instances` Vec into its ManyInstances.
+            let mut raster_instances = self.many_instances.take();
+            let mut raster_instances_is_outer = raster_instances.is_some();
             let mut drew_raster_this_frame = false;
             let mut drew_slug_this_frame = false;
 
@@ -2386,6 +2392,7 @@ impl DrawText {
                     if !use_slug_this_frame {
                         if raster_instances.is_none() {
                             raster_instances = cx.begin_many_aligned_instances(&self.draw_vars);
+                            raster_instances_is_outer = false;
                         }
                         if let Some(instances) = raster_instances.as_mut() {
                             drew_raster_this_frame |= self.draw_slug_raster_fallback_glyph(
@@ -2404,6 +2411,7 @@ impl DrawText {
                             if self.ensure_slug_draw(cx) {
                                 if let Some(instances) = raster_instances.take() {
                                     self.finish_many_instances(cx, instances);
+                                    raster_instances_is_outer = false;
                                 }
                                 self.sync_slug_draw_state(cx);
                                 if let Some(mut slug_draw) = self.slug_draw.take() {
@@ -2435,6 +2443,7 @@ impl DrawText {
                                 if raster_instances.is_none() {
                                     raster_instances =
                                         cx.begin_many_aligned_instances(&self.draw_vars);
+                                    raster_instances_is_outer = false;
                                 }
                                 if let Some(instances) = raster_instances.as_mut() {
                                     drew_raster_this_frame |= self.draw_slug_raster_fallback_glyph(
@@ -2456,6 +2465,7 @@ impl DrawText {
 
                             if raster_instances.is_none() {
                                 raster_instances = cx.begin_many_aligned_instances(&self.draw_vars);
+                                raster_instances_is_outer = false;
                             }
                             let Some(instances) = raster_instances.as_mut() else {
                                 continue;
@@ -2482,7 +2492,13 @@ impl DrawText {
 
             self.flush_slug_textures_if_allowed(cx);
             if let Some(instances) = raster_instances.take() {
-                self.finish_many_instances(cx, instances);
+                if raster_instances_is_outer {
+                    // Hand the outer batch back so the caller's eventual
+                    // end_many_instances can finalize it.
+                    self.many_instances = Some(instances);
+                } else {
+                    self.finish_many_instances(cx, instances);
+                }
             }
             if let Some(mut slug_draw) = self.slug_draw.take() {
                 if slug_draw.has_open_batch() {
@@ -2497,7 +2513,8 @@ impl DrawText {
                 }
                 self.slug_draw = Some(slug_draw);
             }
-            if !drew_raster_this_frame {
+            // Don't clobber the outer batch's area if we've handed it back.
+            if !drew_raster_this_frame && self.many_instances.is_none() {
                 let old_area = self.draw_vars.area;
                 if !old_area.is_empty() {
                     cx.cx.redraw_area_in_draw(old_area);

--- a/draw/src/turtle.rs
+++ b/draw/src/turtle.rs
@@ -1513,7 +1513,49 @@ impl<'a, 'b> Cx2d<'a, 'b> {
             }
             Flow::Right { wrap: true, .. } => {
                 if turtle.deferred_fills.is_empty() {
-                    // TODO
+                    // Horizontal alignment for a wrapping row flow. This only
+                    // shifts walks whose reported `outer_size.x` is narrower
+                    // than the inner width. Text-heavy callers usually want
+                    // per-row text alignment, which the text layouter handles
+                    // via its own `align` option (see `DrawText::layout`).
+                    if turtle.align().x != 0.0 {
+                        let inner_effective_width = turtle.effective_inner_width();
+                        let align_x = turtle.align().x;
+                        let finished_rows_start = turtle.finished_rows_start;
+                        let finished_rows_end = self.finished_rows.len();
+
+                        let mut row_walks_start = turtle_walks_start;
+                        for row_idx in finished_rows_start..finished_rows_end {
+                            let row_walks_end = self.finished_rows[row_idx];
+
+                            let mut row_width = 0.0_f64;
+                            for walk_idx in row_walks_start..row_walks_end {
+                                row_width += self.finished_walks[walk_idx].outer_size.x;
+                            }
+                            let row_unused_width =
+                                (inner_effective_width - row_width).max(0.0);
+                            let dx = align_x * row_unused_width;
+
+                            if dx != 0.0 {
+                                for walk_idx in row_walks_start..row_walks_end {
+                                    let align_list_start =
+                                        self.finished_walks[walk_idx].align_list_start;
+                                    let align_list_end =
+                                        self.finished_walk_align_list_end(walk_idx);
+                                    self.move_align_list(
+                                        align_list_start,
+                                        align_list_end,
+                                        dx,
+                                        0.0,
+                                        false,
+                                    );
+                                    turtle = self.turtles.last_mut().unwrap();
+                                }
+                            }
+
+                            row_walks_start = row_walks_end;
+                        }
+                    }
                 } else {
                     panic!()
                 }

--- a/examples/uizoo/src/tab_html.rs
+++ b/examples/uizoo/src/tab_html.rs
@@ -43,6 +43,30 @@ script_mod! {
                 text_overflow: Ellipsis
                 body: "Stars \u{2B50}\u{2B50}\u{2B50} with <b>bold rockets \u{1F680}\u{1F680}\u{1F680}</b> and <i>italic flags \u{1F3C1}\u{1F3C1}\u{1F3C1}</i> and more content to overflow"
             }
+
+            Hr{}
+            H4{text: "Plain HTML table (no alignment)"}
+            P{text: "Default left-aligned cells. Exercises bold, italic, code, links, sub/sup, emoji, entities, and strikethrough inside cells."}
+            Html{
+                width: Fill height: Fit
+                body: "<table><thead><tr><th>Element</th><th>Symbol</th><th>Notes</th></tr></thead><tbody><tr><td>Hydrogen</td><td><b>H</b></td><td><i>Lightest</i> gas</td></tr><tr><td>Water</td><td>H<sub>2</sub>O</td><td>Covers ~71% of Earth \u{1F30A}</td></tr><tr><td>Carbon-14</td><td><sup>14</sup>C</td><td>Used in <code>dating</code>; see <a href='https://en.wikipedia.org/wiki/Carbon-14'>wiki</a></td></tr><tr><td>Caffeine</td><td>C<sub>8</sub>H<sub>10</sub>N<sub>4</sub>O<sub>2</sub></td><td>\u{2615} keeps you awake</td></tr><tr><td>Specials</td><td>a &amp; b &lt; c</td><td><s>struck</s> / <b>bold</b> / <i>em</i></td></tr></tbody></table>"
+            }
+
+            Hr{}
+            H4{text: "Aligned HTML table (align attr + style='text-align:')"}
+            P{text: "Left / center / right columns set via both the align attribute and inline style. Cells carry mixed formatting, links, sub/sup."}
+            Html{
+                width: Fill height: Fit
+                body: "<table><thead><tr><th align='left'>Task</th><th align='center'>Status</th><th style='text-align: right'>Due</th></tr></thead><tbody><tr><td align='left'>Ship feature <b>X</b></td><td align='center'><code>WIP</code></td><td style='text-align: right'><b>Fri</b></td></tr><tr><td align='left'>Review <a href='https://example.com'>PR #42</a></td><td align='center'><i>Pending</i></td><td style='text-align: right'>Mon</td></tr><tr><td align='left'>Fix <s>critical</s> bug</td><td align='center'>Done \u{2705}</td><td style='text-align: right'>Yesterday</td></tr><tr><td align='left'>Write spec for H<sub>2</sub>O sync</td><td align='center'>50%</td><td style='text-align: right'>2026-05-15</td></tr><tr><td align='left'>Ship Claude<sup>TM</sup> release</td><td align='center'>Blocked</td><td style='text-align: right'>TBD</td></tr></tbody></table>"
+            }
+
+            Hr{}
+            H4{text: "Numeric HTML table (all columns right-aligned)"}
+            P{text: "Typical numeric layout using align='right' on every cell. Header, body rows, and a bold totals row."}
+            Html{
+                width: Fill height: Fit
+                body: "<table><thead><tr><th align='left'>Region</th><th align='right'>Q1</th><th align='right'>Q2</th><th align='right'>Q3</th><th align='right'>YoY</th></tr></thead><tbody><tr><td align='left'><b>North America</b></td><td align='right'>$1.2M</td><td align='right'>$1.5M</td><td align='right'>$1.8M</td><td align='right'>+12%</td></tr><tr><td align='left'><i>Europe</i></td><td align='right'>$0.9M</td><td align='right'>$1.1M</td><td align='right'>$1.3M</td><td align='right'>+8%</td></tr><tr><td align='left'>Asia Pacific</td><td align='right'>$0.7M</td><td align='right'>$0.8M</td><td align='right'>$1.0M</td><td align='right'>+15%</td></tr><tr><td align='left'>LATAM</td><td align='right'>$0.2M</td><td align='right'>$0.3M</td><td align='right'>$0.4M</td><td align='right'>+22%</td></tr><tr><td align='left'><b>Total</b></td><td align='right'><b>$3.0M</b></td><td align='right'><b>$3.7M</b></td><td align='right'><b>$4.5M</b></td><td align='right'><b>+13%</b></td></tr></tbody></table>"
+            }
         }
     }
 }

--- a/examples/uizoo/src/tab_markdown.rs
+++ b/examples/uizoo/src/tab_markdown.rs
@@ -13,6 +13,30 @@ script_mod! {
                 width: Fill height: Fit
                 body: "# Headline 1 \n ## Headline 2 \n ### Headline 3 \n #### Headline 4 \n This is standard text with a  \n\n line break a short ~~strike through~~ demo.\n\n *Italic text* \n\n **Bold text** \n\n - Bullet\n - Another bullet\n - Third bullet\n 1. Numbered list Bullet\n 2. Another list entry\n 3. Third list entry\n `Monospaced text`\n> This is a quote.\nThis is `inline code`.\n ```code block```"
             }
+
+            Hr{}
+            H4{text: "Plain Markdown table (no alignment)"}
+            P{text: "Default left-aligned cells. Exercises bold, italic, code, links, sub/sup, emoji, and entities inside cells."}
+            Markdown{
+                width: Fill height: Fit
+                body: "| Element | Symbol | Notes |\n| --- | --- | --- |\n| Hydrogen | **H** | *Lightest* gas |\n| Water | H<sub>2</sub>O | Covers ~71% of Earth \u{1F30A} |\n| Carbon-14 | <sup>14</sup>C | Used in `dating`; see [wiki](https://en.wikipedia.org/wiki/Carbon-14) |\n| Caffeine | C<sub>8</sub>H<sub>10</sub>N<sub>4</sub>O<sub>2</sub> | \u{2615} keeps you awake |\n| Specials | a &amp; b &lt; c | ~~struck~~ / **bold** / *em* |"
+            }
+
+            Hr{}
+            H4{text: "Aligned Markdown table (left / center / right)"}
+            P{text: "Column alignments set by the separator row. Mixes wide and narrow cells with formatting, links, and sub/sup."}
+            Markdown{
+                width: Fill height: Fit
+                body: "| Task | Status | Due |\n|:-----|:------:|----:|\n| Ship feature **X** | `WIP` | **Fri** |\n| Review [PR #42](https://example.com) | *Pending* | Mon |\n| Fix ~~critical~~ bug | Done \u{2705} | Yesterday |\n| Write spec for H<sub>2</sub>O sync | 50% | 2026-05-15 |\n| Ship Claude<sup>TM</sup> release | Blocked | TBD |"
+            }
+
+            Hr{}
+            H4{text: "Numeric Markdown table (right-aligned)"}
+            P{text: "Typical use-case: every column right-aligned for numeric data. Wide-ish column widths expose the row-by-row alignment."}
+            Markdown{
+                width: Fill height: Fit
+                body: "| Region | Q1 | Q2 | Q3 | YoY |\n| ---:| ---:| ---:| ---:| ---:|\n| **North America** | $1.2M | $1.5M | $1.8M | +12% |\n| *Europe* | $0.9M | $1.1M | $1.3M | +8% |\n| Asia Pacific | $0.7M | $0.8M | $1.0M | +15% |\n| LATAM | $0.2M | $0.3M | $0.4M | +22% |\n| **Total** | **$3.0M** | **$3.7M** | **$4.5M** | **+13%** |"
+            }
         }
     }
 }

--- a/libs/html/src/lib.rs
+++ b/libs/html/src/lib.rs
@@ -322,7 +322,22 @@ pub fn parse_html(
                     Ok(entity) => {
                         *in_entity = None;
                         decoded.truncate(start);
-                        decoded.push(std::char::from_u32(entity).unwrap());
+                        let ch = std::char::from_u32(entity).unwrap();
+                        decoded.push(ch);
+                        // While the entity body was being scanned, each
+                        // character was appended to `decoded` and (if
+                        // non-whitespace) advanced `last_non_whitespace`.
+                        // After truncating, that index is now stale and
+                        // must be corrected — otherwise the next real
+                        // whitespace char collapses against a phantom
+                        // non-whitespace position past the buffer end, and
+                        // gets silently dropped.
+                        if ch.is_whitespace() {
+                            *last_non_whitespace =
+                                (*last_non_whitespace).min(start);
+                        } else {
+                            *last_non_whitespace = decoded.len();
+                        }
                         return;
                     }
                 }

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -330,9 +330,19 @@ impl Html {
 
             some_id!(sub) => {
                 tf.push_size_rel_scale(0.7);
+                // Shift the subscript baseline downward, relative to the
+                // subscript's own (smaller) font size. The value has to
+                // also cancel the natural upward drift that comes from a
+                // smaller font having a smaller ascender.
+                tf.y_shift_scales.push(0.55);
             }
             some_id!(sup) => {
                 tf.push_size_rel_scale(0.7);
+                // Shift the superscript baseline upward, relative to the
+                // superscript's own (smaller) font size. Smaller-than-the
+                // subscript shift because the smaller ascender already
+                // raises the baseline a bit on its own.
+                tf.y_shift_scales.push(-0.2);
             }
             some_id!(ul) => {
                 trim_whitespace_in_text = TrimWhitespaceInText::Trim;
@@ -417,12 +427,12 @@ impl Html {
             }
             some_id!(th) => {
                 tf.table_row_is_header = true;
-                tf.begin_table_cell(cx);
+                tf.begin_table_cell(cx, cell_align_x(node));
                 tf.bold.push();
                 trim_whitespace_in_text = TrimWhitespaceInText::Trim;
             }
             some_id!(td) => {
-                tf.begin_table_cell(cx);
+                tf.begin_table_cell(cx, cell_align_x(node));
                 trim_whitespace_in_text = TrimWhitespaceInText::Trim;
             }
             Some(x) => return (Some(x), trim_whitespace_in_text),
@@ -476,9 +486,11 @@ impl Html {
             }
             some_id!(sub) => {
                 tf.font_sizes.pop();
+                tf.y_shift_scales.pop();
             }
             some_id!(sup) => {
                 tf.font_sizes.pop();
+                tf.y_shift_scales.pop();
             }
             some_id!(ul) | some_id!(ol) => {
                 list_stack.pop();
@@ -966,5 +978,39 @@ pub fn to_roman_numeral(mut count: i32) -> Option<String> {
         Some(output)
     } else {
         None
+    }
+}
+
+/// Returns the horizontal alignment (`Layout::align.x`) for a `<td>` / `<th>`
+/// cell, based on the HTML `align` attribute or an inline
+/// `style="text-align: ..."` declaration. Defaults to left (0.0) when
+/// unspecified or unrecognized.
+fn cell_align_x(node: &HtmlWalker) -> f64 {
+    if let Some(align) = node.find_attr_lc(live_id!(align)) {
+        if let Some(x) = align_keyword_to_x(align) {
+            return x;
+        }
+    }
+    if let Some(style) = node.find_attr_lc(live_id!(style)) {
+        for decl in style.split(';') {
+            let Some((prop, value)) = decl.split_once(':') else {
+                continue;
+            };
+            if prop.trim().eq_ignore_ascii_case("text-align") {
+                if let Some(x) = align_keyword_to_x(value.trim()) {
+                    return x;
+                }
+            }
+        }
+    }
+    0.0
+}
+
+fn align_keyword_to_x(keyword: &str) -> Option<f64> {
+    match keyword.trim().to_ascii_lowercase().as_str() {
+        "left" | "start" | "justify" => Some(0.0),
+        "center" => Some(0.5),
+        "right" | "end" => Some(1.0),
+        _ => None,
     }
 }

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -982,15 +982,11 @@ pub fn to_roman_numeral(mut count: i32) -> Option<String> {
 }
 
 /// Returns the horizontal alignment (`Layout::align.x`) for a `<td>` / `<th>`
-/// cell, based on the HTML `align` attribute or an inline
-/// `style="text-align: ..."` declaration. Defaults to left (0.0) when
-/// unspecified or unrecognized.
+/// cell, based on an inline `style="text-align: ..."` declaration or the
+/// legacy HTML `align` attribute. `style` wins when both are set, matching
+/// CSS precedence over presentational attributes. Defaults to left (0.0)
+/// when unspecified or unrecognized.
 fn cell_align_x(node: &HtmlWalker) -> f64 {
-    if let Some(align) = node.find_attr_lc(live_id!(align)) {
-        if let Some(x) = align_keyword_to_x(align) {
-            return x;
-        }
-    }
     if let Some(style) = node.find_attr_lc(live_id!(style)) {
         for decl in style.split(';') {
             let Some((prop, value)) = decl.split_once(':') else {
@@ -1001,6 +997,11 @@ fn cell_align_x(node: &HtmlWalker) -> f64 {
                     return x;
                 }
             }
+        }
+    }
+    if let Some(align) = node.find_attr_lc(live_id!(align)) {
+        if let Some(x) = align_keyword_to_x(align) {
+            return x;
         }
     }
     0.0

--- a/widgets/src/markdown.rs
+++ b/widgets/src/markdown.rs
@@ -3,7 +3,9 @@ use crate::{
     widget::*, WidgetMatchEvent,
 };
 
-use pulldown_cmark::{CodeBlockKind, Event as MdEvent, HeadingLevel, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{
+    Alignment, CodeBlockKind, Event as MdEvent, HeadingLevel, Options, Parser, Tag, TagEnd,
+};
 
 script_mod! {
     use mod.prelude.widgets_internal.*
@@ -268,6 +270,10 @@ impl Markdown {
         // Track state for nested formatting
         let mut list_stack: Vec<ListState> = Vec::new();
         let mut is_first_block = true;
+        // Per-column alignments for the current table, and the current cell's
+        // column index within its row. Both are reset when a new table starts.
+        let mut table_alignments: Vec<Alignment> = Vec::new();
+        let mut table_cell_index: usize = 0;
 
         let parser = Parser::new_ext(
             self.body.as_ref(),
@@ -541,13 +547,18 @@ impl Markdown {
                     }
                     is_first_block = false;
                     tf.begin_table(cx, alignments.len());
+                    table_alignments = alignments;
+                    table_cell_index = 0;
                 }
                 MdEvent::End(TagEnd::Table) => {
                     tf.end_table(cx);
                     tf.new_line_collapsed_with_spacing(cx, self.paragraph_spacing);
+                    table_alignments.clear();
+                    table_cell_index = 0;
                 }
                 MdEvent::Start(Tag::TableHead) => {
                     tf.begin_table_header_row(cx);
+                    table_cell_index = 0;
                 }
                 MdEvent::End(TagEnd::TableHead) => {
                     tf.end_table_row(cx);
@@ -555,12 +566,17 @@ impl Markdown {
                 }
                 MdEvent::Start(Tag::TableRow) => {
                     tf.begin_table_row(cx);
+                    table_cell_index = 0;
                 }
                 MdEvent::End(TagEnd::TableRow) => {
                     tf.end_table_row(cx);
                 }
                 MdEvent::Start(Tag::TableCell) => {
-                    tf.begin_table_cell(cx);
+                    let align_x = table_alignments
+                        .get(table_cell_index)
+                        .map(alignment_to_x)
+                        .unwrap_or(0.0);
+                    tf.begin_table_cell(cx, align_x);
                     if tf.in_table_header {
                         tf.bold.push();
                     }
@@ -570,10 +586,44 @@ impl Markdown {
                         tf.bold.pop();
                     }
                     tf.end_table_cell(cx);
+                    table_cell_index += 1;
+                }
+                MdEvent::InlineHtml(text) => {
+                    // Support a handful of inline HTML tags that have no
+                    // CommonMark equivalent. Anything not matched is ignored,
+                    // matching the pre-existing behavior.
+                    match text.trim().to_ascii_lowercase().as_str() {
+                        "<sub>" => {
+                            tf.push_size_rel_scale(0.7);
+                            tf.y_shift_scales.push(0.55);
+                        }
+                        "</sub>" => {
+                            tf.font_sizes.pop();
+                            tf.y_shift_scales.pop();
+                        }
+                        "<sup>" => {
+                            tf.push_size_rel_scale(0.7);
+                            tf.y_shift_scales.push(-0.2);
+                        }
+                        "</sup>" => {
+                            tf.font_sizes.pop();
+                            tf.y_shift_scales.pop();
+                        }
+                        _ => {}
+                    }
                 }
                 _ => {} // Unimplemented or unnecessary events
             }
         }
+    }
+}
+
+/// Maps pulldown_cmark table-column alignment to `Layout::align.x`.
+fn alignment_to_x(alignment: &Alignment) -> f64 {
+    match alignment {
+        Alignment::None | Alignment::Left => 0.0,
+        Alignment::Center => 0.5,
+        Alignment::Right => 1.0,
     }
 }
 

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -1143,6 +1143,7 @@ impl TextFlow {
         self.table_row_cell_rects.clear();
         self.table_row_is_header = false;
         self.table_is_first_row = false;
+        self.cell_text_align_x = 0.0;
     }
 
     pub fn push_size_rel_scale(&mut self, scale: f64) {
@@ -1852,7 +1853,7 @@ impl TextFlow {
                     row_height,
                     max_width,
                     wrap,
-                    Align::default(),
+                    dt.layout_align,
                     text,
                 );
 

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -72,10 +72,26 @@ script_mod! {
                 FlowBlockType.TableCell => {
                     sdf.rect(0. 0. self.rect_size.x self.rect_size.y)
                     sdf.fill(self.table_header_bg_color)
-                    sdf.rect(self.rect_size.x-1. 0. 1. self.rect_size.y)
-                    sdf.fill(self.table_border_color)
-                    sdf.rect(0. self.rect_size.y-1. self.rect_size.x 1.)
-                    sdf.fill(self.table_border_color)
+                    // Draw the right/bottom 1px borders as hard-edged
+                    // lines rather than SDF rects, so they stay crisp and
+                    // fully opaque on low-DPI screens where a 1px SDF rect
+                    // gets AA'd across both edges and fades.
+                    //
+                    // Match whichever pixel actually sits in the rightmost
+                    // column / bottom row of the rasterized rect (pos > size - 1)
+                    // rather than a floor-snapped position. Cell dimensions
+                    // can be fractional (total table width isn't always a
+                    // multiple of the column count), and in that case the
+                    // last shaded pixel's local pos exceeds floor(size) by
+                    // a fraction — so floor-snapping would either leave a
+                    // seam at that pixel (gap) or place the line inside,
+                    // leaving a stub past the junction.
+                    let pos = self.pos * self.rect_size
+                    if pos.x > self.rect_size.x - 1.0
+                        || pos.y > self.rect_size.y - 1.0
+                    {
+                        return self.table_border_color
+                    }
                     return sdf.result
                 }
             }
@@ -627,6 +643,11 @@ pub struct TextFlow {
     area_stack: SmallVec<[Area; 4]>,
     #[rust]
     pub font_sizes: SmallVec<[f32; 8]>,
+    /// Per-run vertical baseline shifts, in multiples of the run's font size.
+    /// Positive values shift glyphs down; negative values shift them up.
+    /// Used to render `<sub>` / `<sup>` at a raised or lowered baseline.
+    #[rust]
+    pub y_shift_scales: SmallVec<[f32; 4]>,
     #[rust]
     pub font_colors: SmallVec<[Vec4f; 8]>,
     #[rust]
@@ -693,6 +714,11 @@ pub struct TextFlow {
     table_cell_layout: Layout,
     #[rust]
     pub table_num_columns: usize,
+    /// Horizontal text alignment applied by the layouter within the
+    /// currently active table cell. Set by `begin_table_cell`, cleared
+    /// by `end_table_cell`. Outside a cell it is always 0.0 (left).
+    #[rust]
+    pub cell_text_align_x: f64,
     #[rust]
     pub in_table_header: bool,
     #[rust]
@@ -1106,6 +1132,7 @@ impl TextFlow {
         self.strikethrough.clear();
         self.inline_code.clear();
         self.font_sizes.clear();
+        self.y_shift_scales.clear();
         self.font_colors.clear();
         self.area_stack.clear();
         self.combine_spaces.clear();
@@ -1513,7 +1540,12 @@ impl TextFlow {
         self.table_is_first_row = false;
     }
 
-    pub fn begin_table_cell(&mut self, cx: &mut Cx2d) {
+    /// Begin a table cell with horizontal alignment of its contents.
+    ///
+    /// `align_x` follows `Layout::align.x` semantics: 0.0 = left, 0.5 = center,
+    /// 1.0 = right. For wrapped multi-row content, the whole content block is
+    /// shifted by the same amount (not aligned per-row).
+    pub fn begin_table_cell(&mut self, cx: &mut Cx2d, align_x: f64) {
         let cell_width = if self.table_num_columns > 0 {
             cx.turtle().inner_width() / self.table_num_columns as f64
         } else {
@@ -1524,13 +1556,17 @@ impl TextFlow {
             height: Size::Fit { min: None, max: None },
             ..Walk::default()
         };
-        cx.begin_turtle(walk, self.table_cell_layout);
+        let mut layout = self.table_cell_layout;
+        layout.align.x = align_x;
+        cx.begin_turtle(walk, layout);
         self.first_thing_on_a_line = true;
+        self.cell_text_align_x = align_x;
     }
 
     pub fn end_table_cell(&mut self, cx: &mut Cx2d) {
         let cell_rect = cx.end_turtle();
         self.table_row_cell_rects.push(cell_rect);
+        self.cell_text_align_x = 0.0;
     }
 
     pub fn draw_item_counted(&mut self, cx: &mut Cx2d, template: LiveId) -> LiveId {
@@ -1759,7 +1795,12 @@ impl TextFlow {
             let font_color = self.font_colors.last().unwrap_or(&self.font_color);
             self.draw_text.text_style.font_size = *font_size as _;
             self.draw_text.color = *font_color;
-            self.draw_text.temp_y_shift = top_drop;
+            let y_shift_scale = self.y_shift_scales.last().copied().unwrap_or(0.0);
+            self.draw_text.temp_y_shift = top_drop + y_shift_scale;
+            self.draw_text.layout_align = Align {
+                x: self.cell_text_align_x,
+                y: 0.0,
+            };
 
             // Widget-level max_lines: compute how many layouter rows this run
             // is allowed. A "continuation" run starts mid-line (turtle x > left


### PR DESCRIPTION
- **Sub/sup in HTML**: added a `y_shift_scales` stack on `TextFlow`, composed onto `temp_y_shift` in `draw_text`. `<sub>` pushes `+0.55`, `<sup>` pushes `-0.2` in html.rs
- **Sub/sup in Markdown**: now handles `MdEvent::InlineHtml` for `<sub>`/`<sup>` (case-insensitive), using the same stacks.
- **Space after `&amp;` (and other entities)**: the HTML lib's entity decoder now resets `last_non_whitespace` after truncate+push, so the whitespace-collapse check no longer drops the next real space.
- **Table column alignment (Markdown)**: `begin_table_cell` takes `align_x: f64`; tracks `Tag::Table` alignments and a per-row column index, passing each cell's `Alignment` through.
- **Table column alignment (HTML)**: `<td>`/`<th>` now honor `align="…"` and inline `style="text-align: …"` via new `cell_align_x` / `align_keyword_to_x` helpers in html.rs.
- **Per-row text alignment plumbing**: new `layout_align` field on `DrawText` is passed to the layouter, which already supports per-row alignment. `TextFlow` propagates a `cell_text_align_x` into it. This is the actual fix that makes cell alignment visible.
- **Wrap-flow alignment scaffolding**: implemented the previously-stubbed `Flow::Right { wrap: true }` branch in the turtle logic. Useful for non-text wrapping walks; text goes through the layouter path above.
- Add examples to uizoo: three new tables in both markdown and html tab -- a plain one, a left/center/right aligned one, and a numeric all-right-aligned one. They cover bold/italic/code/links/sub-sup/emoji/entities/strikethrough inside cells.