### PR TITLE
Separate apply-reload and script-reapply into different concepts

### DIFF
--- a/examples/automate/src/main.rs
+++ b/examples/automate/src/main.rs
@@ -684,7 +684,7 @@ impl App {
     fn set_toggle_widget_active(&self, cx: &mut Cx, id: LiveId, active: bool) {
         if let Some(mut toggle) = self.ui.widget(cx, &[id]).borrow_mut::<CheckBox>() {
             if toggle.active(cx) != active {
-                toggle.set_active(cx, active);
+                toggle.set_active(cx, active, Animate::Yes);
             }
         }
     }

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -226,7 +226,7 @@ impl Widget for TodoList {
                             continue;
                         };
                         let item = list.item(cx, item_id, id!(Item));
-                        item.check_box(cx, ids!(check)).set_active(cx, todo.done);
+                        item.check_box(cx, ids!(check)).set_active(cx, todo.done, Animate::Yes);
                         item.label(cx, ids!(label)).set_text(cx, &todo.text);
                         item.label(cx, ids!(tag.tag_label)).set_text(cx, &todo.tag);
                         item.view(cx, ids!(tag))

--- a/platform/script/derive/src/derive_scriptable.rs
+++ b/platform/script/derive/src/derive_scriptable.rs
@@ -179,6 +179,37 @@ fn derive_script_impl_inner(
                 .add(".register_as_ui_root(vm);");
         }
 
+        // Deref'd fields are applied BEFORE apply_default's recursive apply.
+        //
+        // Why this order matters: an `#[apply_default]` field (always an
+        // `Animator` in practice) returns an apply block describing how the
+        // widget's runtime fields should look in its current state — e.g.
+        // `{ height: 0 }` for a "hidden" state. The recursive call then
+        // re-walks the widget with that block as the value, setting the
+        // matching widget fields. If the deref'd field's `script_apply`
+        // (which reapplies the widget's *template* defaults via the inner
+        // base widget) ran AFTER this, it would overwrite the animator's
+        // state-driven values with the template defaults, leaving the
+        // widget visually in its template state for the rest of the apply
+        // pass. On `Apply::ScriptReapply` that produces the "flicker to
+        // defaults" most users notice when a preference change forces a
+        // tree-wide re-walk: every animator-driven widget briefly drops
+        // back to its template visual until the next event handler patches
+        // it up. Running deref first and apply_default's recursive last
+        // means the animator's apply block wins, the widget never visibly
+        // touches its template default, and `Animator::script_apply_default`
+        // can return the *current* state's apply on `ScriptReapply` to
+        // restore the runtime visual state in a single pass.
+        for field in &fields {
+            if field.attrs.iter().any(|a| a.name == "deref") {
+                tb.add("<")
+                    .stream(Some(field.ty.clone()))
+                    .add(" as ScriptApply>::script_apply(&mut self.")
+                    .ident(&field.name)
+                    .add(", vm, apply, scope, value);");
+            }
+        }
+
         for field in &fields {
             if field.attrs.iter().any(|a| a.name == "apply_default") {
                 tb.add("    if let Some(default_value) = <")
@@ -188,16 +219,6 @@ fn derive_script_impl_inner(
                     .add(",vm, apply, scope, value){");
                 tb.add("        self.script_apply(vm, &Apply::Default(apply.as_default().map_or(0, |x| x + 1)), scope, default_value);");
                 tb.add("    }");
-            }
-        }
-
-        for field in &fields {
-            if field.attrs.iter().any(|a| a.name == "deref") {
-                tb.add("<")
-                    .stream(Some(field.ty.clone()))
-                    .add(" as ScriptApply>::script_apply(&mut self.")
-                    .ident(&field.name)
-                    .add(", vm, apply, scope, value);");
             }
         }
 

--- a/platform/script/src/apply.rs
+++ b/platform/script/src/apply.rs
@@ -128,7 +128,18 @@ impl<'a, 'b> Scope<'a, 'b> {
 pub enum Apply {
     #[default]
     New,
+    /// LiveEdit-driven hot-reload. The DSL itself changed; the template
+    /// is the new source of truth and template values should override
+    /// any prior runtime state.
     Reload,
+    /// Heap-mutation broadcast triggered by `cx.request_script_reapply()`
+    /// (e.g. preference change, safe-area inset change). The template has
+    /// NOT changed — the same cached `app_value` is being re-walked so
+    /// shared-heap-object references (`(mod.widgets.X.field)` lookups)
+    /// pick up their new values. Field types whose canonical mutation
+    /// path is an imperative setter (e.g. `Label::set_text`) should
+    /// early-return on this variant so runtime state survives.
+    ScriptReapply,
     Animate,
     Eval,
     Default(usize),
@@ -139,6 +150,7 @@ impl Apply {
         match self {
             Self::New => true,
             Self::Reload => true,
+            Self::ScriptReapply => true,
             Self::Eval => true,
             _ => false,
         }
@@ -147,6 +159,9 @@ impl Apply {
     /// Returns true if this is a template apply (New or Reload) where
     /// the #[source] field should be updated. Excludes Eval since eval
     /// creates temporary objects that would become dangling after GC.
+    /// Excludes ScriptReapply because the template hasn't changed —
+    /// the same source object is being re-walked, so re-binding it is
+    /// unnecessary work.
     pub fn is_template_apply(&self) -> bool {
         match self {
             Self::New => true,
@@ -162,9 +177,46 @@ impl Apply {
         }
     }
 
+    /// True for any re-application after the initial `New` — i.e. either a
+    /// LiveEdit hot-reload (`Apply::Reload`) or a `request_script_reapply`-driven
+    /// walk (`Apply::ScriptReapply`).
+    ///
+    /// Most widgets that branch on this method want to handle "the template
+    /// is being re-applied for whatever reason" uniformly (re-attach
+    /// listeners, re-resolve heap-ref-driven dimensions, refresh derived
+    /// state). They should NOT need to differentiate between the two
+    /// triggers, so we keep `is_reload` as the broad predicate.
+    ///
+    /// Use `is_live_edit_reload()` if you specifically want only LiveEdit,
+    /// or `is_script_reapply()` for only the heap-mutation-broadcast case.
     pub fn is_reload(&self) -> bool {
         match self {
             Self::Reload => true,
+            Self::ScriptReapply => true,
+            _ => false,
+        }
+    }
+
+    /// True only for `Apply::Reload` — a LiveEdit-driven hot-reload where
+    /// the DSL itself changed. Excludes `Apply::ScriptReapply`. Use this
+    /// (rather than `is_reload`) when behavior should fire only when the
+    /// template source has actually changed (e.g. re-running script_mod
+    /// scaffolding, invalidating template-derived caches).
+    pub fn is_live_edit_reload(&self) -> bool {
+        match self {
+            Self::Reload => true,
+            _ => false,
+        }
+    }
+
+    /// True only for `Apply::ScriptReapply` — a `request_script_reapply`-driven
+    /// re-walk where the template has NOT changed. Field impls whose value
+    /// should not be clobbered by template defaults on this kind of re-walk
+    /// should early-return when this is true (canonical example:
+    /// `ArcStringMut::script_apply`).
+    pub fn is_script_reapply(&self) -> bool {
+        match self {
+            Self::ScriptReapply => true,
             _ => false,
         }
     }

--- a/platform/script/src/prims.rs
+++ b/platform/script/src/prims.rs
@@ -334,10 +334,21 @@ script_primitive!(
     fn script_apply(
         &mut self,
         vm: &mut ScriptVm,
-        _apply: &Apply,
+        apply: &Apply,
         _scope: &mut Scope,
         value: ScriptValue,
     ) {
+        // Same rationale as `ArcStringMut::script_apply`: text-bearing fields
+        // (`TextInput.text`, `TextInput.empty_text`, etc.) are canonically
+        // mutated through imperative setters at runtime. A ScriptReapply
+        // walk fired by `cx.request_script_reapply()` (preference broadcast,
+        // safe-area inset change) would otherwise clobber that runtime value
+        // with the stale DSL literal. Strings are not part of the shared-
+        // heap-object propagation pipeline (which uses `Size`/numerics), so
+        // bailing here is safe.
+        if apply.is_script_reapply() {
+            return;
+        }
         self.clear();
         vm.bx.heap.cast_to_string(value, self);
     },

--- a/platform/script/src/traits.rs
+++ b/platform/script/src/traits.rs
@@ -33,7 +33,13 @@ pub trait ScriptHook {
     ) {
         match apply {
             Apply::New => self.on_before_new_scoped(vm, scope),
-            Apply::Reload => self.on_before_reload_scoped(vm, scope),
+            // Both LiveEdit (Reload) and request_script_reapply (ScriptReapply)
+            // fire the reload hooks — `apply.is_reload()` returns true for
+            // both, and widgets that branch on it expect the broader semantic.
+            // Widgets that need to differentiate can branch on
+            // `apply.is_live_edit_reload()` or `apply.is_script_reapply()`
+            // inside the hook.
+            Apply::Reload | Apply::ScriptReapply => self.on_before_reload_scoped(vm, scope),
             _ => (),
         }
     }
@@ -56,7 +62,7 @@ pub trait ScriptHook {
     ) {
         match apply {
             Apply::New => self.on_after_new_scoped(vm, scope),
-            Apply::Reload => self.on_after_reload_scoped(vm, scope),
+            Apply::Reload | Apply::ScriptReapply => self.on_after_reload_scoped(vm, scope),
             _ => (),
         }
         self.on_alive()

--- a/platform/src/app_main.rs
+++ b/platform/src/app_main.rs
@@ -242,6 +242,81 @@ pub trait AppMain {
     }
 }
 
+/// Internal helper for [`app_main!`]. Emits the boxed event-handler
+/// closure that every platform entry point hands to `Cx::new`. Captures
+/// its own `app` and `app_value` `Rc<RefCell<…>>` slots, so the four
+/// platform entry points (desktop, Android activity, OHOS, wasm32) all
+/// share a single source of truth for `Event::Startup` / `LiveEdit` /
+/// `ScriptReapply` / `handle_event` dispatch.
+///
+/// `cx.start_hot_reload_file_observer_if_requested()` is called
+/// unconditionally — its body is `#[cfg]`-gated to desktop OSes, so on
+/// android / ohos / wasm32 it's a compile-time no-op.
+///
+/// Not part of the public API. Use [`app_main!`] instead.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _app_main_event_closure {
+    ($app:ident) => {{
+        let app = std::rc::Rc::new(std::cell::RefCell::new(None));
+        let app_value: std::rc::Rc<std::cell::RefCell<Option<$crate::ScriptObjectRef>>>
+            = std::rc::Rc::new(std::cell::RefCell::new(None));
+        Box::new(move |cx: &mut Cx, event: &Event| {
+            if let Event::Startup = event {
+                *app.borrow_mut() = Some(cx.with_vm(|vm| {
+                    let value = <$app as AppMain>::script_mod(vm);
+                    if let Some(obj) = value.as_object() {
+                        *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
+                    }
+                    let mut app = <$app as $crate::ScriptNew>::script_from_value(vm, value);
+                    <$app as AppMain>::after_new_from_script(vm, &mut app);
+                    app
+                }));
+                cx.start_hot_reload_file_observer_if_requested();
+            }
+            if let Event::LiveEdit = event {
+                let mut app_ref = app.borrow_mut();
+                if let Some(app) = app_ref.as_mut() {
+                    cx.with_vm(|vm| {
+                        let value = vm.with_reload(|vm| <$app as AppMain>::script_mod(vm));
+                        if let Some(obj) = value.as_object() {
+                            *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
+                        }
+                        <$app as $crate::ScriptApply>::script_apply(
+                            app,
+                            vm,
+                            &$crate::Apply::Reload,
+                            &mut $crate::Scope::empty(),
+                            value,
+                        );
+                    });
+                }
+            }
+            if let Event::ScriptReapply = event {
+                let mut app_ref = app.borrow_mut();
+                if let Some(app) = app_ref.as_mut() {
+                    let value = app_value.borrow().as_ref()
+                        .map(|r| $crate::ScriptValue::from(r.as_object()));
+                    if let Some(value) = value {
+                        cx.with_vm(|vm| {
+                            <$app as $crate::ScriptApply>::script_apply(
+                                app,
+                                vm,
+                                &$crate::Apply::ScriptReapply,
+                                &mut $crate::Scope::empty(),
+                                value,
+                            );
+                        });
+                    }
+                }
+            }
+            if let Some(app) = &mut *app.borrow_mut() {
+                <dyn AppMain>::handle_event(app, cx, event);
+            }
+        }) as Box<dyn FnMut(&mut Cx, &Event)>
+    }};
+}
+
 #[macro_export]
 macro_rules! app_main {
     ( $ app: ident) => {
@@ -257,71 +332,12 @@ macro_rules! app_main {
                 return;
             }
 
-            // `app_value` caches the app's script root as a rooted
-            // `ScriptObjectRef` so `Event::ScriptReapply` can re-apply the
-            // widget tree without re-running `script_mod` (which would
-            // wipe runtime heap overrides like preference-driven template
-            // mutations). A rooted ref is required — storing a bare
-            // `ScriptValue` would let the script heap GC the slot out
-            // from under us between `Event::Startup` and the first reapply.
-            let app = std::rc::Rc::new(std::cell::RefCell::new(None));
-            let app_value: std::rc::Rc<std::cell::RefCell<Option<$crate::ScriptObjectRef>>>
-                = std::rc::Rc::new(std::cell::RefCell::new(None));
-            let mut cx = std::rc::Rc::new(std::cell::RefCell::new(Cx::new(Box::new(
-                move |cx, event| {
-                    if let Event::Startup = event {
-                        *app.borrow_mut() = Some(cx.with_vm(|vm| {
-                            let value = <$app as AppMain>::script_mod(vm);
-                            if let Some(obj) = value.as_object() {
-                                *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
-                            }
-                            let mut app = <$app as $crate::ScriptNew>::script_from_value(vm, value);
-                            <$app as AppMain>::after_new_from_script(vm, &mut app);
-                            app
-                        }));
-                        cx.start_hot_reload_file_observer_if_requested();
-                    }
-                    if let Event::LiveEdit = event {
-                        let mut app_ref = app.borrow_mut();
-                        if let Some(app) = app_ref.as_mut() {
-                            cx.with_vm(|vm| {
-                                let value = vm.with_reload(|vm| <$app as AppMain>::script_mod(vm));
-                                if let Some(obj) = value.as_object() {
-                                    *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
-                                }
-                                <$app as $crate::ScriptApply>::script_apply(
-                                    app,
-                                    vm,
-                                    &$crate::Apply::Reload,
-                                    &mut $crate::Scope::empty(),
-                                    value,
-                                );
-                            });
-                        }
-                    }
-                    if let Event::ScriptReapply = event {
-                        let mut app_ref = app.borrow_mut();
-                        if let Some(app) = app_ref.as_mut() {
-                            let value = app_value.borrow().as_ref()
-                                .map(|r| $crate::ScriptValue::from(r.as_object()));
-                            if let Some(value) = value {
-                                cx.with_vm(|vm| {
-                                    <$app as $crate::ScriptApply>::script_apply(
-                                        app,
-                                        vm,
-                                        &$crate::Apply::Reload,
-                                        &mut $crate::Scope::empty(),
-                                        value,
-                                    );
-                                });
-                            }
-                        }
-                    }
-                    if let Some(app) = &mut *app.borrow_mut() {
-                        <dyn AppMain>::handle_event(app, cx, event);
-                    }
-                },
-            ))));
+            // The event-handler closure (which captures `app` and
+            // `app_value` Rcs internally) is shared across all four
+            // platform entry points via `_app_main_event_closure!`.
+            let mut cx = std::rc::Rc::new(std::cell::RefCell::new(
+                Cx::new($crate::_app_main_event_closure!($app)),
+            ));
             let studio_http = $crate::resolve_studio_http();
             cx.borrow_mut().init_websockets(&studio_http);
             if $crate::should_run_stdin_loop_from_env() {
@@ -364,62 +380,7 @@ macro_rules! app_main {
             $crate::os::linux::android::android_jni::apply_studio_env_from_activity(activity);
             Cx::android_entry(activity, || {
                 let studio_http = $crate::resolve_studio_http();
-                let app = std::rc::Rc::new(std::cell::RefCell::new(None));
-                let app_value: std::rc::Rc<std::cell::RefCell<Option<$crate::ScriptObjectRef>>>
-                    = std::rc::Rc::new(std::cell::RefCell::new(None));
-                let mut cx = Box::new(Cx::new(Box::new(move |cx, event| {
-                    if let Event::Startup = event {
-                        *app.borrow_mut() = Some(cx.with_vm(|vm| {
-                            let value = <$app as AppMain>::script_mod(vm);
-                            if let Some(obj) = value.as_object() {
-                                *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
-                            }
-                            let mut app = <$app as $crate::ScriptNew>::script_from_value(vm, value);
-                            <$app as AppMain>::after_new_from_script(vm, &mut app);
-                            app
-                        }));
-                        cx.start_hot_reload_file_observer_if_requested();
-                    }
-                    if let Event::LiveEdit = event {
-                        let mut app_ref = app.borrow_mut();
-                        if let Some(app) = app_ref.as_mut() {
-                            cx.with_vm(|vm| {
-                                let value = vm.with_reload(|vm| <$app as AppMain>::script_mod(vm));
-                                if let Some(obj) = value.as_object() {
-                                    *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
-                                }
-                                <$app as $crate::ScriptApply>::script_apply(
-                                    app,
-                                    vm,
-                                    &$crate::Apply::Reload,
-                                    &mut $crate::Scope::empty(),
-                                    value,
-                                );
-                            });
-                        }
-                    }
-                    if let Event::ScriptReapply = event {
-                        let mut app_ref = app.borrow_mut();
-                        if let Some(app) = app_ref.as_mut() {
-                            let value = app_value.borrow().as_ref()
-                                .map(|r| $crate::ScriptValue::from(r.as_object()));
-                            if let Some(value) = value {
-                                cx.with_vm(|vm| {
-                                    <$app as $crate::ScriptApply>::script_apply(
-                                        app,
-                                        vm,
-                                        &$crate::Apply::Reload,
-                                        &mut $crate::Scope::empty(),
-                                        value,
-                                    );
-                                });
-                            }
-                        }
-                    }
-                    if let Some(app) = &mut *app.borrow_mut() {
-                        <dyn AppMain>::handle_event(app, cx, event);
-                    }
-                })));
+                let mut cx = Box::new(Cx::new($crate::_app_main_event_closure!($app)));
                 cx.init_websockets(&studio_http);
                 cx.init_cx_os();
                 cx
@@ -433,62 +394,7 @@ macro_rules! app_main {
             env: $crate::napi_ohos::Env,
         ) -> $crate::napi_ohos::Result<()> {
             Cx::ohos_init(exports, env, || {
-                let app = std::rc::Rc::new(std::cell::RefCell::new(None));
-                let app_value: std::rc::Rc<std::cell::RefCell<Option<$crate::ScriptObjectRef>>>
-                    = std::rc::Rc::new(std::cell::RefCell::new(None));
-                let mut cx = Box::new(Cx::new(Box::new(move |cx, event| {
-                    if let Event::Startup = event {
-                        *app.borrow_mut() = Some(cx.with_vm(|vm| {
-                            let value = <$app as AppMain>::script_mod(vm);
-                            if let Some(obj) = value.as_object() {
-                                *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
-                            }
-                            let mut app = <$app as $crate::ScriptNew>::script_from_value(vm, value);
-                            <$app as AppMain>::after_new_from_script(vm, &mut app);
-                            app
-                        }));
-                        cx.start_hot_reload_file_observer_if_requested();
-                    }
-                    if let Event::LiveEdit = event {
-                        let mut app_ref = app.borrow_mut();
-                        if let Some(app) = app_ref.as_mut() {
-                            cx.with_vm(|vm| {
-                                let value = vm.with_reload(|vm| <$app as AppMain>::script_mod(vm));
-                                if let Some(obj) = value.as_object() {
-                                    *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
-                                }
-                                <$app as $crate::ScriptApply>::script_apply(
-                                    app,
-                                    vm,
-                                    &$crate::Apply::Reload,
-                                    &mut $crate::Scope::empty(),
-                                    value,
-                                );
-                            });
-                        }
-                    }
-                    if let Event::ScriptReapply = event {
-                        let mut app_ref = app.borrow_mut();
-                        if let Some(app) = app_ref.as_mut() {
-                            let value = app_value.borrow().as_ref()
-                                .map(|r| $crate::ScriptValue::from(r.as_object()));
-                            if let Some(value) = value {
-                                cx.with_vm(|vm| {
-                                    <$app as $crate::ScriptApply>::script_apply(
-                                        app,
-                                        vm,
-                                        &$crate::Apply::Reload,
-                                        &mut $crate::Scope::empty(),
-                                        value,
-                                    );
-                                });
-                            }
-                        }
-                    }
-                    if let Some(app) = &mut *app.borrow_mut() {
-                        <dyn AppMain>::handle_event(app, cx, event);
-                    }
-                })));
+                let mut cx = Box::new(Cx::new($crate::_app_main_event_closure!($app)));
                 let studio_http = $crate::resolve_studio_http();
                 cx.init_websockets(&studio_http);
                 cx.init_cx_os();
@@ -504,61 +410,7 @@ macro_rules! app_main {
         #[cfg(target_arch = "wasm32")]
         pub extern "C" fn create_wasm_app() -> u32 {
             Cx::init_log();
-            let app = std::rc::Rc::new(std::cell::RefCell::new(None));
-            let app_value: std::rc::Rc<std::cell::RefCell<Option<$crate::ScriptObjectRef>>>
-                = std::rc::Rc::new(std::cell::RefCell::new(None));
-            let mut cx = Box::new(Cx::new(Box::new(move |cx, event| {
-                if let Event::Startup = event {
-                    *app.borrow_mut() = Some(cx.with_vm(|vm| {
-                        let value = <$app as AppMain>::script_mod(vm);
-                        if let Some(obj) = value.as_object() {
-                            *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
-                        }
-                        let mut app = <$app as $crate::ScriptNew>::script_from_value(vm, value);
-                        <$app as AppMain>::after_new_from_script(vm, &mut app);
-                        app
-                    }));
-                }
-                if let Event::LiveEdit = event {
-                    let mut app_ref = app.borrow_mut();
-                    if let Some(app) = app_ref.as_mut() {
-                        cx.with_vm(|vm| {
-                            let value = vm.with_reload(|vm| <$app as AppMain>::script_mod(vm));
-                            if let Some(obj) = value.as_object() {
-                                *app_value.borrow_mut() = Some(vm.heap_mut().new_object_ref(obj));
-                            }
-                            <$app as $crate::ScriptApply>::script_apply(
-                                app,
-                                vm,
-                                &$crate::Apply::Reload,
-                                &mut $crate::Scope::empty(),
-                                value,
-                            );
-                        });
-                    }
-                }
-                if let Event::ScriptReapply = event {
-                    let mut app_ref = app.borrow_mut();
-                    if let Some(app) = app_ref.as_mut() {
-                        let value = app_value.borrow().as_ref()
-                            .map(|r| $crate::ScriptValue::from(r.as_object()));
-                        if let Some(value) = value {
-                            cx.with_vm(|vm| {
-                                <$app as $crate::ScriptApply>::script_apply(
-                                    app,
-                                    vm,
-                                    &$crate::Apply::Reload,
-                                    &mut $crate::Scope::empty(),
-                                    value,
-                                );
-                            });
-                        }
-                    }
-                }
-                if let Some(app) = &mut *app.borrow_mut() {
-                    <dyn AppMain>::handle_event(app, cx, event);
-                }
-            })));
+            let mut cx = Box::new(Cx::new($crate::_app_main_event_closure!($app)));
             let studio_http = $crate::resolve_studio_http();
             cx.init_websockets(&studio_http);
             cx.init_cx_os();

--- a/platform/src/arc_string_mut.rs
+++ b/platform/src/arc_string_mut.rs
@@ -86,10 +86,19 @@ impl ScriptApply for ArcStringMut {
     fn script_apply(
         &mut self,
         vm: &mut ScriptVm,
-        _apply: &Apply,
+        apply: &Apply,
         _scope: &mut Scope,
         value: ScriptValue,
     ) {
+        // Same rationale as `String::script_apply` (see `prims.rs`):
+        // text-bearing fields are canonically mutated by imperative setters
+        // (`Label::set_text`, `Button::set_text`, etc.), so a ScriptReapply
+        // walk should not clobber the runtime value with the stale DSL
+        // literal. `Apply::Reload` (LiveEdit) still applies — DSL just
+        // changed, so the new template wins.
+        if apply.is_script_reapply() {
+            return;
+        }
         // Convert to owned String using the heap's cast method
         let mut s = String::new();
         vm.bx.heap.cast_to_string(value, &mut s);

--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -125,9 +125,25 @@ pub struct Cx {
     /// Display context for the main window, used by AdaptiveView
     pub display_context: DisplayContext,
 
-    /// When true, a script re-apply (LiveEdit) will be triggered on the next
-    /// event loop iteration to pick up changed dynamic values like safe area insets.
+    /// When true, the next event-loop iteration will fire `Event::ScriptReapply`,
+    /// which re-applies the captured app value with `Apply::ScriptReapply`
+    /// *without* re-running `script_mod`. Use this when a runtime mutation
+    /// has updated a shared heap object (e.g. `script_eval!` overriding a
+    /// preference); widgets that hold a reference to that object will pick
+    /// up the new value on re-apply, and `script_eval!` overrides are
+    /// preserved because the source-defined defaults aren't re-asserted.
     pub pending_script_reapply: bool,
+
+    /// When true, the next event-loop iteration will fire `Event::LiveEdit`,
+    /// which re-runs `script_mod` and re-applies with `Apply::Reload`. Use
+    /// this when a primitive heap value (e.g. `mod.widgets.SAFE_INSET_PAD_TOP`)
+    /// has changed and needs to be re-baked into widget definitions that
+    /// reference it via expressions like `top: (mod.widgets.SAFE_INSET_PAD_TOP)`
+    /// — those expressions are only re-evaluated when `script_mod` re-runs.
+    /// `Apply::Reload` clobbers runtime widget state (animator values, etc.),
+    /// so prefer `pending_script_reapply` whenever the change can be modeled
+    /// as a shared-heap-object mutation instead.
+    pub pending_live_edit_request: bool,
 
     pub debug: Debug,
 
@@ -436,6 +452,7 @@ impl Cx {
 
             display_context: Default::default(),
             pending_script_reapply: false,
+            pending_live_edit_request: false,
 
             widget_tree_dump_requests: Default::default(),
             widget_snapshot_requests: Default::default(),

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -487,14 +487,33 @@ impl Cx {
         self.in_draw_event
     }
 
-    /// Updates the `mod.widgets.SAFE_INSET_PAD_*` values on the script heap
-    /// so that Splash code can reference them in widget definitions.
-    /// Requests a deferred re-application of all script/Splash widget definitions,
-    /// causing widgets to pick up updated values from the script heap.
-    /// The re-apply happens on the next event loop iteration (not synchronously),
-    /// to avoid re-entrancy issues when called from within an event handler.
+    /// Requests a deferred `Event::ScriptReapply` on the next event-loop
+    /// iteration. The captured app value is re-applied with
+    /// `Apply::ScriptReapply` — no `script_mod` re-run, so runtime
+    /// `script_eval!` overrides on the heap are preserved. Widgets that
+    /// reference shared heap objects (e.g. `mod.widgets.IMG_MSG_FIT`) pick
+    /// up in-place mutations on this re-apply walk.
+    ///
+    /// Use this when the change you made is a runtime mutation of a shared
+    /// heap object — typically a `script_eval!` override.
     pub fn request_script_reapply(&mut self) {
         self.pending_script_reapply = true;
+    }
+
+    /// Requests a deferred `Event::LiveEdit` on the next event-loop iteration.
+    /// The handler re-runs `script_mod` (re-evaluating any expressions that
+    /// reference primitive heap values like `mod.widgets.SAFE_INSET_PAD_TOP`)
+    /// and then re-applies the widget tree with `Apply::Reload`.
+    ///
+    /// Use this only when a primitive heap value has changed and that value
+    /// is consumed by `script_mod!` block expressions — those expressions are
+    /// not re-evaluated by `Apply::ScriptReapply`. `Apply::Reload` walks
+    /// clobber runtime widget state (animator values, dynamic instance
+    /// buffers, user-typed text in widgets that don't early-return on
+    /// LiveEdit), so prefer `request_script_reapply` when the change can be
+    /// modeled as a shared-heap-object mutation instead.
+    pub fn request_live_edit(&mut self) {
+        self.pending_live_edit_request = true;
     }
 
     pub fn update_safe_inset_script_values(&mut self, insets: crate::event::SafeAreaInsets) {

--- a/platform/src/event/event.rs
+++ b/platform/src/event/event.rs
@@ -125,14 +125,18 @@ pub enum Event {
     Draw(DrawEvent),
     LiveEdit,
     /// Request from `Cx::request_script_reapply()` to re-apply the widget
-    /// tree via `Apply::Reload` *without* re-running `script_mod!`.
+    /// tree via `Apply::ScriptReapply` *without* re-running `script_mod!`.
     ///
     /// This is useful when something like a Splash-level script object
     /// has been modified at runtime (e.g., `script_eval!`) and the application
     /// wants every widget in the widget tree to pick up that new modified object value.
     ///
     /// Unlike `Event::LiveEdit`, this preserves any heap object values that have
-    /// already been modified at runtime.
+    /// already been modified at runtime. It also walks the tree with
+    /// `Apply::ScriptReapply` (rather than `Apply::Reload`) so that field
+    /// types whose canonical mutation path is an imperative setter
+    /// (e.g. `Label::set_text`) can early-return and keep their runtime
+    /// value instead of being clobbered by the stale DSL literal.
     ScriptReapply,
     /// A window has gained focus and is now the active window receiving user input.
     WindowGotFocus(WindowId),

--- a/platform/src/live_reload.rs
+++ b/platform/src/live_reload.rs
@@ -83,13 +83,36 @@ impl CxLiveReloadState {
     }
 }
 
+/// Result of [`Cx::handle_live_edit`], discriminating *why* a LiveEdit
+/// was triggered. Callers use this to decide whether to do the heavyweight
+/// follow-up work (shader cache reset, immediate Event::ScriptReapply
+/// pass) that's only justified when the DSL itself just changed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LiveEditTrigger {
+    /// Nothing pending — handler should not fire `Event::LiveEdit`.
+    None,
+    /// A `script_mod!` block was hot-reloaded from a file change (file
+    /// watcher on desktop, or `StudioToApp::LiveChange` over the studio
+    /// websocket). The DSL itself changed; widget trees need a full
+    /// re-walk and shader caches may be stale.
+    FileChange,
+    /// A platform caller invoked `cx.request_live_edit()` (e.g. iOS
+    /// rotation re-baking `mod.widgets.SAFE_INSET_PAD_*`). The DSL did
+    /// NOT change; we just need `script_mod` to re-evaluate so source
+    /// expressions referencing changed primitives pick up new values.
+    /// Shader code is unchanged, and any follow-up `ScriptReapply`
+    /// triggered by the LiveEdit handler can be deferred to the next
+    /// event-loop tick to keep each tick light during the animation.
+    Manual,
+}
+
 impl Cx {
     pub fn start_hot_reload_file_observer_if_requested(&mut self) {
         #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
         self.start_desktop_hot_reload_file_observer_if_requested();
     }
 
-    pub fn handle_live_edit(&mut self) -> bool {
+    pub(crate) fn handle_live_edit(&mut self) -> LiveEditTrigger {
         handle_cx_live_edit(self)
     }
 }
@@ -143,7 +166,24 @@ impl Cx {
     }
 }
 
-fn handle_cx_live_edit(cx: &mut Cx) -> bool {
+fn handle_cx_live_edit(cx: &mut Cx) -> LiveEditTrigger {
+    // Process file changes first so a real DSL hot-reload always wins
+    // over a (cheaper) manual request — the file path also updates the
+    // `script_mod_overrides` map that subsequent `script_mod` re-runs
+    // consult, and we want that done before the LiveEdit fires.
+    let file_changed = handle_cx_live_edit_files(cx);
+    let manual = std::mem::take(&mut cx.pending_live_edit_request);
+
+    if file_changed {
+        LiveEditTrigger::FileChange
+    } else if manual {
+        LiveEditTrigger::Manual
+    } else {
+        LiveEditTrigger::None
+    }
+}
+
+fn handle_cx_live_edit_files(cx: &mut Cx) -> bool {
     let pending = std::mem::take(&mut cx.script_data.live_reload.pending_files);
     if pending.is_empty() {
         return false;

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -832,12 +832,14 @@ impl Cx {
             }
         }
 
-        // If a script re-apply was requested (e.g., safe area insets changed
-        // on rotation), fire LiveEdit now that all event handlers have returned.
-        if self.pending_script_reapply {
-            self.pending_script_reapply = false;
-            self.call_event_handler(&Event::LiveEdit);
-            self.redraw_all();
+        // After every event, drain any pending re-apply. The cheap gate
+        // (both flags false) keeps the hot path zero-cost; everything
+        // else — picking the right `Event` variant for each flag,
+        // skipping shader-cache reset for manual triggers, deferring a
+        // same-tick `ScriptReapply` follow-up to keep rotation light —
+        // is documented in `run_live_edit_if_needed`.
+        if self.pending_script_reapply || self.pending_live_edit_request {
+            self.run_live_edit_if_needed("ios");
         }
 
         if self.any_passes_dirty()

--- a/platform/src/os/cx_shared.rs
+++ b/platform/src/os/cx_shared.rs
@@ -580,47 +580,74 @@ impl Cx {
     }
 
     pub(crate) fn run_live_edit_if_needed(&mut self, _backend: &str) {
-        // Two independent triggers with distinct semantics:
+        // Three independent triggers, fanning out to two events. The
+        // critical distinction between FileChange and Manual is whether
+        // we follow LiveEdit up with an immediate ScriptReapply pass in
+        // the SAME tick — manual triggers (rotation) defer it to the next
+        // tick to keep each tick's work bounded, since rotation can fire
+        // multiple WindowGeomChange events back-to-back during the
+        // animation and each Apply walk over the full widget tree is
+        // non-trivial on mobile hardware.
         //
-        //  1. `handle_live_edit()` returns `true` when the file watcher
-        //     delivered a hot-reloaded `script_mod!` block. We must re-run
-        //     `script_mod` (source-defined module-level assignments) before
-        //     re-applying the widget tree, because the reloaded code may
-        //     have changed those assignments. That's what `Event::LiveEdit`
-        //     signals — the AppMain handler re-runs `script_mod` under
-        //     `vm.with_reload(...)` and then applies the result with
-        //     `Apply::Reload`. Only this path needs `reset_for_live_reload`.
+        // 1. `LiveEditTrigger::FileChange` — file watcher delivered a
+        //    hot-reloaded `script_mod!` block (or studio websocket sent
+        //    a `LiveChange`). The DSL itself changed; shader caches may
+        //    be stale, so `reset_for_live_reload` runs. Any preference
+        //    re-broadcast in the LiveEdit handler propagates immediately
+        //    via the same-tick `ScriptReapply` follow-up — file changes
+        //    are a live-coding scenario where the user wants to see the
+        //    update right away.
         //
-        //  2. `pending_script_reapply` is set by `Cx::request_script_reapply`
-        //     after runtime mutations to the script heap (e.g. `script_eval!`
-        //     overriding a user preference). Re-running `script_mod` would
-        //     clobber those overrides by reasserting source-defined defaults.
-        //     Instead we fire `Event::ScriptReapply`, which the AppMain
-        //     handler services by re-applying the previously-captured app
-        //     value with `Apply::Reload` — no `script_mod` re-run, so the
-        //     overrides stick.
+        // 2. `LiveEditTrigger::Manual` — `cx.request_live_edit()` was
+        //    called (canonical case: safe-area insets changed on iOS
+        //    rotation, where `mod.widgets.SAFE_INSET_PAD_*` heap
+        //    primitives need to be re-baked into `script_mod!` block
+        //    expressions). The DSL did NOT change; we skip
+        //    `reset_for_live_reload` (no shader code changed), and we
+        //    skip the immediate ScriptReapply follow-up — if the
+        //    LiveEdit handler set `pending_script_reapply` (e.g. robrix
+        //    re-broadcasting preferences), it lands on the next event-
+        //    loop tick. Without this split, rotation incurred a visible
+        //    1-2s lag from doing two full Apply walks per geom change.
         //
-        // If a file change just happened AND a user-level handler then
-        // requests a reapply (e.g. an `Event::LiveEdit` handler re-broadcasting
-        // preferences so a fresh source reload doesn't lose them), we follow
-        // up with a single `ScriptReapply` pass. That second pass is bounded
-        // — any further requests settle on the next event-loop tick rather
-        // than looping inside this one.
-        let file_edit_applied = self.handle_live_edit();
-        if file_edit_applied {
-            self.draw_shaders.reset_for_live_reload();
-            self.pending_script_reapply = false;
-            self.call_event_handler(&Event::LiveEdit);
-            self.redraw_all();
-            if self.pending_script_reapply {
+        // 3. `LiveEditTrigger::None` + `pending_script_reapply` — set by
+        //    `cx.request_script_reapply()` after runtime mutations to a
+        //    *shared* heap *object* (`script_eval!` overriding
+        //    `mod.widgets.IMG_MSG_FIT.max`, etc.). Re-running script_mod
+        //    would clobber those overrides; we fire `Event::ScriptReapply`
+        //    which re-applies the captured `app_value` with
+        //    `Apply::ScriptReapply` — no script_mod re-run, runtime
+        //    overrides preserved, imperative-setter fields early-return.
+        use crate::live_reload::LiveEditTrigger;
+        match self.handle_live_edit() {
+            LiveEditTrigger::FileChange => {
+                self.draw_shaders.reset_for_live_reload();
                 self.pending_script_reapply = false;
-                self.call_event_handler(&Event::ScriptReapply);
+                self.call_event_handler(&Event::LiveEdit);
+                self.redraw_all();
+                if self.pending_script_reapply {
+                    self.pending_script_reapply = false;
+                    self.call_event_handler(&Event::ScriptReapply);
+                    self.redraw_all();
+                }
+            }
+            LiveEditTrigger::Manual => {
+                // Clear `pending_script_reapply` defensively — LiveEdit's
+                // script_mod re-run clobbers heap overrides anyway, and an
+                // app-level handler that re-broadcasts (e.g. robrix's
+                // `broadcast_all`) sets a fresh flag that lands on the
+                // next tick.
+                self.pending_script_reapply = false;
+                self.call_event_handler(&Event::LiveEdit);
                 self.redraw_all();
             }
-        } else if self.pending_script_reapply {
-            self.pending_script_reapply = false;
-            self.call_event_handler(&Event::ScriptReapply);
-            self.redraw_all();
+            LiveEditTrigger::None => {
+                if self.pending_script_reapply {
+                    self.pending_script_reapply = false;
+                    self.call_event_handler(&Event::ScriptReapply);
+                    self.redraw_all();
+                }
+            }
         }
     }
 

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -343,12 +343,15 @@ impl Cx {
                         continue;
                     }
                     self.os.openxr.logged_waiting_for_session = false;
-                    // If a script re-apply was requested (e.g., safe area insets
-                    // changed on rotation), fire LiveEdit now.
-                    if self.pending_script_reapply {
-                        self.pending_script_reapply = false;
-                        self.call_event_handler(&Event::LiveEdit);
-                        self.redraw_all();
+                    // After every event, drain any pending re-apply. The
+                    // cheap gate (both flags false) keeps the hot path
+                    // zero-cost; everything else — picking the right
+                    // `Event` variant for each flag, skipping shader-cache
+                    // reset for manual triggers, deferring a same-tick
+                    // `ScriptReapply` follow-up to keep rotation light —
+                    // is documented in `run_live_edit_if_needed`.
+                    if self.pending_script_reapply || self.pending_live_edit_request {
+                        self.run_live_edit_if_needed("android");
                     }
                     // Drop the frame entirely if the window surface has been
                     // torn down (typically during background/foreground or a

--- a/studio/desktop/src/app_backend.rs
+++ b/studio/desktop/src/app_backend.rs
@@ -792,7 +792,7 @@ impl App {
                 .set_text(cx, &log_filter);
             workspace
                 .check_box(cx, ids!(log_tail_toggle))
-                .set_active(cx, log_tail);
+                .set_active(cx, log_tail, Animate::Yes);
             workspace
                 .desktop_log_view(cx, ids!(log_view))
                 .set_tail(cx, log_tail);

--- a/studio/desktop/src/desktop_profiler_view.rs
+++ b/studio/desktop/src/desktop_profiler_view.rs
@@ -1106,7 +1106,7 @@ impl Widget for DesktopProfilerView {
 
         self.view
             .check_box(cx, ids!(running_button))
-            .set_active(cx, running);
+            .set_active(cx, running, Animate::Yes);
         if let Some(mut chart) = self
             .view
             .widget(cx, ids!(chart))

--- a/studio/desktop/src/main.rs
+++ b/studio/desktop/src/main.rs
@@ -276,7 +276,7 @@ impl MatchEvent for App {
                     if was_tailing {
                         workspace
                             .check_box(cx, ids!(log_tail_toggle))
-                            .set_active(cx, false);
+                            .set_active(cx, false, Animate::Yes);
                         self.set_mount_log_tail(cx, &active_mount, false);
                     }
                 }

--- a/widgets/src/animator.rs
+++ b/widgets/src/animator.rs
@@ -330,16 +330,26 @@ impl ScriptApplyDefault for Animator {
         _scope: &mut Scope,
         _value: ScriptValue,
     ) -> Option<ScriptValue> {
-        if !apply.is_new() || apply.is_eval() {
+        if apply.is_live_edit_reload() || apply.is_animate() || apply.is_eval() {
             return None;
         }
-        let index = apply.as_default().map_or(0, |x| x + 1);
-        let (_, group) = self.groups.iter().nth(index)?;
-        let state = group.states.get(&group.default)?;
 
-        // Return the apply value from that state
-        let apply = state.apply?.into();
-        Some(apply)
+        if let Some(state_obj_ref) = self.state_object.as_ref() {
+            if apply.as_default().is_none() {
+                return Some(state_obj_ref.as_object().into());
+            }
+            return None;
+        }
+
+        let index = apply.as_default().map_or(0, |x| x + 1);
+        let (group_id, group) = self.groups.iter().nth(index)?;
+        let state_id = self
+            .current_states
+            .get(group_id)
+            .copied()
+            .unwrap_or(group.default);
+        let state = group.states.get(&state_id)?;
+        Some(state.apply?.into())
     }
 }
 
@@ -359,6 +369,29 @@ impl AnimatorAction {
 }
 
 impl Animator {
+    /// Returns the apply `ScriptObject` for the current state of the given
+    /// state group, falling back to the group's default state if no current
+    /// state is set yet.
+    ///
+    /// Useful from a widget's `on_after_apply` hook on `Apply::ScriptReapply`
+    /// to re-snap animator-driven fields (`walk.height`, `View.visible`,
+    /// shader uniforms, etc.) after a `request_script_reapply` walk has
+    /// clobbered them with the template defaults — the caller can apply
+    /// the returned object via `self.script_apply(vm, &Apply::Animate, ...)`
+    /// directly, without going through `animator_cut` (which calls
+    /// `cx.with_vm` and would panic if the VM is already held by the
+    /// surrounding apply chain).
+    pub fn current_state_apply(&self, group_id: LiveId) -> Option<ScriptObject> {
+        let group = self.groups.get(&group_id)?;
+        let state_id = self
+            .current_states
+            .get(&group_id)
+            .copied()
+            .unwrap_or(group.default);
+        let state = group.states.get(&state_id)?;
+        state.apply
+    }
+
     /// Start animating to a new state
     pub fn play(
         &mut self,

--- a/widgets/src/callout_tooltip.rs
+++ b/widgets/src/callout_tooltip.rs
@@ -257,70 +257,155 @@ impl WidgetMatchEvent for CalloutTooltip {
 }
 
 impl CalloutTooltip {
-    /// Calculate tooltip position and layout parameters for a given position
+    /// Calculate tooltip position and layout parameters for a given position.
+    ///
+    /// For `Top`/`Bottom`, the tooltip is centered horizontally on the target
+    /// widget (clamped to the available rect). For `Left`/`Right`, the tooltip
+    /// is centered vertically on the target widget (clamped to the available
+    /// rect). If the tooltip can't fit the available axis, `fixed_width` is
+    /// set so the caller can constrain the layout width and force text
+    /// wrapping.
+    ///
+    /// `available_rect` is the on-screen region the tooltip is allowed to
+    /// occupy — typically the full pass minus any platform safe-area insets
+    /// (notch, rounded corners, home indicator). Tooltips will not be drawn
+    /// outside this rect.
     fn calculate_position(
         options: &CalloutTooltipOptions,
         widget_rect: Rect,
         expected_dimension: DVec2,
-        screen_size: DVec2,
+        available_rect: Rect,
         triangle_height: f64,
     ) -> PositionCalculation {
         let pos = widget_rect.pos;
         let size = widget_rect.size;
-        let mut tooltip_pos = DVec2 {
-            x: min(pos.x, screen_size.x - expected_dimension.x),
-            y: min(
-                pos.y + widget_rect.size.y,
-                screen_size.y - expected_dimension.y,
-            ),
-        };
+        let widget_center_x = pos.x + size.x * 0.5;
+        let widget_center_y = pos.y + size.y * 0.5;
+
+        let avail_left = available_rect.pos.x;
+        let avail_top = available_rect.pos.y;
+        let avail_right = avail_left + available_rect.size.x;
+        let avail_bottom = avail_top + available_rect.size.y;
+        let avail_width = available_rect.size.x;
+        let avail_height = available_rect.size.y;
+
+        let mut tooltip_pos = DVec2::default();
         let mut fixed_width = false;
         let mut callout_position = 0.0;
-        let mut width_to_be_fixed = screen_size.x;
+        let mut width_to_be_fixed = avail_width;
+
+        // Skip full layout calculations until we know the tooltip's natural
+        // size (first pre-draw pass reports zero). Position at the target's
+        // top-left so the initial invisible draw is cheap.
+        if expected_dimension.x <= 0.0 || avail_width <= 0.0 {
+            tooltip_pos = DVec2 { x: pos.x, y: pos.y };
+            return PositionCalculation {
+                tooltip_pos,
+                callout_position,
+                fixed_width,
+                width_to_be_fixed,
+            };
+        }
 
         match options.position {
-            TooltipPosition::Top => {
-                tooltip_pos.y = widget_rect.pos.y - max(expected_dimension.y, size.y);
-                callout_position = 180.0;
-            }
-            TooltipPosition::Bottom => {
-                if tooltip_pos.y == screen_size.y - expected_dimension.y {
-                    tooltip_pos.y = widget_rect.pos.y - max(expected_dimension.y, size.y);
-                    callout_position = 180.0;
+            TooltipPosition::Top | TooltipPosition::Bottom => {
+                // Center the tooltip horizontally on the target widget.
+                let mut desired_x = widget_center_x - expected_dimension.x * 0.5;
+                if expected_dimension.x >= avail_width {
+                    // Tooltip is (or would be) wider than the available area:
+                    // pin to the available left edge and clamp the width so
+                    // the text wraps.
+                    fixed_width = true;
+                    width_to_be_fixed = avail_width;
+                    desired_x = avail_left;
                 } else {
-                    tooltip_pos.y = widget_rect.pos.y + widget_rect.size.y;
+                    // Clamp so the tooltip stays inside the available rect.
+                    if desired_x < avail_left {
+                        desired_x = avail_left;
+                    } else if desired_x + expected_dimension.x > avail_right {
+                        desired_x = avail_right - expected_dimension.x;
+                    }
+                }
+                tooltip_pos.x = desired_x;
+
+                // Choose vertical placement. For `Top` we go above the widget
+                // (flipping below if there isn't room). For `Bottom` we go
+                // below (flipping above if there isn't room).
+                let y_above = pos.y - max(expected_dimension.y, size.y);
+                let y_below = pos.y + size.y;
+                let fits_above = y_above >= avail_top;
+                let fits_below = y_below + expected_dimension.y <= avail_bottom;
+
+                match options.position {
+                    TooltipPosition::Top => {
+                        if fits_above || !fits_below {
+                            tooltip_pos.y = y_above;
+                            callout_position = 180.0;
+                        } else {
+                            tooltip_pos.y = y_below;
+                            callout_position = 0.0;
+                        }
+                    }
+                    TooltipPosition::Bottom => {
+                        if fits_below || !fits_above {
+                            tooltip_pos.y = y_below;
+                            callout_position = 0.0;
+                        } else {
+                            tooltip_pos.y = y_above;
+                            callout_position = 180.0;
+                        }
+                    }
+                    _ => {}
                 }
             }
             TooltipPosition::Left => {
-                tooltip_pos.x = widget_rect.pos.x
-                    - max(expected_dimension.x, widget_rect.size.x)
-                    - triangle_height;
-                tooltip_pos.y = widget_rect.pos.y
-                    + 0.5 * (widget_rect.size.y - max(expected_dimension.y, widget_rect.size.y));
+                tooltip_pos.x = pos.x - expected_dimension.x - triangle_height;
+                if tooltip_pos.x < avail_left {
+                    fixed_width = true;
+                    // Leave room for the callout arrow.
+                    width_to_be_fixed = (pos.x - triangle_height - avail_left).max(24.0);
+                    tooltip_pos.x = avail_left;
+                }
+
+                let mut desired_y = widget_center_y - expected_dimension.y * 0.5;
+                if desired_y < avail_top {
+                    desired_y = avail_top;
+                } else if desired_y + expected_dimension.y > avail_bottom {
+                    desired_y = (avail_bottom - expected_dimension.y).max(avail_top);
+                }
+                tooltip_pos.y = desired_y;
                 callout_position = 90.0;
             }
             TooltipPosition::Right => {
-                tooltip_pos.x = widget_rect.pos.x + widget_rect.size.x;
-                tooltip_pos.y =
-                    widget_rect.pos.y + 0.5 * widget_rect.size.y - expected_dimension.y * 0.5;
-                width_to_be_fixed = max(
-                    screen_size.x - (pos.x + widget_rect.size.x + triangle_height * 2.0),
-                    expected_dimension.x,
-                );
+                tooltip_pos.x = pos.x + size.x;
+                let available_x =
+                    (avail_right - tooltip_pos.x - triangle_height * 2.0).max(0.0);
+                if expected_dimension.x > available_x {
+                    fixed_width = true;
+                    width_to_be_fixed = available_x.max(24.0);
+                }
+
+                let mut desired_y = widget_center_y - expected_dimension.y * 0.5;
+                if desired_y < avail_top {
+                    desired_y = avail_top;
+                } else if desired_y + expected_dimension.y > avail_bottom {
+                    desired_y = (avail_bottom - expected_dimension.y).max(avail_top);
+                }
+                tooltip_pos.y = desired_y;
                 callout_position = 270.0;
             }
         }
-        if expected_dimension.x > 0.0 && screen_size.x > 0.0 {
-            Self::apply_edge_case_fix(
-                &options.position,
-                &mut tooltip_pos,
-                &mut fixed_width,
-                &mut width_to_be_fixed,
-                screen_size,
-                expected_dimension,
-                widget_rect,
-                triangle_height,
-            );
+
+        // Final top/bottom clamp to keep the tooltip inside the available rect.
+        if tooltip_pos.y < avail_top {
+            tooltip_pos.y = avail_top;
+        } else if tooltip_pos.y + expected_dimension.y > avail_bottom {
+            tooltip_pos.y = (avail_bottom - expected_dimension.y).max(avail_top);
+        }
+        // Vertical height clamp: tooltip wider than available height shouldn't
+        // overflow — pin to top and let the content clip if necessary.
+        if expected_dimension.y >= avail_height {
+            tooltip_pos.y = avail_top;
         }
 
         PositionCalculation {
@@ -328,47 +413,6 @@ impl CalloutTooltip {
             callout_position,
             fixed_width,
             width_to_be_fixed,
-        }
-    }
-
-    /// Check if width fixing is needed for edge cases
-    fn needs_width_fix(tooltip_x: f64, screen_width: f64, expected_width: f64) -> bool {
-        tooltip_x == screen_width - expected_width && tooltip_x < 0.0
-    }
-
-    /// Apply edge case handling for position and width fixing
-    fn apply_edge_case_fix(
-        position: &TooltipPosition,
-        tooltip_pos: &mut DVec2,
-        fixed_width: &mut bool,
-        width_to_be_fixed: &mut f64,
-        screen_size: DVec2,
-        expected_dimension: DVec2,
-        widget_rect: Rect,
-        triangle_height: f64,
-    ) {
-        match position {
-            TooltipPosition::Top | TooltipPosition::Bottom => {
-                if Self::needs_width_fix(tooltip_pos.x, screen_size.x, expected_dimension.x) {
-                    *fixed_width = true;
-                    tooltip_pos.x = 0.0;
-                }
-            }
-            TooltipPosition::Left => {
-                if tooltip_pos.x < 0.0 {
-                    *fixed_width = true;
-                    *width_to_be_fixed = widget_rect.pos.x - triangle_height;
-                    tooltip_pos.x = 0.0;
-                }
-            }
-            TooltipPosition::Right => {
-                if *width_to_be_fixed == expected_dimension.x
-                    && *width_to_be_fixed > screen_size.x - widget_rect.pos.x - widget_rect.size.x
-                {
-                    *fixed_width = true;
-                    *width_to_be_fixed = screen_size.x - widget_rect.pos.x - widget_rect.size.x;
-                }
-            }
         }
     }
 
@@ -398,21 +442,11 @@ impl CalloutTooltip {
             bottom: 0.0,
         };
 
-        let mut content_view = tooltip.view(cx, ids!(content));
-        script_apply_eval!(cx, content_view, {
-            margin: #(margin)
-        });
-        if position_calc.fixed_width {
-            let fixed_width = position_calc.width_to_be_fixed.max(24.0);
-            script_apply_eval!(cx, content_view, {
-                width: #(fixed_width)
-            });
-        } else {
-            script_apply_eval!(cx, content_view, {
-                width: #(Size::fit())
-            });
-        }
-
+        // Apply the draw_bg shader instances FIRST. `script_apply_eval!` on a
+        // View runs `apply` over the whole struct, which can reset fields not
+        // mentioned in the script (like `walk.width`) back to their DSL
+        // defaults (Fit). Doing this BEFORE the direct walk writes below
+        // ensures our width override wins.
         let mut content = tooltip.view(cx, ids!(content));
         script_apply_eval!(cx, content, {
             draw_bg +: {
@@ -426,16 +460,38 @@ impl CalloutTooltip {
             }
         });
 
+        // Now set the content view's walk fields directly via `borrow_mut()`
+        // so the next draw uses the correct width. We use `Size::Fixed` for
+        // both the content view AND the label when `fixed_width` is set,
+        // because the wrapping in `DrawText::draw_walk` keys off the turtle's
+        // resolved width — `Size::Fill` inside an Overlay-flow parent can
+        // resolve to the full pass width on some platforms instead of the
+        // parent's constrained inner width, which is the iOS bug we hit.
+        // `Size::Fixed` removes that ambiguity entirely.
+        const CONTENT_PADDING: f64 = 15.0;
+        let content_view = tooltip.view(cx, ids!(content));
+        if let Some(mut view) = content_view.borrow_mut() {
+            view.walk.margin = margin;
+            if position_calc.fixed_width {
+                let fixed_width = position_calc.width_to_be_fixed.max(24.0);
+                view.walk.width = Size::Fixed(fixed_width);
+            } else {
+                view.walk.width = Size::fit();
+            }
+            view.redraw(cx);
+        }
+
         let tooltip_label = tooltip.label(cx, ids!(content.tooltip_label));
         if let Some(mut label) = tooltip_label.borrow_mut() {
             label.draw_text.color = text_color;
             if position_calc.fixed_width {
-                // Because parent width is constrained, we MUST Fill so the text wraps line-by-line
-                label.walk.width = Size::fill();
+                let fixed_width = position_calc.width_to_be_fixed.max(24.0);
+                let label_width = (fixed_width - CONTENT_PADDING * 2.0).max(24.0);
+                label.walk.width = Size::Fixed(label_width);
             } else {
-                // Because parent width is Fit, we MUST Fit so the string natural width evaluates properly
                 label.walk.width = Size::fit();
             }
+            label.redraw(cx);
         };
     }
 
@@ -466,12 +522,41 @@ impl CalloutTooltip {
             .label(cx, ids!(content.tooltip_label))
             .set_text(cx, &pad_last_line(text));
 
-        let mut expected_dimension = tooltip.view(cx, ids!(content)).area().rect(cx).size;
         let screen_size = tooltip.area().rect(cx).size;
+
+        // Subtract platform safe-area insets (notch, rounded corners, home
+        // indicator) so the tooltip doesn't spill into hardware-occluded
+        // regions. On macOS/desktop these are all zero.
+        let insets = cx.display_context.safe_area_insets;
+        let available_rect = Rect {
+            pos: DVec2 {
+                x: insets.left,
+                y: insets.top,
+            },
+            size: DVec2 {
+                x: (screen_size.x - insets.left - insets.right).max(0.0),
+                y: (screen_size.y - insets.top - insets.bottom).max(0.0),
+            },
+        };
+
+        // On the external (non-internal-redraw) call we MUST NOT trust the
+        // content view's `area().rect()`: it still reflects the previous
+        // draw of the *previous* tooltip text. Saving that as
+        // `text_unwrapped_width` would lock the wrap decision to a stale
+        // value (e.g. a previous "Fully synced" tooltip) and the new long
+        // text would never trigger `fixed_width`. Force `expected_dimension`
+        // to zero on the external call; the next draw measures the new
+        // text's natural width with `Size::Fit`, and the internal redraw
+        // (5ms later) reads that fresh value.
+        let mut expected_dimension = if is_internal_redraw {
+            tooltip.view(cx, ids!(content)).area().rect(cx).size
+        } else {
+            DVec2::default()
+        };
 
         if let Some(w) = self.text_unwrapped_width {
             expected_dimension.x = w;
-        } else if expected_dimension.x > 0.0 {
+        } else if is_internal_redraw && expected_dimension.x > 0.0 {
             self.text_unwrapped_width = Some(expected_dimension.x);
         }
 
@@ -479,7 +564,7 @@ impl CalloutTooltip {
             &options,
             widget_rect,
             expected_dimension,
-            screen_size,
+            available_rect,
             options.triangle_height,
         );
 
@@ -584,16 +669,19 @@ pub enum TooltipAction {
 /// This is useful for creating tooltips that line up with the text above
 /// them.
 fn pad_last_line(text: &str) -> String {
-    let lines = text.split('\n');
-    let (lines_len, _) = lines.size_hint();
-    if lines_len <= 1 {
+    // `Split::size_hint()` returns a bound, not the actual count, so the
+    // previous version often early-returned without padding. Collect once and
+    // use the real length.
+    let lines: Vec<&str> = text.split('\n').collect();
+    if lines.len() <= 1 {
         return text.to_string();
     }
-    let longest_line = lines.clone().map(|s| s.len()).max().unwrap_or(0);
+    let longest_line = lines.iter().map(|s| s.len()).max().unwrap_or(0);
+    let last_idx = lines.len() - 1;
     let mut full_text = String::with_capacity(text.len() + longest_line + 4);
-    for (i, line) in lines.enumerate() {
+    for (i, line) in lines.iter().enumerate() {
         full_text.push_str(line);
-        if i < lines_len - 1 {
+        if i < last_idx {
             full_text.push('\n');
         } else {
             // Plus 4 is added to add more width to the last line otherwise the first line is still being cut off
@@ -601,4 +689,181 @@ fn pad_last_line(text: &str) -> String {
         }
     }
     full_text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_options(position: TooltipPosition) -> CalloutTooltipOptions {
+        CalloutTooltipOptions {
+            position,
+            ..Default::default()
+        }
+    }
+
+    fn full_screen(width: f64, height: f64) -> Rect {
+        Rect {
+            pos: DVec2::default(),
+            size: DVec2 { x: width, y: height },
+        }
+    }
+
+    #[test]
+    fn top_centers_horizontally_on_widget_when_fits() {
+        // Widget at x=180-220 (center=200), screen 400 wide, tooltip natural 100 wide.
+        let options = make_options(TooltipPosition::Top);
+        let widget_rect = Rect {
+            pos: DVec2 { x: 180.0, y: 100.0 },
+            size: DVec2 { x: 40.0, y: 30.0 },
+        };
+        let expected = DVec2 { x: 100.0, y: 50.0 };
+        let avail = full_screen(400.0, 600.0);
+        let calc = CalloutTooltip::calculate_position(&options, widget_rect, expected, avail, 7.5);
+
+        // Tooltip should be centered horizontally on widget (center=200 - 50 = 150).
+        assert_eq!(calc.tooltip_pos.x, 150.0);
+        assert!(!calc.fixed_width, "tooltip fits, should not need fixed_width");
+    }
+
+    #[test]
+    fn top_clamps_to_left_edge_when_widget_near_left() {
+        // Widget at x=10-30 (center=20), tooltip 100 wide, would extend past left edge.
+        let options = make_options(TooltipPosition::Top);
+        let widget_rect = Rect {
+            pos: DVec2 { x: 10.0, y: 100.0 },
+            size: DVec2 { x: 20.0, y: 30.0 },
+        };
+        let expected = DVec2 { x: 100.0, y: 50.0 };
+        let avail = full_screen(400.0, 600.0);
+        let calc = CalloutTooltip::calculate_position(&options, widget_rect, expected, avail, 7.5);
+
+        assert_eq!(calc.tooltip_pos.x, 0.0);
+        assert!(!calc.fixed_width);
+    }
+
+    #[test]
+    fn top_clamps_to_right_edge_when_widget_near_right() {
+        // Widget at x=370-390, tooltip 100 wide centered would extend past right edge (400).
+        let options = make_options(TooltipPosition::Top);
+        let widget_rect = Rect {
+            pos: DVec2 { x: 370.0, y: 100.0 },
+            size: DVec2 { x: 20.0, y: 30.0 },
+        };
+        let expected = DVec2 { x: 100.0, y: 50.0 };
+        let avail = full_screen(400.0, 600.0);
+        let calc = CalloutTooltip::calculate_position(&options, widget_rect, expected, avail, 7.5);
+
+        // Right edge of tooltip should be at screen edge => tooltip_pos.x = 300.
+        assert_eq!(calc.tooltip_pos.x, 300.0);
+        assert!(!calc.fixed_width);
+    }
+
+    #[test]
+    fn top_triggers_fixed_width_when_tooltip_wider_than_screen() {
+        // Tooltip natural width 600 > screen 400. Should set fixed_width = true.
+        let options = make_options(TooltipPosition::Top);
+        let widget_rect = Rect {
+            pos: DVec2 { x: 350.0, y: 100.0 },
+            size: DVec2 { x: 30.0, y: 30.0 },
+        };
+        let expected = DVec2 { x: 600.0, y: 50.0 };
+        let avail = full_screen(400.0, 600.0);
+        let calc = CalloutTooltip::calculate_position(&options, widget_rect, expected, avail, 7.5);
+
+        assert!(calc.fixed_width, "tooltip wider than screen must trigger fixed_width");
+        assert_eq!(calc.tooltip_pos.x, 0.0);
+        assert_eq!(calc.width_to_be_fixed, 400.0);
+    }
+
+    #[test]
+    fn external_call_with_zero_expected_dimension_early_returns() {
+        // expected.x = 0 (uninitialized) => early return, fixed_width = false.
+        let options = make_options(TooltipPosition::Top);
+        let widget_rect = Rect {
+            pos: DVec2 { x: 100.0, y: 100.0 },
+            size: DVec2 { x: 40.0, y: 30.0 },
+        };
+        let expected = DVec2 { x: 0.0, y: 0.0 };
+        let avail = full_screen(400.0, 600.0);
+        let calc = CalloutTooltip::calculate_position(&options, widget_rect, expected, avail, 7.5);
+
+        assert!(!calc.fixed_width);
+        assert_eq!(calc.tooltip_pos.x, 100.0);
+        assert_eq!(calc.tooltip_pos.y, 100.0);
+    }
+
+    #[test]
+    fn safe_area_insets_clamp_to_inset_left_edge() {
+        // Landscape iOS: 60px left inset (notch), tooltip wider than safe area.
+        // Tooltip should pin to the inset left edge, not absolute x=0, and the
+        // fixed width should be the safe-area width, not the full screen.
+        let options = make_options(TooltipPosition::Top);
+        let widget_rect = Rect {
+            pos: DVec2 { x: 700.0, y: 350.0 },
+            size: DVec2 { x: 50.0, y: 50.0 },
+        };
+        let expected = DVec2 { x: 800.0, y: 80.0 };
+        // Full screen is 800x400; safe area excludes 60px on left/right.
+        let avail = Rect {
+            pos: DVec2 { x: 60.0, y: 0.0 },
+            size: DVec2 { x: 680.0, y: 400.0 },
+        };
+        let calc = CalloutTooltip::calculate_position(&options, widget_rect, expected, avail, 7.5);
+
+        assert!(calc.fixed_width);
+        assert_eq!(calc.tooltip_pos.x, 60.0, "should pin to safe-area left, not 0");
+        assert_eq!(calc.width_to_be_fixed, 680.0, "should use safe-area width");
+    }
+
+    #[test]
+    fn safe_area_insets_clamp_centered_tooltip_inside_inset_right_edge() {
+        // Widget near the safe-area right edge: centered tooltip would extend
+        // past the inset right edge — clamp it back inside.
+        let options = make_options(TooltipPosition::Top);
+        let widget_rect = Rect {
+            pos: DVec2 { x: 720.0, y: 200.0 },
+            size: DVec2 { x: 20.0, y: 20.0 },
+        };
+        let expected = DVec2 { x: 200.0, y: 60.0 };
+        let avail = Rect {
+            pos: DVec2 { x: 60.0, y: 0.0 },
+            size: DVec2 { x: 680.0, y: 400.0 },
+        };
+        let calc = CalloutTooltip::calculate_position(&options, widget_rect, expected, avail, 7.5);
+
+        // Available right edge = 60 + 680 = 740. Tooltip right edge clamped
+        // to 740 => tooltip_pos.x = 740 - 200 = 540.
+        assert_eq!(calc.tooltip_pos.x, 540.0);
+        assert!(!calc.fixed_width);
+    }
+
+    #[test]
+    fn pad_last_line_pads_multiline_to_longest() {
+        // Longest line "This device is unverif" is 22 chars; last line
+        // "verify it." is 10 chars. Last line should be padded with
+        // (22 - 10) + 4 = 16 trailing spaces.
+        let input = "Logged in.\nThis device is unverif\nverify it.";
+        let out = pad_last_line(input);
+        assert!(out.starts_with("Logged in.\nThis device is unverif\nverify it."));
+        let trailing_spaces = out.chars().rev().take_while(|c| *c == ' ').count();
+        assert_eq!(trailing_spaces, 16);
+    }
+
+    #[test]
+    fn pad_last_line_leaves_single_line_unchanged() {
+        let input = "Just one line";
+        assert_eq!(pad_last_line(input), input);
+    }
+
+    #[test]
+    fn pad_last_line_handles_empty_lines() {
+        // Real-world tooltip text uses "\n\n" for paragraph breaks.
+        let input = "First.\n\nSecond.";
+        let out = pad_last_line(input);
+        assert!(out.starts_with("First.\n\nSecond."));
+        // Longest is "Second." (7) — last line is "Second." (7) — pad = 0 + 4.
+        let trailing_spaces = out.chars().rev().take_while(|c| *c == ' ').count();
+        assert_eq!(trailing_spaces, 4);
+    }
 }

--- a/widgets/src/check_box.rs
+++ b/widgets/src/check_box.rs
@@ -453,8 +453,16 @@ impl CheckBox {
         self.animator_in_state(cx, ids!(active.on))
     }
 
-    pub fn set_active(&mut self, cx: &mut Cx, value: bool) {
-        self.animator_toggle(cx, value, Animate::Yes, ids!(active.on), ids!(active.off));
+    /// Sets the active state.
+    ///
+    /// Pass `Animate::No` for programmatic state restoration (e.g. after an
+    /// `Event::ScriptReapply` reloads the widget tree) — `Animate::Yes`
+    /// routes through `animator_play`, which early-outs when the animator's
+    /// cached `current_state` already matches the target, leaving the
+    /// shader uniform stale. `Animate::No` uses `animator_cut`, which
+    /// always re-merges the state's values and re-applies them.
+    pub fn set_active(&mut self, cx: &mut Cx, value: bool, animate: Animate) {
+        self.animator_toggle(cx, value, animate, ids!(active.on), ids!(active.off));
     }
 
     pub fn debug_dump_animator(&self, heap: &ScriptHeap) -> String {
@@ -581,9 +589,10 @@ impl CheckBoxRef {
         }
     }
 
-    pub fn set_active(&self, cx: &mut Cx, value: bool) {
+    /// See [`CheckBox::set_active()`].
+    pub fn set_active(&self, cx: &mut Cx, value: bool, animate: Animate) {
         if let Some(mut inner) = self.borrow_mut() {
-            inner.set_active(cx, value);
+            inner.set_active(cx, value, animate);
         }
     }
 

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -1808,12 +1808,22 @@ impl Widget for PortalList {
         );
         if self.suppress_child_events || is_scroll_animating {
             match event {
-                Event::TouchUpdate(_)
-                | Event::MouseDown(_)
-                | Event::MouseMove(_)
-                | Event::MouseUp(_) => {
+                // Suppress in-progress interactions so children don't react to
+                // a gesture that the list is handling as part of a "scroll" action.
+                Event::MouseDown(_) | Event::MouseMove(_) => {
                     pass_through_to_children = false;
                 }
+                // Don't suppress touch events if a touch-stop occurred (finger was released).
+                // Without this, a child widget in this list that captured `FingerDown`
+                // (e.g. a button that has been pressed/hovered) will never see the FingerUp,
+                // meaning it'll get stuck in that old pressed/hovered state.
+                Event::TouchUpdate(e) => {
+                    let has_release = e.touches.iter().any(|t| matches!(t.state, TouchState::Stop));
+                    if !has_release {
+                        pass_through_to_children = false;
+                    }
+                }
+                // Note: MouseUp should pass through just like "touch stop" (finger releases) above.
                 _ => {}
             }
         }

--- a/widgets/src/radio_button.rs
+++ b/widgets/src/radio_button.rs
@@ -365,8 +365,16 @@ impl RadioButton {
         self.animator_in_state(cx, ids!(active.on))
     }
 
-    pub fn set_active(&mut self, cx: &mut Cx, value: bool) {
-        self.animator_toggle(cx, value, Animate::Yes, ids!(active.on), ids!(active.off));
+    /// Sets the active state.
+    ///
+    /// Pass `Animate::No` for programmatic state restoration (e.g. after an
+    /// `Event::ScriptReapply` reloads the widget tree) — `Animate::Yes`
+    /// routes through `animator_play`, which early-outs when the animator's
+    /// cached `current_state` already matches the target, leaving the
+    /// shader uniform stale. `Animate::No` uses `animator_cut`, which
+    /// always re-merges the state's values and re-applies them.
+    pub fn set_active(&mut self, cx: &mut Cx, value: bool, animate: Animate) {
+        self.animator_toggle(cx, value, animate, ids!(active.on), ids!(active.off));
     }
 }
 
@@ -482,9 +490,10 @@ impl RadioButtonRef {
         }
     }
 
-    pub fn set_active(&self, cx: &mut Cx, value: bool) {
+    /// See [`RadioButton::set_active()`].
+    pub fn set_active(&self, cx: &mut Cx, value: bool, animate: Animate) {
         if let Some(mut inner) = self.borrow_mut() {
-            inner.set_active(cx, value);
+            inner.set_active(cx, value, animate);
         }
     }
 }

--- a/widgets/src/stack_navigation.rs
+++ b/widgets/src/stack_navigation.rs
@@ -141,7 +141,7 @@ pub enum StackNavigationTransitionAction {
     HideEnd(WidgetUid), // Include the parent navigation's UID
 }
 
-#[derive(Script, ScriptHook, Widget, Animator)]
+#[derive(Script, Widget, Animator)]
 pub struct StackNavigationView {
     #[source]
     source: ScriptObjectRef,
@@ -174,6 +174,87 @@ pub struct StackNavigationView {
     /// The UID of the parent navigation.
     #[rust]
     parent_navigation_uid: Option<WidgetUid>,
+
+    /// Runtime override for the header title text, set by `set_title`.
+    ///
+    /// Stored here (rather than relying solely on `Label.text` persisting
+    /// across re-applies) because in some configurations — notably nested
+    /// inside an `AdaptiveView` whose variant gets re-instantiated on
+    /// `WindowGeomChange` — the inner `title` `Label` widget can be
+    /// recreated via `Apply::New` on rotation, which bypasses
+    /// `ArcStringMut::script_apply`'s `ScriptReapply` early-return. The
+    /// override is re-asserted in `on_after_apply` after every apply walk
+    /// so the title sticks regardless of whether the label was re-applied
+    /// or recreated. Storage cost is one `Rc<String>` clone per stack
+    /// view that has had a title set — refcount bump, no byte copy.
+    #[rust]
+    runtime_title: Option<ArcStringMut>,
+}
+
+impl ScriptHook for StackNavigationView {
+    fn on_after_apply(
+        &mut self,
+        vm: &mut ScriptVm,
+        apply: &Apply,
+        _scope: &mut Scope,
+        _value: ScriptValue,
+    ) {
+        // After every apply walk, re-install the runtime title (if any) into
+        // the inner header title label. This is the bulletproof path —
+        // independent of whether the label was re-applied (`Apply::Reload` /
+        // `Apply::ScriptReapply`) or freshly recreated (`Apply::New`, e.g.
+        // when an enclosing `AdaptiveView` re-instantiates its variant on
+        // `WindowGeomChange`). Either way, the runtime title wins.
+        //
+        // We skip:
+        //   * `Apply::Eval`     — temporary objects, not real applies.
+        //   * `Apply::Animate`  — animator-driven re-apply; widget structure
+        //                         unchanged, no template values were reset.
+        //   * `Apply::Default(N)` — the recursive call from
+        //                         `#[apply_default] animator`. The outer
+        //                         apply (New/Reload/ScriptReapply) already
+        //                         fired this hook; we don't need to redo
+        //                         the title write at every animator-group
+        //                         recursion level.
+        if apply.is_eval() || apply.is_animate() || apply.as_default().is_some() {
+            return;
+        }
+        if let Some(title) = self.runtime_title.as_ref() {
+            // Borrow only what we need from `runtime_title` — `as_ref()`
+            // returns `&str`, which lives as long as the `&self` borrow.
+            // `write_title_to_header_label` only takes `&self`, so the
+            // outstanding borrow on `self.runtime_title` is fine.
+            let title = title.as_ref();
+            self.write_title_to_header_label(vm.cx_mut(), title);
+        }
+    }
+}
+
+impl StackNavigationView {
+    /// Set the runtime title override for this stack view.
+    ///
+    /// The title persists across every kind of apply walk (LiveEdit,
+    /// `request_script_reapply`, AdaptiveView variant swap, etc.) because
+    /// it's re-asserted in `on_after_apply`.
+    pub(crate) fn set_runtime_title(&mut self, cx: &mut Cx, title: &str) {
+        let mut owned = ArcStringMut::default();
+        owned.set(title);
+        self.runtime_title = Some(owned);
+        // Apply immediately so the change is visible without waiting for the
+        // next apply walk.
+        self.write_title_to_header_label(cx, title);
+    }
+
+    /// Single source of truth for the descendant path that resolves the
+    /// header title `Label`. Both `set_runtime_title` (initial write) and
+    /// `on_after_apply` (re-assertion after every apply walk) go through
+    /// this so the path lives in exactly one place; restructuring the
+    /// `StackViewHeader` DSL only requires updating this one site.
+    fn write_title_to_header_label(&self, cx: &mut Cx, title: &str) {
+        self.view
+            .label(cx, ids!(header.content.title_container.title))
+            .set_text(cx, title);
+    }
 }
 
 impl Widget for StackNavigationView {
@@ -677,16 +758,22 @@ impl StackNavigationRef {
         }
     }
 
-    /// Set the title of a specific view in the navigation stack
+    /// Set the title of a specific view in the navigation stack.
+    ///
+    /// The runtime title is stored on the `StackNavigationView` itself and
+    /// re-asserted in `on_after_apply` after every kind of re-apply walk
+    /// (LiveEdit, `request_script_reapply`, AdaptiveView variant swap on
+    /// `WindowGeomChange`, etc.). Callers therefore set it once at push
+    /// time and never need to refresh it.
     ///
     /// # Arguments
     /// * `view_id` - The LiveId of the view whose title to set
     /// * `title` - The new title text
     pub fn set_title(&self, cx: &mut Cx, view_id: LiveId, title: &str) {
-        if let Some(inner) = self.borrow_mut() {
-            let stack_view_ref = inner.stack_navigation_view(cx, &[view_id]);
-            stack_view_ref.label(cx, ids!(title)).set_text(cx, title);
-        }
+        let Some(inner) = self.borrow_mut() else { return; };
+        let stack_view_ref = inner.stack_navigation_view(cx, &[view_id]);
+        let Some(mut stack_view) = stack_view_ref.borrow_mut() else { return; };
+        stack_view.set_runtime_title(cx, title);
     }
 
     /// Get the current depth of the navigation stack

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -634,10 +634,15 @@ impl Widget for Window {
                         }
                     }
 
-                    // If safe area insets changed, trigger a script re-apply
-                    // so widgets pick up new values.
+                    // If safe area insets changed, request a `script_mod`
+                    // re-run so widget definitions that reference these
+                    // primitives via `mod.widgets.SAFE_INSET_PAD_*` get the
+                    // new values re-baked. `request_script_reapply` would
+                    // not work here: those expressions are evaluated when
+                    // `script_mod` runs, and `Apply::ScriptReapply` does
+                    // not re-evaluate them.
                     if old_insets != ev.new_geom.safe_area_insets {
-                        cx.request_script_reapply();
+                        cx.request_live_edit();
                     }
 
                     cx.widget_action(uid, WindowAction::WindowGeomChange(ev.clone()));


### PR DESCRIPTION
**Note: please merge #1066, then #1067, then #1068, and then this PR.**

The goal here is to differentiate between "applies" that change the actual
Splash script "DSL" (i.e., the template) from a "re-apply" that doesn't
change the DSL template but does change runtime heap objects.

Mostly, we want to ensure that LiveEdit (the former) is different from
things that require heap updates (the latter), such as changing a theme
value or doing screen rotation that changes safe inset areas on mobile.

I don't know that I love this approach as a permanent solution,
but it's a good stepping stone until we can redesign LiveEdit/Apply
to funnel all of these various events through the same singular system.
We probably want to use different attributes on widget fields in order
to have more fine-grained control over what happens on an Apply action.

Generated list of brief details here:

* `Apply::ScriptReapply` variant + `is_script_reapply` /
  `is_live_edit_reload` predicates; `Event::ScriptReapply` now applies
  via `Apply::ScriptReapply`.
* `String` / `ArcStringMut` `script_apply` early-return on
  `ScriptReapply`.
* Codegen: `#[deref]` runs before `#[apply_default]`'s recursive call
  so animator state wins over template defaults.
* `Animator::script_apply_default` returns `state_object` on
  `ScriptReapply`; new `current_state_apply()` helper for
  `on_after_apply` hooks.

* `Cx::request_live_edit()` + `pending_live_edit_request` for primitive
  heap mutations (safe-area insets baked into `script_mod!`
  expressions).
* `handle_live_edit()` returns `LiveEditTrigger {None, FileChange,
  Manual}`; `run_live_edit_if_needed` skips shader-cache reset and
  same-tick `ScriptReapply` follow-up for `Manual` (fixes ~1s rotation
  lag).
* iOS/Android post-event hook now drains both flags via
  `run_live_edit_if_needed` (was firing `LiveEdit` indiscriminately).
* `Window` `WindowGeomChange` uses `request_live_edit()` for
  safe-area.

* `StackNavigationView` gains `runtime_title` field re-asserted in
  `on_after_apply`; new `StackNavigation::set_title` API.
* `app_main!` collapses 4 duplicate platform branches into a shared
  `_app_main_event_closure!` macro.