### PR TITLE
Fix virtual/soft keyboard shift on both iOS & Android

### DIFF
--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -11,7 +11,7 @@ use {
                 VideoSeekableRangesEvent, VideoSource, VideoTextureUpdatedEvent,
                 VideoYuvTexturesReady,
             },
-            Event, KeyEvent, TextInputEvent, TextRangeReplaceEvent,
+            Event, KeyEvent, TextInputEvent, TextRangeReplaceEvent, VirtualKeyboardEvent,
         },
         makepad_live_id::*,
         makepad_objc_sys::objc_block,
@@ -499,6 +499,25 @@ impl Cx {
                 if te.timer_id == 0 {
                     let vk = with_ios_app(|app| app.virtual_keyboard_event.take());
                     if let Some(vk) = vk {
+                        // When the keyboard is going away (user pressed iOS's
+                        // "hide keyboard" button, an external keyboard was
+                        // attached, an inputAccessoryView triggered hide,
+                        // etc.), mark the IME as dismissed so the focused
+                        // TextInput's next `show_text_ime_with_config` call
+                        // is a no-op. Without this, the input still has key
+                        // focus, redraws on the same frame, calls
+                        // `show_text_ime`, and the keyboard pops back up
+                        // (sometimes flipping to whatever language was
+                        // selected last). The flag is cleared automatically
+                        // the next time the user taps a field - see
+                        // `CxKeyboard::set_key_focus`.
+                        if matches!(
+                            vk,
+                            VirtualKeyboardEvent::WillHide { .. }
+                                | VirtualKeyboardEvent::DidHide { .. }
+                        ) {
+                            self.keyboard.set_text_ime_dismissed();
+                        }
                         self.call_event_handler(&Event::VirtualKeyboard(vk));
                     }
                     // Drain iOS text events as one batch to avoid re-entrancy from UITextInput callbacks.

--- a/platform/src/os/apple/ios/ios_delegates.rs
+++ b/platform/src/os/apple/ios/ios_delegates.rs
@@ -480,17 +480,111 @@ pub fn define_ios_timer_delegate() -> *const Class {
 pub fn define_textfield_delegate() -> *const Class {
     let mut decl = ClassDecl::new("NSTextFieldDlg", class!(NSObject)).unwrap();
 
-    // Keyboard notification helpers - used for resizing the canvas when keyboard is shown/hidden
-    fn get_height_delta(notif: ObjcId) -> f64 {
-        unsafe {
-            let info: ObjcId = msg_send![notif, userInfo];
-            let obj: ObjcId = msg_send![info, objectForKey: UIKeyboardFrameBeginUserInfoKey];
-            let begin: NSRect = msg_send![obj, CGRectValue];
-            let obj: ObjcId = msg_send![info, objectForKey: UIKeyboardFrameEndUserInfoKey];
-            let end: NSRect = msg_send![obj, CGRectValue];
-            begin.origin.y - end.origin.y
+    #[derive(Clone, Copy)]
+    struct KeyboardGeometry {
+        is_visible: bool,
+        bottom_overlap: f64,
+    }
+
+    fn positive_min(a: f64, b: f64) -> Option<f64> {
+        match (a > 0.0, b > 0.0) {
+            (true, true) => Some(a.min(b)),
+            (true, false) => Some(a),
+            (false, true) => Some(b),
+            (false, false) => None,
         }
     }
+
+    /// Returns the keyboard visibility and docked bottom overlap in the
+    /// MTKView's coordinate space, in logical points.
+    ///
+    /// UIKit reports the keyboard frame in screen coordinates. Converting
+    /// through the screen coordinate space keeps the value correct for iPad
+    /// Split View, Slide Over, Stage Manager, rotation, and multi-window
+    /// placements where the app window is not the full screen.
+    fn get_keyboard_geometry_in_view(notif: ObjcId, view: ObjcId) -> KeyboardGeometry {
+        let hidden = KeyboardGeometry {
+            is_visible: false,
+            bottom_overlap: 0.0,
+        };
+        if view.is_null() {
+            return hidden;
+        }
+        unsafe {
+            let info: ObjcId = msg_send![notif, userInfo];
+            let obj: ObjcId = msg_send![info, objectForKey: UIKeyboardFrameEndUserInfoKey];
+            if obj.is_null() {
+                return hidden;
+            }
+            let end_in_screen: NSRect = msg_send![obj, CGRectValue];
+
+            // Prefer the screen's coordinate space (correct for multi-window
+            // iPad). Fall back to window-coords-to-view-coords if anything in
+            // the chain is null. That's only reachable on a not-yet-attached
+            // view during early init, when we wouldn't want to shift anyway.
+            let window: ObjcId = msg_send![view, window];
+            let coord_space: ObjcId = if window.is_null() {
+                std::ptr::null_mut()
+            } else {
+                let screen: ObjcId = msg_send![window, screen];
+                if screen.is_null() {
+                    std::ptr::null_mut()
+                } else {
+                    msg_send![screen, coordinateSpace]
+                }
+            };
+            let end_in_view: NSRect = if coord_space.is_null() {
+                msg_send![view, convertRect: end_in_screen fromView: nil as ObjcId]
+            } else {
+                msg_send![view, convertRect: end_in_screen fromCoordinateSpace: coord_space]
+            };
+
+            let view_bounds: NSRect = msg_send![view, bounds];
+            let view_x2 = view_bounds.origin.x + view_bounds.size.width;
+            let view_y2 = view_bounds.origin.y + view_bounds.size.height;
+            let view_left = view_bounds.origin.x.min(view_x2);
+            let view_top = view_bounds.origin.y.min(view_y2);
+            let view_right = view_bounds.origin.x.max(view_x2);
+            let view_bottom = view_bounds.origin.y.max(view_y2);
+            let kbd_x2 = end_in_view.origin.x + end_in_view.size.width;
+            let kbd_y2 = end_in_view.origin.y + end_in_view.size.height;
+            let kbd_left = end_in_view.origin.x.min(kbd_x2);
+            let kbd_top = end_in_view.origin.y.min(kbd_y2);
+            let kbd_right = end_in_view.origin.x.max(kbd_x2);
+            let kbd_bottom = end_in_view.origin.y.max(kbd_y2);
+
+            let visible_width = kbd_right.min(view_right) - kbd_left.max(view_left);
+            let visible_height = kbd_bottom.min(view_bottom) - kbd_top.max(view_top);
+            let is_visible = visible_width > 1.0 && visible_height > 1.0;
+            if !is_visible {
+                return hidden;
+            }
+
+            // A floating or undocked iPad keyboard is visible, but it does not
+            // create a bottom obstruction. Report it as visible with zero
+            // overlap so focus remains intact while KeyboardView clears any
+            // previous docked-keyboard shift.
+            let is_docked = kbd_bottom + 1.0 >= view_bottom;
+            let bottom_overlap = if is_docked {
+                let frame_height = positive_min(
+                    end_in_view.size.height.abs(),
+                    end_in_screen.size.height.abs(),
+                )
+                .unwrap_or(visible_height);
+                visible_height
+                    .max(0.0)
+                    .min(frame_height)
+                    .min((view_bottom - view_top).max(0.0))
+            } else {
+                0.0
+            };
+            KeyboardGeometry {
+                is_visible,
+                bottom_overlap,
+            }
+        }
+    }
+
     fn get_curve_duration(notif: ObjcId) -> (f64, Ease) {
         unsafe {
             let info: ObjcId = msg_send![notif, userInfo];
@@ -498,79 +592,105 @@ pub fn define_textfield_delegate() -> *const Class {
             let duration: f64 = msg_send![obj, doubleValue];
             let obj: ObjcId = msg_send![info, objectForKey: UIKeyboardAnimationCurveUserInfoKey];
             let curve: i64 = msg_send![obj, intValue];
+            let curve = if curve > 3 { curve >> 16 } else { curve };
 
-            let ease = match curve >> 16 {
-                // UIViewAnimationOptionCurveEaseInOut - approximated with bezier
+            let ease = match curve {
+                // UIKit's standard timing curves as cubic-bezier(x1, y1, x2, y2).
                 0 => Ease::Bezier {
-                    cp0: 0.25,
-                    cp1: 0.1,
-                    cp2: 0.25,
-                    cp3: 0.1,
+                    cp0: 0.42,
+                    cp1: 0.0,
+                    cp2: 0.58,
+                    cp3: 1.0,
                 },
-                1 => Ease::InExp,  //UIViewAnimationOptionCurveEaseIn = 1 << 16,
-                2 => Ease::OutExp, //UIViewAnimationOptionCurveEaseOut = 2 << 16,
-                _ => Ease::Linear, //UIViewAnimationOptionCurveLinear = 3 << 16,
+                1 => Ease::Bezier {
+                    cp0: 0.42,
+                    cp1: 0.0,
+                    cp2: 1.0,
+                    cp3: 1.0,
+                },
+                2 => Ease::Bezier {
+                    cp0: 0.0,
+                    cp1: 0.0,
+                    cp2: 0.58,
+                    cp3: 1.0,
+                },
+                _ => Ease::Linear,
             };
             (duration, ease)
         }
     }
 
-    // Required stubs for keyboard frame change notifications (registered with notification center)
-    extern "C" fn keyboard_did_change_frame(_: &Object, _: Sel, _notif: ObjcId) {}
-    extern "C" fn keyboard_will_change_frame(_: &Object, _: Sel, _notif: ObjcId) {}
+    /// Pull the MTKView pointer out of the global app state without holding a
+    /// borrow across the UIKit `msg_send`s that need it. Returns null if the
+    /// app isn't initialized yet or the view hasn't been created.
+    fn get_mtk_view() -> ObjcId {
+        try_with_ios_app(|app| app.mtk_view)
+            .flatten()
+            .unwrap_or(std::ptr::null_mut())
+    }
 
-    extern "C" fn keyboard_will_hide(_: &Object, _: Sel, notif: ObjcId) {
-        // Get notification data OUTSIDE the borrow
-        let height = get_height_delta(notif);
+    /// Queue a `Will{Show,Hide}` event keyed off the absolute post-animation
+    /// height. UIKit fires `keyboardWillChangeFrame` for every keyboard frame
+    /// transition: initial show, mid-flight changes (language switch,
+    /// predictive bar toggle, custom inputAccessoryView height changes,
+    /// rotation), and dismissal. This is the single source of truth.
+    extern "C" fn keyboard_will_change_frame(_: &Object, _: Sel, notif: ObjcId) {
+        let view = get_mtk_view();
+        let geometry = get_keyboard_geometry_in_view(notif, view);
         let (duration, ease) = get_curve_duration(notif);
-        // Now borrow to get time and queue event
         if let Some(time) = try_with_ios_app(|app| app.time_now()) {
             try_with_ios_app(|app| {
-                app.queue_virtual_keyboard_event(VirtualKeyboardEvent::WillHide {
-                    time,
-                    ease,
-                    height: -height,
-                    duration,
-                })
+                let event = if geometry.is_visible {
+                    VirtualKeyboardEvent::WillShow {
+                        time,
+                        height: geometry.bottom_overlap,
+                        ease,
+                        duration,
+                    }
+                } else {
+                    VirtualKeyboardEvent::WillHide {
+                        time,
+                        height: 0.0,
+                        ease,
+                        duration,
+                    }
+                };
+                app.queue_virtual_keyboard_event(event)
             });
         }
     }
 
-    extern "C" fn keyboard_did_hide(_: &Object, _: Sel, _notif: ObjcId) {
+    /// Settled state corresponding to `keyboard_will_change_frame`. A visible
+    /// floating keyboard is still DidShow, but with zero bottom overlap.
+    extern "C" fn keyboard_did_change_frame(_: &Object, _: Sel, notif: ObjcId) {
+        let view = get_mtk_view();
+        let geometry = get_keyboard_geometry_in_view(notif, view);
         if let Some(time) = try_with_ios_app(|app| app.time_now()) {
             try_with_ios_app(|app| {
-                app.queue_virtual_keyboard_event(VirtualKeyboardEvent::DidHide { time })
+                let event = if geometry.is_visible {
+                    VirtualKeyboardEvent::DidShow {
+                        time,
+                        height: geometry.bottom_overlap,
+                    }
+                } else {
+                    VirtualKeyboardEvent::DidHide { time }
+                };
+                app.queue_virtual_keyboard_event(event)
             });
         }
     }
 
-    extern "C" fn keyboard_will_show(_: &Object, _: Sel, notif: ObjcId) {
-        // Get notification data OUTSIDE the borrow
-        let height = get_height_delta(notif);
-        let (duration, ease) = get_curve_duration(notif);
-        // Now borrow to get time and queue event
-        if let Some(time) = try_with_ios_app(|app| app.time_now()) {
-            try_with_ios_app(|app| {
-                app.queue_virtual_keyboard_event(VirtualKeyboardEvent::WillShow {
-                    time,
-                    height,
-                    ease,
-                    duration,
-                })
-            });
-        }
-    }
-
-    extern "C" fn keyboard_did_show(_: &Object, _: Sel, notif: ObjcId) {
-        // Get notification data OUTSIDE the borrow
-        let height = get_height_delta(notif);
-        // Now borrow to get time and queue event
-        if let Some(time) = try_with_ios_app(|app| app.time_now()) {
-            try_with_ios_app(|app| {
-                app.queue_virtual_keyboard_event(VirtualKeyboardEvent::DidShow { time, height })
-            });
-        }
-    }
+    // The Show/Hide notifications fire *in addition* to ChangeFrame for the
+    // appearing/disappearing transitions, with the same parameters. We keep
+    // the observers registered (so UIKit's notification book-keeping stays
+    // intact) but treat ChangeFrame as authoritative. These are no-ops.
+    // IosApp stores one pending virtual-keyboard event, so even if both
+    // pathways queued, the later write wins. Routing through one path keeps
+    // height-change behavior identical to show/hide behavior.
+    extern "C" fn keyboard_will_hide(_: &Object, _: Sel, _notif: ObjcId) {}
+    extern "C" fn keyboard_did_hide(_: &Object, _: Sel, _notif: ObjcId) {}
+    extern "C" fn keyboard_will_show(_: &Object, _: Sel, _notif: ObjcId) {}
+    extern "C" fn keyboard_did_show(_: &Object, _: Sel, _notif: ObjcId) {}
     extern "C" fn input_mode_did_change(_: &Object, _: Sel, _notif: ObjcId) {
         // When keyboard language changes, reload input views so iOS re-queries
         // autocorrectionType (which dynamically checks CJK vs non-CJK).

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -897,23 +897,38 @@ impl Cx {
                 keyboard_height,
                 is_open,
             } => {
-                let keyboard_height = (keyboard_height as f64) / self.os.dpi_factor;
-                if !is_open {
-                    self.os.keyboard_closed = keyboard_height;
-                }
+                // Java reports the bottom IME occlusion in physical pixels.
+                // Convert to logical points and dedup repeated inset/layout
+                // callbacks. A visible IME may still have zero bottom
+                // occlusion (floating keyboard, transient animation frame);
+                // keep it as a visible zero-height keyboard so KeyboardView can
+                // clear any previous bottom shift without treating focus as
+                // dismissed.
+                let height_logical = (keyboard_height as f64) / self.os.dpi_factor;
+                let time = self.os.timers.time_now();
                 if is_open {
+                    if self.os.last_ime_visible
+                        && (height_logical - self.os.last_ime_height).abs() < 0.5
+                    {
+                        return;
+                    }
+                    self.os.last_ime_visible = true;
+                    self.os.last_ime_height = height_logical;
                     self.call_event_handler(&Event::VirtualKeyboard(
                         VirtualKeyboardEvent::DidShow {
-                            height: keyboard_height - self.os.keyboard_closed,
-                            time: self.os.timers.time_now(),
+                            height: height_logical,
+                            time,
                         },
                     ))
-                } else {
+                } else if !is_open {
+                    if !self.os.last_ime_visible {
+                        return;
+                    }
+                    self.os.last_ime_visible = false;
+                    self.os.last_ime_height = 0.0;
                     self.text_ime_was_dismissed();
                     self.call_event_handler(&Event::VirtualKeyboard(
-                        VirtualKeyboardEvent::DidHide {
-                            time: self.os.timers.time_now(),
-                        },
+                        VirtualKeyboardEvent::DidHide { time },
                     ))
                 }
             }
@@ -3071,7 +3086,8 @@ impl Default for CxOs {
             display_size: dvec2(100., 100.),
             dpi_factor: 1.5,
             safe_area_insets: Default::default(),
-            keyboard_closed: 0.0,
+            last_ime_height: 0.0,
+            last_ime_visible: false,
             media: CxAndroidMedia::default(),
             display: None,
             surface_alive: false,
@@ -3150,7 +3166,14 @@ pub struct CxOs {
     pub display_size: Vec2d,
     pub dpi_factor: f64,
     pub safe_area_insets: crate::event::SafeAreaInsets,
-    pub keyboard_closed: f64,
+    /// Last reported soft-keyboard height in logical pixels. Used to dedup
+    /// repeated inset notifications from `onApplyWindowInsets` /
+    /// `onGlobalLayout` so we don't re-fire `VirtualKeyboardEvent`s on
+    /// unrelated layout passes.
+    pub last_ime_height: f64,
+    /// Whether the soft keyboard was visible the last time we dispatched a
+    /// `VirtualKeyboardEvent`. Pairs with `last_ime_height` for dedup.
+    pub last_ime_visible: bool,
     pub frame_time: i64,
     pub quit: bool,
     pub fullscreen: bool,

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -82,6 +82,131 @@ import java.util.concurrent.CompletableFuture;
 
 //% IMPORTS
 
+class MakepadImeInsets {
+    private static final int MIN_KEYBOARD_HEIGHT_DP = 80;
+
+    private static int keyboardThresholdPx(View view) {
+        return Math.max(1, (int) (view.getResources().getDisplayMetrics().density * MIN_KEYBOARD_HEIGHT_DP));
+    }
+
+    private static int rootHeightPx(View view) {
+        View root = view.getRootView();
+        return root == null ? 0 : root.getHeight();
+    }
+
+    private static int clampToRootHeight(View view, int overlap) {
+        int rootHeight = rootHeightPx(view);
+        if (rootHeight <= 0 || overlap <= 0) {
+            return 0;
+        }
+        return Math.min(overlap, rootHeight);
+    }
+
+    private static boolean isNearFullHeightOverlap(View view, int overlap) {
+        int rootHeight = rootHeightPx(view);
+        return rootHeight > 0 && rootHeight - overlap <= keyboardThresholdPx(view);
+    }
+
+    private static int visibleFrameBottomOverlapPx(View view) {
+        Rect visibleFrame = new Rect();
+        view.getWindowVisibleDisplayFrame(visibleFrame);
+
+        View root = view.getRootView();
+        if (root == null || root.getHeight() <= 0) {
+            return 0;
+        }
+
+        int[] rootLocation = new int[2];
+        root.getLocationOnScreen(rootLocation);
+        if (visibleFrame.isEmpty() || visibleFrame.bottom <= rootLocation[1]) {
+            return 0;
+        }
+
+        int rootBottomOnScreen = rootLocation[1] + root.getHeight();
+        return Math.max(0, rootBottomOnScreen - visibleFrame.bottom);
+    }
+
+    static int bottomOverlapPx(View view, WindowInsets insets) {
+        int imeBottom = 0;
+        if (Build.VERSION.SDK_INT >= 30 && insets != null) {
+            Insets imeInsets = insets.getInsets(WindowInsets.Type.ime());
+            imeBottom = clampToRootHeight(view, Math.max(0, imeInsets.bottom));
+        }
+
+        if (imeBottom > 0 && !isNearFullHeightOverlap(view, imeBottom)) {
+            return imeBottom;
+        }
+
+        // Fallback for Android/OEM paths where Type.ime().bottom reports 0,
+        // most commonly landscape keyboards. Using only the bottom edge avoids
+        // counting status-bar differences at the top of the window.
+        int fallback = visibleFrameBottomOverlapPx(view);
+        if (fallback <= keyboardThresholdPx(view)) {
+            return 0;
+        }
+
+        // A visible frame that is basically empty is not a keyboard measurement;
+        // it is a transient/invalid layout result. Do not turn it into a
+        // near-full-screen IME height.
+        if (isNearFullHeightOverlap(view, fallback)) {
+            return 0;
+        }
+        return clampToRootHeight(view, fallback);
+    }
+
+    static boolean isVisible(View view, WindowInsets insets, int bottomOverlapPx) {
+        if (Build.VERSION.SDK_INT >= 30 && insets != null
+                && insets.isVisible(WindowInsets.Type.ime())) {
+            return true;
+        }
+        return bottomOverlapPx > 0;
+    }
+
+    static void report(View view, WindowInsets insets) {
+        int bottomOverlap = bottomOverlapPx(view, insets);
+        boolean visible = isVisible(view, insets, bottomOverlap);
+        MakepadNative.surfaceOnResizeTextIME(bottomOverlap, visible);
+    }
+}
+
+class MakepadSystemInsets {
+    final float top;
+    final float right;
+    final float bottom;
+    final float left;
+
+    private MakepadSystemInsets(float top, float right, float bottom, float left) {
+        this.top = top;
+        this.right = right;
+        this.bottom = bottom;
+        this.left = left;
+    }
+
+    @SuppressWarnings("deprecation")
+    static MakepadSystemInsets from(WindowInsets insets, float density) {
+        if (insets == null) {
+            return new MakepadSystemInsets(0, 0, 0, 0);
+        }
+        if (Build.VERSION.SDK_INT >= 30) {
+            Insets systemBarInsets = insets.getInsets(
+                WindowInsets.Type.systemBars() | WindowInsets.Type.displayCutout()
+            );
+            return new MakepadSystemInsets(
+                systemBarInsets.top / density,
+                systemBarInsets.right / density,
+                systemBarInsets.bottom / density,
+                systemBarInsets.left / density
+            );
+        }
+        return new MakepadSystemInsets(
+            insets.getSystemWindowInsetTop() / density,
+            insets.getSystemWindowInsetRight() / density,
+            insets.getSystemWindowInsetBottom() / density,
+            insets.getSystemWindowInsetLeft() / density
+        );
+    }
+}
+
 class MakepadSurface
     extends
         SurfaceView
@@ -280,18 +405,13 @@ class MakepadSurface
 
     @Override
     public void onGlobalLayout() {
+        // Fallback path: the parent ResizingLayout's OnApplyWindowInsetsListener
+        // is the primary source of IME inset updates (it fires per-frame during
+        // the keyboard animation on API 30+). This handler stays as a safety
+        // net for layout changes that arrive without an inset dispatch, for
+        // example, a focus change that retargets the IME to a different field.
         WindowInsets insets = this.getRootWindowInsets();
-        if (insets == null) {
-            return;
-        }
-
-        Rect r = new Rect();
-        this.getWindowVisibleDisplayFrame(r);
-        int screenHeight = this.getRootView().getHeight();
-        int visibleHeight = r.height();
-        int keyboardHeight = screenHeight - visibleHeight;
-
-        MakepadNative.surfaceOnResizeTextIME(keyboardHeight, insets.isVisible(WindowInsets.Type.ime()));
+        MakepadImeInsets.report(this, insets);
     }
 
     // docs says getCharacters are deprecated
@@ -628,24 +748,65 @@ class ResizingLayout
         // and system transition frames that cannot capture the separate surface layer.
         setBackgroundResource(R.drawable.makepad_launch_background);
         setOnApplyWindowInsetsListener(this);
+
+        // The IME animation API (API 30+) gives us an authoritative per-frame
+        // dispatch of the IME inset that does NOT depend on softInputMode or
+        // on the listener returning the right thing. `onApplyWindowInsets`
+        // alone is unreliable across Android versions and orientations
+        // (we've observed it firing in landscape but not portrait, and on
+        // some OEMs not at all). With this callback attached we are
+        // guaranteed to hear about every IME show / hide / animation
+        // progress event.
+        if (android.os.Build.VERSION.SDK_INT >= 30) {
+            setWindowInsetsAnimationCallback(
+                new android.view.WindowInsetsAnimation.Callback(
+                    android.view.WindowInsetsAnimation.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE
+                ) {
+                    @Override
+                    public android.view.WindowInsets onProgress(
+                        android.view.WindowInsets insets,
+                        java.util.List<android.view.WindowInsetsAnimation> runningAnimations
+                    ) {
+                        MakepadImeInsets.report(ResizingLayout.this, insets);
+                        return insets;
+                    }
+
+                    @Override
+                    public void onEnd(android.view.WindowInsetsAnimation animation) {
+                        // The framework usually delivers a final-state inset
+                        // through onProgress just before onEnd, but on some
+                        // OEM devices it skips that last frame. Fetch the
+                        // current insets directly to make sure native code
+                        // sees the settled state.
+                        android.view.WindowInsets insets = getRootWindowInsets();
+                        if (insets == null) return;
+                        MakepadImeInsets.report(ResizingLayout.this, insets);
+                    }
+                }
+            );
+        }
     }
 
     @Override
     public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
-        Insets imeInsets = insets.getInsets(WindowInsets.Type.ime());
-        v.setPadding(0, 0, 0, imeInsets.bottom);
+        // Report IME inset directly to native code. The in-app KeyboardView
+        // is the single source of truth for shifting content above the soft
+        // keyboard. We do not shrink the SurfaceView via setPadding; that
+        // would double-count the obstruction (system shrinks the surface
+        // *and* the KeyboardView shifts). The activity is configured with
+        // `windowSoftInputMode="adjustNothing"` in the manifest, so the
+        // system doesn't auto-resize either.
+        MakepadImeInsets.report(v, insets);
 
         // Compute safe area insets from system bars and display cutout.
         // These are in physical pixels; convert to logical points by dividing by density.
         float density = getResources().getDisplayMetrics().density;
-        Insets systemBarInsets = insets.getInsets(
-            WindowInsets.Type.systemBars() | WindowInsets.Type.displayCutout()
-        );
+        MakepadSystemInsets systemBarInsets = MakepadSystemInsets.from(insets, density);
         MakepadNative.surfaceOnSafeAreaInsets(
-            systemBarInsets.top / density,
-            systemBarInsets.right / density,
-            systemBarInsets.bottom / density,
-            systemBarInsets.left / density
+            systemBarInsets.top,
+            systemBarInsets.right,
+            systemBarInsets.bottom,
+            systemBarInsets.left
         );
 
         return insets;
@@ -810,6 +971,10 @@ public class MakepadActivity
         super.onCreate(savedInstanceState);
         
         this.requestWindowFeature(Window.FEATURE_NO_TITLE);
+        getWindow().setSoftInputMode(
+            LayoutParams.SOFT_INPUT_ADJUST_NOTHING
+                | LayoutParams.SOFT_INPUT_STATE_UNCHANGED
+        );
 
         // Default state: content below system bars (status bar visible).
         // Apps that want fullscreen can request CxOsOp::FullscreenWindow which
@@ -1561,7 +1726,7 @@ public class MakepadActivity
 
     // Update IME text state for programmatic changes - called from Rust
     // Note: This should only be called for programmatic text changes (e.g., clear button),
-    // NOT during normal IME input (which flows Java→Rust via onImeTextStateChanged)
+    // NOT during normal IME input (which flows Java to Rust via onImeTextStateChanged)
     public void updateImeTextState(final String fullText, final int selStart, final int selEnd) {
         runOnUiThread(new Runnable() {
             @Override

--- a/tools/cargo_makepad/src/android/mod.rs
+++ b/tools/cargo_makepad/src/android/mod.rs
@@ -69,6 +69,7 @@ impl AndroidVariant {
                     android:configChanges="orientation|screenSize|keyboardHidden"
                     android:exported="true"
                     android:launchMode="singleTask"
+                    android:windowSoftInputMode="adjustNothing|stateUnchanged"
                     android:theme="@style/MakepadLaunchTheme">
                     <intent-filter>
                         <action android:name="android.intent.action.MAIN" />
@@ -154,6 +155,7 @@ impl AndroidVariant {
                         android:exported="true"
                         android:launchMode="singleTask"
                         android:screenOrientation="landscape"
+                        android:windowSoftInputMode="adjustNothing|stateUnchanged"
                         android:theme="@style/MakepadLaunchTheme" 
                         >
                         <intent-filter>
@@ -169,6 +171,7 @@ impl AndroidVariant {
                         android:exported="true"
                         android:launchMode="singleTask"
                         android:screenOrientation="landscape"
+                        android:windowSoftInputMode="adjustNothing|stateUnchanged"
                         android:theme="@style/MakepadLaunchTheme" 
                         >
                         <intent-filter>

--- a/widgets/src/keyboard_view.rs
+++ b/widgets/src/keyboard_view.rs
@@ -13,6 +13,10 @@ script_mod! {
     }
 }
 
+const KEYBOARD_SHIFT_EPSILON: f64 = 0.5;
+const KEYBOARD_RECONCILE_DURATION: f64 = 0.10;
+const KEYBOARD_RECONCILE_EASE: Ease = Ease::OutCubic;
+
 #[derive(Script, ScriptHook, Widget)]
 pub struct KeyboardView {
     #[source]
@@ -28,46 +32,133 @@ pub struct KeyboardView {
     outer_walk: Walk,
     #[live]
     keyboard_walk: Walk,
+    /// Minimum gap (in logical pixels) preserved between the focused IME field's
+    /// bottom edge and the top of the on-screen keyboard. Acts as breathing room
+    /// so the cursor isn't pressed flush against the keyboard.
     #[live]
     keyboard_min_shift: f64,
     #[rust]
     next_frame: NextFrame,
 
+    /// Current vertical scroll offset applied to the inner content (logical pixels).
     #[rust]
     keyboard_shift: f64,
+    /// Last known on-screen keyboard height in logical pixels. Stored so the
+    /// shift can be recomputed when the focused IME area moves due to a layout
+    /// reflow that happens while the keyboard stays open.
+    #[rust]
+    keyboard_height: f64,
     #[rust(AnimState::Closed)]
     anim_state: AnimState,
     #[rust]
     draw_state: DrawStateWrap<Walk>,
 }
 
+#[derive(Clone, Copy)]
 enum AnimState {
     Closed,
     Opening {
         duration: f64,
         start_time: f64,
         ease: Ease,
-        height: f64,
+        from_shift: f64,
+        to_shift: f64,
     },
     Open,
     Closing {
         duration: f64,
         start_time: f64,
         ease: Ease,
-        height: f64,
+        from_shift: f64,
     },
 }
 
 impl KeyboardView {
-    fn compute_max_height(&self, height: f64, cx: &Cx) -> f64 {
-        let self_rect = self.area.rect(cx);
-        let ime_rect = cx.get_ime_area_rect();
-        let av_height = self_rect.size.y - height;
-        let ime_height = ime_rect.size.y + ime_rect.pos.y + self.keyboard_min_shift;
-        if ime_height > av_height {
-            return ime_height - av_height;
+    /// Compute the vertical scroll required to keep the focused IME field above
+    /// an on-screen keyboard of `keyboard_height` logical pixels.
+    ///
+    /// The keyboard is a window-level obstruction occupying the bottom strip of
+    /// the active window, so the calculation is anchored to the window's inner
+    /// size, not to `self.area`. That keeps the result correct when this widget
+    /// is nested under padding/scrollers, when the platform has already shrunk
+    /// the surface to make room for the IME, or when there is no settled rect
+    /// yet for `self.area`.
+    fn compute_target_shift(&self, keyboard_height: f64, cx: &Cx) -> f64 {
+        if keyboard_height <= 0.0 {
+            return 0.0;
         }
-        0.0
+        let ime_rect = cx.get_ime_area_rect();
+        // Without a registered IME area there is no field to keep visible.
+        if ime_rect.size.y <= 0.0 {
+            return 0.0;
+        }
+        let window_inner_size = cx.windows[CxWindowPool::id_zero()].window_geom.inner_size;
+        if window_inner_size.y <= 0.0 {
+            return 0.0;
+        }
+        // `ime_rect` comes from `Area::rect`, which reads the GPU-side draw
+        // position, i.e. the IME rect's y AFTER our own `with_scroll` has
+        // been applied. We need its NATURAL (unshifted) y to compute an
+        // absolute target shift. Without re-adding the current shift the
+        // formula oscillates: each applied shift moves the IME up, the next
+        // call sees it unobstructed and returns 0, the shift snaps back to
+        // 0, the IME returns to its original position, the next call sees
+        // it obstructed again, ... and we ping-pong forever, redrawing on
+        // every frame.
+        let keyboard_height = keyboard_height.min(window_inner_size.y).max(0.0);
+        let keyboard_top = window_inner_size.y - keyboard_height;
+        let ime_natural_bottom = ime_rect.pos.y + ime_rect.size.y + self.keyboard_shift;
+        let needed = ime_natural_bottom + self.keyboard_min_shift - keyboard_top;
+        needed
+            .max(0.0)
+            .min(keyboard_height)
+    }
+
+    fn set_keyboard_shift(&mut self, cx: &mut Cx, shift: f64) {
+        self.keyboard_shift = shift.max(0.0);
+        cx.keyboard_shift = self.keyboard_shift;
+    }
+
+    fn animate_to_shift(
+        &mut self,
+        cx: &mut Cx,
+        start_time: f64,
+        target_shift: f64,
+        duration: f64,
+        ease: Ease,
+    ) {
+        let target_shift = target_shift.max(0.0).min(self.keyboard_height.max(0.0));
+        if duration <= 0.0 || (target_shift - self.keyboard_shift).abs() <= KEYBOARD_SHIFT_EPSILON {
+            self.set_keyboard_shift(cx, target_shift);
+            self.anim_state = AnimState::Open;
+        } else {
+            self.anim_state = AnimState::Opening {
+                duration,
+                start_time,
+                ease,
+                from_shift: self.keyboard_shift,
+                to_shift: target_shift,
+            };
+            self.next_frame = cx.new_next_frame();
+        }
+        self.redraw(cx);
+    }
+
+    fn animate_to_zero(&mut self, cx: &mut Cx, start_time: f64, duration: f64, ease: Ease) {
+        if duration <= 0.0 || self.keyboard_shift <= KEYBOARD_SHIFT_EPSILON {
+            self.set_keyboard_shift(cx, 0.0);
+            self.anim_state = AnimState::Closed;
+            self.keyboard_height = 0.0;
+        } else {
+            self.anim_state = AnimState::Closing {
+                from_shift: self.keyboard_shift,
+                duration,
+                start_time,
+                ease,
+            };
+            self.next_frame = cx.new_next_frame();
+        }
+        self.redraw(cx);
     }
 
     fn begin(&mut self, cx: &mut Cx2d, walk: Walk) {
@@ -86,19 +177,22 @@ impl KeyboardView {
 impl Widget for KeyboardView {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         if let Some(e) = self.next_frame.is_event(event) {
-            match &self.anim_state {
+            match self.anim_state {
                 AnimState::Opening {
                     duration,
                     start_time,
                     ease,
-                    height,
+                    from_shift,
+                    to_shift,
                 } => {
-                    if e.time - start_time < *duration {
-                        self.keyboard_shift = ease.map((e.time - start_time) / duration) * height;
+                    let dt = e.time - start_time;
+                    if dt < duration && duration > 0.0 {
+                        let t = ease.map(dt / duration);
+                        self.keyboard_shift = from_shift + (to_shift - from_shift) * t;
                         cx.keyboard_shift = self.keyboard_shift;
                         self.next_frame = cx.new_next_frame();
                     } else {
-                        self.keyboard_shift = *height;
+                        self.keyboard_shift = to_shift;
                         cx.keyboard_shift = self.keyboard_shift;
                         self.anim_state = AnimState::Open;
                     }
@@ -108,73 +202,82 @@ impl Widget for KeyboardView {
                     duration,
                     start_time,
                     ease,
-                    height,
+                    from_shift,
                 } => {
-                    if e.time - start_time < *duration {
-                        self.keyboard_shift =
-                            (1.0 - ease.map((e.time - start_time) / duration)) * height;
+                    let dt = e.time - start_time;
+                    if dt < duration && duration > 0.0 {
+                        let t = ease.map(dt / duration);
+                        self.keyboard_shift = from_shift * (1.0 - t);
                         cx.keyboard_shift = self.keyboard_shift;
                         self.next_frame = cx.new_next_frame();
                     } else {
                         self.keyboard_shift = 0.0;
                         cx.keyboard_shift = self.keyboard_shift;
                         self.anim_state = AnimState::Closed;
+                        self.keyboard_height = 0.0;
                     }
                     self.redraw(cx);
                 }
                 _ => (),
             }
         }
-        match event {
-            Event::VirtualKeyboard(vk) => {
-                match vk {
-                    VirtualKeyboardEvent::WillShow {
-                        time,
-                        height,
-                        ease,
-                        duration,
-                    } => {
-                        // ok so lets run an animation with next
-                        let height = self.compute_max_height(*height, cx);
-                        self.anim_state = AnimState::Opening {
-                            duration: *duration,
-                            start_time: *time,
-                            ease: *ease,
-                            height: height,
-                        };
-                        self.next_frame = cx.new_next_frame();
+        if let Event::VirtualKeyboard(vk) = event {
+            match vk {
+                VirtualKeyboardEvent::WillShow {
+                    time,
+                    height,
+                    ease,
+                    duration,
+                } => {
+                    // "Animate to a keyboard of `height` pts." Used for both
+                    // initial show and any mid-flight height change: keyboard
+                    // language switch, predictive bar toggle, or rotation while
+                    // the keyboard is up. The platform layer can re-fire
+                    // WillShow with the new height instead of needing a separate
+                    // event variant.
+                    self.keyboard_height = *height;
+                    let target = self.compute_target_shift(*height, cx);
+                    self.animate_to_shift(cx, *time, target, *duration, *ease);
+                }
+                VirtualKeyboardEvent::WillHide {
+                    time,
+                    height: _,
+                    ease,
+                    duration,
+                } => {
+                    self.animate_to_zero(cx, *time, *duration, *ease);
+                }
+                VirtualKeyboardEvent::DidShow { time, height } => {
+                    if *height <= 0.0 {
+                        self.keyboard_height = 0.0;
+                        self.animate_to_shift(
+                            cx,
+                            *time,
+                            0.0,
+                            KEYBOARD_RECONCILE_DURATION,
+                            KEYBOARD_RECONCILE_EASE,
+                        );
+                        self.view.handle_event(cx, event, scope);
+                        return;
                     }
-                    VirtualKeyboardEvent::WillHide {
-                        time,
-                        height: _,
-                        ease,
-                        duration,
-                    } => {
-                        self.anim_state = AnimState::Closing {
-                            height: self.keyboard_shift,
-                            duration: *duration,
-                            start_time: *time,
-                            ease: *ease,
-                        };
-                        self.next_frame = cx.new_next_frame();
-                    }
-                    VirtualKeyboardEvent::DidShow { time: _, height } => {
-                        if let AnimState::Closed = self.anim_state {
-                            self.keyboard_shift = self.compute_max_height(*height, cx);
-                            cx.keyboard_shift = self.keyboard_shift;
-                        }
-                        self.anim_state = AnimState::Open;
-                        self.redraw(cx);
-                    }
-                    VirtualKeyboardEvent::DidHide { time: _ } => {
-                        self.anim_state = AnimState::Closed;
-                        self.keyboard_shift = 0.0;
-                        cx.keyboard_shift = self.keyboard_shift;
-                        self.redraw(cx);
-                    }
+                    // Android reports per-frame IME insets via this settled
+                    // event path. Keep `keyboard_shift` paired with the IME
+                    // area from the last draw; post-draw reconciliation below
+                    // computes the pan after the focused input registers its
+                    // current rect.
+                    self.keyboard_height = *height;
+                    self.anim_state = AnimState::Open;
+                    self.redraw(cx);
+                }
+                VirtualKeyboardEvent::DidHide { time } => {
+                    self.animate_to_zero(
+                        cx,
+                        *time,
+                        KEYBOARD_RECONCILE_DURATION,
+                        KEYBOARD_RECONCILE_EASE,
+                    );
                 }
             }
-            _ => (),
         }
         self.view.handle_event(cx, event, scope);
     }
@@ -190,6 +293,43 @@ impl Widget for KeyboardView {
             self.view.draw_walk(cx, scope, walk)?;
         }
         self.end(cx);
+
+        // Post-children reconciliation. This is the SOLE place the shift
+        // is computed during steady-state. We deliberately do NOT do a
+        // pre-draw reconcile, because at that point the IME area's
+        // `redraw_id` stored from the previous frame no longer matches
+        // the current draw list's `redraw_id` (the redraw we scheduled
+        // last frame just incremented it), so `Area::rect` returns
+        // `Rect::default()` and the formula collapses to 0. A pre-draw
+        // recompute against that stale rect would either skip the update
+        // (if shift was already 0) or worse, *reset* a settled non-zero
+        // shift to 0 each frame, oscillating forever.
+        //
+        // Sequence after `DidShow` arrives without a preceding useful
+        // `WillShow` target (Android, or an iOS frame change where the IME
+        // area was stale):
+        //   Frame N: handler sets state=Open, height=H, schedules redraw.
+        //   Frame N draw: shift is still 0; children draw at natural
+        //     positions; the focused TextInput registers its IME area
+        //     with the *current* redraw_id, which makes `ime_rect` valid
+        //     here at post-draw. We compute the correct target and animate
+        //     toward it instead of snapping.
+        //
+        // Cost: one frame (~16 ms) of unshifted content on first show.
+        // Acceptable, and matches what users tolerate elsewhere.
+        if matches!(self.anim_state, AnimState::Open) && self.keyboard_height > 0.0 {
+            let new_target = self.compute_target_shift(self.keyboard_height, cx);
+            if (new_target - self.keyboard_shift).abs() > KEYBOARD_SHIFT_EPSILON {
+                let time = cx.time();
+                self.animate_to_shift(
+                    cx,
+                    time,
+                    new_target,
+                    KEYBOARD_RECONCILE_DURATION,
+                    KEYBOARD_RECONCILE_EASE,
+                );
+            }
+        }
         DrawStep::done()
     }
 }

--- a/widgets/src/stack_navigation.rs
+++ b/widgets/src/stack_navigation.rs
@@ -275,10 +275,19 @@ impl Widget for StackNavigationView {
             // In full screen mode, position at the offset.
             // Use the larger of the safe area inset or the parent's y position
             // so the view respects both mobile safe areas and desktop title bars.
+            //
+            // KeyboardView pans its contents by moving the parent turtle up. If
+            // we clamp directly against `safe_top`, that upward pan is lost
+            // whenever the parent y becomes negative, so fullscreen stack views
+            // stay pinned while the rest of the app moves. Reconstruct the
+            // natural parent y, choose the normal fullscreen anchor, then apply
+            // the keyboard pan back to that anchor.
             let safe_top = cx.display_context.safe_area_insets.top;
+            let keyboard_shift = cx.keyboard_shift.max(0.0);
+            let parent_y_without_keyboard = parent_rect.pos.y + keyboard_shift;
             Vec2d {
                 x: self.offset,
-                y: safe_top.max(parent_rect.pos.y),
+                y: safe_top.max(parent_y_without_keyboard) - keyboard_shift,
             }
         } else {
             // Non-fullscreen: ignore offset, position at parent.


### PR DESCRIPTION
This normalizes the IME geometry calcs across iOS and Android. The main difference is to make KeyboardView shift the content based on the focused TExtInput instance instead of trying to shrink the viewport.

Also make sure that StackNavigation widget properly handles the keyboard shift, even when it is drawing in full-screen mode.