### PR TITLE
Windows: properly catch sigquit and actually exit

### DIFF
--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -337,7 +337,14 @@ impl Cx {
                 self.run_live_edit_if_needed("windows");
                 self.handle_networking_events();
 
-                self.win32_event_callback(Win32Event::Paint, d3d11_cx, d3d11_windows);
+                // The recursive Paint pass drains `platform_ops` (e.g. a `CxOsOp::Quit`
+                // pushed by `handle_termination_signal` above). Propagate its `Exit` so
+                // that Ctrl+C/SIGTERM actually terminates the process.
+                if let EventFlow::Exit =
+                    self.win32_event_callback(Win32Event::Paint, d3d11_cx, d3d11_windows)
+                {
+                    return EventFlow::Exit;
+                }
 
                 return EventFlow::Wait;
             }


### PR DESCRIPTION
Didn't quite nail this on windows in my last PR 