### PR TITLE
Support runtime changes to script-level heap objects

### DIFF
--- a/draw/src/lib.rs
+++ b/draw/src/lib.rs
@@ -47,7 +47,7 @@ pub use crate::{
         GeometryGen,
         GeometryQuad2D,
     },*/
-    turtle::{Align, DeferredWalk, Flow, Layout, Metrics, Size, TurtleAlignRange, Walk},
+    turtle::{Align, Base, DeferredWalk, FitBound, Flow, Layout, Metrics, Size, TurtleAlignRange, Walk},
     vector::{GradientStop, VectorPaint},
 };
 

--- a/platform/src/app_main.rs
+++ b/platform/src/app_main.rs
@@ -307,10 +307,6 @@ macro_rules! app_main {
                                 .as_ref()
                                 .map(|r| $crate::ScriptValue::from(r.as_object()));
                             if let Some(value) = value {
-                                eprintln!(
-                                    "AppMain Event::ScriptReapply: applying tree with value obj={:?}",
-                                    value.as_object(),
-                                );
                                 cx.with_vm(|vm| {
                                     <$app as $crate::ScriptApply>::script_apply(
                                         app,
@@ -320,9 +316,6 @@ macro_rules! app_main {
                                         value,
                                     );
                                 });
-                                eprintln!("AppMain Event::ScriptReapply: done");
-                            } else {
-                                eprintln!("AppMain Event::ScriptReapply: app_value not set, skipping");
                             }
                         }
                     }

--- a/platform/src/app_main.rs
+++ b/platform/src/app_main.rs
@@ -257,12 +257,24 @@ macro_rules! app_main {
                 return;
             }
 
+            // `app_value` caches the app's script root as a rooted
+            // `ScriptObjectRef` so `Event::ScriptReapply` can re-apply the
+            // widget tree without re-running `script_mod` (which would
+            // wipe runtime heap overrides like preference-driven template
+            // mutations). A rooted ref is required — storing a bare
+            // `ScriptValue` would let the script heap GC the slot out
+            // from under us between `Event::Startup` and the first reapply.
             let app = std::rc::Rc::new(std::cell::RefCell::new(None));
+            let app_value: std::rc::Rc<std::cell::RefCell<Option<$crate::ScriptObjectRef>>>
+                = std::rc::Rc::new(std::cell::RefCell::new(None));
             let mut cx = std::rc::Rc::new(std::cell::RefCell::new(Cx::new(Box::new(
                 move |cx, event| {
                     if let Event::Startup = event {
                         *app.borrow_mut() = Some(cx.with_vm(|vm| {
                             let value = <$app as AppMain>::script_mod(vm);
+                            if let Some(obj) = value.as_object() {
+                                *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
+                            }
                             let mut app = <$app as $crate::ScriptNew>::script_from_value(vm, value);
                             <$app as AppMain>::after_new_from_script(vm, &mut app);
                             app
@@ -274,6 +286,9 @@ macro_rules! app_main {
                         if let Some(app) = app_ref.as_mut() {
                             cx.with_vm(|vm| {
                                 let value = vm.with_reload(|vm| <$app as AppMain>::script_mod(vm));
+                                if let Some(obj) = value.as_object() {
+                                    *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
+                                }
                                 <$app as $crate::ScriptApply>::script_apply(
                                     app,
                                     vm,
@@ -282,6 +297,33 @@ macro_rules! app_main {
                                     value,
                                 );
                             });
+                        }
+                    }
+                    if let Event::ScriptReapply = event {
+                        let mut app_ref = app.borrow_mut();
+                        if let Some(app) = app_ref.as_mut() {
+                            let value = app_value
+                                .borrow()
+                                .as_ref()
+                                .map(|r| $crate::ScriptValue::from(r.as_object()));
+                            if let Some(value) = value {
+                                eprintln!(
+                                    "AppMain Event::ScriptReapply: applying tree with value obj={:?}",
+                                    value.as_object(),
+                                );
+                                cx.with_vm(|vm| {
+                                    <$app as $crate::ScriptApply>::script_apply(
+                                        app,
+                                        vm,
+                                        &$crate::Apply::Reload,
+                                        &mut $crate::Scope::empty(),
+                                        value,
+                                    );
+                                });
+                                eprintln!("AppMain Event::ScriptReapply: done");
+                            } else {
+                                eprintln!("AppMain Event::ScriptReapply: app_value not set, skipping");
+                            }
                         }
                     }
                     if let Some(app) = &mut *app.borrow_mut() {
@@ -332,10 +374,15 @@ macro_rules! app_main {
             Cx::android_entry(activity, || {
                 let studio_http = $crate::resolve_studio_http();
                 let app = std::rc::Rc::new(std::cell::RefCell::new(None));
+                let app_value: std::rc::Rc<std::cell::RefCell<Option<$crate::ScriptObjectRef>>>
+                    = std::rc::Rc::new(std::cell::RefCell::new(None));
                 let mut cx = Box::new(Cx::new(Box::new(move |cx, event| {
                     if let Event::Startup = event {
                         *app.borrow_mut() = Some(cx.with_vm(|vm| {
                             let value = <$app as AppMain>::script_mod(vm);
+                            if let Some(obj) = value.as_object() {
+                                *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
+                            }
                             let mut app = <$app as $crate::ScriptNew>::script_from_value(vm, value);
                             <$app as AppMain>::after_new_from_script(vm, &mut app);
                             app
@@ -347,6 +394,9 @@ macro_rules! app_main {
                         if let Some(app) = app_ref.as_mut() {
                             cx.with_vm(|vm| {
                                 let value = vm.with_reload(|vm| <$app as AppMain>::script_mod(vm));
+                                if let Some(obj) = value.as_object() {
+                                    *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
+                                }
                                 <$app as $crate::ScriptApply>::script_apply(
                                     app,
                                     vm,
@@ -355,6 +405,26 @@ macro_rules! app_main {
                                     value,
                                 );
                             });
+                        }
+                    }
+                    if let Event::ScriptReapply = event {
+                        let mut app_ref = app.borrow_mut();
+                        if let Some(app) = app_ref.as_mut() {
+                            let value = app_value
+                                .borrow()
+                                .as_ref()
+                                .map(|r| $crate::ScriptValue::from(r.as_object()));
+                            if let Some(value) = value {
+                                cx.with_vm(|vm| {
+                                    <$app as $crate::ScriptApply>::script_apply(
+                                        app,
+                                        vm,
+                                        &$crate::Apply::Reload,
+                                        &mut $crate::Scope::empty(),
+                                        value,
+                                    );
+                                });
+                            }
                         }
                     }
                     if let Some(app) = &mut *app.borrow_mut() {
@@ -375,10 +445,15 @@ macro_rules! app_main {
         ) -> $crate::napi_ohos::Result<()> {
             Cx::ohos_init(exports, env, || {
                 let app = std::rc::Rc::new(std::cell::RefCell::new(None));
+                let app_value: std::rc::Rc<std::cell::RefCell<Option<$crate::ScriptObjectRef>>>
+                    = std::rc::Rc::new(std::cell::RefCell::new(None));
                 let mut cx = Box::new(Cx::new(Box::new(move |cx, event| {
                     if let Event::Startup = event {
                         *app.borrow_mut() = Some(cx.with_vm(|vm| {
                             let value = <$app as AppMain>::script_mod(vm);
+                            if let Some(obj) = value.as_object() {
+                                *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
+                            }
                             let mut app = <$app as $crate::ScriptNew>::script_from_value(vm, value);
                             <$app as AppMain>::after_new_from_script(vm, &mut app);
                             app
@@ -390,6 +465,9 @@ macro_rules! app_main {
                         if let Some(app) = app_ref.as_mut() {
                             cx.with_vm(|vm| {
                                 let value = vm.with_reload(|vm| <$app as AppMain>::script_mod(vm));
+                                if let Some(obj) = value.as_object() {
+                                    *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
+                                }
                                 <$app as $crate::ScriptApply>::script_apply(
                                     app,
                                     vm,
@@ -398,6 +476,26 @@ macro_rules! app_main {
                                     value,
                                 );
                             });
+                        }
+                    }
+                    if let Event::ScriptReapply = event {
+                        let mut app_ref = app.borrow_mut();
+                        if let Some(app) = app_ref.as_mut() {
+                            let value = app_value
+                                .borrow()
+                                .as_ref()
+                                .map(|r| $crate::ScriptValue::from(r.as_object()));
+                            if let Some(value) = value {
+                                cx.with_vm(|vm| {
+                                    <$app as $crate::ScriptApply>::script_apply(
+                                        app,
+                                        vm,
+                                        &$crate::Apply::Reload,
+                                        &mut $crate::Scope::empty(),
+                                        value,
+                                    );
+                                });
+                            }
                         }
                     }
                     if let Some(app) = &mut *app.borrow_mut() {
@@ -420,10 +518,15 @@ macro_rules! app_main {
         pub extern "C" fn create_wasm_app() -> u32 {
             Cx::init_log();
             let app = std::rc::Rc::new(std::cell::RefCell::new(None));
+            let app_value: std::rc::Rc<std::cell::RefCell<Option<$crate::ScriptObjectRef>>>
+                = std::rc::Rc::new(std::cell::RefCell::new(None));
             let mut cx = Box::new(Cx::new(Box::new(move |cx, event| {
                 if let Event::Startup = event {
                     *app.borrow_mut() = Some(cx.with_vm(|vm| {
                         let value = <$app as AppMain>::script_mod(vm);
+                        if let Some(obj) = value.as_object() {
+                            *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
+                        }
                         let mut app = <$app as $crate::ScriptNew>::script_from_value(vm, value);
                         <$app as AppMain>::after_new_from_script(vm, &mut app);
                         app
@@ -434,6 +537,9 @@ macro_rules! app_main {
                     if let Some(app) = app_ref.as_mut() {
                         cx.with_vm(|vm| {
                             let value = vm.with_reload(|vm| <$app as AppMain>::script_mod(vm));
+                            if let Some(obj) = value.as_object() {
+                                *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
+                            }
                             <$app as $crate::ScriptApply>::script_apply(
                                 app,
                                 vm,
@@ -442,6 +548,26 @@ macro_rules! app_main {
                                 value,
                             );
                         });
+                    }
+                }
+                if let Event::ScriptReapply = event {
+                    let mut app_ref = app.borrow_mut();
+                    if let Some(app) = app_ref.as_mut() {
+                        let value = app_value
+                            .borrow()
+                            .as_ref()
+                            .map(|r| $crate::ScriptValue::from(r.as_object()));
+                        if let Some(value) = value {
+                            cx.with_vm(|vm| {
+                                <$app as $crate::ScriptApply>::script_apply(
+                                    app,
+                                    vm,
+                                    &$crate::Apply::Reload,
+                                    &mut $crate::Scope::empty(),
+                                    value,
+                                );
+                            });
+                        }
                     }
                 }
                 if let Some(app) = &mut *app.borrow_mut() {

--- a/platform/src/app_main.rs
+++ b/platform/src/app_main.rs
@@ -302,9 +302,7 @@ macro_rules! app_main {
                     if let Event::ScriptReapply = event {
                         let mut app_ref = app.borrow_mut();
                         if let Some(app) = app_ref.as_mut() {
-                            let value = app_value
-                                .borrow()
-                                .as_ref()
+                            let value = app_value.borrow().as_ref()
                                 .map(|r| $crate::ScriptValue::from(r.as_object()));
                             if let Some(value) = value {
                                 cx.with_vm(|vm| {
@@ -403,9 +401,7 @@ macro_rules! app_main {
                     if let Event::ScriptReapply = event {
                         let mut app_ref = app.borrow_mut();
                         if let Some(app) = app_ref.as_mut() {
-                            let value = app_value
-                                .borrow()
-                                .as_ref()
+                            let value = app_value.borrow().as_ref()
                                 .map(|r| $crate::ScriptValue::from(r.as_object()));
                             if let Some(value) = value {
                                 cx.with_vm(|vm| {
@@ -474,9 +470,7 @@ macro_rules! app_main {
                     if let Event::ScriptReapply = event {
                         let mut app_ref = app.borrow_mut();
                         if let Some(app) = app_ref.as_mut() {
-                            let value = app_value
-                                .borrow()
-                                .as_ref()
+                            let value = app_value.borrow().as_ref()
                                 .map(|r| $crate::ScriptValue::from(r.as_object()));
                             if let Some(value) = value {
                                 cx.with_vm(|vm| {
@@ -546,9 +540,7 @@ macro_rules! app_main {
                 if let Event::ScriptReapply = event {
                     let mut app_ref = app.borrow_mut();
                     if let Some(app) = app_ref.as_mut() {
-                        let value = app_value
-                            .borrow()
-                            .as_ref()
+                        let value = app_value.borrow().as_ref()
                             .map(|r| $crate::ScriptValue::from(r.as_object()));
                         if let Some(value) = value {
                             cx.with_vm(|vm| {

--- a/platform/src/event/event.rs
+++ b/platform/src/event/event.rs
@@ -124,6 +124,15 @@ pub enum Event {
 
     Draw(DrawEvent),
     LiveEdit,
+    /// Request from `Cx::request_script_reapply()` to re-apply the widget
+    /// tree with `Apply::Reload` *without* re-running `script_mod!`.
+    ///
+    /// Used when runtime code has mutated `mod.widgets.*` in place (e.g.
+    /// `script_eval!` overriding a user preference) and wants every widget
+    /// that captured a template to re-resolve it against the current heap.
+    /// Unlike `Event::LiveEdit`, this preserves any runtime heap overrides
+    /// because the original source-defined defaults are not re-asserted.
+    ScriptReapply,
     /// A window has gained focus and is now the active window receiving user input.
     WindowGotFocus(WindowId),
     /// A window has lost focus and is no longer the active window receiving user input.
@@ -323,6 +332,7 @@ impl Event {
             60 => "Custom",
             61 => "PopupDismissed",
             62 => "SelectionHandleDrag",
+            66 => "ScriptReapply",
             _ => panic!(),
         }
     }
@@ -340,6 +350,7 @@ impl Event {
 
             Self::Draw(_) => 7,
             Self::LiveEdit => 8,
+            Self::ScriptReapply => 66,
             Self::WindowGotFocus(_) => 9,
             Self::WindowLostFocus(_) => 10,
             Self::GameInputConnected(_) => 11,

--- a/platform/src/event/event.rs
+++ b/platform/src/event/event.rs
@@ -125,13 +125,14 @@ pub enum Event {
     Draw(DrawEvent),
     LiveEdit,
     /// Request from `Cx::request_script_reapply()` to re-apply the widget
-    /// tree with `Apply::Reload` *without* re-running `script_mod!`.
+    /// tree via `Apply::Reload` *without* re-running `script_mod!`.
     ///
-    /// Used when runtime code has mutated `mod.widgets.*` in place (e.g.
-    /// `script_eval!` overriding a user preference) and wants every widget
-    /// that captured a template to re-resolve it against the current heap.
-    /// Unlike `Event::LiveEdit`, this preserves any runtime heap overrides
-    /// because the original source-defined defaults are not re-asserted.
+    /// This is useful when something like a Splash-level script object
+    /// has been modified at runtime (e.g., `script_eval!`) and the application
+    /// wants every widget in the widget tree to pick up that new modified object value.
+    ///
+    /// Unlike `Event::LiveEdit`, this preserves any heap object values that have
+    /// already been modified at runtime.
     ScriptReapply,
     /// A window has gained focus and is now the active window receiving user input.
     WindowGotFocus(WindowId),
@@ -350,7 +351,6 @@ impl Event {
 
             Self::Draw(_) => 7,
             Self::LiveEdit => 8,
-            Self::ScriptReapply => 66,
             Self::WindowGotFocus(_) => 9,
             Self::WindowLostFocus(_) => 10,
             Self::GameInputConnected(_) => 11,
@@ -417,6 +417,7 @@ impl Event {
 
             Self::XrLocal(_) => 57,
             Self::Custom(_) => 60,
+            Self::ScriptReapply => 66,
         }
     }
 

--- a/platform/src/os/cx_shared.rs
+++ b/platform/src/os/cx_shared.rs
@@ -580,9 +580,48 @@ impl Cx {
     }
 
     pub(crate) fn run_live_edit_if_needed(&mut self, _backend: &str) {
-        if self.handle_live_edit() {
+        // Two independent triggers with distinct semantics:
+        //
+        //  1. `handle_live_edit()` returns `true` when the file watcher
+        //     delivered a hot-reloaded `script_mod!` block. We must re-run
+        //     `script_mod` (source-defined module-level assignments) before
+        //     re-applying the widget tree, because the reloaded code may
+        //     have changed those assignments. That's what `Event::LiveEdit`
+        //     signals — the AppMain handler re-runs `script_mod` under
+        //     `vm.with_reload(...)` and then applies the result with
+        //     `Apply::Reload`. Only this path needs `reset_for_live_reload`.
+        //
+        //  2. `pending_script_reapply` is set by `Cx::request_script_reapply`
+        //     after runtime mutations to the script heap (e.g. `script_eval!`
+        //     overriding a user preference). Re-running `script_mod` would
+        //     clobber those overrides by reasserting source-defined defaults.
+        //     Instead we fire `Event::ScriptReapply`, which the AppMain
+        //     handler services by re-applying the previously-captured app
+        //     value with `Apply::Reload` — no `script_mod` re-run, so the
+        //     overrides stick.
+        //
+        // If a file change just happened AND a user-level handler then
+        // requests a reapply (e.g. an `Event::LiveEdit` handler re-broadcasting
+        // preferences so a fresh source reload doesn't lose them), we follow
+        // up with a single `ScriptReapply` pass. That second pass is bounded
+        // — any further requests settle on the next event-loop tick rather
+        // than looping inside this one.
+        let file_edit_applied = self.handle_live_edit();
+        if file_edit_applied {
             self.draw_shaders.reset_for_live_reload();
+            self.pending_script_reapply = false;
             self.call_event_handler(&Event::LiveEdit);
+            self.redraw_all();
+            if self.pending_script_reapply {
+                self.pending_script_reapply = false;
+                eprintln!("run_live_edit_if_needed: firing ScriptReapply after LiveEdit");
+                self.call_event_handler(&Event::ScriptReapply);
+                self.redraw_all();
+            }
+        } else if self.pending_script_reapply {
+            self.pending_script_reapply = false;
+            eprintln!("run_live_edit_if_needed: firing ScriptReapply (preference-driven)");
+            self.call_event_handler(&Event::ScriptReapply);
             self.redraw_all();
         }
     }

--- a/platform/src/os/cx_shared.rs
+++ b/platform/src/os/cx_shared.rs
@@ -614,13 +614,11 @@ impl Cx {
             self.redraw_all();
             if self.pending_script_reapply {
                 self.pending_script_reapply = false;
-                eprintln!("run_live_edit_if_needed: firing ScriptReapply after LiveEdit");
                 self.call_event_handler(&Event::ScriptReapply);
                 self.redraw_all();
             }
         } else if self.pending_script_reapply {
             self.pending_script_reapply = false;
-            eprintln!("run_live_edit_if_needed: firing ScriptReapply (preference-driven)");
             self.call_event_handler(&Event::ScriptReapply);
             self.redraw_all();
         }

--- a/widgets/src/dock.rs
+++ b/widgets/src/dock.rs
@@ -667,46 +667,6 @@ impl Dock {
         DockCompactDump { tabs, tab_headers }
     }
 
-    /// Re-captures the content template stored under `template_key` from
-    /// `mod.widgets.<mod_widgets_name>` in the script heap, replacing the
-    /// previously-captured reference in `self.templates`.
-    ///
-    /// Dock templates are declared in DSL like
-    /// `room_screen := mod.widgets.RoomScreen {}`, where the local key
-    /// (`room_screen`) typically doesn't match the `mod.widgets` entry
-    /// (`RoomScreen`). `template_key` is the local key stored in
-    /// `self.templates`; `mod_widgets_name` is the entry in `mod.widgets`
-    /// to look up.
-    ///
-    /// Use this after re-assigning a template in the `widgets` module at
-    /// runtime (via `script_eval!`) so that dock tabs instantiated
-    /// afterwards — e.g. when a closed tab is reopened — are built from
-    /// the updated template. Without this, the Dock keeps serving new
-    /// items from the template object it captured at its initial DSL
-    /// apply.
-    ///
-    /// Returns `true` if the refresh succeeded, `false` if no matching
-    /// entry exists in `mod.widgets`.
-    pub fn refresh_widgets_mod_template(
-        &mut self,
-        cx: &mut Cx,
-        template_key: LiveId,
-        mod_widgets_name: LiveId,
-    ) -> bool {
-        use makepad_script::trap::NoTrap;
-        cx.with_vm(|vm| {
-            let heap = vm.heap_mut();
-            let widgets_mod = heap.module(id!(widgets));
-            let value = heap.value(widgets_mod, mod_widgets_name.into(), NoTrap);
-            let Some(obj) = value.as_object() else {
-                return false;
-            };
-            let new_ref = heap.new_object_ref(obj);
-            self.templates.insert(template_key, new_ref);
-            true
-        })
-    }
-
     fn create_all_items(&mut self, cx: &mut Cx) {
         let mut items = Vec::new();
         for (item_id, item) in self.dock_items.iter() {
@@ -1974,18 +1934,5 @@ impl DockRef {
 
     pub fn tab_start_drag(&self, cx: &mut Cx, _tab_id: LiveId, item: DragItem) {
         cx.start_dragging(vec![item]);
-    }
-
-    /// See [`Dock::refresh_widgets_mod_template()`].
-    pub fn refresh_widgets_mod_template(
-        &self,
-        cx: &mut Cx,
-        template_key: LiveId,
-        mod_widgets_name: LiveId,
-    ) -> bool {
-        let Some(mut dock) = self.borrow_mut() else {
-            return false;
-        };
-        dock.refresh_widgets_mod_template(cx, template_key, mod_widgets_name)
     }
 }

--- a/widgets/src/dock.rs
+++ b/widgets/src/dock.rs
@@ -262,24 +262,15 @@ impl ScriptHook for Dock {
                                     DockItemSplitter::script_type_id_static(),
                                 ) {
                                     if !is_reload || !self.dock_items.contains_key(&id) {
-                                        let splitter =
-                                            DockItemSplitter::script_from_value(vm, kv.value);
+                                        let splitter = DockItemSplitter::script_from_value(vm, kv.value);
                                         self.dock_items.insert(id, splitter.to_dock_item());
                                     }
-                                } else if vm
-                                    .bx
-                                    .heap
-                                    .type_matches_id(val_obj, DockItemTabs::script_type_id_static())
-                                {
+                                } else if vm.bx.heap.type_matches_id(val_obj, DockItemTabs::script_type_id_static()) {
                                     if !is_reload || !self.dock_items.contains_key(&id) {
                                         let tabs = DockItemTabs::script_from_value(vm, kv.value);
                                         self.dock_items.insert(id, tabs.to_dock_item());
                                     }
-                                } else if vm
-                                    .bx
-                                    .heap
-                                    .type_matches_id(val_obj, DockItemTab::script_type_id_static())
-                                {
+                                } else if vm.bx.heap.type_matches_id(val_obj, DockItemTab::script_type_id_static()) {
                                     if !is_reload || !self.dock_items.contains_key(&id) {
                                         let tab = DockItemTab::script_from_value(vm, kv.value);
                                         self.dock_items.insert(id, tab.to_dock_item());

--- a/widgets/src/dock.rs
+++ b/widgets/src/dock.rs
@@ -650,6 +650,46 @@ impl Dock {
         DockCompactDump { tabs, tab_headers }
     }
 
+    /// Re-captures the content template stored under `template_key` from
+    /// `mod.widgets.<mod_widgets_name>` in the script heap, replacing the
+    /// previously-captured reference in `self.templates`.
+    ///
+    /// Dock templates are declared in DSL like
+    /// `room_screen := mod.widgets.RoomScreen {}`, where the local key
+    /// (`room_screen`) typically doesn't match the `mod.widgets` entry
+    /// (`RoomScreen`). `template_key` is the local key stored in
+    /// `self.templates`; `mod_widgets_name` is the entry in `mod.widgets`
+    /// to look up.
+    ///
+    /// Use this after re-assigning a template in the `widgets` module at
+    /// runtime (via `script_eval!`) so that dock tabs instantiated
+    /// afterwards — e.g. when a closed tab is reopened — are built from
+    /// the updated template. Without this, the Dock keeps serving new
+    /// items from the template object it captured at its initial DSL
+    /// apply.
+    ///
+    /// Returns `true` if the refresh succeeded, `false` if no matching
+    /// entry exists in `mod.widgets`.
+    pub fn refresh_widgets_mod_template(
+        &mut self,
+        cx: &mut Cx,
+        template_key: LiveId,
+        mod_widgets_name: LiveId,
+    ) -> bool {
+        use makepad_script::trap::NoTrap;
+        cx.with_vm(|vm| {
+            let heap = vm.heap_mut();
+            let widgets_mod = heap.module(id!(widgets));
+            let value = heap.value(widgets_mod, mod_widgets_name.into(), NoTrap);
+            let Some(obj) = value.as_object() else {
+                return false;
+            };
+            let new_ref = heap.new_object_ref(obj);
+            self.templates.insert(template_key, new_ref);
+            true
+        })
+    }
+
     fn create_all_items(&mut self, cx: &mut Cx) {
         let mut items = Vec::new();
         for (item_id, item) in self.dock_items.iter() {
@@ -1917,5 +1957,18 @@ impl DockRef {
 
     pub fn tab_start_drag(&self, cx: &mut Cx, _tab_id: LiveId, item: DragItem) {
         cx.start_dragging(vec![item]);
+    }
+
+    /// See [`Dock::refresh_widgets_mod_template()`].
+    pub fn refresh_widgets_mod_template(
+        &self,
+        cx: &mut Cx,
+        template_key: LiveId,
+        mod_widgets_name: LiveId,
+    ) -> bool {
+        let Some(mut dock) = self.borrow_mut() else {
+            return false;
+        };
+        dock.refresh_widgets_mod_template(cx, template_key, mod_widgets_name)
     }
 }

--- a/widgets/src/dock.rs
+++ b/widgets/src/dock.rs
@@ -237,8 +237,19 @@ impl ScriptHook for Dock {
         scope: &mut Scope,
         value: ScriptValue,
     ) {
-        // Collect templates and dock items from the object's vec
-        // Only collect during template applies (not eval) to avoid storing temporary objects
+        // Collect templates and dock items from the object's vec. Only
+        // during template applies (not eval) to avoid storing temporaries.
+        //
+        // On `Apply::Reload` we re-collect content templates — that's
+        // the point of reload: pick up freshly-evaluated `mod.widgets.*`
+        // entries. But dock-item entries (Splitter / Tabs / Tab) describe
+        // the *layout*, which at runtime may differ from the DSL defaults
+        // (tabs opened, splitters moved, etc.). Re-inserting from the DSL
+        // would clobber that runtime state and wipe the whole dock. On
+        // reload we therefore only insert dock items for IDs that don't
+        // already exist — allowing LiveEdit to add new default items while
+        // preserving runtime state for existing ones.
+        let is_reload = apply.is_reload();
         if !apply.is_eval() {
             if let Some(obj) = value.as_object() {
                 vm.vec_with(obj, |vm, vec| {
@@ -250,23 +261,29 @@ impl ScriptHook for Dock {
                                     val_obj,
                                     DockItemSplitter::script_type_id_static(),
                                 ) {
-                                    let splitter =
-                                        DockItemSplitter::script_from_value(vm, kv.value);
-                                    self.dock_items.insert(id, splitter.to_dock_item());
+                                    if !is_reload || !self.dock_items.contains_key(&id) {
+                                        let splitter =
+                                            DockItemSplitter::script_from_value(vm, kv.value);
+                                        self.dock_items.insert(id, splitter.to_dock_item());
+                                    }
                                 } else if vm
                                     .bx
                                     .heap
                                     .type_matches_id(val_obj, DockItemTabs::script_type_id_static())
                                 {
-                                    let tabs = DockItemTabs::script_from_value(vm, kv.value);
-                                    self.dock_items.insert(id, tabs.to_dock_item());
+                                    if !is_reload || !self.dock_items.contains_key(&id) {
+                                        let tabs = DockItemTabs::script_from_value(vm, kv.value);
+                                        self.dock_items.insert(id, tabs.to_dock_item());
+                                    }
                                 } else if vm
                                     .bx
                                     .heap
                                     .type_matches_id(val_obj, DockItemTab::script_type_id_static())
                                 {
-                                    let tab = DockItemTab::script_from_value(vm, kv.value);
-                                    self.dock_items.insert(id, tab.to_dock_item());
+                                    if !is_reload || !self.dock_items.contains_key(&id) {
+                                        let tab = DockItemTab::script_from_value(vm, kv.value);
+                                        self.dock_items.insert(id, tab.to_dock_item());
+                                    }
                                 } else {
                                     // Not a dock item, treat as content template - root it
                                     self.templates

--- a/widgets/src/flat_list.rs
+++ b/widgets/src/flat_list.rs
@@ -23,6 +23,10 @@ pub enum FlatListAction {
     None,
 }
 
+/// A single entry managed by a list widget (e.g., [`FlatList`] or
+/// [`crate::portal_list::PortalList`]): the widget instance and the `LiveId`
+/// of the template it was created from.
+#[derive(Default)]
 pub struct WidgetItem {
     pub widget: WidgetRef,
     pub template: LiveId,

--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -103,7 +103,7 @@ pub struct Image {
     #[source]
     source: ScriptObjectRef,
     #[walk]
-    walk: Walk,
+    pub walk: Walk,
     #[apply_default]
     animator: Animator,
     #[redraw]
@@ -437,6 +437,22 @@ impl Image {
         };
 
         let aspect = width / height;
+        // When `walk.height` is `Size::Fit { max: Some(m) }`, the rect returned by
+        // `peek_walk_turtle` has `size.y == NaN` (Fit evaluates to NaN — see
+        // `Turtle::next_walk_height`), so the max would otherwise be ignored by the
+        // aspect calculations below. Treat it as the effective vertical bound so
+        // the image scales proportionally instead of rendering at its natural
+        // height and getting clipped by an outer view.
+        let height_cap = if let Size::Fit { max: Some(fb), .. } = walk.height {
+            fb.eval_height(cx).unwrap_or(f64::INFINITY)
+        } else {
+            f64::INFINITY
+        };
+        let avail_height = if rect.size.y.is_nan() {
+            height_cap
+        } else {
+            rect.size.y.min(height_cap)
+        };
         match self.fit {
             ImageFit::Size => {
                 walk.width = Size::Fixed(width);
@@ -447,20 +463,23 @@ impl Image {
                 walk.height = Size::Fixed(rect.size.x / aspect);
             }
             ImageFit::Vertical => {
-                walk.width = Size::Fixed(rect.size.y * aspect);
+                walk.width = Size::Fixed(avail_height * aspect);
+                walk.height = Size::Fixed(avail_height);
             }
             ImageFit::Smallest => {
                 let walk_height = rect.size.x / aspect;
-                if walk_height > rect.size.y {
-                    walk.width = Size::Fixed(rect.size.y * aspect);
+                if walk_height > avail_height {
+                    walk.width = Size::Fixed(avail_height * aspect);
+                    walk.height = Size::Fixed(avail_height);
                 } else {
                     walk.height = Size::Fixed(walk_height);
                 }
             }
             ImageFit::Biggest => {
                 let walk_height = rect.size.x / aspect;
-                if walk_height < rect.size.y {
-                    walk.width = Size::Fixed(rect.size.y * aspect);
+                if walk_height < avail_height {
+                    walk.width = Size::Fixed(avail_height * aspect);
+                    walk.height = Size::Fixed(avail_height);
                 } else {
                     walk.height = Size::Fixed(walk_height);
                 }

--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -96,7 +96,7 @@ pub enum ImageAnimation {
     BounceFps(f64),
 }
 
-#[derive(Script, ScriptHook, Widget, Animator)]
+#[derive(Script, Widget, Animator)]
 pub struct Image {
     #[uid]
     uid: WidgetUid,
@@ -148,6 +148,61 @@ impl ImageCacheImpl for Image {
 
     fn set_texture(&mut self, texture: Option<Texture>, _id: usize) {
         self.texture = texture;
+    }
+}
+
+impl ScriptHook for Image {
+    fn on_before_apply(
+        &mut self,
+        vm: &mut ScriptVm,
+        apply: &Apply,
+        _scope: &mut Scope,
+        value: ScriptValue,
+    ) {
+        // DIAGNOSTIC: only for Reload on Image widgets whose height was
+        // already an `Fit{max: Some(...)}` (i.e., an image-message image).
+        if apply.is_reload() {
+            if let Size::Fit { max: Some(_), .. } = self.walk.height {
+                use makepad_script::trap::NoTrap;
+                let value_obj = value.as_object();
+                let source_obj = self.source.as_object();
+                let raw_height = value_obj.map(|obj| {
+                    vm.bx.heap.value(obj, id!(height).into(), NoTrap)
+                });
+                let raw_height_from_source =
+                    vm.bx.heap.value(source_obj, id!(height).into(), NoTrap);
+                eprintln!(
+                    "Image::on_before_apply uid={:?}\n  \
+                     current walk.height={:?}\n  \
+                     value obj={:?}  source obj={:?}\n  \
+                     value.height (proto-walk)={:?}\n  \
+                     source.height (proto-walk)={:?}",
+                    self.uid, self.walk.height,
+                    value_obj, source_obj, raw_height, raw_height_from_source,
+                );
+            }
+        }
+    }
+
+    fn on_after_apply(
+        &mut self,
+        vm: &mut ScriptVm,
+        apply: &Apply,
+        _scope: &mut Scope,
+        value: ScriptValue,
+    ) {
+        if apply.is_reload() {
+            if let Size::Fit { max: Some(_), .. } = self.walk.height {
+                use makepad_script::trap::NoTrap;
+                let raw_height = value.as_object().map(|obj| {
+                    vm.bx.heap.value(obj, id!(height).into(), NoTrap)
+                });
+                eprintln!(
+                    "Image::on_after_apply  uid={:?} post-apply walk.height={:?}  value.height={:?}",
+                    self.uid, self.walk.height, raw_height,
+                );
+            }
+        }
     }
 }
 

--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -96,7 +96,7 @@ pub enum ImageAnimation {
     BounceFps(f64),
 }
 
-#[derive(Script, Widget, Animator)]
+#[derive(Script, ScriptHook, Widget, Animator)]
 pub struct Image {
     #[uid]
     uid: WidgetUid,
@@ -148,61 +148,6 @@ impl ImageCacheImpl for Image {
 
     fn set_texture(&mut self, texture: Option<Texture>, _id: usize) {
         self.texture = texture;
-    }
-}
-
-impl ScriptHook for Image {
-    fn on_before_apply(
-        &mut self,
-        vm: &mut ScriptVm,
-        apply: &Apply,
-        _scope: &mut Scope,
-        value: ScriptValue,
-    ) {
-        // DIAGNOSTIC: only for Reload on Image widgets whose height was
-        // already an `Fit{max: Some(...)}` (i.e., an image-message image).
-        if apply.is_reload() {
-            if let Size::Fit { max: Some(_), .. } = self.walk.height {
-                use makepad_script::trap::NoTrap;
-                let value_obj = value.as_object();
-                let source_obj = self.source.as_object();
-                let raw_height = value_obj.map(|obj| {
-                    vm.bx.heap.value(obj, id!(height).into(), NoTrap)
-                });
-                let raw_height_from_source =
-                    vm.bx.heap.value(source_obj, id!(height).into(), NoTrap);
-                eprintln!(
-                    "Image::on_before_apply uid={:?}\n  \
-                     current walk.height={:?}\n  \
-                     value obj={:?}  source obj={:?}\n  \
-                     value.height (proto-walk)={:?}\n  \
-                     source.height (proto-walk)={:?}",
-                    self.uid, self.walk.height,
-                    value_obj, source_obj, raw_height, raw_height_from_source,
-                );
-            }
-        }
-    }
-
-    fn on_after_apply(
-        &mut self,
-        vm: &mut ScriptVm,
-        apply: &Apply,
-        _scope: &mut Scope,
-        value: ScriptValue,
-    ) {
-        if apply.is_reload() {
-            if let Size::Fit { max: Some(_), .. } = self.walk.height {
-                use makepad_script::trap::NoTrap;
-                let raw_height = value.as_object().map(|obj| {
-                    vm.bx.heap.value(obj, id!(height).into(), NoTrap)
-                });
-                eprintln!(
-                    "Image::on_after_apply  uid={:?} post-apply walk.height={:?}  value.height={:?}",
-                    self.uid, self.walk.height, raw_height,
-                );
-            }
-        }
     }
 }
 

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -519,6 +519,32 @@ impl ScriptHook for PortalList {
 
         // Update existing items if templates changed
         if apply.is_reload() {
+            // DIAGNOSTIC: log each template's captured object id + what its
+            // nested `.body.content.message.image_view.image.height` path
+            // resolves to, so we can tell whether an in-place heap mutation
+            // on the template chain is visible when we re-apply items.
+            {
+                use makepad_script::trap::NoTrap;
+                for (tid, template_ref) in self.templates.iter() {
+                    let obj = template_ref.as_object();
+                    let height = vm.bx.heap.value(obj, id!(body).into(), NoTrap)
+                        .as_object()
+                        .map(|o| vm.bx.heap.value(o, id!(content).into(), NoTrap))
+                        .and_then(|v| v.as_object())
+                        .map(|o| vm.bx.heap.value(o, id!(message).into(), NoTrap))
+                        .and_then(|v| v.as_object())
+                        .map(|o| vm.bx.heap.value(o, id!(image_view).into(), NoTrap))
+                        .and_then(|v| v.as_object())
+                        .map(|o| vm.bx.heap.value(o, id!(image).into(), NoTrap))
+                        .and_then(|v| v.as_object())
+                        .map(|o| vm.bx.heap.value(o, id!(height).into(), NoTrap));
+                    eprintln!(
+                        "PortalList reload: template {:?} -> obj={:?}  deep-height={:?}",
+                        tid, obj, height,
+                    );
+                }
+            }
+
             for (_, item) in self.items.iter_mut() {
                 if let Some(template_ref) = self.templates.get(&item.template) {
                     let template_value: ScriptValue = template_ref.as_object().into();

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -2547,22 +2547,6 @@ impl PortalListRef {
         inner.get_item(entry_id)
     }
 
-    /// Returns a cloned vector of all current items in this PortalList.
-    ///
-    /// Note: this is an expensive operation; if you just want to iterate
-    /// over the items, borrow the PortalListRef and call [`PortalList::items()`].
-    pub fn clone_items(&self) -> Vec<(LiveId, WidgetRef)> {
-        self.borrow()
-            .map(|inner| {
-                inner
-                    .items()
-                    .values()
-                    .map(|item| (item.template, item.widget.clone()))
-                    .collect()
-            })
-            .unwrap_or_default()
-    }
-
     pub fn position_of_item(&self, cx: &Cx, entry_id: usize) -> Option<f64> {
         let Some(inner) = self.borrow() else {
             return None;

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -2,6 +2,7 @@ use {
     crate::{
         animator::AnimatorImpl,
         event::{TouchState, TAP_COUNT_DISTANCE},
+        flat_list::WidgetItem,
         makepad_derive_widget::*,
         makepad_draw::*,
         scroll_bar::{ScrollAxis, ScrollBar, ScrollBarAction},
@@ -109,12 +110,6 @@ impl ListDrawState {
     fn is_down_again(&self) -> bool {
         matches!(self, Self::DownAgain { .. })
     }
-}
-
-#[derive(Default)]
-struct WidgetItem {
-    widget: WidgetRef,
-    template: LiveId,
 }
 
 struct AlignItem {
@@ -1168,6 +1163,62 @@ impl PortalList {
         self.items
             .get(&entry_id)
             .map(|item| (item.template, item.widget.clone()))
+    }
+
+    /// Returns the current in-use items in this PortalList, keyed by entry id.
+    ///
+    /// This excludes widgets in the reusable pool.
+    pub fn items(&self) -> &ComponentMap<usize, WidgetItem> {
+        &self.items
+    }
+
+    /// Returns an iterator over every widget instance this PortalList owns,
+    /// i.e., the currently-active items AND the widgets parked in the
+    /// reusable pool waiting to be re-used for a future entry. Each yielded
+    /// tuple is `(template, widget)`.
+    ///
+    /// Useful when you need to push a runtime change into every widget that
+    /// could plausibly be drawn — including ones that were scrolled out of
+    /// view and will be pulled back out of the pool when the user scrolls
+    /// back to them.
+    pub fn all_items_and_pool(&self) -> impl Iterator<Item = (LiveId, &WidgetRef)> + '_ {
+        let active = self
+            .items
+            .values()
+            .map(|item| (item.template, &item.widget));
+        let reusable = self
+            .reusable_items
+            .values()
+            .flat_map(|pool| pool.iter().map(|item| (item.template, &item.widget)));
+        active.chain(reusable)
+    }
+
+    /// Re-captures the template identified by `template_id` from
+    /// `mod.widgets.<template_id>` in the script heap, replacing the
+    /// previously-captured reference.
+    ///
+    /// Use this after re-assigning a template in the `widgets` module at
+    /// runtime (via `script_eval!`) so that future items — and items
+    /// re-applied from the reusable pool when scrolled back into view —
+    /// instantiate from the updated template. Without this, the PortalList
+    /// keeps serving items from the template object it captured at its
+    /// initial DSL apply.
+    ///
+    /// Returns `true` if the refresh succeeded, `false` if no matching
+    /// entry exists in `mod.widgets`.
+    pub fn refresh_widgets_mod_template(&mut self, cx: &mut Cx, template_id: LiveId) -> bool {
+        use makepad_script::trap::NoTrap;
+        cx.with_vm(|vm| {
+            let heap = vm.heap_mut();
+            let widgets_mod = heap.module(id!(widgets));
+            let value = heap.value(widgets_mod, template_id.into(), NoTrap);
+            let Some(obj) = value.as_object() else {
+                return false;
+            };
+            let new_ref = heap.new_object_ref(obj);
+            self.templates.insert(template_id, new_ref);
+            true
+        })
     }
 
     pub fn set_item_range(&mut self, cx: &mut Cx, range_start: usize, range_end: usize) {
@@ -2543,6 +2594,30 @@ impl PortalListRef {
             return None;
         };
         inner.get_item(entry_id)
+    }
+
+    /// See [`PortalList::refresh_widgets_mod_template()`].
+    pub fn refresh_widgets_mod_template(&self, cx: &mut Cx, template_id: LiveId) -> bool {
+        let Some(mut inner) = self.borrow_mut() else {
+            return false;
+        };
+        inner.refresh_widgets_mod_template(cx, template_id)
+    }
+
+    /// Returns a cloned vector of all current items in this PortalList.
+    ///
+    /// Note: this is an expensive operation; if you just want to iterate
+    /// over the items, borrow the PortalListRef and call [`PortalList::items()`].
+    pub fn clone_items(&self) -> Vec<(LiveId, WidgetRef)> {
+        self.borrow()
+            .map(|inner| {
+                inner
+                    .items()
+                    .values()
+                    .map(|item| (item.template, item.widget.clone()))
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     pub fn position_of_item(&self, cx: &Cx, entry_id: usize) -> Option<f64> {

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -519,32 +519,6 @@ impl ScriptHook for PortalList {
 
         // Update existing items if templates changed
         if apply.is_reload() {
-            // DIAGNOSTIC: log each template's captured object id + what its
-            // nested `.body.content.message.image_view.image.height` path
-            // resolves to, so we can tell whether an in-place heap mutation
-            // on the template chain is visible when we re-apply items.
-            {
-                use makepad_script::trap::NoTrap;
-                for (tid, template_ref) in self.templates.iter() {
-                    let obj = template_ref.as_object();
-                    let height = vm.bx.heap.value(obj, id!(body).into(), NoTrap)
-                        .as_object()
-                        .map(|o| vm.bx.heap.value(o, id!(content).into(), NoTrap))
-                        .and_then(|v| v.as_object())
-                        .map(|o| vm.bx.heap.value(o, id!(message).into(), NoTrap))
-                        .and_then(|v| v.as_object())
-                        .map(|o| vm.bx.heap.value(o, id!(image_view).into(), NoTrap))
-                        .and_then(|v| v.as_object())
-                        .map(|o| vm.bx.heap.value(o, id!(image).into(), NoTrap))
-                        .and_then(|v| v.as_object())
-                        .map(|o| vm.bx.heap.value(o, id!(height).into(), NoTrap));
-                    eprintln!(
-                        "PortalList reload: template {:?} -> obj={:?}  deep-height={:?}",
-                        tid, obj, height,
-                    );
-                }
-            }
-
             for (_, item) in self.items.iter_mut() {
                 if let Some(template_ref) = self.templates.get(&item.template) {
                     let template_value: ScriptValue = template_ref.as_object().into();
@@ -1196,55 +1170,6 @@ impl PortalList {
     /// This excludes widgets in the reusable pool.
     pub fn items(&self) -> &ComponentMap<usize, WidgetItem> {
         &self.items
-    }
-
-    /// Returns an iterator over every widget instance this PortalList owns,
-    /// i.e., the currently-active items AND the widgets parked in the
-    /// reusable pool waiting to be re-used for a future entry. Each yielded
-    /// tuple is `(template, widget)`.
-    ///
-    /// Useful when you need to push a runtime change into every widget that
-    /// could plausibly be drawn — including ones that were scrolled out of
-    /// view and will be pulled back out of the pool when the user scrolls
-    /// back to them.
-    pub fn all_items_and_pool(&self) -> impl Iterator<Item = (LiveId, &WidgetRef)> + '_ {
-        let active = self
-            .items
-            .values()
-            .map(|item| (item.template, &item.widget));
-        let reusable = self
-            .reusable_items
-            .values()
-            .flat_map(|pool| pool.iter().map(|item| (item.template, &item.widget)));
-        active.chain(reusable)
-    }
-
-    /// Re-captures the template identified by `template_id` from
-    /// `mod.widgets.<template_id>` in the script heap, replacing the
-    /// previously-captured reference.
-    ///
-    /// Use this after re-assigning a template in the `widgets` module at
-    /// runtime (via `script_eval!`) so that future items — and items
-    /// re-applied from the reusable pool when scrolled back into view —
-    /// instantiate from the updated template. Without this, the PortalList
-    /// keeps serving items from the template object it captured at its
-    /// initial DSL apply.
-    ///
-    /// Returns `true` if the refresh succeeded, `false` if no matching
-    /// entry exists in `mod.widgets`.
-    pub fn refresh_widgets_mod_template(&mut self, cx: &mut Cx, template_id: LiveId) -> bool {
-        use makepad_script::trap::NoTrap;
-        cx.with_vm(|vm| {
-            let heap = vm.heap_mut();
-            let widgets_mod = heap.module(id!(widgets));
-            let value = heap.value(widgets_mod, template_id.into(), NoTrap);
-            let Some(obj) = value.as_object() else {
-                return false;
-            };
-            let new_ref = heap.new_object_ref(obj);
-            self.templates.insert(template_id, new_ref);
-            true
-        })
     }
 
     pub fn set_item_range(&mut self, cx: &mut Cx, range_start: usize, range_end: usize) {
@@ -2620,14 +2545,6 @@ impl PortalListRef {
             return None;
         };
         inner.get_item(entry_id)
-    }
-
-    /// See [`PortalList::refresh_widgets_mod_template()`].
-    pub fn refresh_widgets_mod_template(&self, cx: &mut Cx, template_id: LiveId) -> bool {
-        let Some(mut inner) = self.borrow_mut() else {
-            return false;
-        };
-        inner.refresh_widgets_mod_template(cx, template_id)
     }
 
     /// Returns a cloned vector of all current items in this PortalList.

--- a/widgets/src/stack_navigation.rs
+++ b/widgets/src/stack_navigation.rs
@@ -437,18 +437,23 @@ impl ScriptHook for StackNavigation {
 
 impl Widget for StackNavigation {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        // If the event requires visibility, only forward it to the visible views.
-        // If the event does not require visibility, forward it to all views,
-        // ensuring that we don't forward it to the root view twice.
-        let mut visible_views = self.get_visible_views(cx);
-        if !event.requires_visibility() {
-            let root_view = self.view.widget(cx, ids!(root_view));
-            if !visible_views.iter().any(|(_, w)| w == &root_view) {
-                visible_views.insert(0, (live_id!(root_view), root_view));
+        if event.requires_visibility() {
+            // Visibility-gated input (e.g., MouseDown): only forward to the
+            // currently-visible stack views, so inactive views don't receive
+            // input they shouldn't.
+            for (_id, widget_ref) in self.get_visible_views(cx) {
+                widget_ref.handle_event(cx, event, scope);
             }
-        }
-        for (_id, widget_ref) in visible_views {
-            widget_ref.handle_event(cx, event, scope);
+        } else {
+            // App-wide event (e.g., `Event::Actions`): delegate to the inner
+            // `View`, which propagates to every child — including inactive
+            // stack views. This lets them react to global state changes
+            // (e.g., preference updates) that are broadcast once and have no
+            // other way of reaching views that aren't currently on the stack.
+            // `View::handle_event` still gates children whose own `visible`
+            // flag is false, but only for events that require visibility,
+            // which this branch doesn't cover.
+            self.view.handle_event(cx, event, scope);
         }
 
         // Leaving this to the final step, so that the active stack view can handle the event first.

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -530,6 +530,21 @@ pub struct TextInput {
     return_key_type: ReturnKeyType,
     #[live(false)]
     is_multiline: bool,
+    /// When `is_multiline` is true, controls whether plain Enter inserts a
+    /// newline or emits the `Returned` action.
+    ///
+    /// * `false` (default): plain Enter inserts a newline; the `Returned`
+    ///   action is emitted for Primary modifier + Enter (Cmd on macOS,
+    ///   Ctrl on other platforms).
+    /// * `true`: plain Enter emits `Returned`; Shift+Enter inserts a newline.
+    ///
+    /// Regardless of this setting, Primary modifier + Enter always emits
+    /// `Returned`, and Shift+Enter always inserts a newline.
+    ///
+    /// Ignored when `is_multiline` is false (single-line inputs always emit
+    /// `Returned` on Enter).
+    #[live(false)]
+    submit_on_enter: bool,
     #[live]
     scroll_bar: ScrollBar,
     #[live]
@@ -633,6 +648,18 @@ impl TextInput {
 
     pub fn is_multiline(&self) -> bool {
         self.is_multiline
+    }
+
+    /// Returns whether this (multiline) text input emits `Returned` on plain
+    /// Enter. See the [`TextInput::submit_on_enter`] field for details.
+    pub fn submit_on_enter(&self) -> bool {
+        self.submit_on_enter
+    }
+
+    /// Sets whether this (multiline) text input emits `Returned` on plain
+    /// Enter. See the [`TextInput::submit_on_enter`] field for details.
+    pub fn set_submit_on_enter(&mut self, submit_on_enter: bool) {
+        self.submit_on_enter = submit_on_enter;
     }
 
     pub fn set_is_multiline(&mut self, cx: &mut Cx, is_multiline: bool) {
@@ -1958,9 +1985,24 @@ impl Widget for TextInput {
                 modifiers: mods @ KeyModifiers { shift: false, .. },
                 ..
             }) => {
-                // For multiline text input, plain Return inserts a newline
-                // For single-line, Return hides the keyboard and emits Returned action
-                if self.is_multiline && !self.is_read_only {
+                // Decide whether this Enter press should submit (emit Returned)
+                // or insert a newline:
+                // * Single-line inputs always submit.
+                // * Primary modifier (Cmd on macOS, Ctrl on other platforms)
+                //   + Enter always submits — even in multiline mode.
+                // * When `submit_on_enter` is set, plain (un-modified) Enter
+                //   also submits.
+                // Any other modifier combination (e.g., Alt+Enter, or Ctrl+Enter
+                // on macOS) falls through to the newline-insertion path, which
+                // itself is gated on the input not being read-only.
+                let should_submit = !self.is_multiline
+                    || mods.is_primary()
+                    || (self.submit_on_enter && !mods.any());
+                if should_submit {
+                    cx.hide_text_ime();
+                    cx.set_key_focus(Area::Empty);
+                    self.emit_return(cx, uid, mods);
+                } else if !self.is_read_only {
                     self.reset_blink_timer(cx);
                     self.create_or_extend_edit_group(EditKind::Other);
                     self.apply_edit(
@@ -1973,10 +2015,6 @@ impl Widget for TextInput {
                     );
                     self.draw_bg.redraw(cx);
                     self.emit_change(cx, uid);
-                } else {
-                    cx.hide_text_ime();
-                    cx.set_key_focus(Area::Empty);
-                    self.emit_return(cx, uid, mods);
                 }
             }
 
@@ -2336,6 +2374,20 @@ impl TextInputRef {
         }
     }
 
+    /// Returns whether this (multiline) text input emits `Returned` on plain
+    /// Enter. See [`TextInput::submit_on_enter`] for details.
+    pub fn submit_on_enter(&self) -> bool {
+        self.borrow().map(|inner| inner.submit_on_enter()).unwrap_or(false)
+    }
+
+    /// Sets whether this (multiline) text input emits `Returned` on plain
+    /// Enter. See [`TextInput::submit_on_enter`] for details.
+    pub fn set_submit_on_enter(&self, submit_on_enter: bool) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_submit_on_enter(submit_on_enter);
+        }
+    }
+
     pub fn is_password(&self) -> bool {
         if let Some(inner) = self.borrow() {
             inner.is_password()
@@ -2458,6 +2510,16 @@ impl TextInputRef {
     pub fn escaped(&self, actions: &Actions) -> bool {
         for action in actions.filter_widget_actions_cast::<TextInputAction>(self.widget_uid()) {
             if let TextInputAction::Escaped = action {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Returns true if this TextInput lost keyboard focus in the given actions.
+    pub fn key_focus_lost(&self, actions: &Actions) -> bool {
+        for action in actions.filter_widget_actions_cast::<TextInputAction>(self.widget_uid()) {
+            if let TextInputAction::KeyFocusLost = action {
                 return true;
             }
         }


### PR DESCRIPTION
And ensure that these changes get applied to all widgets within the entire widget tree.
We realize this via a new `ScriptReapply` event that doesn't re-do the whole `script_mod` thing,
which is why it's different from `LiveEdit`.

Details below:

---------------------------------

This PR adds a small, general-purpose mechanism for propagating runtime
script-heap mutations to materialized widgets without re-running the entire
`script_mod!`. The primary driver was a user-preference feature in Robrix
(a "maximum image thumbnail height" setting that needs to retarget already-
drawn widgets), but the mechanism is intentionally generic — any runtime
DSL field write followed by `Cx::request_script_reapply()` will now
propagate to every widget that captured that field through any derived
template chain.

Along the way this PR also closes a desktop gap in `request_script_reapply`
that was mobile-only, and fixes a few independent widget-level issues
surfaced by this work.

## Changes

### Script-reapply pathway (core of the PR)

- **New `Event::ScriptReapply` variant** — signals "re-apply the widget
  tree with `Apply::Reload` using the *previously captured* app value".
  Unlike `Event::LiveEdit`, this does NOT re-run `script_mod!`, so runtime
  heap mutations (e.g. a `script_eval!` overriding a user preference) are
  preserved.

- **Desktop wiring for `Cx::request_script_reapply()`** — `run_live_edit_if_needed`
  now honors `pending_script_reapply` and fires `Event::ScriptReapply`
  (previously, the flag was set on desktop but never observed — only iOS
  and Android checked it). If a file-driven `LiveEdit` handler itself
  requests a reapply (e.g. to re-broadcast runtime overrides that the
  source reload just clobbered), a single bounded follow-up `ScriptReapply`
  pass runs in the same tick.

- **`AppMain` macro: rooted `app_value` cache + `ScriptReapply` handler
  in all four entry points** (desktop, android, ohos, wasm). The app's
  script root is captured as a `ScriptObjectRef` (not a bare `ScriptValue`,
  which would be a dangling heap index after GC) and reused on each
  `ScriptReapply` to run `script_apply(&Apply::Reload, …)` without the
  `with_reload(script_mod)` re-evaluation path that `LiveEdit` uses.

### `Dock`: preserve runtime state across `Apply::Reload`

On reload, the Dock previously re-inserted every DSL-declared `dock_items`
entry (splitters / tabs-groups / tabs) unconditionally, which wiped any
runtime-modified dock state (user-opened tabs, modified splitter positions,
selected tab indices). Now, on reload, DSL items are only inserted for IDs
that don't already exist in `self.dock_items`. LiveEdit no longer wipes
the user's open tabs.

### `StackNavigation`: forward non-visibility events to all children

`handle_event` now delegates `Event::Actions` (and any other non-visibility
event) through the inner `View`, so inactive stack views (e.g. pre-created
but not-yet-visible deep-stack room screens) can react to app-wide state
actions. Visibility-gated events (MouseDown, MouseMove, TouchUpdate, etc.)
still only go to visible views, as before.

### Independent widget fixes

- **`Image`**: honor `Size::Fit { max: Some(...) }` when
  `peek_walk_turtle` returns NaN — previously the outer view clipped the
  texture instead of letting `ImageFit::Smallest` scale it proportionally.

- **`TextInput`**: new `submit_on_enter: bool` field so callers can opt
  into Cmd/Ctrl+Enter submit semantics, plus a `key_focus_lost` helper
  suitable for commit-on-blur inputs.

- **`FlatList`**: derive `Default` on the shared `WidgetItem` struct so
  it can share the type with `PortalList` cleanly.

- **`draw`**: re-export `Base` and `FitBound` from `turtle` so downstream
  crates can reference them in `script_eval!` blocks.