### PR TITLE
Support overriding the dpi factor at runtime, on all platforms

### DIFF
--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -11,7 +11,7 @@ use {
         draw_matrix::CxDrawMatrixPool,
         draw_pass::CxDrawPassPool,
         draw_shader::CxDrawShaders,
-        event::{CxDragDrop, CxFingers, CxKeyboard, DrawEvent, Event, NextFrame, Trigger},
+        event::{CxDragDrop, CxFingers, CxKeyboard, DrawEvent, Event, NextFrame, Trigger, WindowGeomChangeEvent},
         geometry::CxGeometryPool,
         gpu_info::GpuInfo,
         os::CxOs,
@@ -144,6 +144,15 @@ pub struct Cx {
     /// so prefer `pending_script_reapply` whenever the change can be modeled
     /// as a shared-heap-object mutation instead.
     pub pending_live_edit_request: bool,
+
+    /// `WindowGeomChange` events queued by code that runs *during* an event
+    /// dispatch (e.g. `set_window_dpi_override` invoked from a settings
+    /// widget reacting to a dropdown). Synthesizing the event inline would
+    /// re-enter `call_event_handler` and panic on the `event_handler.take()`,
+    /// so the dispatcher drains this vec after each top-level dispatch via
+    /// `handle_pending_window_geom_changes` — listeners then see the event
+    /// normally on the same event-loop iteration.
+    pub(crate) pending_window_geom_changes: Vec<WindowGeomChangeEvent>,
 
     pub debug: Debug,
 
@@ -456,6 +465,7 @@ impl Cx {
             display_context: Default::default(),
             pending_script_reapply: false,
             pending_live_edit_request: false,
+            pending_window_geom_changes: Vec::new(),
 
             widget_tree_dump_requests: Default::default(),
             widget_snapshot_requests: Default::default(),

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -517,6 +517,75 @@ impl Cx {
         self.pending_live_edit_request = true;
     }
 
+    /// Remap an absolute coordinate from the OS-reported logical-point space
+    /// into the layout's logical-point space when a `dpi_override` is active
+    /// on the given window. No-op if no override is set or `os_dpi_factor`
+    /// hasn't been recorded yet.
+    ///
+    /// Platform-specific event handlers call this on every `abs` field of
+    /// pointer/touch/scroll events so input still hits the right widget when
+    /// zoom is active. Android/OpenHarmony don't need it because they divide
+    /// raw pixels by the override-aware `dpi_factor` at the source — so this
+    /// helper is dead code on those builds, hence the `allow(dead_code)`.
+    #[allow(dead_code)]
+    pub(crate) fn dpi_override_scale(&self, pos: &mut Vec2d, window_id: WindowId) {
+        *pos = self.windows[window_id].remap_dpi_override(*pos);
+    }
+
+    /// Set or clear a window's `dpi_override` at runtime, rewrite its
+    /// `window_geom` accordingly, and queue a synthetic `WindowGeomChange`
+    /// event so every listener (`AdaptiveView`, `display_context`, custom
+    /// widgets) reacts the same way it would to an OS-driven change.
+    ///
+    /// `dpi_override = Some(f)` makes the entire UI render as if the OS had
+    /// reported `f` as its scale factor: `inner_size` is recomputed inversely
+    /// so the same physical screen ends up with fewer logical points (UI
+    /// appears bigger) or more logical points (UI appears smaller). Pass
+    /// `None` to revert to the OS-reported scale factor.
+    ///
+    /// **Re-entrancy:** safe to call from inside an event handler. The
+    /// synthetic event isn't dispatched directly (that would panic on the
+    /// `event_handler.take()` in `cx_shared.rs`); it's queued onto
+    /// `pending_window_geom_changes` and drained by `call_event_handler`
+    /// after the active handler has fully returned, in the same cycle as
+    /// `handle_actions` / `handle_triggers`.
+    ///
+    /// The platform-side `WindowGeomChange` handlers also apply `dpi_override`
+    /// when the OS itself emits a geom change (e.g. orientation, resize, move
+    /// across monitors), so this helper is only needed when the override
+    /// itself changes — typically driven by a user-facing zoom/scale setting.
+    pub fn set_window_dpi_override(
+        &mut self,
+        window_id: WindowId,
+        dpi_override: Option<f64>,
+    ) {
+        let window = &mut self.windows[window_id];
+        let current_dpi = window.window_geom.dpi_factor;
+        let target_dpi = dpi_override
+            .or(window.os_dpi_factor)
+            .unwrap_or(current_dpi);
+        if target_dpi <= 0.0 || (target_dpi - current_dpi).abs() < f64::EPSILON {
+            // Even if the effective scale didn't change, store the override
+            // value itself so future OS-driven geom changes reapply it.
+            window.dpi_override = dpi_override;
+            return;
+        }
+        let scale = current_dpi / target_dpi;
+        let old_geom = window.window_geom.clone();
+        window.dpi_override = dpi_override;
+        window.window_geom.inner_size *= scale;
+        window.window_geom.dpi_factor = target_dpi;
+        let new_geom = window.window_geom.clone();
+
+        self.pending_window_geom_changes
+            .push(crate::event::WindowGeomChangeEvent {
+                window_id,
+                old_geom,
+                new_geom,
+            });
+        self.redraw_all();
+    }
+
     pub fn update_safe_inset_script_values(&mut self, insets: crate::event::SafeAreaInsets) {
         use makepad_script::trap::NoTrap;
         let Some(vm) = self.script_vm.as_mut() else {

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -617,10 +617,20 @@ impl Cx {
             IosEvent::WindowLostFocus(window_id) => {
                 self.call_event_handler(&Event::WindowLostFocus(window_id));
             }
-            IosEvent::WindowGeomChange(re) => {
+            IosEvent::WindowGeomChange(mut re) => {
                 let window_id = CxWindowPool::id_zero();
-                let window = &mut self.windows[window_id];
-                window.window_geom = re.new_geom.clone();
+                // Stash the OS-reported scale factor so dpi_override coordinate
+                // remapping (input events) can recover it later.
+                self.windows[window_id].os_dpi_factor = Some(re.new_geom.dpi_factor);
+                // If a dpi_override is set, rewrite the geom to use it. The
+                // logical inner_size scales inversely with the new factor so
+                // the same physical screen ends up with fewer (override > os)
+                // or more (override < os) logical points.
+                if let Some(dpi_override) = self.windows[window_id].dpi_override {
+                    re.new_geom.inner_size *= re.new_geom.dpi_factor / dpi_override;
+                    re.new_geom.dpi_factor = dpi_override;
+                }
+                self.windows[window_id].window_geom = re.new_geom.clone();
                 self.call_event_handler(&Event::WindowGeomChange(re));
                 self.redraw_all();
             }
@@ -766,7 +776,14 @@ impl Cx {
                 // ok here we send out to all our childprocesses
                 self.handle_repaint(metal_cx);
             }
-            IosEvent::TouchUpdate(e) => {
+            IosEvent::TouchUpdate(mut e) => {
+                // Touch coords arrive in the OS-reported logical-point space.
+                // If a dpi_override is active the rendered layout uses a
+                // different scale, so remap each touch back into that space.
+                let window_id = e.window_id;
+                for touch in e.touches.iter_mut() {
+                    self.dpi_override_scale(&mut touch.abs, window_id);
+                }
                 // Check for outside-click popup dismiss on touch start
                 if e.touches
                     .iter()
@@ -826,10 +843,12 @@ impl Cx {
 
                 self.fingers.process_touch_update_end(&e.touches);
             }
-            IosEvent::LongPress(e) => {
+            IosEvent::LongPress(mut e) => {
+                self.dpi_override_scale(&mut e.abs, e.window_id);
                 self.call_event_handler(&Event::LongPress(e.into()));
             }
-            IosEvent::MouseDown(e) => {
+            IosEvent::MouseDown(mut e) => {
+                self.dpi_override_scale(&mut e.abs, e.window_id);
                 // Check for outside-click popup dismiss
                 if let Some(popup_window_id) = self.find_popup_to_dismiss_on_mouse(e.abs) {
                     self.dismiss_popup_window(
@@ -841,18 +860,23 @@ impl Cx {
                 self.fingers.mouse_down(e.button, e.window_id);
                 self.call_event_handler(&Event::MouseDown(e.into()))
             }
-            IosEvent::MouseMove(e) => {
+            IosEvent::MouseMove(mut e) => {
+                self.dpi_override_scale(&mut e.abs, e.window_id);
                 self.call_event_handler(&Event::MouseMove(e.into()));
                 self.fingers.cycle_hover_area(live_id!(mouse).into());
                 self.fingers.switch_captures();
             }
-            IosEvent::MouseUp(e) => {
+            IosEvent::MouseUp(mut e) => {
+                self.dpi_override_scale(&mut e.abs, e.window_id);
                 let button = e.button;
                 self.call_event_handler(&Event::MouseUp(e.into()));
                 self.fingers.mouse_up(button);
                 self.fingers.cycle_hover_area(live_id!(mouse).into());
             }
-            IosEvent::Scroll(e) => self.call_event_handler(&Event::Scroll(e.into())),
+            IosEvent::Scroll(mut e) => {
+                self.dpi_override_scale(&mut e.abs, e.window_id);
+                self.call_event_handler(&Event::Scroll(e.into()))
+            }
             IosEvent::TextInput(e) => self.call_event_handler(&Event::TextInput(e)),
             IosEvent::TextRangeReplace(e) => self.call_event_handler(&Event::TextRangeReplace(e)),
             IosEvent::SelectionHandleDrag(e) => {

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -883,10 +883,6 @@ impl Cx {
         }
     }
 
-    fn dpi_override_scale(&self, pos: &mut Vec2d, window_id: WindowId) {
-        *pos = self.windows[window_id].remap_dpi_override(*pos)
-    }
-
     fn handle_platform_ops(
         &mut self,
         metal_windows: &mut Vec<MetalWindow>,

--- a/platform/src/os/cx_shared.rs
+++ b/platform/src/os/cx_shared.rs
@@ -766,11 +766,38 @@ impl Cx {
         }
     }
 
+    /// Dispatch any `WindowGeomChange` events queued by code that ran during
+    /// the current event dispatch (typically `Cx::set_window_dpi_override`
+    /// called from a widget handler). Drained the same way as `handle_actions`
+    /// — swap, dispatch each, repeat until quiescent. Each dispatch is a
+    /// fresh `inner_call_event_handler` call after the previous one's handler
+    /// has been put back, so the `event_handler.take()` is safe.
+    pub fn handle_pending_window_geom_changes(&mut self) {
+        let mut counter = 0;
+        while !self.pending_window_geom_changes.is_empty() {
+            counter += 1;
+            let mut events = Vec::new();
+            std::mem::swap(&mut self.pending_window_geom_changes, &mut events);
+            for event in events {
+                self.inner_call_event_handler(&Event::WindowGeomChange(event));
+                self.inner_key_focus_change();
+            }
+            if counter > 100 {
+                crate::error!("WindowGeomChange feedback loop detected");
+                break;
+            }
+        }
+    }
+
     pub(crate) fn call_event_handler(&mut self, event: &Event) {
         if let Event::PermissionResult(result) = event {
             self.handle_camera_permission_result(result);
         }
         self.inner_call_event_handler(event);
+        // Dispatch any synthetic geom changes queued during the original
+        // handler (e.g. runtime dpi_override updates) before triggers and
+        // actions, so layout-dependent reactions see the new geometry.
+        self.handle_pending_window_geom_changes();
         self.inner_key_focus_change();
         self.handle_triggers();
         self.handle_actions();
@@ -778,6 +805,7 @@ impl Cx {
         // widget->script calls run immediately instead of waiting for tick/timer paths.
         self.handle_script_tasks();
         // Script callbacks can enqueue actions/triggers; flush them in the same cycle.
+        self.handle_pending_window_geom_changes();
         self.inner_key_focus_change();
         self.handle_triggers();
         self.handle_actions();

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -678,6 +678,13 @@ impl Cx {
                 self.os.display_size = dvec2(width as f64, height as f64);
                 let window_id = CxWindowPool::id_zero();
                 let window = &mut self.windows[window_id];
+                // Stash the OS-reported scale factor so a later
+                // `set_window_dpi_override(None)` can recover the native scale,
+                // and so `remap_dpi_override` (used by `dpi_override_scale`
+                // on platforms whose touch coords aren't already in
+                // override-points) has a baseline. Android itself converts
+                // touch coords at the source, so the helper is a no-op here.
+                window.os_dpi_factor = Some(self.os.dpi_factor);
                 let old_geom = window.window_geom.clone();
 
                 let dpi_factor = window.dpi_override.unwrap_or(self.os.dpi_factor);
@@ -2224,6 +2231,7 @@ impl Cx {
             match op {
                 CxOsOp::CreateWindow(window_id) => {
                     let window = &mut self.windows[window_id];
+                    window.os_dpi_factor = Some(self.os.dpi_factor);
                     let dpi_factor = window.dpi_override.unwrap_or(self.os.dpi_factor);
                     let size = self.os.display_size / dpi_factor;
                     window.window_geom = WindowGeom {
@@ -2260,6 +2268,7 @@ impl Cx {
                         .dpi_override
                         .unwrap_or(self.os.dpi_factor);
                     let window = &mut self.windows[window_id];
+                    window.os_dpi_factor = Some(self.os.dpi_factor);
                     window.window_geom = WindowGeom {
                         dpi_factor,
                         can_fullscreen: false,

--- a/platform/src/os/linux/direct/linux_direct.rs
+++ b/platform/src/os/linux/direct/linux_direct.rs
@@ -137,23 +137,29 @@ impl Cx {
                 self.handle_repaint(direct_app);
                 //profile_end("paint openGL", p);
             }
-            DirectEvent::MouseDown(e) => {
+            DirectEvent::MouseDown(mut e) => {
+                self.dpi_override_scale(&mut e.abs, e.window_id);
                 self.fingers.process_tap_count(e.abs, e.time);
                 self.fingers.mouse_down(e.button, CxWindowPool::id_zero());
                 self.call_event_handler(&Event::MouseDown(e.into()))
             }
-            DirectEvent::MouseMove(e) => {
+            DirectEvent::MouseMove(mut e) => {
+                self.dpi_override_scale(&mut e.abs, e.window_id);
                 self.call_event_handler(&Event::MouseMove(e.into()));
                 self.fingers.cycle_hover_area(live_id!(mouse).into());
                 self.fingers.switch_captures();
             }
-            DirectEvent::MouseUp(e) => {
+            DirectEvent::MouseUp(mut e) => {
+                self.dpi_override_scale(&mut e.abs, e.window_id);
                 let button = e.button;
                 self.call_event_handler(&Event::MouseUp(e.into()));
                 self.fingers.mouse_up(button);
                 self.fingers.cycle_hover_area(live_id!(mouse).into());
             }
-            DirectEvent::Scroll(e) => self.call_event_handler(&Event::Scroll(e.into())),
+            DirectEvent::Scroll(mut e) => {
+                self.dpi_override_scale(&mut e.abs, e.window_id);
+                self.call_event_handler(&Event::Scroll(e.into()))
+            }
             DirectEvent::KeyDown(e) => {
                 self.keyboard.process_key_down(e.clone());
                 self.call_event_handler(&Event::KeyDown(e))
@@ -273,12 +279,18 @@ impl Cx {
             match op {
                 CxOsOp::CreateWindow(window_id) => {
                     let window = &mut self.windows[window_id];
+                    window.os_dpi_factor = Some(direct_app.dpi_factor);
+                    // Honor a preset `dpi_override` (e.g. set in the DSL on
+                    // the Window block) by using it as the effective scale.
+                    // `Cx::set_window_dpi_override` at runtime hits the same
+                    // field and re-emits the geom directly.
+                    let dpi_factor = window.dpi_override.unwrap_or(direct_app.dpi_factor);
                     let size = dvec2(
-                        direct_app.drm.width as f64 / direct_app.dpi_factor,
-                        direct_app.drm.height as f64 / direct_app.dpi_factor,
+                        direct_app.drm.width as f64 / dpi_factor,
+                        direct_app.drm.height as f64 / dpi_factor,
                     );
                     window.window_geom = WindowGeom {
-                        dpi_factor: direct_app.dpi_factor,
+                        dpi_factor,
                         can_fullscreen: false,
                         xr_is_presenting: false,
                         is_fullscreen: true,
@@ -298,8 +310,10 @@ impl Cx {
                     grab_keyboard,
                 } => {
                     let window = &mut self.windows[window_id];
+                    window.os_dpi_factor = Some(direct_app.dpi_factor);
+                    let dpi_factor = window.dpi_override.unwrap_or(direct_app.dpi_factor);
                     window.window_geom = WindowGeom {
-                        dpi_factor: direct_app.dpi_factor,
+                        dpi_factor,
                         can_fullscreen: false,
                         xr_is_presenting: false,
                         is_fullscreen: false,

--- a/platform/src/os/linux/open_harmony/open_harmony.rs
+++ b/platform/src/os/linux/open_harmony/open_harmony.rs
@@ -173,6 +173,12 @@ impl Cx {
                 self.os.display_size = dvec2(width as f64, height as f64);
                 let window_id = CxWindowPool::id_zero();
                 let window = &mut self.windows[window_id];
+                // Stash the OS-reported scale factor so a later
+                // `set_window_dpi_override(None)` can recover the native scale.
+                // OpenHarmony converts touch coords at the source so the
+                // helper-based remap is unnecessary, but this field is also
+                // consulted by `Cx::set_window_dpi_override`.
+                window.os_dpi_factor = Some(self.os.dpi_factor);
                 let old_geom = window.window_geom.clone();
 
                 let dpi_factor = window.dpi_override.unwrap_or(self.os.dpi_factor);
@@ -516,6 +522,7 @@ impl Cx {
             match op {
                 CxOsOp::CreateWindow(window_id) => {
                     let window = &mut self.windows[window_id];
+                    window.os_dpi_factor = Some(self.os.dpi_factor);
                     let size = dvec2(
                         self.os.display_size.x / self.os.dpi_factor,
                         self.os.display_size.y / self.os.dpi_factor,

--- a/platform/src/os/linux/wayland/linux_wayland.rs
+++ b/platform/src/os/linux/wayland/linux_wayland.rs
@@ -204,6 +204,10 @@ impl WaylandCx {
                     .iter_mut()
                     .find(|w| w.window_id == re.window_id)
                 {
+                    // Stash the OS-reported scale factor so dpi_override
+                    // input-coord remapping and `set_window_dpi_override(None)`
+                    // reverts can recover the native scale.
+                    cx.windows[re.window_id].os_dpi_factor = Some(re.new_geom.dpi_factor);
                     if let Some(dpi_override) = cx.windows[re.window_id].dpi_override {
                         re.new_geom.inner_size *= re.new_geom.dpi_factor / dpi_override;
                         re.new_geom.dpi_factor = dpi_override;
@@ -225,6 +229,11 @@ impl WaylandCx {
                     .iter_mut()
                     .find(|w| w.window_id == re.window_id)
                 {
+                    cx.windows[re.window_id].os_dpi_factor = Some(re.new_geom.dpi_factor);
+                    if let Some(dpi_override) = cx.windows[re.window_id].dpi_override {
+                        re.new_geom.inner_size *= re.new_geom.dpi_factor / dpi_override;
+                        re.new_geom.dpi_factor = dpi_override;
+                    }
                     window.window_geom = re.new_geom.clone();
                     cx.windows[re.window_id].window_geom = re.new_geom.clone();
                     if re.old_geom.inner_size != re.new_geom.inner_size
@@ -285,31 +294,36 @@ impl WaylandCx {
 
                 self.handle_repaint(state);
             }
-            XlibEvent::MouseMove(e) => {
+            XlibEvent::MouseMove(mut e) => {
                 let mut cx = self.cx.borrow_mut();
+                cx.dpi_override_scale(&mut e.abs, e.window_id);
                 cx.call_event_handler(&Event::MouseMove(e.into()));
                 cx.fingers.cycle_hover_area(live_id!(mouse).into());
                 cx.fingers.switch_captures();
             }
-            XlibEvent::MouseDown(e) => {
+            XlibEvent::MouseDown(mut e) => {
                 let mut cx = self.cx.borrow_mut();
+                cx.dpi_override_scale(&mut e.abs, e.window_id);
                 cx.fingers.process_tap_count(e.abs, e.time);
                 cx.fingers.mouse_down(e.button, e.window_id);
                 cx.call_event_handler(&Event::MouseDown(e.into()))
             }
-            XlibEvent::MouseUp(e) => {
+            XlibEvent::MouseUp(mut e) => {
                 let mut cx = self.cx.borrow_mut();
+                cx.dpi_override_scale(&mut e.abs, e.window_id);
                 let button = e.button;
                 cx.call_event_handler(&Event::MouseUp(e.into()));
                 cx.fingers.mouse_up(button);
                 cx.fingers.cycle_hover_area(live_id!(mouse).into());
             }
-            XlibEvent::Scroll(e) => {
+            XlibEvent::Scroll(mut e) => {
                 let mut cx = self.cx.borrow_mut();
+                cx.dpi_override_scale(&mut e.abs, e.window_id);
                 cx.call_event_handler(&Event::Scroll(e.into()))
             }
-            XlibEvent::WindowDragQuery(e) => {
+            XlibEvent::WindowDragQuery(mut e) => {
                 let mut cx = self.cx.borrow_mut();
+                cx.dpi_override_scale(&mut e.abs, e.window_id);
                 cx.call_event_handler(&Event::WindowDragQuery(e))
             }
             XlibEvent::WindowCloseRequested(e) => {

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -134,6 +134,10 @@ impl X11Cx {
                     .iter_mut()
                     .find(|w| w.window_id == re.window_id)
                 {
+                    // Stash the OS-reported scale factor so dpi_override
+                    // input-coord remapping and `set_window_dpi_override(None)`
+                    // reverts can recover the native scale.
+                    cx.windows[re.window_id].os_dpi_factor = Some(re.new_geom.dpi_factor);
                     if let Some(dpi_override) = cx.windows[re.window_id].dpi_override {
                         re.new_geom.inner_size *= re.new_geom.dpi_factor / dpi_override;
                         re.new_geom.dpi_factor = dpi_override;
@@ -194,14 +198,16 @@ impl X11Cx {
 
                 self.handle_repaint(opengl_windows);
             }
-            XlibEvent::MouseDown(e) => {
+            XlibEvent::MouseDown(mut e) => {
                 let mut cx = self.cx.borrow_mut();
+                cx.dpi_override_scale(&mut e.abs, e.window_id);
                 cx.fingers.process_tap_count(e.abs, e.time);
                 cx.fingers.mouse_down(e.button, e.window_id);
                 cx.call_event_handler(&Event::MouseDown(e.into()))
             }
-            XlibEvent::MouseMove(e) => {
+            XlibEvent::MouseMove(mut e) => {
                 let mut cx = self.cx.borrow_mut();
+                cx.dpi_override_scale(&mut e.abs, e.window_id);
                 let abs = e.abs;
                 let modifiers = e.modifiers;
                 cx.call_event_handler(&Event::MouseMove(e.into()));
@@ -218,8 +224,9 @@ impl X11Cx {
                 cx.fingers.cycle_hover_area(live_id!(mouse).into());
                 cx.fingers.switch_captures();
             }
-            XlibEvent::MouseUp(e) => {
+            XlibEvent::MouseUp(mut e) => {
                 let mut cx = self.cx.borrow_mut();
+                cx.dpi_override_scale(&mut e.abs, e.window_id);
                 let button = e.button;
                 let abs = e.abs;
                 let modifiers = e.modifiers;
@@ -240,12 +247,14 @@ impl X11Cx {
                     }
                 }
             }
-            XlibEvent::Scroll(e) => {
+            XlibEvent::Scroll(mut e) => {
                 let mut cx = self.cx.borrow_mut();
+                cx.dpi_override_scale(&mut e.abs, e.window_id);
                 cx.call_event_handler(&Event::Scroll(e.into()))
             }
-            XlibEvent::WindowDragQuery(e) => {
+            XlibEvent::WindowDragQuery(mut e) => {
                 let mut cx = self.cx.borrow_mut();
+                cx.dpi_override_scale(&mut e.abs, e.window_id);
                 cx.call_event_handler(&Event::WindowDragQuery(e))
             }
             XlibEvent::WindowCloseRequested(e) => {

--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -100,7 +100,17 @@ impl Cx {
                     );
                     self.os_type = tw.browser_info.into();
                     self.xr_capabilities = tw.xr_capabilities.into();
-                    self.os.window_geom = tw.window_info.into();
+                    let mut new_geom: WindowGeom = tw.window_info.into();
+                    let id_zero = CxWindowPool::id_zero();
+                    // Stash the OS-reported scale factor so dpi_override
+                    // input-coord remapping and `set_window_dpi_override(None)`
+                    // reverts can recover the native scale.
+                    self.windows[id_zero].os_dpi_factor = Some(new_geom.dpi_factor);
+                    if let Some(dpi_override) = self.windows[id_zero].dpi_override {
+                        new_geom.inner_size *= new_geom.dpi_factor / dpi_override;
+                        new_geom.dpi_factor = dpi_override;
+                    }
+                    self.os.window_geom = new_geom;
                     //self.default_inner_window_size = self.os.window_geom.inner_size;
 
                     self.call_event_handler(&Event::Startup);
@@ -111,10 +121,15 @@ impl Cx {
                 live_id!(ToWasmResizeWindow) => {
                     let tw = ToWasmResizeWindow::read_to_wasm(&mut to_wasm);
                     let old_geom = self.os.window_geom.clone();
-                    let new_geom = tw.window_info.into();
+                    let mut new_geom: WindowGeom = tw.window_info.into();
+                    let id_zero = CxWindowPool::id_zero();
+                    self.windows[id_zero].os_dpi_factor = Some(new_geom.dpi_factor);
+                    if let Some(dpi_override) = self.windows[id_zero].dpi_override {
+                        new_geom.inner_size *= new_geom.dpi_factor / dpi_override;
+                        new_geom.dpi_factor = dpi_override;
+                    }
                     if old_geom != new_geom {
                         self.os.window_geom = new_geom.clone();
-                        let id_zero = CxWindowPool::id_zero();
                         self.windows[id_zero].window_geom = new_geom.clone();
                         self.call_event_handler(&Event::WindowGeomChange(WindowGeomChangeEvent {
                             window_id: id_zero,
@@ -134,7 +149,11 @@ impl Cx {
                 }
 
                 live_id!(ToWasmTouchUpdate) => {
-                    let e: TouchUpdateEvent = ToWasmTouchUpdate::read_to_wasm(&mut to_wasm).into();
+                    let mut e: TouchUpdateEvent = ToWasmTouchUpdate::read_to_wasm(&mut to_wasm).into();
+                    let window_id = e.window_id;
+                    for touch in e.touches.iter_mut() {
+                        self.dpi_override_scale(&mut touch.abs, window_id);
+                    }
                     self.fingers.process_touch_update_start(e.time, &e.touches);
                     let e = Event::TouchUpdate(e);
                     self.call_event_handler(&e);
@@ -147,21 +166,24 @@ impl Cx {
                 }
 
                 live_id!(ToWasmMouseDown) => {
-                    let e: MouseDownEvent = ToWasmMouseDown::read_to_wasm(&mut to_wasm).into();
+                    let mut e: MouseDownEvent = ToWasmMouseDown::read_to_wasm(&mut to_wasm).into();
+                    self.dpi_override_scale(&mut e.abs, e.window_id);
                     self.fingers.process_tap_count(e.abs, e.time);
                     self.fingers.mouse_down(e.button, e.window_id);
                     self.call_event_handler(&Event::MouseDown(e))
                 }
 
                 live_id!(ToWasmMouseMove) => {
-                    let e: MouseMoveEvent = ToWasmMouseMove::read_to_wasm(&mut to_wasm).into();
+                    let mut e: MouseMoveEvent = ToWasmMouseMove::read_to_wasm(&mut to_wasm).into();
+                    self.dpi_override_scale(&mut e.abs, e.window_id);
                     self.call_event_handler(&Event::MouseMove(e.into()));
                     self.fingers.cycle_hover_area(live_id!(mouse).into());
                     self.fingers.switch_captures();
                 }
 
                 live_id!(ToWasmMouseUp) => {
-                    let e: MouseUpEvent = ToWasmMouseUp::read_to_wasm(&mut to_wasm).into();
+                    let mut e: MouseUpEvent = ToWasmMouseUp::read_to_wasm(&mut to_wasm).into();
+                    self.dpi_override_scale(&mut e.abs, e.window_id);
                     let button = e.button;
                     self.call_event_handler(&Event::MouseUp(e.into()));
                     self.fingers.mouse_up(button);
@@ -169,7 +191,8 @@ impl Cx {
                 }
 
                 live_id!(ToWasmScroll) => {
-                    let e: ScrollEvent = ToWasmScroll::read_to_wasm(&mut to_wasm).into();
+                    let mut e: ScrollEvent = ToWasmScroll::read_to_wasm(&mut to_wasm).into();
+                    self.dpi_override_scale(&mut e.abs, e.window_id);
                     self.call_event_handler(&Event::Scroll(e.into()));
                 }
 
@@ -562,8 +585,14 @@ impl Cx {
 
                     self.os.from_wasm(FromWasmSetDocumentTitle { title });
 
+                    // Inherit the OS-reported scale factor recorded by
+                    // ToWasmGetInfo / ToWasmResizeWindow on id_zero so the
+                    // freshly-created window's `dpi_override` machinery has
+                    // a baseline.
+                    let id_zero_os_dpi = self.windows[CxWindowPool::id_zero()].os_dpi_factor;
                     {
                         let window = &mut self.windows[window_id];
+                        window.os_dpi_factor = id_zero_os_dpi;
                         window.window_geom = self.os.window_geom.clone();
                     }
 
@@ -583,11 +612,13 @@ impl Cx {
                     size,
                     grab_keyboard,
                 } => {
+                    let parent_os_dpi = self.windows[parent_window_id].os_dpi_factor;
                     let mut geom = self.os.window_geom.clone();
                     geom.position = position;
                     geom.inner_size = size;
                     geom.outer_size = size;
                     let window = &mut self.windows[window_id];
+                    window.os_dpi_factor = parent_os_dpi;
                     window.window_geom = geom;
                     window.is_popup = true;
                     window.popup_parent = Some(parent_window_id);

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -126,6 +126,11 @@ impl Cx {
                     .iter_mut()
                     .find(|w| w.window_id == re.window_id)
                 {
+                    // Stash the OS-reported scale factor so dpi_override
+                    // input-coord remapping (mouse/scroll/drag-query) and
+                    // `Cx::set_window_dpi_override(None)` reverts can recover
+                    // the native scale.
+                    self.windows[re.window_id].os_dpi_factor = Some(re.new_geom.dpi_factor);
                     if let Some(dpi_override) = self.windows[re.window_id].dpi_override {
                         re.new_geom.inner_size *= re.new_geom.dpi_factor / dpi_override;
                         re.new_geom.dpi_factor = dpi_override;
@@ -261,29 +266,39 @@ impl Cx {
 
                 self.handle_repaint(d3d11_windows, d3d11_cx);
             }
-            Win32Event::MouseDown(e) => {
+            Win32Event::MouseDown(mut e) => {
+                self.dpi_override_scale(&mut e.abs, e.window_id);
                 self.fingers.process_tap_count(e.abs, e.time);
                 self.fingers.mouse_down(e.button, e.window_id);
                 self.call_event_handler(&Event::MouseDown(e.into()))
             }
-            Win32Event::MouseMove(e) => {
+            Win32Event::MouseMove(mut e) => {
+                self.dpi_override_scale(&mut e.abs, e.window_id);
                 self.call_event_handler(&Event::MouseMove(e.into()));
                 self.fingers.cycle_hover_area(live_id!(mouse).into());
                 self.fingers.switch_captures();
             }
-            Win32Event::MouseUp(e) => {
+            Win32Event::MouseUp(mut e) => {
+                self.dpi_override_scale(&mut e.abs, e.window_id);
                 let button = e.button;
                 self.call_event_handler(&Event::MouseUp(e.into()));
                 self.fingers.mouse_up(button);
                 self.fingers.cycle_hover_area(live_id!(mouse).into());
             }
-            Win32Event::MouseLeave(e) => {
+            Win32Event::MouseLeave(mut e) => {
+                self.dpi_override_scale(&mut e.abs, e.window_id);
                 self.call_event_handler(&Event::MouseLeave(e.into()));
                 self.fingers.cycle_hover_area(live_id!(mouse).into());
                 self.fingers.switch_captures();
             }
-            Win32Event::Scroll(e) => self.call_event_handler(&Event::Scroll(e.into())),
-            Win32Event::WindowDragQuery(e) => self.call_event_handler(&Event::WindowDragQuery(e)),
+            Win32Event::Scroll(mut e) => {
+                self.dpi_override_scale(&mut e.abs, e.window_id);
+                self.call_event_handler(&Event::Scroll(e.into()))
+            }
+            Win32Event::WindowDragQuery(mut e) => {
+                self.dpi_override_scale(&mut e.abs, e.window_id);
+                self.call_event_handler(&Event::WindowDragQuery(e))
+            }
             Win32Event::WindowCloseRequested(e) => {
                 self.call_event_handler(&Event::WindowCloseRequested(e))
             }


### PR DESCRIPTION
Add `Cx::set_window_dpi_override` for runtime UI zoom, but dispatch it in a deferred manner so it's safe to call in an event handler.

For each platform, we connect the dpi override to the click/tap coordinates to remap it properly, which was done on some platforms but not most.