### PR TITLE
iOS: don't always prompt the user for camera/mic access on app startup

### DIFF
--- a/draw/src/match_event.rs
+++ b/draw/src/match_event.rs
@@ -4,6 +4,9 @@ use crate::{Cx2d, CxDraw};
 pub trait MatchEvent {
     fn handle_startup(&mut self, _cx: &mut Cx) {}
     fn handle_shutdown(&mut self, _cx: &mut Cx) {}
+    fn handle_quit_requested(&mut self, _cx: &mut Cx, _e: &QuitRequestedEvent) -> bool {
+        false
+    }
     fn handle_foreground(&mut self, _cx: &mut Cx) {}
     fn handle_background(&mut self, _cx: &mut Cx) {}
     fn handle_pause(&mut self, _cx: &mut Cx) {}
@@ -104,6 +107,10 @@ pub trait MatchEvent {
         match event {
             Event::Startup => self.handle_startup(cx),
             Event::Shutdown => self.handle_shutdown(cx),
+            Event::QuitRequested(e) if !e.handled.get() => {
+                let was_handled = self.handle_quit_requested(cx, e);
+                e.handled.set(was_handled);
+            }
             Event::Foreground => self.handle_foreground(cx),
             Event::Background => self.handle_background(cx),
             Event::Pause => self.handle_pause(cx),

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -78,6 +78,9 @@ napi-derive-ohos = "0.0.9"
 napi-ohos = "0.1.3"
 ohos-sys = { version = "0.2.1", features = ["xcomponent"] }
 
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]
+ctrlc = { version = "3.4", features = ["termination"] }
+
 [target.'cfg(windows)'.dependencies.makepad-futures-legacy]
 path = "../libs/futures_legacy"
 version = "1.0.0"

--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -331,6 +331,9 @@ impl OsType {
 
 impl Cx {
     pub fn new(event_handler: Box<dyn FnMut(&mut Cx, &Event)>) -> Self {
+        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+        crate::os::termination_signal::install();
+
         //#[cfg(any(target_arch = "wasm32", target_os = "android"))]
         //crate::makepad_error_log::set_panic_hook();
         // the null texture

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -11,7 +11,8 @@ use {
         event::keyboard::CharOffset,
         event::xr::XrAnchor,
         event::{
-            video_playback::CameraPreviewMode, DragItem, NextFrame, Timer, Trigger, VideoSource,
+            video_playback::CameraPreviewMode, DragItem, Event, NextFrame, QuitReason,
+            QuitRequestedEvent, Timer, Trigger, VideoSource,
         },
         gpu_info::GpuInfo,
         ime::TextInputConfig,
@@ -811,6 +812,27 @@ impl Cx {
 
     pub fn quit(&mut self) {
         self.platform_ops.push(CxOsOp::Quit);
+    }
+
+    pub fn request_quit(&mut self, reason: QuitReason) -> bool {
+        let event = Event::QuitRequested(QuitRequestedEvent::new(reason));
+        self.call_event_handler(&event);
+
+        let was_handled = match &event {
+            Event::QuitRequested(e) => e.handled.get(),
+            _ => false,
+        };
+        if !was_handled {
+            self.quit();
+        }
+        was_handled
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    pub(crate) fn handle_termination_signal(&mut self) {
+        if crate::os::termination_signal::take_requested() {
+            self.request_quit(QuitReason::Signal);
+        }
     }
 
     pub fn browser_update_url(&mut self, url: &str, replace: bool) {

--- a/platform/src/event/event.rs
+++ b/platform/src/event/event.rs
@@ -58,6 +58,14 @@ pub enum Event {
     /// [`onDestroy`]: https://developer.android.com/reference/android/app/Activity#onDestroy()
     Shutdown,
 
+    /// The application has been asked to quit.
+    ///
+    /// This is sent before [`Event::Shutdown`] for graceful quit requests such
+    /// as application-menu Quit and polite process termination signals.
+    /// Handlers may set `handled` to `true` to defer or cancel the quit, for
+    /// example while showing a confirmation dialog.
+    QuitRequested(QuitRequestedEvent),
+
     /// The application has been started in the foreground and is now visible to the user,
     /// but is not yet actively receiving user input.
     ///
@@ -262,6 +270,7 @@ impl Event {
         match v {
             1 => "Startup",
             2 => "Shutdown",
+            67 => "QuitRequested",
 
             3 => "Foreground",
             4 => "Background",
@@ -346,6 +355,7 @@ impl Event {
         match self {
             Self::Startup => 1,
             Self::Shutdown => 2,
+            Self::QuitRequested(_) => 67,
 
             Self::Foreground => 3,
             Self::Background => 4,
@@ -437,6 +447,35 @@ impl Event {
             }
         }
         false
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QuitReason {
+    /// The app requested a quit programmatically.
+    App,
+    /// The user chose a native/application menu Quit command.
+    Menu,
+    /// The process received a polite termination signal, such as Ctrl+C or SIGTERM.
+    Signal,
+}
+
+#[derive(Debug)]
+pub struct QuitRequestedEvent {
+    pub reason: QuitReason,
+    pub handled: Cell<bool>,
+}
+
+impl QuitRequestedEvent {
+    pub fn new(reason: QuitReason) -> Self {
+        Self {
+            reason,
+            handled: Cell::new(false),
+        }
+    }
+
+    pub fn handle(&self) {
+        self.handled.set(true);
     }
 }
 

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -151,6 +151,8 @@ pub use {
             NetworkResponsesEvent,
             NextFrame,
             NextFrameEvent,
+            QuitReason,
+            QuitRequestedEvent,
             SafeAreaInsets,
             SelectionHandleDragEvent,
             SelectionHandleKind,

--- a/platform/src/os/apple/apple_media.rs
+++ b/platform/src/os/apple/apple_media.rs
@@ -317,12 +317,13 @@ impl CxMediaApi for Cx {
     }
 
     fn video_encoder_push_frame(&mut self, index: usize, frame: CameraFrameRef<'_>) {
-        self.os
-            .media
-            .av_capture()
-            .lock()
-            .unwrap()
-            .video_encoder_push_frame(index, frame);
+        // Don't lazily create AvCaptureAccess here — that fires the iOS camera
+        // permission prompt. If no encoder's been configured the call would be
+        // a no-op anyway (push without an encoder is silently dropped).
+        let Some(av_capture) = self.os.media.av_capture.as_ref() else {
+            return;
+        };
+        av_capture.lock().unwrap().video_encoder_push_frame(index, frame);
     }
 
     fn video_encoder_capture_texture_frame(
@@ -330,21 +331,24 @@ impl CxMediaApi for Cx {
         index: usize,
         timestamp_ns: u64,
     ) -> Result<(), VideoEncodeError> {
-        self.os
-            .media
-            .av_capture()
+        // Don't lazily create AvCaptureAccess here — that fires the iOS camera
+        // permission prompt every frame for apps that never use the camera.
+        // The inner call would have returned EncoderNotStarted anyway.
+        let Some(av_capture) = self.os.media.av_capture.as_ref() else {
+            return Err(VideoEncodeError::EncoderNotStarted);
+        };
+        av_capture
             .lock()
             .unwrap()
             .video_encoder_capture_texture_frame(index, timestamp_ns, &mut self.textures)
     }
 
     fn video_encoder_request_keyframe(&mut self, index: usize) -> Result<(), VideoEncodeError> {
-        self.os
-            .media
-            .av_capture()
-            .lock()
-            .unwrap()
-            .video_encoder_request_keyframe(index)
+        // Same reason as above: no encoder configured ⇒ no AvCaptureAccess yet.
+        let Some(av_capture) = self.os.media.av_capture.as_ref() else {
+            return Err(VideoEncodeError::EncoderNotStarted);
+        };
+        av_capture.lock().unwrap().video_encoder_request_keyframe(index)
     }
 
     fn video_capabilities(&self) -> VideoCapabilities {

--- a/platform/src/os/apple/audio_unit.rs
+++ b/platform/src/os/apple/audio_unit.rs
@@ -99,6 +99,21 @@ pub struct AudioUnitAccess {
     failed_devices: Arc<Mutex<HashSet<AudioDeviceId>>>,
     #[cfg(target_os = "macos")]
     audio_tap: Option<Arc<Mutex<AudioTapAccess>>>,
+    #[cfg(target_os = "ios")]
+    ios_session_state: IosSessionState,
+}
+
+/// Tracks how the shared `AVAudioSession` has been configured on iOS so we
+/// only set/upgrade it when the app actually needs input or output, rather
+/// than blanket-activating PlayAndRecord (which would needlessly trigger
+/// the microphone permission prompt on playback-only apps).
+#[cfg(target_os = "ios")]
+#[derive(Default, Clone, Copy, PartialEq)]
+enum IosSessionState {
+    #[default]
+    Inactive,
+    PlaybackOnly,
+    PlayAndRecord,
 }
 
 impl Default for AudioUnitAccess {
@@ -113,6 +128,8 @@ impl Default for AudioUnitAccess {
             failed_devices: Default::default(),
             #[cfg(target_os = "macos")]
             audio_tap: None,
+            #[cfg(target_os = "ios")]
+            ios_session_state: IosSessionState::default(),
         }
     }
 }
@@ -137,8 +154,14 @@ impl AudioUnitAccess {
     pub fn new(change_signal: SignalToUI) -> Arc<Mutex<Self>> {
         Self::observe_route_changes(change_signal.clone());
 
-        #[cfg(target_os = "ios")]
-        Self::init_ios_access();
+        // Note: on iOS we used to set the AVAudioSession category to
+        // PlayAndRecord here unconditionally. That's wrong for playback-only
+        // apps — it eventually causes a microphone permission prompt the
+        // first time the session is activated for input, and it forces
+        // VoiceChat mode (VPIO) on apps that just want to play media.
+        // The session is now configured lazily by `ensure_ios_session()`,
+        // which picks the right category based on whether `use_audio_inputs`
+        // or `use_audio_outputs` was called.
 
         #[cfg(target_os = "tvos")]
         Self::init_tvos_access();
@@ -156,6 +179,8 @@ impl AudioUnitAccess {
             audio_outputs: Default::default(),
             #[cfg(target_os = "macos")]
             audio_tap,
+            #[cfg(target_os = "ios")]
+            ios_session_state: IosSessionState::Inactive,
         }))
     }
 
@@ -215,25 +240,57 @@ impl AudioUnitAccess {
         }
     }
 
+    /// Configure and activate the shared `AVAudioSession` for the requested
+    /// usage. Idempotent: a no-op if the session is already at this level
+    /// (or higher — once upgraded to PlayAndRecord we never downgrade).
     #[cfg(target_os = "ios")]
-    pub fn init_ios_access() {
+    fn ensure_ios_session(&mut self, for_input: bool) {
+        let target = if for_input {
+            IosSessionState::PlayAndRecord
+        } else {
+            IosSessionState::PlaybackOnly
+        };
+        // Don't downgrade an already-recording session, and don't redo work
+        // when we're already at the target state.
+        if self.ios_session_state == IosSessionState::PlayAndRecord
+            || self.ios_session_state == target
+        {
+            return;
+        }
+        Self::configure_ios_session(for_input);
+        self.ios_session_state = target;
+    }
+
+    #[cfg(target_os = "ios")]
+    fn configure_ios_session(for_input: bool) {
         unsafe {
             let session: ObjcId = msg_send![class!(AVAudioSession), sharedInstance];
             let mut error: ObjcId = nil;
-            let _success: bool = msg_send![
-                session,
-                setCategory:AVAudioSessionCategoryPlayAndRecord
-                withOptions:AVAudioSessionCategoryOption::DefaultToSpeaker as usize | AVAudioSessionCategoryOption::AllowBluetooth as usize
-                error:&mut error
-            ];
-            // Use VoiceChat mode with VoiceProcessingIO for both input and output
-            // This provides AEC/AGC/NS with proper volume
-            let mode: ObjcId = str_to_nsstring("AVAudioSessionModeVoiceChat");
-            let () = msg_send![session, setMode: mode error:&mut error];
-            // Prefer 48 kHz to avoid 48k↔44.1k drift on AirPods, however this might
-            // be overriden by the system or some other configuration.
-            let () = msg_send![session, setPreferredSampleRate: 48000.0 error:&mut error];
-            let () = msg_send![session, setPreferredIOBufferDuration:0.005 error:&mut error];
+            if for_input {
+                let _success: bool = msg_send![
+                    session,
+                    setCategory: AVAudioSessionCategoryPlayAndRecord
+                    withOptions: AVAudioSessionCategoryOption::DefaultToSpeaker as usize
+                        | AVAudioSessionCategoryOption::AllowBluetooth as usize
+                    error: &mut error
+                ];
+                // VoiceChat mode pairs with VoiceProcessingIO for AEC/AGC/NS;
+                // only relevant when we actually have an input.
+                let mode: ObjcId = str_to_nsstring("AVAudioSessionModeVoiceChat");
+                let () = msg_send![session, setMode: mode error: &mut error];
+            } else {
+                // Playback-only: no mic, no VPIO, no permission prompt.
+                let _success: bool = msg_send![
+                    session,
+                    setCategory: AVAudioSessionCategoryPlayback
+                    withOptions: 0usize
+                    error: &mut error
+                ];
+            }
+            // Prefer 48 kHz to avoid 48k↔44.1k drift on AirPods, however this
+            // might be overridden by the system or some other configuration.
+            let () = msg_send![session, setPreferredSampleRate: 48000.0 error: &mut error];
+            let () = msg_send![session, setPreferredIOBufferDuration: 0.005 error: &mut error];
             let () = msg_send![session, setActive: true error: &mut error];
             // Set initial audio route based on connected devices
             Self::update_ios_audio_route();
@@ -255,6 +312,9 @@ impl AudioUnitAccess {
     }
 
     pub fn use_audio_inputs(&mut self, devices: &[AudioDeviceId]) {
+        #[cfg(target_os = "ios")]
+        self.ensure_ios_session(true);
+
         // Handle loopback device separately on macOS
         #[cfg(target_os = "macos")]
         {
@@ -375,6 +435,9 @@ impl AudioUnitAccess {
     }
 
     pub fn use_audio_outputs(&mut self, devices: &[AudioDeviceId]) {
+        #[cfg(target_os = "ios")]
+        self.ensure_ios_session(false);
+
         let new = {
             let mut audio_outputs = self.audio_outputs.lock().unwrap();
             // lets shut down the ones we dont use

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -451,21 +451,27 @@ impl Cx {
             }
         }
 
-        let timestamp_ns = self
-            .os
-            .start_time
-            .map(|start| Instant::now().duration_since(start).as_nanos() as u64)
-            .unwrap_or(0);
-        for index in 0..MAX_VIDEO_DEVICE_INDEX {
-            if let Err(err) = self.video_encoder_capture_texture_frame(index, timestamp_ns) {
-                if err != crate::video::VideoEncodeError::UnsupportedSource
-                    && err != crate::video::VideoEncodeError::EncoderNotStarted
-                {
-                    crate::error!(
-                        "ios video texture capture failed on slot {}: {:?}",
-                        index,
-                        err
-                    );
+        // Only sweep encoder slots if an encoder's actually been set up.
+        // Otherwise we'd burn 32 mutex locks per frame on every iOS app,
+        // and the very first call would lazy-init AvCaptureAccess and
+        // trigger the camera permission prompt for apps that never use it.
+        if self.os.media.av_capture.is_some() {
+            let timestamp_ns = self
+                .os
+                .start_time
+                .map(|start| Instant::now().duration_since(start).as_nanos() as u64)
+                .unwrap_or(0);
+            for index in 0..MAX_VIDEO_DEVICE_INDEX {
+                if let Err(err) = self.video_encoder_capture_texture_frame(index, timestamp_ns) {
+                    if err != crate::video::VideoEncodeError::UnsupportedSource
+                        && err != crate::video::VideoEncodeError::EncoderNotStarted
+                    {
+                        crate::error!(
+                            "ios video texture capture failed on slot {}: {:?}",
+                            index,
+                            err
+                        );
+                    }
                 }
             }
         }

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -563,7 +563,26 @@ impl Cx {
                 self.display_context.safe_area_insets = geom.safe_area_insets;
                 self.update_safe_inset_script_values(geom.safe_area_insets);
                 self.call_event_handler(&Event::Startup);
+                self.call_event_handler(&Event::Foreground);
                 self.redraw_all();
+            }
+            IosEvent::Foreground => {
+                self.call_event_handler(&Event::Foreground);
+                self.redraw_all();
+            }
+            IosEvent::Background => {
+                self.call_event_handler(&Event::Background);
+            }
+            IosEvent::Pause => {
+                self.call_event_handler(&Event::Pause);
+            }
+            IosEvent::Resume => {
+                self.call_event_handler(&Event::Resume);
+                self.redraw_all();
+            }
+            IosEvent::Shutdown => {
+                self.call_event_handler(&Event::Shutdown);
+                return EventFlow::Exit;
             }
             IosEvent::WindowGotFocus(window_id) => {
                 // repaint all window passes. Metal sometimes doesnt flip buffers when hidden/no focus

--- a/platform/src/os/apple/ios/ios_delegates.rs
+++ b/platform/src/os/apple/ios/ios_delegates.rs
@@ -97,11 +97,51 @@ pub fn define_ios_app_delegate() -> *const Class {
         YES
     }
 
+    extern "C" fn application_will_enter_foreground(_: &Object, _: Sel, _: ObjcId) {
+        IosApp::do_callback(crate::os::apple::ios::ios_event::IosEvent::Foreground);
+    }
+
+    extern "C" fn application_did_enter_background(_: &Object, _: Sel, _: ObjcId) {
+        IosApp::do_callback(crate::os::apple::ios::ios_event::IosEvent::Background);
+    }
+
+    extern "C" fn application_will_resign_active(_: &Object, _: Sel, _: ObjcId) {
+        IosApp::do_callback(crate::os::apple::ios::ios_event::IosEvent::Pause);
+    }
+
+    extern "C" fn application_did_become_active(_: &Object, _: Sel, _: ObjcId) {
+        IosApp::do_callback(crate::os::apple::ios::ios_event::IosEvent::Resume);
+    }
+
+    extern "C" fn application_will_terminate(_: &Object, _: Sel, _: ObjcId) {
+        IosApp::do_callback(crate::os::apple::ios::ios_event::IosEvent::Shutdown);
+    }
+
     unsafe {
         decl.add_method(
             sel!(application: didFinishLaunchingWithOptions:),
             did_finish_launching_with_options
                 as extern "C" fn(&Object, Sel, ObjcId, ObjcId) -> BOOL,
+        );
+        decl.add_method(
+            sel!(applicationWillEnterForeground:),
+            application_will_enter_foreground as extern "C" fn(&Object, Sel, ObjcId),
+        );
+        decl.add_method(
+            sel!(applicationDidEnterBackground:),
+            application_did_enter_background as extern "C" fn(&Object, Sel, ObjcId),
+        );
+        decl.add_method(
+            sel!(applicationWillResignActive:),
+            application_will_resign_active as extern "C" fn(&Object, Sel, ObjcId),
+        );
+        decl.add_method(
+            sel!(applicationDidBecomeActive:),
+            application_did_become_active as extern "C" fn(&Object, Sel, ObjcId),
+        );
+        decl.add_method(
+            sel!(applicationWillTerminate:),
+            application_will_terminate as extern "C" fn(&Object, Sel, ObjcId),
         );
     }
 

--- a/platform/src/os/apple/ios/ios_event.rs
+++ b/platform/src/os/apple/ios/ios_event.rs
@@ -11,6 +11,11 @@ use crate::{
 #[derive(Debug, Clone)]
 pub enum IosEvent {
     Init,
+    Foreground,
+    Background,
+    Pause,
+    Resume,
+    Shutdown,
     WindowGotFocus(WindowId),
     WindowLostFocus(WindowId),
     WindowGeomChange(WindowGeomChangeEvent),

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -10,7 +10,8 @@ use {
                 VideoPlaybackPreparedEvent, VideoPlaybackResourcesReleasedEvent,
                 VideoSeekableRangesEvent, VideoTextureUpdatedEvent, VideoYuvTexturesReady,
             },
-            Event, GameInputEventChannel, MouseButton, MouseUpEvent, VideoSource, WindowGeom,
+            Event, GameInputEventChannel, MouseButton, MouseUpEvent, QuitReason, VideoSource,
+            WindowGeom,
         },
         makepad_live_id::*,
         makepad_math::*,
@@ -571,6 +572,13 @@ impl Cx {
         }
         //self.process_desktop_pre_event(&mut event);
         match event {
+            MacosEvent::AppQuitRequested => {
+                self.request_quit(QuitReason::App);
+                if let EventFlow::Exit = self.handle_platform_ops(metal_windows, metal_cx) {
+                    self.call_event_handler(&Event::Shutdown);
+                    return EventFlow::Exit;
+                }
+            }
             MacosEvent::WindowGotFocus(window_id) => {
                 // repaint all window passes. Metal sometimes doesnt flip buffers when hidden/no focus
                 for window in metal_windows.iter_mut() {

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -515,6 +515,7 @@ impl Cx {
 
                     // check signals
                     if SignalToUI::check_and_clear_ui_signal() {
+                        self.handle_termination_signal();
                         self.handle_media_signals();
                         self.handle_script_signals();
                         self.call_event_handler(&Event::Signal);

--- a/platform/src/os/apple/macos/macos_app.rs
+++ b/platform/src/os/apple/macos/macos_app.rs
@@ -106,7 +106,8 @@ pub struct MacosApp {
     pasteboard: ObjcId,
     startup_focus_hack_ran: bool,
     event_callback: Option<Box<dyn FnMut(MacosEvent) -> EventFlow>>,
-    event_flow: EventFlow,
+    pub(crate) event_flow: EventFlow,
+    pub(crate) terminating_from_app_delegate: bool,
 
     pub cursors: HashMap<MouseCursor, ObjcId>,
     pub current_cursor: MouseCursor,
@@ -141,6 +142,7 @@ impl MacosApp {
                 event_callback: Some(event_callback),
                 cursors: HashMap::new(),
                 current_cursor: MouseCursor::Default,
+                terminating_from_app_delegate: false,
                 //current_ns_event: None,
             }
         }
@@ -631,8 +633,11 @@ impl MacosApp {
         let cb = with_macos_app(|app| app.event_callback.take());
         if let Some(mut callback) = cb {
             let event_flow = callback(event);
-            with_macos_app(|app| app.event_flow = event_flow);
-            if let EventFlow::Exit = event_flow {
+            let should_terminate = with_macos_app(|app| {
+                app.event_flow = event_flow;
+                event_flow == EventFlow::Exit && !app.terminating_from_app_delegate
+            });
+            if should_terminate {
                 unsafe {
                     let ns_app: ObjcId = msg_send![class!(NSApplication), sharedApplication];
                     let () = msg_send![ns_app, terminate: nil];

--- a/platform/src/os/apple/macos/macos_delegates.rs
+++ b/platform/src/os/apple/macos/macos_delegates.rs
@@ -11,6 +11,7 @@ use {
                 get_event_key_modifier, get_event_mouse_button, load_mouse_cursor,
                 nsstring_to_string, superclass,
             },
+            cx_native::EventFlow,
             macos::{
                 macos_app::{with_macos_app, MacosApp},
                 macos_event::MacosEvent,
@@ -49,8 +50,36 @@ pub fn define_macos_timer_delegate() -> *const Class {
 }
 
 pub fn define_app_delegate() -> *const Class {
+    extern "C" fn application_should_terminate(_: &Object, _: Sel, _: ObjcId) -> isize {
+        const NSTERMINATE_CANCEL: isize = 0;
+        const NSTERMINATE_NOW: isize = 1;
+
+        if with_macos_app(|app| app.event_flow == EventFlow::Exit) {
+            return NSTERMINATE_NOW;
+        }
+
+        with_macos_app(|app| app.terminating_from_app_delegate = true);
+        MacosApp::do_callback(MacosEvent::AppQuitRequested);
+        let should_terminate = with_macos_app(|app| {
+            app.terminating_from_app_delegate = false;
+            app.event_flow == EventFlow::Exit
+        });
+
+        if should_terminate {
+            NSTERMINATE_NOW
+        } else {
+            NSTERMINATE_CANCEL
+        }
+    }
+
     let superclass = class!(NSObject);
-    let decl = ClassDecl::new("NSAppDelegate", superclass).unwrap();
+    let mut decl = ClassDecl::new("NSAppDelegate", superclass).unwrap();
+    unsafe {
+        decl.add_method(
+            sel!(applicationShouldTerminate:),
+            application_should_terminate as extern "C" fn(&Object, Sel, ObjcId) -> isize,
+        );
+    }
 
     return decl.register();
 }

--- a/platform/src/os/apple/macos/macos_event.rs
+++ b/platform/src/os/apple/macos/macos_event.rs
@@ -12,6 +12,7 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub enum MacosEvent {
+    AppQuitRequested,
     PopupDismissed(PopupDismissedEvent),
     WindowGotFocus(WindowId),
     WindowLostFocus(WindowId),

--- a/platform/src/os/apple/macos/macos_stdin.rs
+++ b/platform/src/os/apple/macos/macos_stdin.rs
@@ -291,6 +291,7 @@ impl Cx {
                     }
                 }
                 if SignalToUI::check_and_clear_ui_signal() {
+                    self.handle_termination_signal();
                     self.handle_media_signals();
                     self.handle_script_signals();
                     self.call_event_handler(&Event::Signal);

--- a/platform/src/os/headless/event_loop.rs
+++ b/platform/src/os/headless/event_loop.rs
@@ -118,6 +118,7 @@ impl Cx {
         let mut completed_cycles = 0usize;
         while running && completed_cycles < draw_cycles {
             if SignalToUI::check_and_clear_ui_signal() {
+                self.handle_termination_signal();
                 self.handle_script_signals();
                 self.call_event_handler(&Event::Signal);
             }
@@ -369,6 +370,7 @@ impl Cx {
                 StudioToApp::RunViewFrameRequest(_) => {}
                 StudioToApp::Tick => {
                     if SignalToUI::check_and_clear_ui_signal() {
+                        self.handle_termination_signal();
                         self.handle_script_signals();
                         self.call_event_handler(&Event::Signal);
                     }

--- a/platform/src/os/linux/direct/linux_direct.rs
+++ b/platform/src/os/linux/direct/linux_direct.rs
@@ -166,6 +166,7 @@ impl Cx {
             DirectEvent::Timer(e) => {
                 if e.timer_id == 0 {
                     if SignalToUI::check_and_clear_ui_signal() {
+                        self.handle_termination_signal();
                         self.handle_media_signals();
                         self.handle_script_signals();
                         self.call_event_handler(&Event::Signal);

--- a/platform/src/os/linux/wayland/linux_wayland.rs
+++ b/platform/src/os/linux/wayland/linux_wayland.rs
@@ -363,6 +363,7 @@ impl WaylandCx {
                 let mut cx = self.cx.borrow_mut();
                 if e.timer_id == 0 {
                     if SignalToUI::check_and_clear_ui_signal() {
+                        cx.handle_termination_signal();
                         cx.handle_media_signals();
                         cx.handle_script_signals();
                         cx.call_event_handler(&Event::Signal);

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -302,6 +302,7 @@ impl X11Cx {
                 let mut cx = self.cx.borrow_mut();
                 if e.timer_id == 0 {
                     if SignalToUI::check_and_clear_ui_signal() {
+                        cx.handle_termination_signal();
                         cx.handle_media_signals();
                         cx.handle_script_signals();
                         cx.call_event_handler(&Event::Signal);

--- a/platform/src/os/linux/x11/linux_x11_stdin.rs
+++ b/platform/src/os/linux/x11/linux_x11_stdin.rs
@@ -421,6 +421,7 @@ impl Cx {
             StudioToApp::RunViewFrameRequest(_) => {}
             StudioToApp::Tick => {
                 if SignalToUI::check_and_clear_ui_signal() {
+                    self.handle_termination_signal();
                     self.handle_media_signals();
                     self.handle_script_signals();
                     self.call_event_handler(&Event::Signal);

--- a/platform/src/os/mod.rs
+++ b/platform/src/os/mod.rs
@@ -14,6 +14,9 @@ pub mod cx_shared;
 
 pub mod shared_framebuf;
 
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+pub(crate) mod termination_signal;
+
 #[cfg(headless)]
 pub mod headless;
 

--- a/platform/src/os/termination_signal.rs
+++ b/platform/src/os/termination_signal.rs
@@ -1,0 +1,24 @@
+use {
+    crate::{log, thread::SignalToUI},
+    std::sync::atomic::{AtomicBool, Ordering},
+};
+
+static INSTALLED: AtomicBool = AtomicBool::new(false);
+static REQUESTED: AtomicBool = AtomicBool::new(false);
+
+pub(crate) fn install() {
+    if INSTALLED.swap(true, Ordering::AcqRel) {
+        return;
+    }
+
+    if let Err(err) = ctrlc::set_handler(move || {
+        REQUESTED.store(true, Ordering::Release);
+        SignalToUI::set_ui_signal();
+    }) {
+        log!("Failed to install termination signal handler: {err}");
+    }
+}
+
+pub(crate) fn take_requested() -> bool {
+    REQUESTED.swap(false, Ordering::AcqRel)
+}

--- a/platform/src/os/web/to_wasm.rs
+++ b/platform/src/os/web/to_wasm.rs
@@ -125,6 +125,11 @@ pub struct ToWasmSignal {
 }
 
 #[derive(ToWasm)]
+pub struct ToWasmAppLifecycle {
+    pub state: u32,
+}
+
+#[derive(ToWasm)]
 pub struct ToWasmPaintDirty {}
 
 #[derive(ToWasm)]

--- a/platform/src/os/web/web.js
+++ b/platform/src/os/web/web.js
@@ -48,6 +48,67 @@ export class WasmWebBrowser extends WasmBridge {
         this.dispatch_first_msg();
     }
 
+    emit_app_lifecycle(state) {
+        this.to_wasm.ToWasmAppLifecycle({ state });
+    }
+
+    emit_app_inactive() {
+        if (!this.lifecycle_is_visible) {
+            return;
+        }
+        this.lifecycle_is_visible = false;
+        this.emit_app_lifecycle(2);
+        this.emit_app_lifecycle(1);
+    }
+
+    emit_app_active() {
+        if (this.lifecycle_is_visible) {
+            return;
+        }
+        this.lifecycle_is_visible = true;
+        this.lifecycle_shutdown_sent = false;
+        this.emit_app_lifecycle(0);
+        this.emit_app_lifecycle(3);
+    }
+
+    emit_app_shutdown() {
+        if (this.lifecycle_shutdown_sent) {
+            return;
+        }
+        this.lifecycle_shutdown_sent = true;
+        this.emit_app_lifecycle(4);
+    }
+
+    bind_app_lifecycle() {
+        this.lifecycle_is_visible = !document.hidden;
+        this.lifecycle_shutdown_sent = false;
+
+        document.addEventListener("visibilitychange", () => {
+            if (document.hidden) {
+                this.emit_app_inactive();
+            } else {
+                this.emit_app_active();
+            }
+            this.do_wasm_pump();
+        });
+
+        window.addEventListener("pagehide", (event) => {
+            this.emit_app_inactive();
+            if (!event.persisted) {
+                this.emit_app_shutdown();
+            }
+            this.do_wasm_pump();
+        });
+
+        window.addEventListener("pageshow", (event) => {
+            if (event.persisted) {
+                this.emit_app_active();
+                this.do_wasm_pump();
+            }
+        });
+
+    }
+
     emit_location_change() {
         this.to_wasm.ToWasmLocationChange({
             pathname: location.pathname + "",
@@ -99,6 +160,7 @@ export class WasmWebBrowser extends WasmBridge {
         this.bind_mouse_and_touch();
         this.bind_keyboard();
         this.bind_screen_resize();
+        this.bind_app_lifecycle();
         window.addEventListener("popstate", () => {
             this.emit_location_change();
             this.do_wasm_pump();

--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -214,6 +214,30 @@ impl Cx {
                     }
                 }
 
+                live_id!(ToWasmAppLifecycle) => {
+                    let tw = ToWasmAppLifecycle::read_to_wasm(&mut to_wasm);
+                    match tw.state {
+                        0 => {
+                            self.call_event_handler(&Event::Foreground);
+                            self.redraw_all();
+                        }
+                        1 => {
+                            self.call_event_handler(&Event::Background);
+                        }
+                        2 => {
+                            self.call_event_handler(&Event::Pause);
+                        }
+                        3 => {
+                            self.call_event_handler(&Event::Resume);
+                            self.redraw_all();
+                        }
+                        4 => {
+                            self.call_event_handler(&Event::Shutdown);
+                        }
+                        _ => {}
+                    }
+                }
+
                 live_id!(ToWasmTimerFired) => {
                     let tw = ToWasmTimerFired::read_to_wasm(&mut to_wasm);
                     let e = TimerEvent {
@@ -860,6 +884,7 @@ impl CxOsApi for Cx {
             ToWasmWebSocketString::to_js_code(),
             ToWasmWebSocketBinary::to_js_code(),*/
             ToWasmSignal::to_js_code(),
+            ToWasmAppLifecycle::to_js_code(),
             ToWasmMidiInputData::to_js_code(),
             ToWasmMidiPortList::to_js_code(),
             ToWasmAudioDeviceList::to_js_code(),

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -324,6 +324,7 @@ impl Cx {
             }
             Win32Event::Signal => {
                 if SignalToUI::check_and_clear_ui_signal() {
+                    self.handle_termination_signal();
                     self.handle_media_signals();
                     self.handle_script_signals();
                     self.call_event_handler(&Event::Signal);

--- a/platform/src/os/windows/windows_stdin.rs
+++ b/platform/src/os/windows/windows_stdin.rs
@@ -265,6 +265,7 @@ impl Cx {
             StudioToApp::RunViewFrameRequest(_) => {}
             StudioToApp::Tick => {
                 if SignalToUI::check_and_clear_ui_signal() {
+                    self.handle_termination_signal();
                     self.handle_media_signals();
                     self.handle_script_signals();
                     self.call_event_handler(&Event::Signal);

--- a/platform/src/script/cx.rs
+++ b/platform/src/script/cx.rs
@@ -9,7 +9,7 @@ pub fn script_mod(vm: &mut ScriptVm) {
     set_script_value_to_api!(vm, cx.OsType);
 
     vm.add_method(cx, id_lut!(quit), script_args_def!(), |vm, _args| {
-        vm.cx_mut().quit();
+        vm.cx_mut().request_quit(QuitReason::App);
         NIL
     });
 

--- a/widgets/src/window_menu.rs
+++ b/widgets/src/window_menu.rs
@@ -161,7 +161,7 @@ impl Widget for WindowMenu {
         match event {
             Event::MacosMenuCommand(item) => {
                 if *item == live_id!(quit) {
-                    cx.quit();
+                    cx.request_quit(QuitReason::Menu);
                 }
             }
             _ => (),


### PR DESCRIPTION
This fixes two unrelated but similar-structure issues, both on iOS:

- `Cx::handle_repaint` ran a 32-slot encoder-capture sweep every frame, which lazy-created `AvCaptureAccess` and fired `requestAccessForMediaType:AVMediaTypeVideo` — i.e. the camera prompt — on every Makepad app, even ones that never touch the camera. Gate the loop on `av_capture.is_some()` and stop the three `video_encoder_*` methods in `apple_media.rs` from lazy-creating it; they now return `EncoderNotStarted` (or no-op for `push_frame`) when no encoder exists.

- `AudioUnitAccess::new()` unconditionally activated the shared `AVAudioSession` with category `PlayAndRecord` + `VoiceChat` mode, which is wrong for playback-only apps (mic prompt + forced VPIO). Defer session config to a new `ensure_ios_session(for_input)` helper, called from `use_audio_inputs` (PlayAndRecord) and `use_audio_outputs` (Playback). Idempotent, never downgrades.