### PR TITLE
App menu bar: restore Quit option, use proper app name

### DIFF
--- a/platform/build.rs
+++ b/platform/build.rs
@@ -3,6 +3,27 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
 
+/// Best-effort default for the macOS bundle name when MAKEPAD_BUNDLE_NAME isn't
+/// set. Cargo doesn't expose the consuming binary's package name to a
+/// dependency's build script (`CARGO_PKG_NAME` here is "makepad-platform"), so
+/// we walk up from `OUT_DIR` (which is always
+/// `<root>/target/<profile>/build/<crate>-<hash>/out`) to the directory that
+/// contains `target/` and use that directory's name. For a typical project
+/// that's the package or workspace root, which is almost always a meaningful
+/// label. Capitalize the first letter so the menu bar shows "Sample app" rather
+/// than "sample app". Returns `None` if the path doesn't have the expected shape
+/// or the directory name isn't valid UTF-8.
+fn detect_app_name(out_dir: &Path) -> Option<String> {
+    let workspace_root = out_dir.ancestors().nth(5)?;
+    let dir_name = workspace_root.file_name()?.to_str()?;
+    if dir_name.is_empty() {
+        return None;
+    }
+    let mut chars = dir_name.chars();
+    let first = chars.next()?;
+    Some(first.to_uppercase().collect::<String>() + chars.as_str())
+}
+
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let path = Path::new(&out_dir)
@@ -21,16 +42,31 @@ fn main() {
     let target = env::var("TARGET").unwrap();
 
     if target_os == "macos" {
-        let command_line_plist = r#"<?xml version="1.0" encoding="UTF-8"?>
+        // The downstream app can override the bundle name shown in the macOS
+        // application menu by setting MAKEPAD_BUNDLE_NAME — typically via its
+        // `.cargo/config.toml` `[env]` section with `force = true`. macOS uses
+        // CFBundleName from this Info.plist as the first menu bar item title
+        // for unbundled `cargo run` launches, and it overrides whatever NSMenu
+        // title we pass to setMainMenu:. When the env var isn't set, we fall
+        // back to the workspace/package directory name (capitalized), which
+        // is almost always more meaningful than a hardcoded placeholder.
+        let bundle_name = env::var("MAKEPAD_BUNDLE_NAME")
+            .ok()
+            .or_else(|| detect_app_name(Path::new(&out_dir)))
+            .unwrap_or_else(|| "Makepad App".to_string());
+        let bundle_id = env::var("MAKEPAD_BUNDLE_IDENTIFIER")
+            .unwrap_or_else(|_| format!("dev.makepad.{}", bundle_name.to_lowercase().replace(' ', "-")));
+        let command_line_plist = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>CFBundleIdentifier</key>
-    <string>dev.makepad.stdin-loop</string>
+    <string>{bundle_id}</string>
     <key>CFBundleName</key>
-    <string>MakepadStdinLoop</string>
+    <string>{bundle_name}</string>
     <key>CFBundleDisplayName</key>
-    <string>MakepadStdinLoop</string>
+    <string>{bundle_name}</string>
     <key>GCSupportsControllerUserInteraction</key>
     <true/>
     <key>GCSupportedGameControllers</key>
@@ -42,7 +78,8 @@ fn main() {
     </array>
 </dict>
 </plist>
-"#;
+"#
+        );
         std::fs::write(path.join("Info.plist"), command_line_plist).unwrap();
     }
 
@@ -86,6 +123,8 @@ pub static CUSTOM_ICON_ICO: &'static [u8] = {};\n",
     println!("cargo:rustc-check-cfg=cfg(apple_bundle,apple_sim,lines,use_gles_3,use_vulkan,linux_direct,quest,no_android_choreographer,ohos_sim,headless,use_unstable_unix_socket_ancillary_data_2021)");
     println!("cargo:rerun-if-env-changed=MAKEPAD");
     println!("cargo:rerun-if-env-changed=MAKEPAD_PACKAGE_DIR");
+    println!("cargo:rerun-if-env-changed=MAKEPAD_BUNDLE_NAME");
+    println!("cargo:rerun-if-env-changed=MAKEPAD_BUNDLE_IDENTIFIER");
     println!("cargo:rerun-if-env-changed=IPHONEOS_DEPLOYMENT_TARGET");
     for var in icon_vars {
         println!("cargo:rerun-if-env-changed={var}");

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -555,7 +555,21 @@ impl Cx {
                     self.run_live_edit_if_needed("macos");
                     self.handle_networking_events();
                     self.handle_gamepad_events();
-                    self.cocoa_event_callback(MacosEvent::Paint, metal_cx, metal_windows);
+                    // Propagate Exit from the inner Paint dispatch. The
+                    // signal handling above (Ctrl+C / SIGTERM) calls
+                    // `request_quit`, which queues a `CxOsOp::Quit`; that op
+                    // is drained by `handle_platform_ops` at the top of this
+                    // recursive call and surfaces as `EventFlow::Exit`
+                    // (after `Event::Shutdown` is dispatched). If we ignore
+                    // the return value here and fall through to
+                    // `EventFlow::Wait`, `do_callback` overwrites the just-
+                    // set Exit and the main loop blocks indefinitely on the
+                    // next NSEvent — the symptom being a Ctrl+C that runs
+                    // the user's `QuitRequested` / `Shutdown` handlers but
+                    // never actually exits.
+                    if let EventFlow::Exit = self.cocoa_event_callback(MacosEvent::Paint, metal_cx, metal_windows) {
+                        return EventFlow::Exit;
+                    }
 
                     // Run garbage collection if needed - safe moment after paint, before waiting
                     self.with_vm(|vm| {

--- a/platform/src/os/apple/macos/macos_app.rs
+++ b/platform/src/os/apple/macos/macos_app.rs
@@ -55,6 +55,22 @@ pub fn get_macos_class_global() -> &'static MacosClasses {
     unsafe { &*(MACOS_CLASSES) }
 }
 
+/// Reads CFBundleName from `[NSBundle mainBundle]`'s Info.plist. Returns
+/// `None` when the running binary has no bundle metadata (e.g. truly bare
+/// `cargo run` without the platform crate's generated stub Info.plist).
+pub unsafe fn current_bundle_name() -> Option<String> {
+    let bundle: ObjcId = msg_send![class!(NSBundle), mainBundle];
+    if bundle == nil {
+        return None;
+    }
+    let key = str_to_nsstring("CFBundleName");
+    let name: ObjcId = msg_send![bundle, objectForInfoDictionaryKey: key];
+    if name == nil {
+        return None;
+    }
+    Some(nsstring_to_string(name))
+}
+
 #[derive(Clone)]
 pub struct CocoaTimer {
     timer_id: u64,
@@ -148,15 +164,22 @@ impl MacosApp {
         }
     }
     pub fn init_quit_menu(&mut self) {
+        // Use the running app's CFBundleName (which is what macOS already
+        // shows as the application menu title in the menu bar) so the
+        // submenu and the "Quit X" item label match. NSBundle returns nil
+        // when the binary isn't bundled at all; fall back to a generic
+        // label in that case.
+        let app_name = unsafe { current_bundle_name() }
+            .unwrap_or_else(|| "Application".to_string());
         self.update_macos_menu(&MacosMenu::Main {
             items: vec![MacosMenu::Sub {
-                name: "Makepad".to_string(),
+                name: app_name.clone(),
                 items: vec![MacosMenu::Item {
                     command: live_id!(quit),
                     key: KeyCode::KeyQ,
                     shift: false,
                     enabled: true,
-                    name: "Quit Example".to_string(),
+                    name: format!("Quit {}", app_name),
                 }],
             }],
         });
@@ -221,33 +244,38 @@ impl MacosApp {
                     key,
                     enabled,
                 } => {
+                    // Wire the well-known `quit` command to NSApp's standard
+                    // `terminate:` selector instead of our custom
+                    // `menuAction:` callback. `terminate:` routes through
+                    // `applicationShouldTerminate:`, which dispatches
+                    // `MacosEvent::AppQuitRequested` from the main loop —
+                    // i.e. *outside* any in-flight event handler — so apps
+                    // can call `cx.request_quit` from their `QuitRequested`
+                    // arm without re-entering `call_event_handler` and
+                    // panicking on `event_handler.take().unwrap()`. Other
+                    // commands keep going through `menuAction:` →
+                    // `Event::MacosMenuCommand`.
+                    let is_quit = *command == live_id!(quit);
+                    let action = if is_quit {
+                        sel!(terminate:)
+                    } else {
+                        sel!(menuAction:)
+                    };
                     let sub_item: ObjcId = msg_send![
                         parent_menu,
                         addItemWithTitle: str_to_nsstring(name)
-                        action: sel!(menuAction:)
+                        action: action
                         keyEquivalent: str_to_nsstring(keycode_to_menu_key(*key, *shift))
                     ];
-                    let target: ObjcId = msg_send![menu_target_class, new];
-                    let () = msg_send![sub_item, setTarget: target];
                     let () = msg_send![sub_item, setEnabled: if *enabled {YES}else {NO}];
-                    /*
-                    let command_usize = if let Ok(mut status_map) = status_map.lock() {
-                        if let Some(id) = status_map.command_to_usize.get(&command) {
-                            *id
-                        }
-                        else {
-                            let id = status_map.status_to_usize.len();
-                            status_map.command_to_usize.insert(*command, id);
-                            status_map.usize_to_command.insert(id, *command);
-                            id
-                        }
+                    if !is_quit {
+                        // Leave target nil for `terminate:` so it bubbles up
+                        // to NSApp; for everything else, install the
+                        // MenuTarget instance that re-emits the LiveId.
+                        let target: ObjcId = msg_send![menu_target_class, new];
+                        let () = msg_send![sub_item, setTarget: target];
+                        (*target).set_ivar("command_u64", command.0);
                     }
-                    else {
-                        panic!("cannot lock cmd_map");
-                    };*/
-
-                    //(*target).set_ivar("macos_app_ptr", GLOBAL_COCOA_APP as *mut _ as *mut c_void);
-                    (*target).set_ivar("command_u64", command.0);
                 }
                 MacosMenu::Line => {
                     let sep_item: ObjcId = msg_send![class!(NSMenuItem), separatorItem];
@@ -579,7 +607,12 @@ impl MacosApp {
             let ns_app: ObjcId = msg_send![class!(NSApplication), sharedApplication];
             //let () = msg_send![ns_app, activateIgnoringOtherApps:YES];
             let () = msg_send![ns_app, finishLaunching];
-            // get_macos_app_global().init_quit_menu();
+            // Install a minimal default app menu (just "Quit X" bound to
+            // Cmd+Q) so unbundled `cargo run` apps get the standard macOS
+            // Quit affordance out of the box. Apps that build their own menu
+            // (via `cx.update_macos_menu` or the `WindowMenu` widget) will
+            // overwrite this; the call is harmless either way.
+            with_macos_app(|app| app.init_quit_menu());
             // get_macos_app_global().startup_focus_hack();
 
             loop {

--- a/widgets/src/window_menu.rs
+++ b/widgets/src/window_menu.rs
@@ -161,7 +161,16 @@ impl Widget for WindowMenu {
         match event {
             Event::MacosMenuCommand(item) => {
                 if *item == live_id!(quit) {
-                    cx.request_quit(QuitReason::Menu);
+                    // The macOS menu code now wires `live_id!(quit)` items
+                    // to `NSApp terminate:` (see `macos_app.rs`), so this
+                    // arm only fires for app-dispatched menu commands —
+                    // never from the Quit menu item itself. We still can't
+                    // call `cx.request_quit` here: it synchronously calls
+                    // `call_event_handler`, and we're already inside one,
+                    // so it would panic on `event_handler.take().unwrap()`.
+                    // `cx.quit()` just enqueues a `Quit` op for the next
+                    // event-loop tick, which is safe.
+                    cx.quit();
                 }
             }
             _ => (),


### PR DESCRIPTION
The menu bar shows "MakepadStdInLoop" by default, which is really strange especially for published apps. This fixes that and also allows the app to set the name, as well as using a sensible default for it if the app didn't specify it.

We also now restore the previous Makepad 1.0 behavior of having a default "Quit" entry in the main app's first menu bar entry. We also hook that through the infra i just added for requesting a quit and allowing the app logic to respond to it.

<img width="271" height="103" alt="image" src="https://github.com/user-attachments/assets/05730dad-de91-4cf1-ad63-250bb6f2664c" />
