### PR TITLE
Add RowAlign::Center, per-row FinishedWalk support, and inline widget alignment

### DIFF
--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -2312,7 +2312,10 @@ impl DrawText {
                 if let Some(mut instances) =
                     cx.begin_many_aligned_instances(&self.draw_vars)
                 {
+                    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
                     self.draw_row(cx, row_origin, row, &mut instances.instances);
+                    #[cfg(any(target_os = "linux", target_os = "windows"))]
+                    let _ = (row_origin, row, &mut instances.instances);
                     self.finish_many_instances(cx, instances);
                 }
 

--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -2141,11 +2141,10 @@ impl DrawText {
             }
         }
 
-        let wrap = cx.turtle().layout().flow
-            == Flow::Right {
-                row_align: RowAlign::Top,
-                wrap: true,
-            };
+        let wrap = matches!(
+            cx.turtle().layout().flow,
+            Flow::Right { wrap: true, .. }
+        );
 
         let text = self.layout(cx, 0.0, 0.0, max_width_in_lpxs, wrap, align, text);
         self.draw_walk_laidout(cx, walk, &text)
@@ -2201,29 +2200,37 @@ impl DrawText {
     /// Draws text within the current turtle flow, calling `f` for each laid-out row.
     /// Returns `(row_count, is_truncated)`: the number of rows produced, and whether
     /// the text was truncated (e.g., by `max_lines` / ellipsis).
+    ///
+    /// When text wraps to multiple visual rows, each row is emitted as its own
+    /// `FinishedWalk` with a single-row `outer_size.y`. Between rows,
+    /// `turtle_new_line_with_spacing` is called to finish the previous visual
+    /// row (triggering `finish_row` → `RowAlign::Center`, etc.) and position
+    /// the turtle for the next row. This lets per-row alignment work correctly
+    /// when inline block widgets (pills, badges, etc.) share a visual row with
+    /// text of a different height.
     pub fn draw_walk_resumable_with(
         &mut self,
         cx: &mut Cx2d,
         text_str: &str,
         mut f: impl FnMut(&mut Cx2d, Rect, f32),
     ) -> (usize, bool) {
+        // ── Layout parameters ──
         let turtle_pos = cx.turtle().pos();
         let turtle_rect = cx.turtle().inner_rect();
         let origin_in_lpxs = Point::new(turtle_rect.pos.x as f32, turtle_pos.y as f32);
         let first_row_indent_in_lpxs = turtle_pos.x as f32 - origin_in_lpxs.x;
         let row_height = cx.turtle().next_row_offset();
-
         let max_width_in_lpxs = if !turtle_rect.size.x.is_nan() {
             Some(turtle_rect.size.x as f32)
         } else {
             None
         };
-        let wrap = cx.turtle().layout().flow
-            == Flow::Right {
-                row_align: RowAlign::Top,
-                wrap: true,
-            };
+        let wrap = matches!(
+            cx.turtle().layout().flow,
+            Flow::Right { wrap: true, .. }
+        );
 
+        // ── Text layout ──
         let text = self.layout(
             cx,
             first_row_indent_in_lpxs,
@@ -2233,84 +2240,198 @@ impl DrawText {
             Align::default(),
             text_str,
         );
-        self.draw_text(cx, origin_in_lpxs, &text);
 
+        // ── Common computations ──
         let last_row = text.rows.last().unwrap();
-        let new_turtle_pos = origin_in_lpxs
-            + Size::new(
-                last_row.width_in_lpxs,
-                last_row.origin_in_lpxs.y - last_row.ascender_in_lpxs,
-            ) * self.font_scale;
+        let new_turtle_pos = {
+            let p = origin_in_lpxs
+                + Size::new(
+                    last_row.width_in_lpxs,
+                    last_row.origin_in_lpxs.y - last_row.ascender_in_lpxs,
+                ) * self.font_scale;
+            dvec2(p.x as f64, p.y as f64)
+        };
         let used_size_in_lpxs = text.size_in_lpxs * self.font_scale;
-        // Account for temp_y_shift in the allocated height so that shifted
-        // glyphs (e.g., from top_drop) don't get clipped by their container.
-        let shift_extra_height = if self.temp_y_shift != 0.0 {
-            let fs = text
-                .rows
-                .first()
-                .and_then(|r| r.glyphs.first())
-                .map(|g| g.font_size_in_lpxs)
-                .unwrap_or(0.0);
-            (self.temp_y_shift * fs * self.font_scale).abs() as f64
-        } else {
-            0.0
-        };
-        let new_turtle_pos = dvec2(new_turtle_pos.x as f64, new_turtle_pos.y as f64);
-        let turtle = cx.turtle_mut();
+        let shift_y = text.rows.first()
+            .and_then(|r| r.glyphs.first())
+            .map(|g| g.font_size_in_lpxs * self.temp_y_shift)
+            .unwrap_or(0.0);
 
-        turtle.move_to(dvec2(origin_in_lpxs.x as f64, origin_in_lpxs.y as f64));
-        turtle.allocate_width(used_size_in_lpxs.width as f64);
-        turtle.allocate_height(used_size_in_lpxs.height as f64 + shift_extra_height);
-        turtle.move_to(new_turtle_pos);
+        // ── Decide whether to use per-row glyph batching ──
+        // Per-row batching gives each visual row its own AlignEntry so that
+        // finish_row alignment shifts apply independently per row. This
+        // requires a fresh draw (no `many_instances` reuse buffer).
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        let per_row = self.many_instances.is_none() && text.rows.len() > 1;
+        #[cfg(any(target_os = "linux", target_os = "windows"))]
+        let per_row = false;
 
-        turtle.set_wrap_spacing(
-            (last_row.ascender_in_lpxs * last_row.line_spacing_scale - last_row.ascender_in_lpxs)
-                as f64,
-        );
+        if per_row {
+            // ── PER-ROW path ──
+            // Draw each visual row as a separate instance batch so its glyphs
+            // get their own AlignEntry. Emit a FinishedWalk per row and call
+            // turtle_new_line between rows so finish_row runs at each row
+            // boundary — enabling RowAlign::Center to center text relative to
+            // any inline widget (pill) on the same visual row.
 
-        cx.emit_turtle_walk(Rect {
-            pos: new_turtle_pos,
-            size: dvec2(
-                used_size_in_lpxs.width as f64,
-                used_size_in_lpxs.height as f64 + shift_extra_height,
-            ),
-        });
+            self.update_draw_vars(cx);
+            self.glyph_depth = self.draw_depth;
+            let saved_extend_area = self.extend_area;
 
-        let shift = if let Some(row) = text.rows.first() {
-            if let Some(glyph) = row.glyphs.first() {
-                glyph.font_size_in_lpxs * self.temp_y_shift
-            } else {
-                0.0
+            for (row_idx, row) in text.rows.iter().enumerate() {
+                let row_h =
+                    ((row.ascender_in_lpxs - row.descender_in_lpxs) * self.font_scale) as f64;
+
+                // Between rows: finish the previous visual row (triggers
+                // finish_row → RowAlign::Center) and position for the next.
+                if row_idx > 0 {
+                    let ws = cx.turtle().wrap_spacing();
+                    cx.turtle_new_line_with_spacing(ws);
+                    self.extend_area = true;
+                }
+
+                // Compute row_origin: for row 0 (continuation row), use the
+                // layouter's position (correct indent on the existing line).
+                // For wrapped rows (1+), use the TURTLE's current position so
+                // glyphs land where the turtle tracks — not at the layouter's
+                // position which doesn't account for taller inline widgets
+                // (pills) inflating the previous row's height.
+                let row_origin = if row_idx == 0 {
+                    origin_in_lpxs + Size::from(row.origin_in_lpxs) * self.font_scale
+                } else {
+                    let tp = cx.turtle().pos();
+                    Point::new(
+                        tp.x as f32 + row.origin_in_lpxs.x * self.font_scale,
+                        tp.y as f32 + row.ascender_in_lpxs * self.font_scale,
+                    )
+                };
+                let row_top_y = (row_origin.y - row.ascender_in_lpxs * self.font_scale) as f64;
+
+                // Draw this row's glyphs as a separate aligned-instance batch.
+                let row_als = cx.align_list_len();
+                if let Some(mut instances) =
+                    cx.begin_many_aligned_instances(&self.draw_vars)
+                {
+                    self.draw_row(cx, row_origin, row, &mut instances.instances);
+                    self.finish_many_instances(cx, instances);
+                }
+
+                // Update turtle allocation for this row.
+                if row_idx == 0 {
+                    let turtle = cx.turtle_mut();
+                    turtle.move_to(dvec2(
+                        origin_in_lpxs.x as f64,
+                        origin_in_lpxs.y as f64,
+                    ));
+                    turtle.allocate_width(used_size_in_lpxs.width as f64);
+                    turtle.allocate_height(row_h);
+                } else {
+                    let turtle = cx.turtle_mut();
+                    turtle.allocate_height(row_h);
+                    turtle.allocate_width(
+                        (row.width_in_lpxs * self.font_scale) as f64,
+                    );
+                }
+
+                // Set wrap spacing from this row's line-spacing metrics.
+                cx.turtle_mut().set_wrap_spacing(
+                    (row.ascender_in_lpxs * row.line_spacing_scale
+                        - row.ascender_in_lpxs) as f64,
+                );
+
+                // Call the `f` callback for this row (draws inline-code bg,
+                // strikethrough, underline, or plain area tracking).
+                let (sx, ex) = row_span_x_bounds_in_lpxs(
+                    row,
+                    row_idx == 0,
+                    row_idx + 1 == text.rows.len(),
+                );
+                f(
+                    cx,
+                    rect(
+                        (row_origin.x + sx * self.font_scale) as f64,
+                        row_top_y + shift_y as f64,
+                        ((ex - sx) * self.font_scale) as f64,
+                        row_h,
+                    ),
+                    row.ascender_in_lpxs,
+                );
+
+                // Emit a per-row FinishedWalk covering this row's glyphs +
+                // callback rect-areas.
+                cx.emit_turtle_walk(
+                    Rect {
+                        pos: dvec2(row_origin.x as f64, row_top_y),
+                        size: dvec2(
+                            (row.width_in_lpxs * self.font_scale) as f64,
+                            row_h,
+                        ),
+                    },
+                    row_als,
+                );
             }
-        } else {
-            0.0
-        };
 
-        for (row_index, row) in text.rows.iter().enumerate() {
-            let (start_x_in_lpxs, end_x_in_lpxs) =
-                row_span_x_bounds_in_lpxs(row, row_index == 0, row_index + 1 == text.rows.len());
-            let rect_in_lpxs = TextRect::new(
-                Point::new(
-                    origin_in_lpxs.x + (row.origin_in_lpxs.x + start_x_in_lpxs) * self.font_scale,
-                    origin_in_lpxs.y
-                        + (row.origin_in_lpxs.y - row.ascender_in_lpxs) * self.font_scale,
-                ),
-                Size::new(
-                    (end_x_in_lpxs - start_x_in_lpxs) * self.font_scale,
-                    (row.ascender_in_lpxs - row.descender_in_lpxs) * self.font_scale,
-                ),
+            // Position turtle at end of last row for subsequent inline content.
+            // pos.y is already at the last row's top (from turtle_new_line).
+            // Advance pos.x past the last row's text width.
+            let last = text.rows.last().unwrap();
+            let end_x = cx.turtle().pos().x
+                + (last.width_in_lpxs * self.font_scale) as f64;
+            let end_y = cx.turtle().pos().y;
+            cx.turtle_mut().move_to(dvec2(end_x, end_y));
+            self.extend_area = saved_extend_area;
+            self.flush_slug_textures_if_allowed(cx);
+        } else {
+            // ── SINGLE-WALK path (single-row text, reuse mode, or Linux/Win) ──
+            let align_list_start = cx.align_list_len();
+            self.draw_text(cx, origin_in_lpxs, &text);
+
+            let turtle = cx.turtle_mut();
+            turtle.move_to(dvec2(origin_in_lpxs.x as f64, origin_in_lpxs.y as f64));
+            turtle.allocate_width(used_size_in_lpxs.width as f64);
+            turtle.allocate_height(used_size_in_lpxs.height as f64);
+            turtle.move_to(new_turtle_pos);
+            turtle.set_wrap_spacing(
+                (last_row.ascender_in_lpxs * last_row.line_spacing_scale
+                    - last_row.ascender_in_lpxs) as f64,
             );
-            f(
-                cx,
-                rect(
-                    rect_in_lpxs.origin.x as f64,
-                    rect_in_lpxs.origin.y as f64 + shift as f64,
-                    rect_in_lpxs.size.width as f64,
-                    rect_in_lpxs.size.height as f64,
-                ),
-                row.ascender_in_lpxs,
-            )
+
+            cx.emit_turtle_walk(
+                Rect {
+                    pos: new_turtle_pos,
+                    size: dvec2(
+                        used_size_in_lpxs.width as f64,
+                        used_size_in_lpxs.height as f64,
+                    ),
+                },
+                align_list_start,
+            );
+
+            for (row_index, row) in text.rows.iter().enumerate() {
+                let (sx, ex) = row_span_x_bounds_in_lpxs(
+                    row,
+                    row_index == 0,
+                    row_index + 1 == text.rows.len(),
+                );
+                f(
+                    cx,
+                    rect(
+                        (origin_in_lpxs.x
+                            + (row.origin_in_lpxs.x + sx) * self.font_scale)
+                            as f64,
+                        (origin_in_lpxs.y
+                            + (row.origin_in_lpxs.y - row.ascender_in_lpxs)
+                                * self.font_scale) as f64
+                            + shift_y as f64,
+                        ((ex - sx) * self.font_scale) as f64,
+                        ((row.ascender_in_lpxs - row.descender_in_lpxs)
+                            * self.font_scale) as f64,
+                    ),
+                    row.ascender_in_lpxs,
+                );
+            }
         }
+
         (text.rows.len(), text.is_truncated)
     }
 

--- a/draw/src/turtle.rs
+++ b/draw/src/turtle.rs
@@ -544,11 +544,28 @@ impl Default for Flow {
     }
 }
 
+/// How each walk in a `Flow::Right { wrap: true }` row is vertically aligned
+/// relative to the row's other walks.
+///
+/// All alignment is performed at row-finish time (i.e., when the row wraps
+/// or when the turtle ends) by shifting the already-rendered items in the
+/// turtle's align list. `Top` (the default) is a no-op.
 #[derive(Copy, Clone, PartialEq, Debug, Script, ScriptHook)]
 pub enum RowAlign {
+    /// Each walk is placed at the top of the row (no post-adjustment). This
+    /// is the default and matches the historical layout behavior.
     #[pick]
     Top,
+    /// Each walk is shifted down so its bottom sits on the row baseline,
+    /// using `Walk::metrics.descender` to separate baseline from bottom.
+    /// Useful for text-heavy rows with mixed font sizes.
     Bottom,
+    /// Each walk is shifted down so its vertical center aligns with the row's
+    /// vertical center. Useful for mixing inline block widgets (e.g. pills)
+    /// with surrounding text: the block stays put (it's the tallest item on
+    /// the row), and the text slides down to the row's center so that the
+    /// block's internal content visually aligns with the surrounding text.
+    Center,
 }
 
 /// The turtle is the main layout primitive in Makepad.
@@ -2011,13 +2028,40 @@ impl<'a, 'b> Cx2d<'a, 'b> {
         }
     }
 
-    pub fn emit_turtle_walk(&mut self, rect: Rect) {
+    /// Returns the current length of the turtle's align list. Call this
+    /// BEFORE drawing something you later intend to register with
+    /// [`emit_turtle_walk`], and pass the captured value as that call's
+    /// `align_list_start` argument.
+    pub fn align_list_len(&self) -> usize {
+        self.align_list.len()
+    }
+
+    /// Records that the current turtle has emitted a `Rect`-shaped walk.
+    ///
+    /// `align_list_start` must be the value of [`Cx2d::align_list_len`]
+    /// captured BEFORE the caller added any align entries for this walk. This
+    /// mirrors how `walk_turtle_internal` records `align_list_start`, and lets
+    /// `finish_row`'s row-alignment passes (e.g., `RowAlign::Center`) correctly
+    /// identify and shift the walk's own align entries.
+    pub fn emit_turtle_walk(&mut self, rect: Rect, align_list_start: usize) {
+        self.emit_turtle_walk_with_metrics(rect, align_list_start, Metrics::default())
+    }
+
+    /// Like [`emit_turtle_walk`] but lets the caller specify the walk's
+    /// `Metrics` (descender/line_gap/line_scale) for baseline-aware row
+    /// alignment (`RowAlign::Bottom`).
+    pub fn emit_turtle_walk_with_metrics(
+        &mut self,
+        rect: Rect,
+        align_list_start: usize,
+        metrics: Metrics,
+    ) {
         let turtle = self.turtles.last().unwrap();
         self.finished_walks.push(FinishedWalk {
-            align_list_start: self.align_list.len(),
+            align_list_start,
             deferred_before_count: turtle.deferred_fills.len(),
             outer_size: rect.size,
-            metrics: Metrics::default(),
+            metrics,
         });
     }
 
@@ -2079,84 +2123,165 @@ impl<'a, 'b> Cx2d<'a, 'b> {
     }
 
     fn finish_row(&mut self, align_list_start: usize) {
-        if let Flow::Right {
-            row_align: RowAlign::Bottom,
-            ..
-        } = self.turtle().flow()
-        {
-            let current_row_height = self.turtle().row_height();
-            let current_row_metrics = self.turtle().current_row_metrics;
+        let row_align = if let Flow::Right { row_align, .. } = self.turtle().flow() {
+            row_align
+        } else {
+            RowAlign::Top
+        };
 
-            // We're going to push down each finished walk for the current row so that their
-            // baseline aligns with the bottom of the current row. Therefore, the height of the
-            // ascender of the current row will be the height of the current row, minus the height
-            // of the descender of the current row.
-            let current_row_ascender = current_row_height - current_row_metrics.descender;
-
-            // If the current row is not the first row, compute the amount by which we have to shift
-            // each finished walk for the current row so that the actual spacing between the
-            // baseline of the previous and the current row is equal to the desired spacing.
-            let line_spacing_shift = if self.turtle_is_at_first_row() {
-                0.0
-            } else {
-                // After we've pushed down each finished walk for the current row so that their
-                // baseline aligns with the bottom of the current row, the actual spacing
-                // between the baseline of the previous and current row will be the height of
-                // the descender of the previous row, plus the height of the current row.
-                let prev_row_metrics = self.turtle().prev_row_metrics;
-                let actual_line_spacing = prev_row_metrics.descender + current_row_height;
-
-                // The desired spacing between the baseline of the previous and current row is
-                // the sum of the height of the descender and line gap of the previous row, and
-                // the ascender of the current row, scaled up by the line scale of the current
-                // row.
-                let desired_line_spacing =
-                    (prev_row_metrics.descender + prev_row_metrics.line_gap + current_row_ascender)
-                        * current_row_metrics.line_scale;
-
-                // The amount by which we have to shift each finished walk is the difference between
-                // the desired and the actual spacing.
-                desired_line_spacing - actual_line_spacing
-            };
-
-            // Update the height of the row to account for the shifts we're about to do.
-            self.turtle_mut().used_height += current_row_metrics.descender + line_spacing_shift;
-
-            let finished_walks_start =
-                if self.turtle().finished_rows_start == self.finished_rows.len() {
-                    self.turtle().finished_walks_start
-                } else {
-                    self.finished_rows[self.turtle().finished_rows_start]
-                };
-            let finished_walks_end = self.finished_walks.len();
-            for finished_walk_index in finished_walks_start..finished_walks_end {
-                let finished_walk_height = self.finished_walks[finished_walk_index].outer_size.y;
-                let finished_walk_metrics = self.finished_walks[finished_walk_index].metrics;
-
-                // The amount by which we have to shift the current finished walk so that its
-                // descender aligns with the bottom of the current row.
-                let descender_shift = current_row_height - finished_walk_height;
-
-                // The amount by which we have to shift the current finished walk so that its
-                // baseline aligns with the bottom of the current row.
-                let baseline_shift = finished_walk_metrics.descender;
-
-                // The total amount by which we have to shift the current finished walk.
-                let shift = descender_shift + baseline_shift + line_spacing_shift;
-
-                let start = self.finished_walks[finished_walk_index].align_list_start;
-                let end = if finished_walk_index + 1 < self.finished_walks.len() {
-                    self.finished_walks[finished_walk_index + 1].align_list_start
-                } else {
-                    align_list_start
-                };
-                self.move_align_list(start, end, 0.0, shift, false);
+        match row_align {
+            RowAlign::Top => {
+                // No per-walk shifts needed — items stay at the row top.
+            }
+            RowAlign::Bottom => {
+                self.finish_row_bottom(align_list_start);
+            }
+            RowAlign::Center => {
+                self.finish_row_center(align_list_start);
             }
         }
 
         self.turtle_mut().prev_row_metrics = self.turtle().current_row_metrics;
         self.turtle_mut().current_row_metrics = Metrics::default();
         self.finished_rows.push(self.finished_walks.len());
+    }
+
+    /// Baseline-aligns every finished walk in the current row so that its
+    /// descender sits on the row's baseline. Requires each walk's
+    /// `metrics.descender` to describe the distance from its bottom to its
+    /// internal baseline.
+    fn finish_row_bottom(&mut self, align_list_start: usize) {
+        let current_row_height = self.turtle().row_height();
+        let current_row_metrics = self.turtle().current_row_metrics;
+
+        // We're going to push down each finished walk for the current row so that their
+        // baseline aligns with the bottom of the current row. Therefore, the height of the
+        // ascender of the current row will be the height of the current row, minus the height
+        // of the descender of the current row.
+        let current_row_ascender = current_row_height - current_row_metrics.descender;
+
+        // If the current row is not the first row, compute the amount by which we have to shift
+        // each finished walk for the current row so that the actual spacing between the
+        // baseline of the previous and the current row is equal to the desired spacing.
+        let line_spacing_shift = if self.turtle_is_at_first_row() {
+            0.0
+        } else {
+            // After we've pushed down each finished walk for the current row so that their
+            // baseline aligns with the bottom of the current row, the actual spacing
+            // between the baseline of the previous and current row will be the height of
+            // the descender of the previous row, plus the height of the current row.
+            let prev_row_metrics = self.turtle().prev_row_metrics;
+            let actual_line_spacing = prev_row_metrics.descender + current_row_height;
+
+            // The desired spacing between the baseline of the previous and current row is
+            // the sum of the height of the descender and line gap of the previous row, and
+            // the ascender of the current row, scaled up by the line scale of the current
+            // row.
+            let desired_line_spacing =
+                (prev_row_metrics.descender + prev_row_metrics.line_gap + current_row_ascender)
+                    * current_row_metrics.line_scale;
+
+            // The amount by which we have to shift each finished walk is the difference between
+            // the desired and the actual spacing.
+            desired_line_spacing - actual_line_spacing
+        };
+
+        // Update the height of the row to account for the shifts we're about to do.
+        self.turtle_mut().used_height += current_row_metrics.descender + line_spacing_shift;
+
+        let finished_walks_start = self.current_row_walks_start();
+        let finished_walks_end = self.finished_walks.len();
+        for finished_walk_index in finished_walks_start..finished_walks_end {
+            let finished_walk_height = self.finished_walks[finished_walk_index].outer_size.y;
+            let finished_walk_metrics = self.finished_walks[finished_walk_index].metrics;
+
+            // The amount by which we have to shift the current finished walk so that its
+            // descender aligns with the bottom of the current row.
+            let descender_shift = current_row_height - finished_walk_height;
+
+            // The amount by which we have to shift the current finished walk so that its
+            // baseline aligns with the bottom of the current row.
+            let baseline_shift = finished_walk_metrics.descender;
+
+            // The total amount by which we have to shift the current finished walk.
+            let shift = descender_shift + baseline_shift + line_spacing_shift;
+
+            let start = self.finished_walks[finished_walk_index].align_list_start;
+            let end = if finished_walk_index + 1 < self.finished_walks.len() {
+                self.finished_walks[finished_walk_index + 1].align_list_start
+            } else {
+                align_list_start
+            };
+            self.move_align_list(start, end, 0.0, shift, false);
+        }
+    }
+
+    /// Returns the `finished_walks` index where the current (unfinished) row's
+    /// walks begin for the current turtle.
+    ///
+    /// * If this turtle has no finished rows yet, the current row's walks start
+    ///   at `turtle.finished_walks_start`.
+    /// * Otherwise, they start just after the last finished row of this turtle.
+    ///   `finished_rows` holds cumulative `finished_walks.len()` snapshots at
+    ///   each row boundary; nested turtles truncate their own entries when they
+    ///   end, so `finished_rows.last()` is always the current turtle's most
+    ///   recent row end (as long as this turtle has any).
+    fn current_row_walks_start(&self) -> usize {
+        if self.turtle().finished_rows_start == self.finished_rows.len() {
+            self.turtle().finished_walks_start
+        } else {
+            // Safe: finished_rows.len() > finished_rows_start, so at least one
+            // entry exists for this turtle and it's at the end of the vec.
+            *self.finished_rows.last().unwrap()
+        }
+    }
+
+    /// Vertically centers every finished walk in the current row on the row's
+    /// vertical center line.
+    ///
+    /// The row height is the max height of any walk on the row, so the tallest
+    /// walk (e.g. an inline pill widget) has a zero shift and stays put. Shorter
+    /// walks (e.g. surrounding text) are shifted down by half the difference,
+    /// so their vertical centers land on the same horizontal line as the tallest
+    /// walk's center. For symmetrically-padded pills this makes the pill's
+    /// internal text visually align with the surrounding text.
+    ///
+    /// This alignment does not grow the row's `used_height` — every walk stays
+    /// entirely within the row's bounds because each shift is at most
+    /// `(row_height - walk_height) / 2` and each walk has height
+    /// `<= row_height`.
+    fn finish_row_center(&mut self, align_list_start: usize) {
+        let current_row_height = self.turtle().row_height();
+
+        let finished_walks_start = self.current_row_walks_start();
+        let finished_walks_end = self.finished_walks.len();
+
+        for finished_walk_index in finished_walks_start..finished_walks_end {
+            let finished_walk_height = self.finished_walks[finished_walk_index].outer_size.y;
+            let shift = (current_row_height - finished_walk_height) * 0.5;
+
+            if shift <= 0.0 {
+                continue;
+            }
+
+            let start = self.finished_walks[finished_walk_index].align_list_start;
+            let end = if finished_walk_index + 1 < self.finished_walks.len() {
+                self.finished_walks[finished_walk_index + 1].align_list_start
+            } else {
+                align_list_start
+            };
+            self.move_align_list(start, end, 0.0, shift, false);
+        }
+    }
+
+    /// Shifts the rendered content in the align list range `[start, end)` by
+    /// `(dx, dy)` logical pixels. This moves already-drawn instances and rect
+    /// areas without changing the turtle's allocation.
+    ///
+    /// Use [`Cx2d::align_list_len`] to capture `start` before drawing and
+    /// `end` after drawing, then call this to reposition the drawn content.
+    pub fn shift_align_entries(&mut self, start: usize, end: usize, dx: f64, dy: f64) {
+        self.move_align_list(start, end, dx, dy, false);
     }
 
     fn move_align_list(&mut self, start: usize, end: usize, dx: f64, dy: f64, shift_clip: bool) {

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -1803,7 +1803,10 @@ impl TextFlow {
                 } else {
                     None
                 };
-                let wrap = cx.turtle().layout().flow == Flow::right_wrap();
+                let wrap = matches!(
+                    cx.turtle().layout().flow,
+                    Flow::Right { wrap: true, .. }
+                );
 
                 let laidout_text = dt.layout(
                     cx,
@@ -1827,12 +1830,21 @@ impl TextFlow {
                     let rect = TextFlow::walk_margin(cx, self.inline_code_margin.left);
                     areas_tracker.track_rect(cx, rect);
                 }
+                let code_pad_h = (self.inline_code_padding.top
+                    + self.inline_code_padding.bottom
+                    + self.inline_code_margin.top
+                    + self.inline_code_margin.bottom) as f64;
                 let result = dt.draw_walk_resumable_with(cx, text, |cx, mut rect, _| {
                     rect.pos -= self.inline_code_padding.left_top();
                     rect.size += self.inline_code_padding.size();
                     db.draw_abs(cx, rect);
                     areas_tracker.track_rect(cx, rect);
                 });
+                // The inline_code padding/margin extends the visual rect
+                // beyond what draw_walk_resumable_with allocated in the
+                // turtle. Grow used_height so the next row starts below the
+                // padded area instead of overlapping it.
+                cx.turtle_mut().allocate_height(code_pad_h);
                 let rect = TextFlow::walk_margin(cx, self.inline_code_margin.right);
                 areas_tracker.track_rect(cx, rect);
                 result


### PR DESCRIPTION
Closes #712

turtle.rs:
- Add RowAlign::Center variant for vertically centering walks within a row
- Add finish_row_center() that shifts shorter walks to the row's vertical midline
- Fix finish_row's current_row_walks_start() to use last finished row (not first)
- Add Cx2d::align_list_len(), shift_align_entries(), emit_turtle_walk_with_metrics()

draw_text.rs (draw_walk_resumable_with):
- Per-row path: multi-row wrapped text now emits one FinishedWalk per visual row with separate glyph instance batches, enabling RowAlign::Center per row
- Between rows: call turtle_new_line_with_spacing to trigger finish_row at each visual-row boundary
- Wrapped rows draw glyphs at turtle position (not layouter position) so glyph positions stay in sync with turtle tracking when pills inflate row height
- Remove shift_extra_height from allocation (caused turtle/glyph position divergence)

text_flow.rs:
- Fix wrap check to use matches!(Flow::Right { wrap: true, .. }) instead of equality against Flow::right_wrap() (broke wrapping with non-Top RowAlign)
- Account for inline_code padding in turtle allocation (fixes overlap bug)