### PR TITLE
Overhaul android tooling and platform layers to support Android 8

### DIFF
--- a/libs/toml_parser/src/toml.rs
+++ b/libs/toml_parser/src/toml.rs
@@ -47,6 +47,10 @@ pub enum Toml {
     Num(f64, TomlSpan),
     Date(String, TomlSpan),
     Array(Vec<Toml>),
+    /// An inline table `{ k = v, ... }` encountered in a value position (e.g.
+    /// an array element). Top-level inline tables in `key = { ... }` form are
+    /// instead flattened into dotted keys by `parse_key_value`.
+    Table(HashMap<String, Toml>),
 }
 
 impl Toml {
@@ -87,37 +91,12 @@ pub fn parse_toml(data: &str) -> Result<HashMap<String, Toml>, TomlErr> {
                 return Ok(out);
             }
             TomlTok::BlockOpen => {
-                // its a scope
-                // we should expect an ident or a string
-                let tok = t.next_tok(i)?;
-                let (tok, double_block) = if let TomlTok::BlockOpen = tok.tok {
-                    (t.next_tok(i)?, true)
-                } else {
-                    (tok, false)
-                };
-
-                match tok.tok {
-                    TomlTok::Str(key) => {
-                        // a key
-                        local_scope = key;
-                    }
-                    TomlTok::Ident(key) => {
-                        // also a key
-                        local_scope = key;
-                    }
-                    _ => return Err(t.err_token(tok)),
-                }
-                let tok = t.next_tok(i)?;
-
-                if tok.tok != TomlTok::BlockClose {
-                    return Err(t.err_token(tok));
-                }
-                if double_block {
-                    let tok = t.next_tok(i)?;
-                    if tok.tok != TomlTok::BlockClose {
-                        return Err(t.err_token(tok));
-                    }
-                }
+                // A `[table]` or `[[array-of-tables]]` header. `next_tok`
+                // consumed the first `[`; `read_table_header` handles an
+                // optional second `[`, the dotted key path (each segment a
+                // bare key or a quoted string, e.g. `patch."https://..."` or
+                // `target.'cfg(...)'`), and the closing `]` / `]]`.
+                local_scope = t.read_table_header(i)?;
             }
             TomlTok::Str(key) => {
                 // a key
@@ -150,6 +129,29 @@ impl TomlParser {
                     }
                 }
                 Ok(Toml::Array(vals))
+            }
+            TomlTok::ObjectOpen => {
+                // An inline table `{ key = val, ... }` in value position —
+                // e.g. an array element like `resources = [{ src = "..." }]`.
+                let mut map = HashMap::new();
+                loop {
+                    let tok = self.next_tok(i)?;
+                    match tok.tok {
+                        TomlTok::ObjectClose | TomlTok::Eof => break,
+                        TomlTok::Comma => {}
+                        TomlTok::Str(key) | TomlTok::Ident(key) => {
+                            let eq = self.next_tok(i)?;
+                            if eq.tok != TomlTok::Equals {
+                                return Err(self.err_token(eq));
+                            }
+                            let val_tok = self.next_tok(i)?;
+                            let val = self.to_val(val_tok, i)?;
+                            map.insert(key, val);
+                        }
+                        _ => return Err(self.err_token(tok)),
+                    }
+                }
+                Ok(Toml::Table(map))
             }
             TomlTok::Str(v) => Ok(Toml::Str(v, tok.span)),
             TomlTok::U64(v) => Ok(Toml::Num(v as f64, tok.span)),
@@ -496,19 +498,38 @@ impl TomlParser {
             }
 
             '"' => {
-                let mut val = String::new();
                 self.next(i);
-                while self.cur != '"' {
-                    if self.cur == '\\' {
+                // Distinguish `"..."` (basic) from `"""..."""` (multi-line basic),
+                // and the empty string `""`.
+                let multiline = if self.cur == '"' {
+                    self.next(i);
+                    if self.cur == '"' {
+                        self.next(i);
+                        true
+                    } else {
+                        // `""` — an empty single-line basic string.
+                        return Ok(TomlTokWithSpan {
+                            tok: TomlTok::Str(String::new()),
+                            span: TomlSpan {
+                                start,
+                                len: self.pos - start,
+                            },
+                        });
+                    }
+                } else {
+                    false
+                };
+                if multiline {
+                    // A newline immediately following the opening `"""` is
+                    // trimmed (TOML spec).
+                    if self.cur == '\r' {
                         self.next(i);
                     }
-                    if self.cur == '\0' {
-                        return Err(self.err_parse("string"));
+                    if self.cur == '\n' {
+                        self.next(i);
                     }
-                    val.push(self.cur);
-                    self.next(i);
                 }
-                self.next(i);
+                let val = self.read_basic_string(i, multiline)?;
                 Ok(TomlTokWithSpan {
                     tok: TomlTok::Str(val),
                     span: TomlSpan {
@@ -518,19 +539,36 @@ impl TomlParser {
                 })
             }
             '\'' => {
-                let mut val = String::new();
                 self.next(i);
-                while self.cur != '\'' {
-                    if self.cur == '\\' {
+                // Distinguish `'...'` (literal) from `'''...'''` (multi-line
+                // literal), and the empty string `''`.
+                let multiline = if self.cur == '\'' {
+                    self.next(i);
+                    if self.cur == '\'' {
+                        self.next(i);
+                        true
+                    } else {
+                        // `''` — an empty single-line literal string.
+                        return Ok(TomlTokWithSpan {
+                            tok: TomlTok::Str(String::new()),
+                            span: TomlSpan {
+                                start,
+                                len: self.pos - start,
+                            },
+                        });
+                    }
+                } else {
+                    false
+                };
+                if multiline {
+                    if self.cur == '\r' {
                         self.next(i);
                     }
-                    if self.cur == '\0' {
-                        return Err(self.err_parse("string"));
+                    if self.cur == '\n' {
+                        self.next(i);
                     }
-                    val.push(self.cur);
-                    self.next(i);
                 }
-                self.next(i);
+                let val = self.read_literal_string(i, multiline)?;
                 Ok(TomlTokWithSpan {
                     tok: TomlTok::Str(val),
                     span: TomlSpan {
@@ -541,5 +579,313 @@ impl TomlParser {
             }
             _ => Err(self.err_parse("tokenizer")),
         }
+    }
+
+    /// Read a `[table]` / `[[array-of-tables]]` header. `next_tok` has already
+    /// consumed the first `[`. Handles an optional second `[`, a dotted key
+    /// path whose segments may each be a bare key or a quoted string, and the
+    /// closing `]` / `]]`. Returns the dotted path with quotes stripped, so
+    /// `[a."b".c]` and `[a.b.c]` both yield `a.b.c`.
+    pub fn read_table_header(&mut self, i: &mut Chars) -> Result<String, TomlErr> {
+        let double = self.cur == '[';
+        if double {
+            self.next(i);
+        }
+        let mut path = String::new();
+        loop {
+            while self.cur == ' ' || self.cur == '\t' {
+                self.next(i);
+            }
+            match self.cur {
+                '\0' | '\n' | '\r' => return Err(self.err_parse("table header")),
+                ']' => {
+                    self.next(i);
+                    if double {
+                        if self.cur != ']' {
+                            return Err(self.err_parse("table header"));
+                        }
+                        self.next(i);
+                    }
+                    return Ok(path);
+                }
+                // Dot separates segments; nothing to collect.
+                '.' => {
+                    self.next(i);
+                }
+                '"' => {
+                    self.next(i);
+                    let seg = self.read_basic_string(i, false)?;
+                    if !path.is_empty() {
+                        path.push('.');
+                    }
+                    path.push_str(&seg);
+                }
+                '\'' => {
+                    self.next(i);
+                    let seg = self.read_literal_string(i, false)?;
+                    if !path.is_empty() {
+                        path.push('.');
+                    }
+                    path.push_str(&seg);
+                }
+                _ => {
+                    // A bare-key segment: read until a separator.
+                    let mut seg = String::new();
+                    while !matches!(
+                        self.cur,
+                        '.' | ']' | ' ' | '\t' | '\0' | '\n' | '\r'
+                    ) {
+                        seg.push(self.cur);
+                        self.next(i);
+                    }
+                    if !path.is_empty() {
+                        path.push('.');
+                    }
+                    path.push_str(&seg);
+                }
+            }
+        }
+    }
+
+    /// Read a basic (double-quoted) string body. The opening delimiter — `"`
+    /// for single-line, `"""` for multi-line — has already been consumed, as
+    /// has the newline that immediately follows a `"""`. Processes backslash
+    /// escape sequences. `multiline` selects which closing delimiter to expect.
+    pub fn read_basic_string(
+        &mut self,
+        i: &mut Chars,
+        multiline: bool,
+    ) -> Result<String, TomlErr> {
+        let mut val = String::new();
+        loop {
+            match self.cur {
+                '\0' => return Err(self.err_parse("string")),
+                // A raw newline can't appear in a single-line basic string.
+                '\n' | '\r' if !multiline => return Err(self.err_parse("string")),
+                '"' => {
+                    if !multiline {
+                        self.next(i);
+                        return Ok(val);
+                    }
+                    // Multi-line: the closing delimiter is a run of >= 3 `"`.
+                    // Quotes beyond the final three belong to the content.
+                    let mut quotes = 0;
+                    while self.cur == '"' {
+                        quotes += 1;
+                        self.next(i);
+                    }
+                    if quotes >= 3 {
+                        for _ in 0..(quotes - 3) {
+                            val.push('"');
+                        }
+                        return Ok(val);
+                    }
+                    for _ in 0..quotes {
+                        val.push('"');
+                    }
+                }
+                '\\' => {
+                    self.next(i);
+                    match self.cur {
+                        'b' => {
+                            val.push('\u{0008}');
+                            self.next(i);
+                        }
+                        't' => {
+                            val.push('\t');
+                            self.next(i);
+                        }
+                        'n' => {
+                            val.push('\n');
+                            self.next(i);
+                        }
+                        'f' => {
+                            val.push('\u{000C}');
+                            self.next(i);
+                        }
+                        'r' => {
+                            val.push('\r');
+                            self.next(i);
+                        }
+                        '"' => {
+                            val.push('"');
+                            self.next(i);
+                        }
+                        '\\' => {
+                            val.push('\\');
+                            self.next(i);
+                        }
+                        'u' | 'U' => {
+                            let digits = if self.cur == 'u' { 4 } else { 8 };
+                            self.next(i);
+                            let mut code: u32 = 0;
+                            for _ in 0..digits {
+                                let d = self
+                                    .cur
+                                    .to_digit(16)
+                                    .ok_or_else(|| self.err_parse("unicode escape"))?;
+                                code = code * 16 + d;
+                                self.next(i);
+                            }
+                            val.push(
+                                char::from_u32(code)
+                                    .ok_or_else(|| self.err_parse("unicode escape"))?,
+                            );
+                        }
+                        // Multi-line "line-ending backslash": a `\` followed by
+                        // whitespace trims that whitespace, newlines included.
+                        ' ' | '\t' | '\n' | '\r' if multiline => {
+                            while matches!(self.cur, ' ' | '\t' | '\n' | '\r') {
+                                self.next(i);
+                            }
+                        }
+                        '\0' => return Err(self.err_parse("string")),
+                        // Unknown escape: keep the char, drop the backslash.
+                        _ => {
+                            val.push(self.cur);
+                            self.next(i);
+                        }
+                    }
+                }
+                c => {
+                    val.push(c);
+                    self.next(i);
+                }
+            }
+        }
+    }
+
+    /// Read a literal (single-quoted) string body. The opening delimiter — `'`
+    /// for single-line, `'''` for multi-line — has already been consumed, as
+    /// has the newline that immediately follows a `'''`. Literal strings do NO
+    /// escape processing: every character is taken verbatim.
+    pub fn read_literal_string(
+        &mut self,
+        i: &mut Chars,
+        multiline: bool,
+    ) -> Result<String, TomlErr> {
+        let mut val = String::new();
+        loop {
+            match self.cur {
+                '\0' => return Err(self.err_parse("string")),
+                '\n' | '\r' if !multiline => return Err(self.err_parse("string")),
+                '\'' => {
+                    if !multiline {
+                        self.next(i);
+                        return Ok(val);
+                    }
+                    let mut quotes = 0;
+                    while self.cur == '\'' {
+                        quotes += 1;
+                        self.next(i);
+                    }
+                    if quotes >= 3 {
+                        for _ in 0..(quotes - 3) {
+                            val.push('\'');
+                        }
+                        return Ok(val);
+                    }
+                    for _ in 0..quotes {
+                        val.push('\'');
+                    }
+                }
+                c => {
+                    val.push(c);
+                    self.next(i);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn get_str<'a>(map: &'a HashMap<String, Toml>, key: &str) -> Option<&'a str> {
+        match map.get(key) {
+            Some(Toml::Str(v, _)) => Some(v.as_str()),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn parses_single_line_strings() {
+        let map = parse_toml("[package]\nname = \"robrix\"\nx = 'literal'\n").unwrap();
+        assert_eq!(get_str(&map, "package.name"), Some("robrix"));
+        assert_eq!(get_str(&map, "package.x"), Some("literal"));
+    }
+
+    #[test]
+    fn parses_multiline_basic_string_and_following_keys() {
+        // A `"""` value must not derail parsing of keys that come after it.
+        let toml = "[package]\n\
+                    version = \"1.0.0-alpha.1\"\n\
+                    long_description = \"\"\"\n\
+                    line one\n\
+                    line two\n\
+                    \"\"\"\n\
+                    identifier = \"rs.robius.robrix\"\n";
+        let map = parse_toml(toml).expect("multi-line basic string should parse");
+        assert_eq!(get_str(&map, "package.version"), Some("1.0.0-alpha.1"));
+        assert_eq!(get_str(&map, "package.identifier"), Some("rs.robius.robrix"));
+        // Leading newline after `"""` is trimmed.
+        assert_eq!(
+            get_str(&map, "package.long_description"),
+            Some("line one\nline two\n")
+        );
+    }
+
+    #[test]
+    fn parses_multiline_literal_string() {
+        let toml = "[package]\n\
+                    cmd = '''\n\
+                    raw \\n not an escape\n\
+                    '''\n\
+                    after = \"ok\"\n";
+        let map = parse_toml(toml).expect("multi-line literal string should parse");
+        // Literal strings do not process escapes.
+        assert_eq!(
+            get_str(&map, "package.cmd"),
+            Some("raw \\n not an escape\n")
+        );
+        assert_eq!(get_str(&map, "package.after"), Some("ok"));
+    }
+
+    #[test]
+    fn parses_quoted_section_headers() {
+        // `[patch."url"]` and `[target.'cfg(...)']` must not break parsing.
+        let toml = "[patch.\"https://github.com/kevinaboos/makepad\"]\n\
+                    makepad-widgets = \"1.0\"\n\
+                    [target.'cfg(target_os = \"ios\")'.dependencies]\n\
+                    foo = \"2.0\"\n\
+                    [package.metadata.packager]\n\
+                    identifier = \"rs.robius.robrix\"\n";
+        let map = parse_toml(toml).expect("quoted section headers should parse");
+        assert_eq!(
+            get_str(&map, "package.metadata.packager.identifier"),
+            Some("rs.robius.robrix")
+        );
+        // Quoted segments have their quotes stripped.
+        assert_eq!(
+            get_str(
+                &map,
+                "patch.https://github.com/kevinaboos/makepad.makepad-widgets"
+            ),
+            Some("1.0")
+        );
+    }
+
+    #[test]
+    fn basic_string_escapes_are_processed() {
+        let map = parse_toml("[s]\na = \"tab\\there\"\nb = \"q\\\"q\"\n").unwrap();
+        assert_eq!(get_str(&map, "s.a"), Some("tab\there"));
+        assert_eq!(get_str(&map, "s.b"), Some("q\"q"));
+    }
+
+    #[test]
+    fn array_of_tables_header_still_parses() {
+        let map = parse_toml("[[bin]]\nname = \"app\"\n").unwrap();
+        assert_eq!(get_str(&map, "bin.name"), Some("app"));
     }
 }

--- a/platform/src/action.rs
+++ b/platform/src/action.rs
@@ -113,15 +113,28 @@ impl Cx {
     ///
     /// This will produce a bare action, *not* a widget action,
     /// so you cannot use `as_widget_action()` when handling this action.
+    ///
+    /// If there is no live `Cx` to receive the action — because one has not
+    /// been created yet, or (commonly on mobile) because the app is shutting
+    /// down or being backgrounded and the `Cx` was already dropped — the
+    /// action is silently discarded. A background thread (a tokio task, a
+    /// `robius-*` crate callback, etc.) racing app teardown is normal and
+    /// must not panic the whole process.
     pub fn post_action(action: impl ActionTrait + Send) {
-        ACTION_SENDER_GLOBAL
-            .lock()
-            .unwrap()
-            .as_mut()
-            .unwrap()
-            .send(Box::new(action))
-            .unwrap();
-        SignalToUI::set_action_signal();
+        let Ok(mut sender_guard) = ACTION_SENDER_GLOBAL.lock() else {
+            // The mutex is poisoned (a thread panicked while holding it).
+            // Nothing useful we can do — drop the action.
+            return;
+        };
+        let Some(sender) = sender_guard.as_mut() else {
+            // No `Cx` has installed an action sender (yet / anymore).
+            return;
+        };
+        // `send` fails once the `Cx`'s receiver has been dropped at shutdown.
+        // Only signal the UI when the action was actually enqueued.
+        if sender.send(Box::new(action)).is_ok() {
+            SignalToUI::set_action_signal();
+        }
     }
 
     pub fn action(&mut self, action: impl ActionTrait) {

--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -148,13 +148,7 @@ pub struct Cx {
     /// as a shared-heap-object mutation instead.
     pub pending_live_edit_request: bool,
 
-    /// `WindowGeomChange` events queued by code that runs *during* an event
-    /// dispatch (e.g. `set_window_dpi_override` invoked from a settings
-    /// widget reacting to a dropdown). Synthesizing the event inline would
-    /// re-enter `call_event_handler` and panic on the `event_handler.take()`,
-    /// so the dispatcher drains this vec after each top-level dispatch via
-    /// `handle_pending_window_geom_changes` — listeners then see the event
-    /// normally on the same event-loop iteration.
+    /// `WindowGeomChange` events queued up during an event dispatch.
     pub(crate) pending_window_geom_changes: Vec<WindowGeomChangeEvent>,
 
     pub debug: Debug,

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -5,6 +5,7 @@ use {
         area::Area,
         cursor::MouseCursor,
         cx::{Cx, CxRef, OsType, XrCapabilities},
+        display_context::SystemBarAppearance,
         draw_list::DrawListId,
         draw_pass::{CxDrawPassParent, CxDrawPassRect, DrawPassId},
         dvec2,
@@ -259,6 +260,9 @@ pub enum CxOsOp {
     SetTopmost(WindowId, bool),
     SetWindowVisuals(WindowId, WindowVisuals),
     ShowInDock(bool),
+    /// Tints the system bar (status/navigation bar) icons: `true` requests
+    /// dark icons, `false` requests light icons. Currently only Android.
+    SetSystemBarDarkIcons(bool),
 
     ShowTextIME(Area, Vec2d, TextInputConfig),
     HideTextIME,
@@ -416,6 +420,7 @@ impl std::fmt::Debug for CxOsOp {
             Self::SetTopmost(..) => write!(f, "SetTopmost"),
             Self::SetWindowVisuals(..) => write!(f, "SetWindowVisuals"),
             Self::ShowInDock(..) => write!(f, "ShowInDock"),
+            Self::SetSystemBarDarkIcons(..) => write!(f, "SetSystemBarDarkIcons"),
 
             Self::ShowTextIME(..) => write!(f, "ShowTextIME"),
             Self::HideTextIME => write!(f, "HideTextIME"),
@@ -869,6 +874,21 @@ impl Cx {
     // You can remove the dock icon by setting this value to false.
     pub fn show_in_dock(&mut self, show: bool) {
         self.platform_ops.push(CxOsOp::ShowInDock(show));
+    }
+
+    /// Controls how the system bars (status bar and navigation bar) icons and
+    /// text are tinted, on platforms that support it (currently Android only).
+    ///
+    /// The default is [`SystemBarAppearance::Auto`], which picks dark or light
+    /// system-bar icons automatically from the luminance of the window's
+    /// background color (`clear_color`): a light background gets dark icons, a
+    /// dark background gets light icons. Pass [`SystemBarAppearance::DarkIcons`]
+    /// or [`SystemBarAppearance::LightIcons`] to override that automatic choice.
+    ///
+    /// The request is resolved and applied by the `Window` widget on its next
+    /// event cycle.
+    pub fn set_system_bar_appearance(&mut self, appearance: SystemBarAppearance) {
+        self.display_context.system_bar_appearance = appearance;
     }
     pub fn push_unique_platform_op(&mut self, op: CxOsOp) {
         if self.platform_ops.iter().find(|o| **o == op).is_none() {

--- a/platform/src/display_context.rs
+++ b/platform/src/display_context.rs
@@ -3,6 +3,21 @@ use crate::Vec2d;
 
 const DEFAULT_MIN_DESKTOP_WIDTH: f64 = 860.;
 
+/// Controls how the system bars (status bar and navigation bar) icons and
+/// text are tinted, on platforms that support it (currently Android only).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum SystemBarAppearance {
+    /// Pick dark or light system-bar icons automatically based on the
+    /// luminance of the window's background color: a light background gets
+    /// dark icons, a dark background gets light icons. This is the default.
+    #[default]
+    Auto,
+    /// Force dark icons/text in the system bars (best for light backgrounds).
+    DarkIcons,
+    /// Force light icons/text in the system bars (best for dark backgrounds).
+    LightIcons,
+}
+
 /// The current context data relevant to adaptive views.
 /// Later to be expanded with more context data like platfrom information, accessibility settings, etc.
 #[derive(Clone, Debug, Default)]
@@ -14,6 +29,10 @@ pub struct DisplayContext {
     /// Safe area insets for the current window in Makepad layout points
     /// (non-zero on devices with notches, rounded corners, home indicators, etc.)
     pub safe_area_insets: SafeAreaInsets,
+    /// Controls the tint of the system bar (status/navigation bar) icons.
+    /// Set via [`crate::Cx::set_system_bar_appearance`]; resolved and applied
+    /// by the `Window` widget.
+    pub system_bar_appearance: SystemBarAppearance,
 }
 
 impl DisplayContext {

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -107,6 +107,7 @@ pub use {
         cursor::MouseCursor,
         cx::{Cx, CxRef, LinuxWindowParams, OsType},
         cx_api::{AccessibilityUpdatePayload, CxOsApi, CxOsOp, CxThreadPriority, OpenUrlInPlace},
+        display_context::{DisplayContext, SystemBarAppearance},
         draw_list::{CxDrawCall, CxDrawItem, CxDrawListPool, CxRectArea, DrawList, DrawListId},
         draw_matrix::DrawMatrix,
         draw_pass::{

--- a/platform/src/os/linux/android/amidi_sys.rs
+++ b/platform/src/os/linux/android/amidi_sys.rs
@@ -1,7 +1,23 @@
+//! Android MIDI (AMidi) FFI bindings.
+//!
+//! `libamidi.so` was added in Android 10 / API 29. To allow Makepad apps to
+//! target a lower `minSdkVersion` (e.g. API 26 for broader device coverage),
+//! we **don't** statically link against `libamidi.so`. Instead, the symbols
+//! are resolved at runtime via `dlopen(libamidi.so)` + `dlsym(...)`. On
+//! devices below API 29 the library isn't present and every entry point
+//! below returns an error, gracefully disabling MIDI; on API 29+ devices
+//! they call through to the OS implementation.
+//!
+//! Callers don't need to know about this — the public `pub unsafe fn`
+//! signatures match the original `extern "C"` block, and a missing symbol
+//! is reported as `media_status_t = -1`.
 #![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+use crate::os::linux::module_loader::ModuleLoader;
 use jni_sys::*;
 use makepad_jni_sys as jni_sys;
 use std::os::raw::{c_long, c_ulong};
+use std::sync::OnceLock;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -22,41 +38,184 @@ pub struct AMidiOutputPort {
 }
 
 pub type media_status_t = std::os::raw::c_int;
+/// Error returned when libamidi.so is not present (i.e. device API < 29).
+const AMIDI_UNAVAILABLE: media_status_t = -1;
 
-#[link(name = "amidi")]
-extern "C" {
-    pub fn AMidiDevice_fromJava(
-        env: *mut JNIEnv,
-        midiDeviceObj: jobject,
-        outDevicePtrPtr: *mut *mut AMidiDevice,
-    ) -> media_status_t;
-    pub fn AMidiDevice_release(midiDevice: *const AMidiDevice) -> media_status_t;
+type Fn_AMidiDevice_fromJava =
+    unsafe extern "C" fn(*mut JNIEnv, jobject, *mut *mut AMidiDevice) -> media_status_t;
+type Fn_AMidiDevice_release = unsafe extern "C" fn(*const AMidiDevice) -> media_status_t;
+type Fn_AMidiDevice_getNumInputPorts = unsafe extern "C" fn(*const AMidiDevice) -> c_long;
+type Fn_AMidiDevice_getNumOutputPorts = unsafe extern "C" fn(*const AMidiDevice) -> c_long;
+type Fn_AMidiOutputPort_open =
+    unsafe extern "C" fn(*const AMidiDevice, i32, *mut *mut AMidiOutputPort) -> media_status_t;
+type Fn_AMidiOutputPort_close = unsafe extern "C" fn(*const AMidiOutputPort);
+type Fn_AMidiInputPort_open =
+    unsafe extern "C" fn(*const AMidiDevice, i32, *mut *mut AMidiInputPort) -> media_status_t;
+type Fn_AMidiInputPort_send =
+    unsafe extern "C" fn(*const AMidiInputPort, *const u8, c_ulong) -> c_long;
+type Fn_AMidiInputPort_close = unsafe extern "C" fn(*const AMidiInputPort);
+type Fn_AMidiOutputPort_receive = unsafe extern "C" fn(
+    *const AMidiOutputPort,
+    *mut i32,
+    *mut u8,
+    c_ulong,
+    *mut c_ulong,
+    *mut i64,
+) -> c_long;
 
-    pub fn AMidiDevice_getNumInputPorts(device: *const AMidiDevice) -> c_long;
-    pub fn AMidiDevice_getNumOutputPorts(device: *const AMidiDevice) -> c_long;
-    pub fn AMidiOutputPort_open(
-        device: *const AMidiDevice,
-        portNumber: i32,
-        outOutputPortPtr: *mut *mut AMidiOutputPort,
-    ) -> media_status_t;
-    pub fn AMidiOutputPort_close(outputPort: *const AMidiOutputPort);
-    pub fn AMidiInputPort_open(
-        device: *const AMidiDevice,
-        portNumber: i32,
-        outInputPortPtr: *mut *mut AMidiInputPort,
-    ) -> media_status_t;
-    pub fn AMidiInputPort_send(
-        inputPort: *const AMidiInputPort,
-        buffer: *const u8,
-        numBytes: c_ulong,
-    ) -> c_long;
-    pub fn AMidiInputPort_close(inputPort: *const AMidiInputPort);
-    pub fn AMidiOutputPort_receive(
-        outputPort: *const AMidiOutputPort,
-        opcodePtr: *mut i32,
-        buffer: *mut u8,
-        maxBytes: c_ulong,
-        numBytesReceivedPtr: *mut c_ulong,
-        outTimestampPtr: *mut i64,
-    ) -> c_long;
+struct AMidiVtable {
+    device_from_java: Fn_AMidiDevice_fromJava,
+    device_release: Fn_AMidiDevice_release,
+    device_get_num_input_ports: Fn_AMidiDevice_getNumInputPorts,
+    device_get_num_output_ports: Fn_AMidiDevice_getNumOutputPorts,
+    output_port_open: Fn_AMidiOutputPort_open,
+    output_port_close: Fn_AMidiOutputPort_close,
+    input_port_open: Fn_AMidiInputPort_open,
+    input_port_send: Fn_AMidiInputPort_send,
+    input_port_close: Fn_AMidiInputPort_close,
+    output_port_receive: Fn_AMidiOutputPort_receive,
+}
+
+// All fields are raw fn pointers, which are Send+Sync.
+unsafe impl Send for AMidiVtable {}
+unsafe impl Sync for AMidiVtable {}
+
+/// Cached vtable for `libamidi.so`. `None` means the library couldn't be loaded
+/// (typically because we're on API < 29 and the OS doesn't provide it).
+static AMIDI: OnceLock<Option<AMidiVtable>> = OnceLock::new();
+
+fn vtable() -> Option<&'static AMidiVtable> {
+    AMIDI
+        .get_or_init(|| {
+            // Try to load libamidi.so. If it isn't available we cache the None and
+            // every entry point becomes a graceful no-op for the rest of the
+            // process lifetime.
+            let lib = ModuleLoader::load("libamidi.so").ok()?;
+            let vt = AMidiVtable {
+                device_from_java: lib.get_symbol("AMidiDevice_fromJava").ok()?,
+                device_release: lib.get_symbol("AMidiDevice_release").ok()?,
+                device_get_num_input_ports: lib.get_symbol("AMidiDevice_getNumInputPorts").ok()?,
+                device_get_num_output_ports: lib
+                    .get_symbol("AMidiDevice_getNumOutputPorts")
+                    .ok()?,
+                output_port_open: lib.get_symbol("AMidiOutputPort_open").ok()?,
+                output_port_close: lib.get_symbol("AMidiOutputPort_close").ok()?,
+                input_port_open: lib.get_symbol("AMidiInputPort_open").ok()?,
+                input_port_send: lib.get_symbol("AMidiInputPort_send").ok()?,
+                input_port_close: lib.get_symbol("AMidiInputPort_close").ok()?,
+                output_port_receive: lib.get_symbol("AMidiOutputPort_receive").ok()?,
+            };
+            // Leak the ModuleLoader so libamidi.so stays mapped for the symbol
+            // pointers we just captured. dlclose() in Drop would only decrement
+            // the refcount, but this avoids relying on libamidi being kept alive
+            // by anyone else — and we want to load it exactly once anyway.
+            std::mem::forget(lib);
+            Some(vt)
+        })
+        .as_ref()
+}
+
+// Wrapper functions matching the original extern "C" signatures. Each one
+// looks up the cached symbol; when the library isn't loaded (API < 29) it
+// returns an error code so callers can no-op gracefully.
+
+pub unsafe fn AMidiDevice_fromJava(
+    env: *mut JNIEnv,
+    midiDeviceObj: jobject,
+    outDevicePtrPtr: *mut *mut AMidiDevice,
+) -> media_status_t {
+    match vtable() {
+        Some(vt) => (vt.device_from_java)(env, midiDeviceObj, outDevicePtrPtr),
+        None => AMIDI_UNAVAILABLE,
+    }
+}
+
+pub unsafe fn AMidiDevice_release(midiDevice: *const AMidiDevice) -> media_status_t {
+    match vtable() {
+        Some(vt) => (vt.device_release)(midiDevice),
+        None => AMIDI_UNAVAILABLE,
+    }
+}
+
+pub unsafe fn AMidiDevice_getNumInputPorts(device: *const AMidiDevice) -> c_long {
+    match vtable() {
+        Some(vt) => (vt.device_get_num_input_ports)(device),
+        None => 0,
+    }
+}
+
+pub unsafe fn AMidiDevice_getNumOutputPorts(device: *const AMidiDevice) -> c_long {
+    match vtable() {
+        Some(vt) => (vt.device_get_num_output_ports)(device),
+        None => 0,
+    }
+}
+
+pub unsafe fn AMidiOutputPort_open(
+    device: *const AMidiDevice,
+    portNumber: i32,
+    outOutputPortPtr: *mut *mut AMidiOutputPort,
+) -> media_status_t {
+    match vtable() {
+        Some(vt) => (vt.output_port_open)(device, portNumber, outOutputPortPtr),
+        None => AMIDI_UNAVAILABLE,
+    }
+}
+
+pub unsafe fn AMidiOutputPort_close(outputPort: *const AMidiOutputPort) {
+    if let Some(vt) = vtable() {
+        (vt.output_port_close)(outputPort);
+    }
+}
+
+pub unsafe fn AMidiInputPort_open(
+    device: *const AMidiDevice,
+    portNumber: i32,
+    outInputPortPtr: *mut *mut AMidiInputPort,
+) -> media_status_t {
+    match vtable() {
+        Some(vt) => (vt.input_port_open)(device, portNumber, outInputPortPtr),
+        None => AMIDI_UNAVAILABLE,
+    }
+}
+
+pub unsafe fn AMidiInputPort_send(
+    inputPort: *const AMidiInputPort,
+    buffer: *const u8,
+    numBytes: c_ulong,
+) -> c_long {
+    match vtable() {
+        Some(vt) => (vt.input_port_send)(inputPort, buffer, numBytes),
+        // Return -1 to indicate failure (matches AMidi convention for the
+        // "send" family).
+        None => -1,
+    }
+}
+
+pub unsafe fn AMidiInputPort_close(inputPort: *const AMidiInputPort) {
+    if let Some(vt) = vtable() {
+        (vt.input_port_close)(inputPort);
+    }
+}
+
+pub unsafe fn AMidiOutputPort_receive(
+    outputPort: *const AMidiOutputPort,
+    opcodePtr: *mut i32,
+    buffer: *mut u8,
+    maxBytes: c_ulong,
+    numBytesReceivedPtr: *mut c_ulong,
+    outTimestampPtr: *mut i64,
+) -> c_long {
+    match vtable() {
+        Some(vt) => (vt.output_port_receive)(
+            outputPort,
+            opcodePtr,
+            buffer,
+            maxBytes,
+            numBytesReceivedPtr,
+            outTimestampPtr,
+        ),
+        // 0 received messages is a valid AMidi response.
+        None => 0,
+    }
 }

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -58,6 +58,7 @@ use {
             WindowGeomChangeEvent,
         },
         gpu_info::GpuPerformance,
+        ime::TextInputConfig,
         makepad_live_id::*,
         makepad_math::*,
         media_api::CxMediaApi,
@@ -932,6 +933,9 @@ impl Cx {
                         },
                     ))
                 } else if !is_open {
+                    // Java says the keyboard is down; forget the last shown
+                    // config so the next `ShowTextIME` re-issues the request.
+                    self.os.last_ime_config = None;
                     if !self.os.last_ime_visible {
                         return;
                     }
@@ -2319,11 +2323,28 @@ impl Cx {
                     self.os.timers.timers.remove(&timer_id);
                 }
                 CxOsOp::ShowTextIME(_area, _pos, config) => unsafe {
-                    android_jni::to_java_configure_keyboard(&config);
-                    android_jni::to_java_show_keyboard(true);
+                    // A focused `TextInput` re-issues `ShowTextIME` on every
+                    // draw. Calling into Java each time thrashes the IME:
+                    // `configure_keyboard` can restart the input connection,
+                    // and under the edge-to-edge insets of targetSdk 35 the
+                    // resulting inset change triggers a `redraw_all()`, which
+                    // re-draws the `TextInput`, which re-issues `ShowTextIME`
+                    // — a loop that flickers the soft keyboard open then shut.
+                    // Only touch Java when the requested config actually
+                    // changes; `last_ime_config` is cleared whenever the
+                    // keyboard goes down (here or via `ResizeTextIME`).
+                    if self.os.last_ime_config != Some(config) {
+                        android_jni::to_java_configure_keyboard(&config);
+                        android_jni::to_java_show_keyboard(true);
+                        self.os.last_ime_config = Some(config);
+                    }
                 },
                 CxOsOp::HideTextIME => unsafe {
+                    // Unconditional on purpose: unlike `ShowTextIME` this is not
+                    // issued per-frame, so there is no thrash to dedup — and a
+                    // skipped hide would leave the soft keyboard stuck open.
                     android_jni::to_java_show_keyboard(false);
+                    self.os.last_ime_config = None;
                 },
                 CxOsOp::SyncImeState {
                     text,
@@ -3123,6 +3144,7 @@ impl Default for CxOs {
             native_safe_area_insets: Default::default(),
             last_ime_height: 0.0,
             last_ime_visible: false,
+            last_ime_config: None,
             media: CxAndroidMedia::default(),
             display: None,
             surface_alive: false,
@@ -3211,6 +3233,13 @@ pub struct CxOs {
     /// Whether the soft keyboard was visible the last time we dispatched a
     /// `VirtualKeyboardEvent`. Pairs with `last_ime_height` for dedup.
     pub last_ime_visible: bool,
+    /// The `TextInputConfig` last sent to the Android IME via `ShowTextIME`,
+    /// or `None` while the keyboard is requested-hidden. A focused `TextInput`
+    /// re-issues `ShowTextIME` every draw; this dedups those so the JNI IME
+    /// calls (and the inset-driven redraw loop they trigger) fire only on a
+    /// real change. Reset to `None` on `HideTextIME` and when Java reports the
+    /// keyboard closed.
+    pub last_ime_config: Option<TextInputConfig>,
     pub frame_time: i64,
     pub quit: bool,
     pub fullscreen: bool,

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -2252,8 +2252,13 @@ impl Cx {
                         ..Default::default()
                     };
                     window.is_created = true;
-                    //let ret = unsafe{ndk_sys::ANativeWindow_setFrameRate(self.os.display.as_ref().unwrap().window, 120.0, 0)};
-                    //crate::log!("{}",ret);
+                    // To request a specific surface frame rate here, use
+                    // `ANativeWindow_setFrameRate` — but note it is API 30+.
+                    // It must be `dlsym`-resolved from libandroid.so and gated
+                    // on `sdk_version >= 30` (the same pattern as the
+                    // Choreographer callbacks in `ndk_sys.rs` / `android_jni.rs`),
+                    // never declared as a plain `extern "C"`, or it breaks
+                    // `dlopen` of libmakepad.so on API 26-29 devices.
                     let new_geom = window.window_geom.clone();
                     let old_geom = window.window_geom.clone();
                     self.call_event_handler(&Event::WindowGeomChange(WindowGeomChangeEvent {

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -2853,6 +2853,12 @@ impl Cx {
                         android_jni::to_java_set_full_screen(env, false);
                     }
                 }
+                CxOsOp::SetSystemBarDarkIcons(dark_icons) => {
+                    unsafe {
+                        let env = attach_jni_env();
+                        android_jni::to_java_set_system_bar_appearance(env, dark_icons);
+                    }
+                }
                 CxOsOp::SetCursor(_) => {
                     // no need
                 }

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -1977,7 +1977,6 @@ pub unsafe fn to_java_configure_keyboard(config: &TextInputConfig) {
     let env = attach_jni_env();
 
     let input_mode = match config.soft_keyboard.input_mode {
-        InputMode::None => 8,
         InputMode::Text => 0,
         InputMode::Ascii => 1,
         InputMode::Url => 2,

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -516,29 +516,30 @@ pub unsafe extern "C" fn Java_dev_makepad_android_MakepadNative_initChoreographe
     #[allow(unused)]
     #[cfg(not(no_android_choreographer))]
     {
-        // Otherwise use the actual Choreographer
+        // Otherwise use the actual Choreographer.
         CHOREOGRAPHER = ndk_sys::AChoreographer_getInstance();
-        if sdk_version >= 33 {
-            let lib = ModuleLoader::load("libandroid.so").expect("Failed to load libandroid.so");
-            let func: Option<ndk_sys::AChoreographerPostCallbackFn> =
-                lib.get_symbol("AChoreographer_postVsyncCallback").ok();
-            // Some runtimes/NDK combos may not expose postVsyncCallback even on API 33+.
-            // Fall back to the older frame callback to keep rendering alive.
-            CHOREOGRAPHER_POST_CALLBACK_FN =
-                func.or(Some(ndk_sys::AChoreographer_postFrameCallback64 as _));
-        } else if sdk_version >= 29 {
-            CHOREOGRAPHER_POST_CALLBACK_FN = Some(ndk_sys::AChoreographer_postFrameCallback64 as _);
-        } else {
-            init_simple_render_loop(device_refresh_rate);
+        // AChoreographer_postFrameCallback64 (API 29) and
+        // AChoreographer_postVsyncCallback (API 33) must be resolved via dlsym,
+        // never declared as `extern "C"` — see the note in ndk_sys.rs. On API
+        // 26-28 neither symbol exists, so the callback fn stays None and we
+        // fall back to the manual frame loop below.
+        if sdk_version >= 29 {
+            if let Ok(lib) = ModuleLoader::load("libandroid.so") {
+                // Prefer the newer vsync callback (API 33+); fall back to the
+                // API 29 frame callback when it isn't available.
+                let vsync: Option<ndk_sys::AChoreographerPostCallbackFn> = if sdk_version >= 33 {
+                    lib.get_symbol("AChoreographer_postVsyncCallback").ok()
+                } else {
+                    None
+                };
+                let frame_callback_64: Option<ndk_sys::AChoreographerPostCallbackFn> =
+                    lib.get_symbol("AChoreographer_postFrameCallback64").ok();
+                CHOREOGRAPHER_POST_CALLBACK_FN = vsync.or(frame_callback_64);
+            }
         }
-        let has_choreographer_callback = match CHOREOGRAPHER_POST_CALLBACK_FN {
-            Some(_) => true,
-            None => false,
-        };
-        if has_choreographer_callback {
-            post_vsync_callback();
-        } else {
-            init_simple_render_loop(device_refresh_rate);
+        match CHOREOGRAPHER_POST_CALLBACK_FN {
+            Some(_) => post_vsync_callback(),
+            None => init_simple_render_loop(device_refresh_rate),
         }
     }
 }
@@ -561,11 +562,36 @@ pub unsafe fn post_vsync_callback() {
     }
 }
 
+/// Fallback render loop used when the Android Choreographer isn't available
+/// (API < 29, and `no_android_choreographer` builds such as OHOS). A dedicated
+/// thread paces frames manually, since there is no system vsync callback.
 fn init_simple_render_loop(device_refresh_rate: f32) {
     std::thread::spawn(move || {
         let mut last_frame_time = std::time::Instant::now();
         let target_frame_time = std::time::Duration::from_secs_f32(1.0 / device_refresh_rate);
         loop {
+            // Exit the thread once the app has shut down and the Java->native
+            // message channel has been torn down by `from_java_messages_clear()`
+            // (called when the main event loop quits). This mirrors
+            // `post_vsync_callback`, which likewise stops re-arming the
+            // Choreographer once `from_java_messages_already_set()` is false.
+            //
+            // Without this, the thread spins forever after the activity is
+            // destroyed, sending `RenderLoop` into a dead channel and spamming
+            // "Receiving message from java whilst already shutdown" until the
+            // OS reclaims the process.
+            //
+            // This check is safe at startup: `MESSAGES_TX` is installed
+            // synchronously in the JNI bootstrap (`jni_set_from_java_tx`),
+            // before the Makepad thread is spawned and well before
+            // `initChoreographer` spawns this loop — so it is always `Some`
+            // here on the first iteration and only becomes `None` at genuine
+            // shutdown. The check is at the top of the loop, before the send,
+            // so a shutdown during the sleep produces no stray send.
+            if !from_java_messages_already_set() {
+                break;
+            }
+
             let now = std::time::Instant::now();
             let elapsed = now - last_frame_time;
 

--- a/platform/src/os/linux/android/android_jni.rs
+++ b/platform/src/os/linux/android/android_jni.rs
@@ -1324,6 +1324,16 @@ pub unsafe fn to_java_set_full_screen(env: *mut jni_sys::JNIEnv, fullscreen: boo
     );
 }
 
+pub unsafe fn to_java_set_system_bar_appearance(env: *mut jni_sys::JNIEnv, dark_icons: bool) {
+    ndk_utils::call_void_method!(
+        env,
+        get_activity(),
+        "setSystemBarAppearance",
+        "(Z)V",
+        dark_icons as i32
+    );
+}
+
 pub unsafe fn to_java_set_surface_cover_visible(visible: bool) {
     let env = attach_jni_env();
     ndk_utils::call_void_method!(

--- a/platform/src/os/linux/android/ndk_sys.rs
+++ b/platform/src/os/linux/android/ndk_sys.rs
@@ -54,12 +54,14 @@ extern "C" {
         assetManager: jni_sys::jobject,
     ) -> *mut AAssetManager;
 
-    pub fn ANativeWindow_setFrameRate(
-        window: *mut ANativeWindow,
-        frameRate: f32,
-        compatibility: i8,
-    ) -> i32;
+    // NOTE: `ANativeWindow_setFrameRate` is deliberately NOT declared here.
+    // It is API 30+; a plain `extern "C"` strong reference to it would break
+    // `dlopen` of libmakepad.so on API 26-29 devices. If surface frame-rate
+    // control is wanted, resolve it via `dlsym(libandroid.so, ...)` gated on
+    // `sdk_version >= 30`, the same way the Choreographer post-callbacks are
+    // handled below.
 
+    // AHardwareBuffer_acquire / _release are API 26 — safe at the minSdk floor.
     pub fn AHardwareBuffer_acquire(buffer: *mut AHardwareBuffer);
     pub fn AHardwareBuffer_release(buffer: *mut AHardwareBuffer);
 }
@@ -83,21 +85,22 @@ pub type AChoreographerPostCallbackFn = unsafe extern "C" fn(
 
 #[cfg(not(no_android_choreographer))]
 extern "C" {
+    // AChoreographer_getInstance was introduced in API 24, so it's safe to
+    // link directly at our minSdk floor (26).
     pub fn AChoreographer_getInstance() -> *mut AChoreographer;
-    // Android SDK >= 33
-    pub fn AChoreographer_postVsyncCallback(
-        choreographer: *mut AChoreographer,
-        callback: Option<AChoreographer_vsyncCallback>,
-        data: *mut c_void,
-    ) -> i32;
-
-    // Android SDK < 33 && >= 29
-    pub fn AChoreographer_postFrameCallback64(
-        choreographer: *mut AChoreographer,
-        callback: Option<AChoreographer_vsyncCallback>,
-        data: *mut c_void,
-    ) -> i32;
 }
+
+// AChoreographer_postVsyncCallback (API 33) and AChoreographer_postFrameCallback64
+// (API 29) are deliberately NOT declared in an `extern "C"` block.
+//
+// A strong undefined reference to a symbol that doesn't exist on API 26-28
+// devices makes the entire `libmakepad.so` fail to `dlopen` at process start
+// (`UnsatisfiedLinkError: cannot locate symbol ...`), even if the call site is
+// runtime-gated behind an `sdk_version >= 29` check — the relocation is still
+// emitted. Rust's `extern "C"` can't express weak linkage on stable, so these
+// are instead resolved at runtime with `dlsym(libandroid.so, ...)` in
+// android_jni.rs, typed via `AChoreographerPostCallbackFn`, only on devices
+// where they actually exist.
 
 #[repr(C)]
 pub struct ANativeActivity {

--- a/tools/cargo_makepad/src/android/compile.rs
+++ b/tools/cargo_makepad/src/android/compile.rs
@@ -563,6 +563,7 @@ fn rust_build(
     android_targets: &[AndroidTarget],
     variant: &AndroidVariant,
     urls: &AndroidSDKUrls,
+    prefer_dynamic: bool,
 ) -> Result<(), String> {
     let cwd = std::env::current_dir().unwrap();
     let target_root = cargo_target_root(&cwd);
@@ -646,8 +647,11 @@ fn rust_build(
 
         let target_arch_str = android_target.to_str();
         let cfg_flag = format!("--cfg android_target=\"{}\"", target_arch_str);
-        let rustflags =
-            compose_android_rustflags(std::env::var("RUSTFLAGS").ok().as_deref(), &cfg_flag);
+        let rustflags = compose_android_rustflags(
+            std::env::var("RUSTFLAGS").ok().as_deref(),
+            &cfg_flag,
+            prefer_dynamic,
+        );
 
         let makepad_env = if let AndroidVariant::Quest = variant {
             Some(match std::env::var("MAKEPAD") {
@@ -731,22 +735,32 @@ fn rust_build(
     Ok(())
 }
 
-fn compose_android_rustflags(existing: Option<&str>, cfg_flag: &str) -> String {
+/// Builds the `RUSTFLAGS` value for an Android `cargo rustc` invocation.
+///
+/// `prefer_dynamic`: APK/dev builds pass `true` (dynamically linked `std`
+/// keeps incremental relinks fast). AAB builds pass `false` — `prefer-dynamic`
+/// makes Rust ship `std` as a separate `libstd-<hash>.so`, and the toolchain's
+/// prebuilt copy of that library is only 4 KB-page aligned, which fails Google
+/// Play's 16 KB page-size requirement for apps targeting Android 15+. Static
+/// `std` keeps the app a single self-contained, NDK-linked (16 KB-aligned) `.so`.
+fn compose_android_rustflags(existing: Option<&str>, cfg_flag: &str, prefer_dynamic: bool) -> String {
     let mut rustflags = existing.unwrap_or_default().trim().to_string();
-    let has_prefer_dynamic = rustflags
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .windows(2)
-        .any(|pair| pair == ["-C", "prefer-dynamic"])
-        || rustflags
+    if prefer_dynamic {
+        let has_prefer_dynamic = rustflags
             .split_whitespace()
-            .any(|token| token == "-Cprefer-dynamic");
+            .collect::<Vec<_>>()
+            .windows(2)
+            .any(|pair| pair == ["-C", "prefer-dynamic"])
+            || rustflags
+                .split_whitespace()
+                .any(|token| token == "-Cprefer-dynamic");
 
-    if !has_prefer_dynamic {
-        if !rustflags.is_empty() {
-            rustflags.push(' ');
+        if !has_prefer_dynamic {
+            if !rustflags.is_empty() {
+                rustflags.push(' ');
+            }
+            rustflags.push_str("-C prefer-dynamic");
         }
-        rustflags.push_str("-C prefer-dynamic");
     }
     if !cfg_flag.trim().is_empty() {
         if !rustflags.is_empty() {
@@ -2529,6 +2543,10 @@ pub fn build_aab(
         android_targets,
         variant,
         urls,
+        // AAB: statically link `std` so the bundle has no separate libstd.so
+        // (the toolchain's prebuilt one is only 4 KB-page aligned, which fails
+        // Play's 16 KB page-size requirement).
+        false,
     )?;
     // AABs uploaded to Play Store must have `android:debuggable="false"`. Force
     // it here regardless of cargo profile so we never produce an unshippable AAB.
@@ -2686,6 +2704,8 @@ pub fn build(
         android_targets,
         variant,
         urls,
+        // APK/dev builds keep `-C prefer-dynamic` for faster incremental relinks.
+        true,
     )?;
     // For APK builds, debuggable matches the cargo profile: release -> false,
     // anything else -> true (matches the historical behavior of `cargo makepad
@@ -3113,7 +3133,7 @@ default via 192.168.0.1 dev wlan0 proto dhcp src 192.168.0.42 metric 303\n\
     #[test]
     fn compose_android_rustflags_adds_prefer_dynamic() {
         assert_eq!(
-            compose_android_rustflags(None, "--cfg android_target=\"aarch64\""),
+            compose_android_rustflags(None, "--cfg android_target=\"aarch64\"", true),
             "-C prefer-dynamic --cfg android_target=\"aarch64\""
         );
     }
@@ -3121,7 +3141,7 @@ default via 192.168.0.1 dev wlan0 proto dhcp src 192.168.0.42 metric 303\n\
     #[test]
     fn compose_android_rustflags_preserves_existing_flags() {
         assert_eq!(
-            compose_android_rustflags(Some("-C debuginfo=1"), "--cfg android_target=\"aarch64\""),
+            compose_android_rustflags(Some("-C debuginfo=1"), "--cfg android_target=\"aarch64\"", true),
             "-C debuginfo=1 -C prefer-dynamic --cfg android_target=\"aarch64\""
         );
     }
@@ -3131,9 +3151,22 @@ default via 192.168.0.1 dev wlan0 proto dhcp src 192.168.0.42 metric 303\n\
         assert_eq!(
             compose_android_rustflags(
                 Some("-C prefer-dynamic -C debuginfo=1"),
-                "--cfg android_target=\"aarch64\""
+                "--cfg android_target=\"aarch64\"",
+                true,
             ),
             "-C prefer-dynamic -C debuginfo=1 --cfg android_target=\"aarch64\""
+        );
+    }
+
+    #[test]
+    fn compose_android_rustflags_omits_prefer_dynamic_when_disabled() {
+        assert_eq!(
+            compose_android_rustflags(
+                Some("-C debuginfo=1"),
+                "--cfg android_target=\"aarch64\"",
+                false,
+            ),
+            "-C debuginfo=1 --cfg android_target=\"aarch64\""
         );
     }
 }

--- a/tools/cargo_makepad/src/android/compile.rs
+++ b/tools/cargo_makepad/src/android/compile.rs
@@ -1,11 +1,14 @@
-use super::sdk::{AndroidSDKUrls, BUILD_TOOLS_DIR, PLATFORMS_DIR};
-use crate::android::{AndroidConfig, AndroidTarget, AndroidVariant, HostOs};
+use super::sdk::{AndroidSDKUrls, BUILD_TOOLS_DIR, BUNDLETOOL_JAR_REL, PLATFORMS_DIR};
+use crate::android::{AndroidConfig, AndroidTarget, AndroidVariant, HostOs, ManifestArgs};
 use crate::makepad_shell::*;
 use crate::utils::*;
+use makepad_zip_file::*;
 use std::{
     collections::{hash_map::DefaultHasher, HashSet},
     fs,
+    fs::File,
     hash::{Hash, Hasher},
+    io::Write,
     path::{Path, PathBuf},
     thread,
     time::Duration,
@@ -16,6 +19,222 @@ fn aapt_path(sdk_dir: &Path, urls: &AndroidSDKUrls) -> PathBuf {
         .join(BUILD_TOOLS_DIR)
         .join(urls.build_tools_version)
         .join("aapt")
+}
+
+fn aapt2_path(sdk_dir: &Path, urls: &AndroidSDKUrls) -> PathBuf {
+    sdk_dir
+        .join(BUILD_TOOLS_DIR)
+        .join(urls.build_tools_version)
+        .join("aapt2")
+}
+
+fn bundletool_jar_path(sdk_dir: &Path) -> PathBuf {
+    sdk_dir.join(BUNDLETOOL_JAR_REL)
+}
+
+fn keytool_path(sdk_dir: &Path) -> PathBuf {
+    let bundled = sdk_dir.join("openjdk/bin/keytool");
+    if bundled.is_file() {
+        return bundled;
+    }
+    let bundled_exe = sdk_dir.join("openjdk/bin/keytool.exe");
+    if bundled_exe.is_file() {
+        return bundled_exe;
+    }
+    // Fall back to bundled path even if missing — caller will surface the error
+    // when keytool is invoked. We don't search PATH here because creating a
+    // keystore is a one-time setup; a clear error pointing at install-toolchain
+    // is better than silently using whatever the user has.
+    bundled
+}
+
+/// Path to the `<keystore>.makepad` metadata file written next to a keystore by
+/// `keystore-create`. Plain `key = value` text, intentionally password-free.
+pub fn keystore_sidecar_path(keystore: &Path) -> PathBuf {
+    let mut name = keystore
+        .file_name()
+        .map(|n| n.to_os_string())
+        .unwrap_or_default();
+    name.push(".makepad");
+    keystore.with_file_name(name)
+}
+
+#[derive(Debug, Default)]
+pub struct KeystoreSidecar {
+    pub alias: Option<String>,
+    pub store_type: Option<String>,
+}
+
+pub fn read_keystore_sidecar(keystore: &Path) -> Option<KeystoreSidecar> {
+    let path = keystore_sidecar_path(keystore);
+    let text = fs::read_to_string(&path).ok()?;
+    let mut sc = KeystoreSidecar::default();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((k, v)) = line.split_once('=') else {
+            continue;
+        };
+        let key = k.trim();
+        let val = v.trim().trim_matches('"').to_string();
+        match key {
+            "alias" => sc.alias = Some(val),
+            "store_type" => sc.store_type = Some(val),
+            _ => {}
+        }
+    }
+    Some(sc)
+}
+
+fn write_keystore_sidecar(keystore: &Path, sc: &KeystoreSidecar) -> Result<(), String> {
+    let path = keystore_sidecar_path(keystore);
+    let mut body = String::from(
+        "# Keystore metadata written by `cargo makepad android keystore-create`.\n\
+         # Safe to commit: contains no passwords. `cargo makepad android build-aab` reads this\n\
+         # next to the keystore so you only need to pass --keystore + password on each build.\n",
+    );
+    if let Some(alias) = &sc.alias {
+        body.push_str(&format!("alias = {alias}\n"));
+    }
+    if let Some(store_type) = &sc.store_type {
+        body.push_str(&format!("store_type = {store_type}\n"));
+    }
+    fs::write(&path, body).map_err(|e| format!("Cant write {:?}: {e}", path))
+}
+
+pub struct KeystoreCreateOpts {
+    pub keystore_path: PathBuf,
+    pub alias: String,
+    pub validity_days: u32,
+    pub key_size: u32,
+    pub key_alg: String,
+    pub store_type: String,
+    pub dname: Option<String>,
+}
+
+pub fn keystore_create(sdk_dir: &Path, opts: &KeystoreCreateOpts) -> Result<(), String> {
+    if opts.keystore_path.exists() {
+        return Err(format!(
+            "Refusing to overwrite existing file {:?}. Pick a new path or delete the existing keystore first.",
+            opts.keystore_path
+        ));
+    }
+    let keytool = keytool_path(sdk_dir);
+    if !keytool.is_file() {
+        return Err(format!(
+            "keytool not found at {:?}. Run `cargo makepad android install-toolchain` to download it.",
+            keytool
+        ));
+    }
+    if let Some(parent) = opts.keystore_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            mkdir(parent)?;
+        }
+    }
+
+    println!("================================================================================");
+    println!("CREATING ANDROID UPLOAD KEYSTORE");
+    println!("================================================================================");
+    println!();
+    println!("  This keystore is your *upload key* for the Google Play Store.");
+    println!();
+    println!("  CRITICAL — you MUST keep this file and its password forever:");
+    println!("    * If you lose either, you cannot push updates to your Play Store listing");
+    println!("      without going through Google's manual key-recovery process.");
+    println!("    * Back up the keystore file AND the password somewhere safe");
+    println!("      (password manager, offline copy, secret manager).");
+    println!("    * Do not commit the keystore to a public git repository.");
+    println!();
+    println!("  keytool will now prompt you for:");
+    println!("    1. A keystore password (you'll need this on every build).");
+    println!("    2. Your name / org / city / country (goes into the certificate; permanent).");
+    println!("    3. A key password — press Enter to reuse the keystore password (recommended).");
+    println!();
+    println!("================================================================================");
+    println!();
+
+    let java_home = sdk_dir.join("openjdk");
+    let cwd = std::env::current_dir().unwrap();
+
+    let validity = opts.validity_days.to_string();
+    let keysize = opts.key_size.to_string();
+    let keystore_str = opts.keystore_path.to_str().unwrap().to_string();
+
+    let mut args: Vec<String> = vec![
+        "-genkeypair".to_string(),
+        "-v".to_string(),
+        "-keystore".to_string(),
+        keystore_str,
+        "-alias".to_string(),
+        opts.alias.clone(),
+        "-keyalg".to_string(),
+        opts.key_alg.clone(),
+        "-keysize".to_string(),
+        keysize,
+        "-validity".to_string(),
+        validity,
+        "-storetype".to_string(),
+        opts.store_type.clone(),
+    ];
+    if let Some(dname) = &opts.dname {
+        args.push("-dname".to_string());
+        args.push(dname.clone());
+    }
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    // Use shell_env (interactive, not _cap) so keytool's prompts go straight
+    // to the terminal and the user can type passwords without echo.
+    shell_env(
+        &[("JAVA_HOME", java_home.to_str().unwrap())],
+        &cwd,
+        keytool.to_str().unwrap(),
+        &arg_refs,
+    )?;
+
+    write_keystore_sidecar(
+        &opts.keystore_path,
+        &KeystoreSidecar {
+            alias: Some(opts.alias.clone()),
+            store_type: Some(opts.store_type.clone()),
+        },
+    )?;
+
+    println!();
+    println!("================================================================================");
+    println!("KEYSTORE CREATED SUCCESSFULLY");
+    println!("================================================================================");
+    println!();
+    println!("  Keystore: {}", opts.keystore_path.display());
+    println!(
+        "  Metadata: {}  (alias auto-discovered by build-aab; safe to commit)",
+        keystore_sidecar_path(&opts.keystore_path).display()
+    );
+    println!();
+    println!("  BACK UP THE KEYSTORE FILE AND ITS PASSWORD NOW. Suggested locations:");
+    println!("    * 1Password / Bitwarden / your team's password manager");
+    println!("    * An offline encrypted backup (USB drive in a safe)");
+    println!("    * Your CI's secret store (GitHub Actions secrets, etc.) for automation");
+    println!();
+    println!("  Build a signed AAB with:");
+    println!(
+        "    cargo makepad android --keystore={} \\",
+        opts.keystore_path.display()
+    );
+    println!("        --keystore-pass=<password> \\");
+    println!("        build-aab -p <your-app> --release");
+    println!();
+    println!("  Or set MAKEPAD_KEYSTORE_PASS in your environment to skip the password flag:");
+    println!("    export MAKEPAD_KEYSTORE_PASS=<password>");
+    println!(
+        "    cargo makepad android --keystore={} build-aab -p <your-app> --release",
+        opts.keystore_path.display()
+    );
+    println!();
+    println!("================================================================================");
+
+    Ok(())
 }
 
 fn d8_jar_path(sdk_dir: &Path, urls: &AndroidSDKUrls) -> PathBuf {
@@ -405,9 +624,13 @@ fn rust_build(
         let target_opt = format!("--target={toolchain}");
         let target_dir_arg = format!("--target-dir={target_dir_str}");
 
+        // Android builds on stable: all android targets are tier-2 and the
+        // build uses no nightly-only cargo/rustc features. `rustup run stable`
+        // pins the channel explicitly so it doesn't matter what the build
+        // crate's rust-toolchain.toml (if any) selects.
         let base_args = &[
             "run",
-            "nightly",
+            "stable",
             "cargo",
             "rustc",
             "--lib",
@@ -557,16 +780,148 @@ fn cargo_target_dir(cwd: &Path) -> PathBuf {
     }
 }
 
-fn prepare_build(
+/// Final, resolved values for the manifest + APK/AAB packaging inputs.
+/// Produced by `resolve_packaging_inputs` from CLI flags + Cargo.toml metadata
+/// + sensible defaults, then consumed by both `build` and `build_aab`.
+struct ResolvedPackagingInputs {
+    /// Android package id (`com.foo.bar`). Becomes both the manifest `package=`
+    /// attribute and the Java module path.
+    java_url: String,
+    /// Launcher label (`<application android:label="...">`).
+    app_label: String,
+    /// `android:versionCode` — monotonic integer, required by Play Store.
+    version_code: u32,
+    /// `android:versionName` — human-readable, e.g. "1.0.0".
+    version_name: String,
+    /// Effective NDK target / `android:minSdkVersion` for this build. None
+    /// means use the cargo-makepad default from `urls.sdk_version`. Validated
+    /// to be ≥ 21 (NDK floor) and ≤ `urls.target_sdk_version` (Android rule).
+    min_sdk_version_override: Option<usize>,
+}
+
+/// Resolve packaging inputs with priority: CLI flag > Cargo.toml metadata > built-in default.
+///
+/// Cargo.toml fields read:
+///   `[package].version`                                  -> default `version_name`
+///   `[package.metadata.packager].identifier`             -> default `package_name`
+///   `[package.metadata.packager].product_name`           -> default `app_label`
+///   `[package.metadata.makepad.android].version_code`    -> default `version_code`
+///   `[package.metadata.makepad.android].version_name`    -> overrides `[package].version`
+fn resolve_packaging_inputs(
     build_crate: &str,
-    java_url: &str,
-    app_label: &str,
-    variant: &AndroidVariant,
+    binary_name: &str,
+    package_name_flag: Option<String>,
+    app_label_flag: Option<String>,
+    version_code_flag: Option<VersionCodeStrategy>,
+    version_name_flag: Option<String>,
+    min_sdk_version_flag: Option<usize>,
     urls: &AndroidSDKUrls,
-) -> Result<BuildPaths, String> {
+) -> Result<ResolvedPackagingInputs, String> {
+    let underscore_binary = binary_name.replace('-', "_");
+    let metadata = read_android_package_metadata(build_crate);
+
+    let java_url = package_name_flag
+        .or(metadata.identifier.clone())
+        .unwrap_or_else(|| format!("dev.makepad.{underscore_binary}"));
+
+    let app_label = app_label_flag
+        .or(metadata.product_name.clone())
+        .unwrap_or_else(|| {
+            let mut chars = underscore_binary.chars();
+            match chars.next() {
+                Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        });
+
+    let version_code_strategy = version_code_flag
+        .or(metadata.version_code)
+        .unwrap_or(VersionCodeStrategy::Explicit(1));
+    let version_code = version_code_strategy.resolve();
+
+    let version_name = version_name_flag
+        .or(metadata.version_name_override.clone())
+        .or(metadata.package_version.clone())
+        .unwrap_or_else(|| "1.0".to_string());
+
+    // Resolve and validate the per-app min SDK override. Default = unset,
+    // meaning the build uses `urls.sdk_version` as before. When set, must be:
+    //   - >= 21 (the NDK r28 floor for arm64; lower targets fail to build)
+    //   - <= `urls.target_sdk_version` (Android rule: minSdk <= targetSdk)
+    //   - >= `urls.sdk_version` (going *below* the cargo-makepad floor would
+    //     require knowing for sure that all NDK extern fns Makepad uses still
+    //     link cleanly at that lower API; we don't audit that automatically)
+    let min_sdk_version_override = min_sdk_version_flag.or(metadata.min_sdk_version);
+    if let Some(min) = min_sdk_version_override {
+        if min < 21 {
+            return Err(format!(
+                "min_sdk_version = {min} is below the NDK r28 arm64 floor of 21"
+            ));
+        }
+        if min > urls.target_sdk_version {
+            return Err(format!(
+                "min_sdk_version = {min} cannot exceed targetSdkVersion = {} (Android rule: minSdk <= targetSdk)",
+                urls.target_sdk_version
+            ));
+        }
+        if min < urls.sdk_version {
+            return Err(format!(
+                "min_sdk_version = {min} is below cargo-makepad's audited floor of {}. Lowering further requires verifying all NDK extern fns still link at API {min}; if you've done that audit, raise cargo-makepad's `urls.sdk_version` instead.",
+                urls.sdk_version
+            ));
+        }
+    }
+
+    Ok(ResolvedPackagingInputs {
+        java_url,
+        app_label,
+        version_code,
+        version_name,
+        min_sdk_version_override,
+    })
+}
+
+/// Inputs to `prepare_build`. Covers everything that influences the staged
+/// `tmp_dir/AndroidManifest.xml` so the file can vary per build mode (release
+/// APK vs debug APK vs Play Store AAB).
+pub struct PrepareBuildOpts<'a> {
+    pub build_crate: &'a str,
+    pub java_url: &'a str,
+    pub app_label: &'a str,
+    pub variant: &'a AndroidVariant,
+    pub urls: &'a AndroidSDKUrls,
+    pub version_code: u32,
+    pub version_name: &'a str,
+    pub debuggable: bool,
+}
+
+/// Replace `{key}` placeholders in a custom AndroidManifest template with the
+/// values cargo-makepad always knows. Used when the app crate ships its own
+/// `resources/android/AndroidManifest.xml.template`.
+fn substitute_manifest_template(template: &str, args: &ManifestArgs<'_>) -> String {
+    template
+        .replace("{label}", args.label)
+        .replace("{class_name}", args.class_name)
+        .replace("{package_id}", args.url)
+        .replace("{url}", args.url)
+        .replace("{min_sdk_version}", &args.sdk_version.to_string())
+        // `{sdk_version}` historically meant "the one SDK number" — alias to min
+        // so older templates keep compiling. New templates should prefer
+        // `{min_sdk_version}` / `{target_sdk_version}`.
+        .replace("{sdk_version}", &args.sdk_version.to_string())
+        .replace("{target_sdk_version}", &args.target_sdk_version.to_string())
+        .replace("{version_code}", &args.version_code.to_string())
+        .replace("{version_name}", args.version_name)
+        .replace(
+            "{debuggable}",
+            if args.debuggable { "true" } else { "false" },
+        )
+}
+
+fn prepare_build(opts: &PrepareBuildOpts<'_>) -> Result<BuildPaths, String> {
     let cwd = std::env::current_dir().unwrap();
     let target_dir = cargo_target_dir(&cwd);
-    let underscore_build_crate = build_crate.replace('-', "_");
+    let underscore_build_crate = opts.build_crate.replace('-', "_");
 
     let tmp_dir = target_dir
         .join("makepad-android-apk")
@@ -591,7 +946,7 @@ fn prepare_build(
     let cargo_manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     cp_all(&cargo_manifest_dir.join("src/android/res"), &res_dir, false)?;
 
-    let build_crate_dir = get_crate_dir(build_crate)?;
+    let build_crate_dir = get_crate_dir(opts.build_crate)?;
     let app_android_res = build_crate_dir.join("resources/android/res");
     if app_android_res.is_dir() {
         cp_all(&app_android_res, &res_dir, false)?;
@@ -614,26 +969,47 @@ fn prepare_build(
         );
     }
 
-    let manifest_xml = variant.manifest_xml(
-        app_label,
-        "MakepadApp",
-        java_url,
-        urls.sdk_version,
-        has_android_icon,
-    );
+    let manifest_args = ManifestArgs {
+        label: opts.app_label,
+        class_name: "MakepadApp",
+        url: opts.java_url,
+        sdk_version: opts.urls.sdk_version,
+        target_sdk_version: opts.urls.target_sdk_version,
+        has_icon: has_android_icon,
+        version_code: opts.version_code,
+        version_name: opts.version_name,
+        debuggable: opts.debuggable,
+    };
+
+    // Custom manifest override: if `<crate>/resources/android/AndroidManifest.xml.template`
+    // exists, use it after substituting `{key}` placeholders. Useful for declaring a
+    // permissions/features set tailored to the app (Play Store rejects most of the
+    // default kitchen-sink permission list without justification).
+    let custom_template = build_crate_dir.join("resources/android/AndroidManifest.xml.template");
+    let manifest_xml = if custom_template.is_file() {
+        let template = fs::read_to_string(&custom_template)
+            .map_err(|e| format!("Cant read custom manifest {:?}: {e}", custom_template))?;
+        println!(
+            "Using custom AndroidManifest template: {}",
+            custom_template.display()
+        );
+        substitute_manifest_template(&template, &manifest_args)
+    } else {
+        opts.variant.manifest_xml(&manifest_args)
+    };
     let manifest_file = tmp_dir.join("AndroidManifest.xml");
     write_text(&manifest_file, &manifest_xml)?;
 
-    let main_java = main_java(java_url);
-    let java_path = java_url.replace('.', "/");
+    let main_java = main_java(opts.java_url);
+    let java_path = opts.java_url.replace('.', "/");
     let java_file = tmp_dir.join(&java_path).join("MakepadApp.java");
     write_text(&java_file, &main_java)?;
 
-    let xr_java = xr_java(java_url);
+    let xr_java = xr_java(opts.java_url);
     let xr_file = tmp_dir.join(&java_path).join("MakepadAppXr.java");
     write_text(&xr_file, &xr_java)?;
 
-    let apk_filename = to_snakecase(app_label);
+    let apk_filename = to_snakecase(opts.app_label);
     let dst_unaligned_apk = out_dir.join(format!("{apk_filename}.unaligned.apk"));
     let dst_apk = out_dir.join(format!("{apk_filename}.apk"));
 
@@ -1495,35 +1871,649 @@ fn sign_apk(sdk_dir: &Path, build_paths: &BuildPaths, urls: &AndroidSDKUrls) -> 
     Ok(())
 }
 
-pub fn build(
+// ============================================================================
+// AAB (Android App Bundle) build pipeline.
+//
+// Unlike the legacy APK pipeline which uses aapt v1 + apksigner, AABs require:
+//   1. aapt2 compile + aapt2 link --proto-format  -> proto-format base APK
+//   2. Repackage into the bundletool "module zip" layout
+//      (manifest/, dex/, res/, lib/, assets/, resources.pb)
+//   3. bundletool build-bundle -> .aab
+//   4. jarsigner               -> signed .aab
+//
+// The Play Store rejects debug-signed AABs, so the keystore is configurable.
+// ============================================================================
+
+/// Where to place the AAB-specific intermediate and output files.
+struct AabPaths {
+    staged_assets_dir: PathBuf,
+    staged_libs_dir: PathBuf,
+    compiled_res_zip: PathBuf,
+    proto_apk: PathBuf,
+    base_module_dir: PathBuf,
+    base_module_zip: PathBuf,
+    dst_aab: PathBuf,
+}
+
+fn prepare_aab_paths(build_crate: &str, app_label: &str) -> Result<AabPaths, String> {
+    let cwd = std::env::current_dir().unwrap();
+    let target_dir = cargo_target_dir(&cwd);
+    let underscore_build_crate = build_crate.replace('-', "_");
+    let aab_dir = target_dir
+        .join("makepad-android-aab")
+        .join(&underscore_build_crate);
+    let _ = rmdir(&aab_dir);
+    mkdir(&aab_dir)?;
+
+    let staged_assets_dir = aab_dir.join("assets");
+    let staged_libs_dir = aab_dir.join("lib");
+    let compiled_res_zip = aab_dir.join("compiled_res.zip");
+    let proto_apk = aab_dir.join("base_proto.apk");
+    let base_module_dir = aab_dir.join("base");
+    let base_module_zip = aab_dir.join("base.zip");
+    let dst_aab = aab_dir.join(format!("{}.aab", to_snakecase(app_label)));
+
+    mkdir(&staged_assets_dir)?;
+    mkdir(&staged_libs_dir)?;
+
+    Ok(AabPaths {
+        staged_assets_dir,
+        staged_libs_dir,
+        compiled_res_zip,
+        proto_apk,
+        base_module_dir,
+        base_module_zip,
+        dst_aab,
+    })
+}
+
+/// Mirror of `add_assets_dir_to_apk` that only stages files into a directory tree
+/// (no aapt invocation). Output structure: `<assets_root>/makepad/<crate>/<asset_subdir>/...`.
+fn stage_makepad_assets_subdir(
+    assets_root: &Path,
+    crate_name: &str,
+    source_dir: &Path,
+    asset_subdir: &str,
+    config: &AndroidConfig,
+) -> Result<(), String> {
+    if !source_dir.is_dir() {
+        return Ok(());
+    }
+    let crate_name = crate_name.replace('-', "_");
+    let dst_dir = assets_root.join(format!("makepad/{crate_name}/{asset_subdir}"));
+    mkdir(&dst_dir)?;
+    cp_all(source_dir, &dst_dir, false)?;
+    if config.small_fonts && asset_subdir == "resources" {
+        for (target_name, replacement_name) in SMALL_FONT_REPLACEMENTS {
+            let replacement = source_dir.join(replacement_name);
+            let target = dst_dir.join(target_name);
+            if replacement.is_file() && target.is_file() {
+                cp(&replacement, &target, false)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Mirror of `add_font_assets_dir_to_apk` that only stages files into a directory tree.
+fn stage_makepad_font_subdir(
+    assets_root: &Path,
+    crate_name: &str,
+    source_dir: &Path,
+    resource_dir: &Path,
+    config: &AndroidConfig,
+) -> Result<(), String> {
+    if !source_dir.is_dir() {
+        return Ok(());
+    }
+    let crate_name = crate_name.replace('-', "_");
+    let dst_dir = assets_root.join(format!("makepad/{crate_name}/fonts"));
+    let assets = ls(source_dir)?;
+    for path in &assets {
+        let ext = path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| ext.to_ascii_lowercase());
+        if !matches!(
+            ext.as_deref(),
+            Some("ttf" | "otf" | "ttc" | "woff" | "woff2")
+        ) {
+            continue;
+        }
+        if resource_dir.join(path).is_file() {
+            continue;
+        }
+        cp(&source_dir.join(path), &dst_dir.join(path), false)?;
+    }
+    if config.small_fonts {
+        for (target_name, replacement_name) in SMALL_FONT_REPLACEMENTS {
+            let replacement = source_dir
+                .join(replacement_name)
+                .is_file()
+                .then(|| source_dir.join(replacement_name))
+                .or_else(|| {
+                    resource_dir
+                        .join(replacement_name)
+                        .is_file()
+                        .then(|| resource_dir.join(replacement_name))
+                });
+            let target = dst_dir.join(target_name);
+            if let Some(replacement) = replacement {
+                if target.is_file() {
+                    cp(&replacement, &target, false)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn stage_aab_assets(
+    build_crate: &str,
+    assets_root: &Path,
+    build_dir: &Path,
+    android_targets: &[AndroidTarget],
+    variant: &AndroidVariant,
+    config: &AndroidConfig,
+) -> Result<(), String> {
+    let build_crate_dir = get_crate_dir(build_crate)?;
+    stage_makepad_assets_subdir(
+        assets_root,
+        build_crate,
+        &build_crate_dir.join("resources"),
+        "resources",
+        config,
+    )?;
+    stage_makepad_font_subdir(
+        assets_root,
+        build_crate,
+        &build_crate_dir.join("fonts"),
+        &build_crate_dir.join("resources"),
+        config,
+    )?;
+
+    let deps = get_crate_dep_dirs(build_crate, build_dir, &android_targets[0].toolchain());
+    for (name, dep_dir) in deps.iter() {
+        stage_makepad_assets_subdir(
+            assets_root,
+            name,
+            &dep_dir.join("resources"),
+            "resources",
+            config,
+        )?;
+        stage_makepad_font_subdir(
+            assets_root,
+            name,
+            &dep_dir.join("fonts"),
+            &dep_dir.join("resources"),
+            config,
+        )?;
+    }
+
+    if let AndroidVariant::Quest = variant {
+        let dst_dir = assets_root.join("makepad/makepad_widgets/resources");
+        let remove = [
+            "fa-solid-900.ttf",
+            "LiberationMono-Regular.ttf",
+            "NotoSans-Regular.ttf",
+        ];
+        for r in remove {
+            let _ = rm(&dst_dir.join(r));
+        }
+    }
+
+    Ok(())
+}
+
+/// Mirror of `bundle_ndk_shared_deps` that only stages files into `libs_root/<abi>/`.
+fn stage_ndk_shared_deps_for_so(
+    sdk_dir: &Path,
+    host_os: HostOs,
+    urls: &AndroidSDKUrls,
+    android_target: &AndroidTarget,
+    so_path: &Path,
+    abi: &str,
+    libs_root: &Path,
+) -> Result<(), String> {
+    let (_ndk_version, ndk_prebuilt_root) =
+        resolve_ndk_prebuilt_root(sdk_dir, host_os, urls.ndk_version_full)?;
+    let readelf_path = ndk_prebuilt_root.join("bin/llvm-readelf");
+    if !readelf_path.exists() {
+        return Ok(());
+    }
+    let cwd = std::env::current_dir().unwrap();
+    let output = shell_env_cap(
+        &[],
+        &cwd,
+        readelf_path.to_str().unwrap(),
+        &["-d", so_path.to_str().unwrap()],
+    )?;
+    let clang_triple = android_target.clang();
+    let sysroot_lib_dir = ndk_prebuilt_root.join("sysroot/usr/lib").join(clang_triple);
+    for line in output.lines() {
+        if !line.contains("(NEEDED)") {
+            continue;
+        }
+        let lib_name = match line.find('[').and_then(|start| {
+            line[start + 1..]
+                .find(']')
+                .map(|end| &line[start + 1..start + 1 + end])
+        }) {
+            Some(name) => name,
+            None => continue,
+        };
+        let candidate = sysroot_lib_dir.join(lib_name);
+        if !candidate.exists() || !candidate.is_file() {
+            continue;
+        }
+        let api_level_stub = sysroot_lib_dir
+            .join(urls.sdk_version.to_string())
+            .join(lib_name);
+        if api_level_stub.exists() {
+            continue;
+        }
+        let dst_lib = libs_root.join(abi).join(lib_name);
+        if dst_lib.exists() {
+            continue;
+        }
+        cp(&candidate, &dst_lib, false)?;
+        println!("  Bundled NDK shared dep: {lib_name} (for {abi})");
+    }
+    Ok(())
+}
+
+/// Mirror of `bundle_local_shared_deps` that only stages into `libs_root/<abi>/`.
+fn stage_local_shared_deps(
+    sdk_dir: &Path,
+    host_os: HostOs,
+    urls: &AndroidSDKUrls,
+    android_target: &AndroidTarget,
+    so_path: &Path,
+    abi: &str,
+    libs_root: &Path,
+    build_dir: &Path,
+) -> Result<(), String> {
+    let mut pending = vec![so_path.to_path_buf()];
+    let mut visited = HashSet::<String>::new();
+    let search_dirs = [build_dir.to_path_buf(), build_dir.join("deps")];
+    while let Some(current_so) = pending.pop() {
+        for lib_name in read_needed_shared_libs(sdk_dir, host_os, urls, &current_so)? {
+            if !visited.insert(lib_name.clone()) {
+                continue;
+            }
+            let dst_lib = libs_root.join(abi).join(&lib_name);
+            if dst_lib.exists() {
+                continue;
+            }
+            let candidate = search_dirs
+                .iter()
+                .map(|dir| dir.join(&lib_name))
+                .find(|path| path.is_file())
+                .or_else(|| find_rustup_shared_lib(android_target, &lib_name));
+            let Some(candidate) = candidate else {
+                continue;
+            };
+            cp(&candidate, &dst_lib, false)?;
+            stage_ndk_shared_deps_for_so(
+                sdk_dir,
+                host_os,
+                urls,
+                android_target,
+                &dst_lib,
+                abi,
+                libs_root,
+            )?;
+            println!("  Bundled local shared dep: {lib_name} (for {abi})");
+            pending.push(candidate);
+        }
+    }
+    Ok(())
+}
+
+fn stage_aab_native_libs(
+    sdk_dir: &Path,
+    host_os: HostOs,
+    underscore_target: &str,
+    libs_root: &Path,
+    android_targets: &[AndroidTarget],
+    args: &[String],
+    variant: &AndroidVariant,
+    urls: &AndroidSDKUrls,
+) -> Result<PathBuf, String> {
+    let cwd = std::env::current_dir().unwrap();
+    let target_dir = cargo_target_dir(&cwd);
+    let profile = get_profile_from_args(args);
+    let mut build_dir = None;
+    for android_target in android_targets {
+        let abi = android_target.abi_identifier();
+        mkdir(&libs_root.join(abi))?;
+
+        let android_target_dir = android_target.toolchain();
+        if profile == "debug" {
+            println!("WARNING - compiling a DEBUG build of the application, this creates a very slow and big app. Try adding --release for a fast, or --profile=small for a small build.");
+        }
+        let src_lib = target_dir.join(format!(
+            "{android_target_dir}/{profile}/lib{underscore_target}.so"
+        ));
+        let current_build_dir = target_dir.join(format!("{android_target_dir}/{profile}"));
+        build_dir = Some(current_build_dir.clone());
+        let dst_lib = libs_root.join(abi).join("libmakepad.so");
+        cp(&src_lib, &dst_lib, false)?;
+
+        stage_ndk_shared_deps_for_so(
+            sdk_dir,
+            host_os,
+            urls,
+            android_target,
+            &dst_lib,
+            abi,
+            libs_root,
+        )?;
+        stage_local_shared_deps(
+            sdk_dir,
+            host_os,
+            urls,
+            android_target,
+            &src_lib,
+            abi,
+            libs_root,
+            &current_build_dir,
+        )?;
+    }
+    if let AndroidVariant::Quest = variant {
+        let cargo_manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        for (rel_path, src_lib) in [("arm64-v8a/libopenxr_loader.so", "quest/libopenxr_loader.so")]
+        {
+            let src_lib = cargo_manifest_dir.join(src_lib);
+            let dst_lib = libs_root.join(rel_path);
+            cp(&src_lib, &dst_lib, false)?;
+        }
+    }
+    Ok(build_dir.unwrap())
+}
+
+fn aapt2_compile_resources(
+    sdk_dir: &Path,
+    res_dir: &Path,
+    out_zip: &Path,
+    urls: &AndroidSDKUrls,
+) -> Result<(), String> {
+    let cwd = std::env::current_dir().unwrap();
+    shell_env_cap(
+        &[],
+        &cwd,
+        aapt2_path(sdk_dir, urls).to_str().unwrap(),
+        &[
+            "compile",
+            "--dir",
+            res_dir.to_str().unwrap(),
+            "-o",
+            out_zip.to_str().unwrap(),
+        ],
+    )?;
+    Ok(())
+}
+
+fn aapt2_link_proto_apk(
+    sdk_dir: &Path,
+    manifest_xml: &Path,
+    compiled_res_zip: &Path,
+    assets_dir: &Path,
+    out_apk: &Path,
+    urls: &AndroidSDKUrls,
+) -> Result<(), String> {
+    let cwd = std::env::current_dir().unwrap();
+    let android_jar = android_jar_path(sdk_dir, urls);
+    let android_jar_str = android_jar.to_str().unwrap().to_string();
+    let manifest_str = manifest_xml.to_str().unwrap().to_string();
+    let out_str = out_apk.to_str().unwrap().to_string();
+    let res_zip_str = compiled_res_zip.to_str().unwrap().to_string();
+    let assets_str = assets_dir.to_str().unwrap().to_string();
+
+    let has_assets = assets_dir.is_dir() && ls(assets_dir).map(|v| !v.is_empty()).unwrap_or(false);
+
+    let mut args: Vec<&str> = vec![
+        "link",
+        "--proto-format",
+        "--auto-add-overlay",
+        "-I",
+        &android_jar_str,
+        "--manifest",
+        &manifest_str,
+        "-o",
+        &out_str,
+    ];
+    if has_assets {
+        args.push("-A");
+        args.push(&assets_str);
+    }
+    args.push(&res_zip_str);
+    shell_env_cap(
+        &[],
+        &cwd,
+        aapt2_path(sdk_dir, urls).to_str().unwrap(),
+        &args,
+    )?;
+    Ok(())
+}
+
+/// Repackage a proto-format APK produced by `aapt2 link --proto-format` into
+/// the bundle module layout that bundletool expects, then zip it.
+///
+/// Layout produced under `base_dir`:
+///   manifest/AndroidManifest.xml   <- moved from APK root
+///   dex/classes.dex                <- copied from d8 output
+///   res/...                        <- carried from proto APK as-is
+///   resources.pb                   <- carried from proto APK
+///   assets/...                     <- carried from proto APK (added via aapt2 -A)
+///   lib/<abi>/*.so                 <- copied from staged libs dir
+fn assemble_aab_base_module(
+    sdk_dir: &Path,
+    proto_apk: &Path,
+    classes_dex: &Path,
+    libs_root: &Path,
+    base_dir: &Path,
+    base_zip: &Path,
+) -> Result<(), String> {
+    let _ = rmdir(base_dir);
+    mkdir(base_dir)?;
+
+    // Extract proto APK entries into the base dir, rewriting the manifest path.
+    let mut zip_file =
+        File::open(proto_apk).map_err(|e| format!("Cant open proto APK {:?}: {e}", proto_apk))?;
+    let directory = zip_read_central_directory(&mut zip_file)
+        .map_err(|e| format!("Cant read proto APK {:?}: {:?}", proto_apk, e))?;
+
+    for header in &directory.file_headers {
+        let entry_name = &header.file_name;
+        if entry_name.ends_with('/') {
+            continue;
+        }
+        let data = header
+            .extract(&mut zip_file)
+            .map_err(|e| format!("Failed to extract {entry_name} from proto APK: {:?}", e))?;
+        let dst_rel = if entry_name == "AndroidManifest.xml" {
+            "manifest/AndroidManifest.xml".to_string()
+        } else {
+            entry_name.clone()
+        };
+        let dst_path = base_dir.join(&dst_rel);
+        mkdir(dst_path.parent().unwrap())?;
+        let mut f =
+            File::create(&dst_path).map_err(|e| format!("Cant write {:?}: {e}", dst_path))?;
+        f.write_all(&data)
+            .map_err(|e| format!("Cant write to {:?}: {e}", dst_path))?;
+    }
+
+    // dex/classes.dex
+    cp(classes_dex, &base_dir.join("dex/classes.dex"), false)?;
+
+    // lib/<abi>/*.so (only if the staged libs dir actually has anything).
+    if libs_root.is_dir() && ls(libs_root).map(|v| !v.is_empty()).unwrap_or(false) {
+        cp_all(libs_root, &base_dir.join("lib"), false)?;
+    }
+
+    // Zip the base module using the bundled `jar` tool. `M` flag suppresses
+    // META-INF/MANIFEST.MF; bundletool rejects modules with an unexpected
+    // META-INF entry.
+    let java_home = sdk_dir.join("openjdk");
+    let jar_bin = java_home.join("bin/jar");
+    if base_zip.is_file() {
+        rm(base_zip)?;
+    }
+    shell_env_cap(
+        &[("JAVA_HOME", java_home.to_str().unwrap())],
+        base_dir,
+        jar_bin.to_str().unwrap(),
+        &["cMf", base_zip.to_str().unwrap(), "."],
+    )?;
+
+    Ok(())
+}
+
+fn run_bundletool_build_bundle(
+    sdk_dir: &Path,
+    base_zip: &Path,
+    aab_path: &Path,
+) -> Result<(), String> {
+    let java_home = sdk_dir.join("openjdk");
+    let bundletool = bundletool_jar_path(sdk_dir);
+    if !bundletool.is_file() {
+        return Err(format!(
+            "bundletool jar not found at {:?}. Re-run `cargo makepad android install-toolchain` to download it.",
+            bundletool
+        ));
+    }
+    if aab_path.is_file() {
+        rm(aab_path)?;
+    }
+    let cwd = std::env::current_dir().unwrap();
+    let modules_arg = format!("--modules={}", base_zip.display());
+    let output_arg = format!("--output={}", aab_path.display());
+    shell_env_cap(
+        &[("JAVA_HOME", java_home.to_str().unwrap())],
+        &cwd,
+        java_home.join("bin/java").to_str().unwrap(),
+        &[
+            "-jar",
+            bundletool.to_str().unwrap(),
+            "build-bundle",
+            &modules_arg,
+            &output_arg,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Pick a jarsigner binary from (in order): the bundled JDK, JAVA_HOME, PATH.
+fn resolve_jarsigner(sdk_dir: &Path) -> Option<PathBuf> {
+    let bundled = sdk_dir.join("openjdk/bin/jarsigner");
+    let bundled_exe = sdk_dir.join("openjdk/bin/jarsigner.exe");
+    if bundled.is_file() {
+        return Some(bundled);
+    }
+    if bundled_exe.is_file() {
+        return Some(bundled_exe);
+    }
+    if let Some(java_home) = std::env::var_os("JAVA_HOME") {
+        let from_home = PathBuf::from(&java_home).join("bin/jarsigner");
+        let from_home_exe = PathBuf::from(&java_home).join("bin/jarsigner.exe");
+        if from_home.is_file() {
+            return Some(from_home);
+        }
+        if from_home_exe.is_file() {
+            return Some(from_home_exe);
+        }
+    }
+    if let Some(paths) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&paths) {
+            for name in ["jarsigner", "jarsigner.exe"] {
+                let candidate = dir.join(name);
+                if candidate.is_file() {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
+}
+
+#[derive(Debug)]
+pub struct AabSigningOpts {
+    pub keystore: PathBuf,
+    pub storepass: String,
+    pub key_alias: String,
+    pub keypass: String,
+}
+
+fn sign_aab(sdk_dir: &Path, aab_path: &Path, opts: &AabSigningOpts) -> Result<(), String> {
+    let jarsigner = resolve_jarsigner(sdk_dir).ok_or_else(|| {
+        "jarsigner not found. Re-run `cargo makepad android install-toolchain` to extract it, or set JAVA_HOME to a full JDK install."
+            .to_string()
+    })?;
+    let java_home = sdk_dir.join("openjdk");
+    let cwd = std::env::current_dir().unwrap();
+    shell_env_cap(
+        &[("JAVA_HOME", java_home.to_str().unwrap())],
+        &cwd,
+        jarsigner.to_str().unwrap(),
+        &[
+            "-keystore",
+            opts.keystore.to_str().unwrap(),
+            "-storepass",
+            &opts.storepass,
+            "-keypass",
+            &opts.keypass,
+            aab_path.to_str().unwrap(),
+            &opts.key_alias,
+        ],
+    )?;
+    Ok(())
+}
+
+pub struct BuildAabResult {
+    #[allow(dead_code)]
+    pub dst_aab: PathBuf,
+}
+
+pub fn build_aab(
     sdk_dir: &Path,
     host_os: HostOs,
     package_name: Option<String>,
     app_label: Option<String>,
+    version_code: Option<VersionCodeStrategy>,
+    version_name: Option<String>,
+    min_sdk_version: Option<usize>,
     args: &[String],
     android_targets: &[AndroidTarget],
     variant: &AndroidVariant,
     config: &AndroidConfig,
     urls: &AndroidSDKUrls,
-) -> Result<BuildResult, String> {
+    signing: Option<AabSigningOpts>,
+) -> Result<BuildAabResult, String> {
     let build_crate = get_build_crate_from_args(args)?;
     let binary_name =
         get_package_binary_name(build_crate).unwrap_or_else(|| build_crate.to_string());
-    let underscore_binary_name = binary_name.replace('-', "_");
     let underscore_build_crate = build_crate.replace('-', "_");
 
-    let java_url = package_name.unwrap_or_else(|| format!("dev.makepad.{underscore_binary_name}"));
-    // When the caller didn't pass --app-label, fall back to the binary name with the
-    // first letter capitalized so the launcher icon doesn't show a lowercased crate
-    // name. The package name (java_url) stays lowercase since Android package IDs
-    // conventionally are.
-    let app_label = app_label.unwrap_or_else(|| {
-        let mut chars = underscore_binary_name.chars();
-        match chars.next() {
-            Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
-            None => String::new(),
-        }
-    });
+    let resolved = resolve_packaging_inputs(
+        build_crate,
+        &binary_name,
+        package_name,
+        app_label,
+        version_code,
+        version_name,
+        min_sdk_version,
+        urls,
+    )?;
+    // Apply the per-app min SDK override by mutating a copy of urls. Downstream
+    // code (NDK clang triple, sysroot stub lookup, manifest emission) reads
+    // `urls.sdk_version`, so this single point of override propagates cleanly.
+    let mut effective_urls = *urls;
+    if let Some(min) = resolved.min_sdk_version_override {
+        effective_urls.sdk_version = min;
+    }
+    let urls = &effective_urls;
 
     if let Some(icon) = resolve_app_icon_env(build_crate)? {
         for (var, value) in APP_ICON_ENV_VARS.iter().zip(icon.iter()) {
@@ -1540,9 +2530,187 @@ pub fn build(
         variant,
         urls,
     )?;
-    let build_paths = prepare_build(build_crate, &java_url, &app_label, variant, urls)?;
+    // AABs uploaded to Play Store must have `android:debuggable="false"`. Force
+    // it here regardless of cargo profile so we never produce an unshippable AAB.
+    let prep_opts = PrepareBuildOpts {
+        build_crate,
+        java_url: &resolved.java_url,
+        app_label: &resolved.app_label,
+        variant,
+        urls,
+        version_code: resolved.version_code,
+        version_name: &resolved.version_name,
+        debuggable: false,
+    };
+    let build_paths = prepare_build(&prep_opts)?;
+    let aab_paths = prepare_aab_paths(build_crate, &resolved.app_label)?;
 
-    println!("Building APK");
+    println!(
+        "Building AAB (package={}, label={}, versionCode={}, versionName={})",
+        resolved.java_url, resolved.app_label, resolved.version_code, resolved.version_name
+    );
+
+    // Reuse the existing R-class / javac / d8 pipeline; outputs `classes.dex`
+    // into `build_paths.out_dir`.
+    build_r_class(sdk_dir, &build_paths, urls)?;
+    compile_java(sdk_dir, &build_paths, urls)?;
+    build_dex(sdk_dir, &build_paths, urls)?;
+    let classes_dex = build_paths.out_dir.join("classes.dex");
+    if !classes_dex.is_file() {
+        return Err(format!(
+            "d8 did not produce classes.dex at {:?}",
+            classes_dex
+        ));
+    }
+
+    // Stage native libs.
+    let build_dir = stage_aab_native_libs(
+        sdk_dir,
+        host_os,
+        &underscore_build_crate,
+        &aab_paths.staged_libs_dir,
+        android_targets,
+        args,
+        variant,
+        urls,
+    )?;
+
+    // Stage assets (mirrors `add_resources` / `add_assets_dir_to_apk` / font logic).
+    stage_aab_assets(
+        build_crate,
+        &aab_paths.staged_assets_dir,
+        &build_dir,
+        android_targets,
+        variant,
+        config,
+    )?;
+
+    // aapt2 compile + link --proto-format. Assets are picked up via -A.
+    aapt2_compile_resources(
+        sdk_dir,
+        &build_paths.res_dir,
+        &aab_paths.compiled_res_zip,
+        urls,
+    )?;
+    aapt2_link_proto_apk(
+        sdk_dir,
+        &build_paths.manifest_file,
+        &aab_paths.compiled_res_zip,
+        &aab_paths.staged_assets_dir,
+        &aab_paths.proto_apk,
+        urls,
+    )?;
+
+    // Repackage proto APK into the bundle module layout, then zip it.
+    assemble_aab_base_module(
+        sdk_dir,
+        &aab_paths.proto_apk,
+        &classes_dex,
+        &aab_paths.staged_libs_dir,
+        &aab_paths.base_module_dir,
+        &aab_paths.base_module_zip,
+    )?;
+
+    // bundletool build-bundle
+    run_bundletool_build_bundle(sdk_dir, &aab_paths.base_module_zip, &aab_paths.dst_aab)?;
+
+    // Sign with jarsigner if a keystore was provided (or default).
+    if let Some(opts) = &signing {
+        sign_aab(sdk_dir, &aab_paths.dst_aab, opts)?;
+    } else {
+        println!("Skipping signing (--no-sign). The AAB is unsigned and will not be accepted by the Play Store as-is.");
+    }
+
+    println!("AAB Build completed: {}", aab_paths.dst_aab.display());
+    if let Some(opts) = &signing {
+        let cargo_manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        if opts.keystore == cargo_manifest_dir.join("debug.keystore") {
+            println!(
+                "NOTE: signed with the bundled debug keystore. The Play Store will reject this AAB. Pass --keystore=<path> --keystore-pass=<pw> --keystore-key-alias=<alias> --keystore-key-pass=<pw> to sign with a release keystore."
+            );
+        }
+    }
+
+    Ok(BuildAabResult {
+        dst_aab: aab_paths.dst_aab,
+    })
+}
+
+pub fn build(
+    sdk_dir: &Path,
+    host_os: HostOs,
+    package_name: Option<String>,
+    app_label: Option<String>,
+    version_code: Option<VersionCodeStrategy>,
+    version_name: Option<String>,
+    min_sdk_version: Option<usize>,
+    args: &[String],
+    android_targets: &[AndroidTarget],
+    variant: &AndroidVariant,
+    config: &AndroidConfig,
+    urls: &AndroidSDKUrls,
+) -> Result<BuildResult, String> {
+    let build_crate = get_build_crate_from_args(args)?;
+    let binary_name =
+        get_package_binary_name(build_crate).unwrap_or_else(|| build_crate.to_string());
+    let underscore_build_crate = build_crate.replace('-', "_");
+
+    let resolved = resolve_packaging_inputs(
+        build_crate,
+        &binary_name,
+        package_name,
+        app_label,
+        version_code,
+        version_name,
+        min_sdk_version,
+        urls,
+    )?;
+    // Apply the per-app min SDK override; see the same pattern in `build_aab`.
+    let mut effective_urls = *urls;
+    if let Some(min) = resolved.min_sdk_version_override {
+        effective_urls.sdk_version = min;
+    }
+    let urls = &effective_urls;
+
+    if let Some(icon) = resolve_app_icon_env(build_crate)? {
+        for (var, value) in APP_ICON_ENV_VARS.iter().zip(icon.iter()) {
+            std::env::set_var(var, value);
+        }
+    }
+
+    rust_build(
+        sdk_dir,
+        host_os,
+        build_crate,
+        args,
+        android_targets,
+        variant,
+        urls,
+    )?;
+    // For APK builds, debuggable matches the cargo profile: release -> false,
+    // anything else -> true (matches the historical behavior of `cargo makepad
+    // android run`).
+    let debuggable = get_profile_from_args(args) != "release";
+    let prep_opts = PrepareBuildOpts {
+        build_crate,
+        java_url: &resolved.java_url,
+        app_label: &resolved.app_label,
+        variant,
+        urls,
+        version_code: resolved.version_code,
+        version_name: &resolved.version_name,
+        debuggable,
+    };
+    let build_paths = prepare_build(&prep_opts)?;
+
+    println!(
+        "Building APK (package={}, label={}, versionCode={}, versionName={}, debuggable={})",
+        resolved.java_url,
+        resolved.app_label,
+        resolved.version_code,
+        resolved.version_name,
+        debuggable
+    );
     build_r_class(sdk_dir, &build_paths, urls)?;
     compile_java(sdk_dir, &build_paths, urls)?;
     build_dex(sdk_dir, &build_paths, urls)?;
@@ -1573,7 +2741,7 @@ pub fn build(
     println!("APK Build completed");
     Ok(BuildResult {
         dst_apk: build_paths.dst_apk,
-        java_url,
+        java_url: resolved.java_url,
     })
 }
 
@@ -1582,6 +2750,9 @@ pub fn run(
     host_os: HostOs,
     package_name: Option<String>,
     app_label: Option<String>,
+    version_code: Option<VersionCodeStrategy>,
+    version_name: Option<String>,
+    min_sdk_version: Option<usize>,
     args: &[String],
     targets: &[AndroidTarget],
     android_variant: &AndroidVariant,
@@ -1595,6 +2766,9 @@ pub fn run(
         host_os,
         package_name,
         app_label,
+        version_code,
+        version_name,
+        min_sdk_version,
         args,
         targets,
         android_variant,

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -589,7 +589,14 @@ class MakepadSurface
         int selEnd = Selection.getSelectionEnd(mEditable);
         outAttrs.initialSelStart = Math.max(0, selStart);
         outAttrs.initialSelEnd = Math.max(0, selEnd);
-        outAttrs.setInitialSurroundingSubText(mEditable, 0);
+        // EditorInfo.setInitialSurroundingSubText is API 30+. It's only an
+        // optimization (it hands the IME the surrounding text up-front); on
+        // older devices the IME just queries it on demand through the
+        // InputConnection. Calling it unconditionally crashes API 26-29 with
+        // NoSuchMethodError.
+        if (Build.VERSION.SDK_INT >= 30) {
+            outAttrs.setInitialSurroundingSubText(mEditable, 0);
+        }
 
         // Create InputConnection with fullEditor=true since we have an Editable
         mInputConnection = new MakepadInputConnection(this, true);
@@ -1615,9 +1622,15 @@ public class MakepadActivity
         View decorView = getWindow().getDecorView();
 
         if (fullscreen) {
-            // LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS = 3 (API 30+), fall back to SHORT_EDGES
-            getWindow().getAttributes().layoutInDisplayCutoutMode =
-                Build.VERSION.SDK_INT >= 30 ? 3 : LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+            // WindowManager.LayoutParams.layoutInDisplayCutoutMode is API 28+
+            // (display cutouts didn't exist before Android 9). Touching the
+            // field at all on API 26-27 throws NoSuchFieldError, so guard it.
+            // LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS = 3 is API 30+; on 28-29 we
+            // fall back to SHORT_EDGES.
+            if (Build.VERSION.SDK_INT >= 28) {
+                getWindow().getAttributes().layoutInDisplayCutoutMode =
+                    Build.VERSION.SDK_INT >= 30 ? 3 : LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+            }
             if (Build.VERSION.SDK_INT >= 30) {
                 getWindow().setDecorFitsSystemWindows(false);
                 android.view.WindowInsetsController controller = getWindow().getInsetsController();

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -52,6 +52,7 @@ import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.view.Window;
 import android.view.WindowInsets;
+import android.view.WindowInsetsController;
 import android.view.WindowManager;
 import android.view.WindowManager.LayoutParams;
 import android.view.inputmethod.BaseInputConnection;
@@ -884,6 +885,10 @@ public class MakepadActivity
     static HashMap<Long, MakepadSocketStream> mActiveSocketStreams = new HashMap<>();
     private boolean mIsSwitchingActivity = false;
 
+    // Desired system-bar (status/navigation bar) icon tint, set from Rust via
+    // setSystemBarAppearance(). true = dark icons (for light app backgrounds).
+    private boolean mSystemBarDarkIcons = false;
+
     // clipboard actions (ActionMode for copy/paste/cut)
     private ActionMode mActionMode;
     private boolean mHasSelection = false;
@@ -1326,6 +1331,51 @@ public class MakepadActivity
             });
     }
 
+    // Tints the system bar (status/navigation bar) icons and text. A "light"
+    // system bar has a light background, so it needs dark icons for contrast;
+    // we therefore request dark icons when the app's background is light.
+    public void setSystemBarAppearance(final boolean darkIcons) {
+        runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    mSystemBarDarkIcons = darkIcons;
+                    applySystemBarAppearance();
+                }
+            });
+    }
+
+    // Applies the currently desired system-bar icon tint (mSystemBarDarkIcons)
+    // to the window. Safe to call repeatedly. It is also re-invoked from
+    // applyFullScreen(), because the legacy (pre-API-30) fullscreen path
+    // rewrites the whole systemUiVisibility bitmask and would otherwise drop
+    // the light-status/navigation-bar bits.
+    @SuppressWarnings("deprecation")
+    private void applySystemBarAppearance() {
+        Window window = getWindow();
+        if (window == null) {
+            return;
+        }
+        if (Build.VERSION.SDK_INT >= 30) {
+            WindowInsetsController controller = window.getInsetsController();
+            if (controller != null) {
+                int mask = WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
+                    | WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS;
+                controller.setSystemBarsAppearance(mSystemBarDarkIcons ? mask : 0, mask);
+            }
+        } else {
+            View decorView = window.getDecorView();
+            int lightBars = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+                | View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
+            int flags = decorView.getSystemUiVisibility();
+            if (mSystemBarDarkIcons) {
+                flags |= lightBars;
+            } else {
+                flags &= ~lightBars;
+            }
+            decorView.setSystemUiVisibility(flags);
+        }
+    }
+
     private boolean canCaptureSurfaceSnapshot() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             return false;
@@ -1660,6 +1710,12 @@ public class MakepadActivity
                 decorView.setSystemUiVisibility(0);
             }
         }
+
+        // The legacy (pre-API-30) branches above replace the entire
+        // systemUiVisibility bitmask, so re-assert the system-bar icon tint
+        // on top of the new flags. On API 30+ this is an independent,
+        // idempotent re-apply.
+        applySystemBarAppearance();
 
         // Force a layout pass so the SurfaceView gets the new dimensions
         if (view != null) {

--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -86,6 +86,13 @@ import java.util.concurrent.CompletableFuture;
 class MakepadImeInsets {
     private static final int MIN_KEYBOARD_HEIGHT_DP = 80;
 
+    // True while a soft-keyboard (IME) show/hide animation is running. While an
+    // animation is in flight the per-frame WindowInsetsAnimation callback
+    // (onProgress/onEnd) is the authoritative inset source; the layout-driven
+    // fallbacks (onApplyWindowInsets, onGlobalLayout) observe a contradictory
+    // mix of target and stale insets mid-animation, so they defer to it.
+    static boolean imeAnimationInProgress = false;
+
     private static int keyboardThresholdPx(View view) {
         return Math.max(1, (int) (view.getResources().getDisplayMetrics().density * MIN_KEYBOARD_HEIGHT_DP));
     }
@@ -93,6 +100,23 @@ class MakepadImeInsets {
     private static int rootHeightPx(View view) {
         View root = view.getRootView();
         return root == null ? 0 : root.getHeight();
+    }
+
+    // Distance in pixels from the bottom edge of the render surface up to the
+    // bottom edge of the window. Zero when the window is edge-to-edge; equal to
+    // the navigation-bar height when it is not (the framework then lays the
+    // surface out above the navigation bar). The IME and visible-frame
+    // measurements below are relative to the window bottom, so this gap must be
+    // subtracted to get the IME's overlap with the surface itself.
+    private static int surfaceBottomGapPx(View view) {
+        View root = view.getRootView();
+        if (root == null || root.getHeight() <= 0 || view.getHeight() <= 0) {
+            return 0;
+        }
+        int[] loc = new int[2];
+        view.getLocationInWindow(loc);
+        int surfaceBottom = loc[1] + view.getHeight();
+        return Math.max(0, root.getHeight() - surfaceBottom);
     }
 
     private static int clampToRootHeight(View view, int overlap) {
@@ -124,14 +148,21 @@ class MakepadImeInsets {
         }
 
         int rootBottomOnScreen = rootLocation[1] + root.getHeight();
-        return Math.max(0, rootBottomOnScreen - visibleFrame.bottom);
+        // visibleFrame.bottom is relative to the window; subtract the gap below
+        // the surface so the fallback also measures overlap with the surface.
+        return Math.max(0, rootBottomOnScreen - visibleFrame.bottom - surfaceBottomGapPx(view));
     }
 
     static int bottomOverlapPx(View view, WindowInsets insets) {
         int imeBottom = 0;
         if (Build.VERSION.SDK_INT >= 30 && insets != null) {
             Insets imeInsets = insets.getInsets(WindowInsets.Type.ime());
-            imeBottom = clampToRootHeight(view, Math.max(0, imeInsets.bottom));
+            // imeInsets.bottom is measured from the window bottom; subtract the
+            // gap below the surface so only the IME's overlap with the surface
+            // shifts content (a non-edge-to-edge window would otherwise
+            // over-shift the content by the navigation-bar height).
+            int imeOverlap = Math.max(0, imeInsets.bottom - surfaceBottomGapPx(view));
+            imeBottom = clampToRootHeight(view, imeOverlap);
         }
 
         if (imeBottom > 0 && !isNearFullHeightOverlap(view, imeBottom)) {
@@ -155,17 +186,44 @@ class MakepadImeInsets {
         return clampToRootHeight(view, fallback);
     }
 
-    static boolean isVisible(View view, WindowInsets insets, int bottomOverlapPx) {
-        if (Build.VERSION.SDK_INT >= 30 && insets != null
-                && insets.isVisible(WindowInsets.Type.ime())) {
-            return true;
+    // Whether the IME should be reported as "open" to native code.
+    //
+    // This must reflect the *target* (settled) IME visibility, not the
+    // per-frame animated inset. During a show animation onProgress() delivers
+    // insets whose IME height ramps up from 0, and at height 0 those animated
+    // insets report isVisible(ime)==false — treating that first frame as
+    // "closed" makes showing the keyboard look like an instant dismissal (and
+    // the native side then actually hides it). getRootWindowInsets() reflects
+    // the requested IME visibility and stays stable for the whole animation,
+    // so it is the authoritative source for the open/closed flag; the
+    // per-frame bottomOverlap height still drives the content-shift animation.
+    static boolean isVisible(View view, int bottomOverlapPx) {
+        if (Build.VERSION.SDK_INT >= 30 && view != null) {
+            WindowInsets root = view.getRootWindowInsets();
+            if (root != null && root.isVisible(WindowInsets.Type.ime())) {
+                // Target is "shown": open for the whole show animation, even
+                // while the animated height is still ramping up from 0.
+                return true;
+            }
         }
+        // Target is "hidden" (or pre-API-30): still open while the IME
+        // occupies space, so a hide animation reports open until it finishes
+        // collapsing and then closed.
         return bottomOverlapPx > 0;
     }
 
-    static void report(View view, WindowInsets insets) {
+    static void report(View view, WindowInsets insets, String src) {
+        // While an IME animation is running, only the per-frame
+        // WindowInsetsAnimation callback (onProgress/onEnd) is authoritative.
+        // The layout-driven fallbacks (onApplyWindowInsets, onGlobalLayout) see
+        // contradictory insets mid-animation and would fight the animation
+        // callback, so they defer to it.
+        if (imeAnimationInProgress
+                && (src.equals("onApplyWindowInsets") || src.equals("onGlobalLayout"))) {
+            return;
+        }
         int bottomOverlap = bottomOverlapPx(view, insets);
-        boolean visible = isVisible(view, insets, bottomOverlap);
+        boolean visible = isVisible(view, bottomOverlap);
         MakepadNative.surfaceOnResizeTextIME(bottomOverlap, visible);
     }
 }
@@ -183,28 +241,90 @@ class MakepadSystemInsets {
         this.left = left;
     }
 
+    // Computes the safe-area insets the render surface actually needs.
+    //
+    // The system-bar + display-cutout insets describe bands at the *window*
+    // edges. When the window is not edge-to-edge (the default below Android 15
+    // / API 35, where targetSdk-35 edge-to-edge enforcement does not apply),
+    // the framework already lays our content out *inside* the system bars, so
+    // the surface does not overlap them at all. Reporting the raw window-edge
+    // insets there would pad the content twice — once by the OS, once by
+    // Makepad — leaving an oversized gap. To stay correct in both regimes we
+    // report only the part of each bar band that actually overlaps the
+    // surface's on-screen rectangle (the same overlap approach used for the
+    // IME inset). Edge-to-edge: overlap == full bar size. Content inside the
+    // bars: overlap == 0.
     @SuppressWarnings("deprecation")
-    static MakepadSystemInsets from(WindowInsets insets, float density) {
-        if (insets == null) {
+    static MakepadSystemInsets from(View view, WindowInsets insets, float density) {
+        if (insets == null || view == null || density <= 0.0f) {
             return new MakepadSystemInsets(0, 0, 0, 0);
         }
+
+        // Raw system-bar + display-cutout insets, in pixels, at the window edges.
+        int barTop, barRight, barBottom, barLeft;
         if (Build.VERSION.SDK_INT >= 30) {
-            Insets systemBarInsets = insets.getInsets(
+            Insets bars = insets.getInsets(
                 WindowInsets.Type.systemBars() | WindowInsets.Type.displayCutout()
             );
-            return new MakepadSystemInsets(
-                systemBarInsets.top / density,
-                systemBarInsets.right / density,
-                systemBarInsets.bottom / density,
-                systemBarInsets.left / density
-            );
+            barTop = bars.top;
+            barRight = bars.right;
+            barBottom = bars.bottom;
+            barLeft = bars.left;
+        } else {
+            barTop = insets.getSystemWindowInsetTop();
+            barRight = insets.getSystemWindowInsetRight();
+            barBottom = insets.getSystemWindowInsetBottom();
+            barLeft = insets.getSystemWindowInsetLeft();
         }
+
+        View root = view.getRootView();
+        if (root == null || root.getWidth() <= 0 || root.getHeight() <= 0) {
+            return new MakepadSystemInsets(0, 0, 0, 0);
+        }
+        int windowWidth = root.getWidth();
+        int windowHeight = root.getHeight();
+
+        // The surface rectangle in window coordinates (same space as the
+        // system-bar insets above). An un-laid-out view yields a degenerate
+        // rect, which the intersections below collapse to zero insets.
+        int[] loc = new int[2];
+        view.getLocationInWindow(loc);
+        int surfaceLeft = loc[0];
+        int surfaceTop = loc[1];
+        int surfaceRight = surfaceLeft + view.getWidth();
+        int surfaceBottom = surfaceTop + view.getHeight();
+
+        // Intersection length of each window-edge bar band with the surface.
+        int top = Math.max(0,
+            Math.min(barTop, surfaceBottom) - Math.max(0, surfaceTop));
+        int left = Math.max(0,
+            Math.min(barLeft, surfaceRight) - Math.max(0, surfaceLeft));
+        int bottom = Math.max(0,
+            Math.min(windowHeight, surfaceBottom) - Math.max(windowHeight - barBottom, surfaceTop));
+        int right = Math.max(0,
+            Math.min(windowWidth, surfaceRight) - Math.max(windowWidth - barRight, surfaceLeft));
+
         return new MakepadSystemInsets(
-            insets.getSystemWindowInsetTop() / density,
-            insets.getSystemWindowInsetRight() / density,
-            insets.getSystemWindowInsetBottom() / density,
-            insets.getSystemWindowInsetLeft() / density
+            top / density,
+            right / density,
+            bottom / density,
+            left / density
         );
+    }
+
+    // Computes the safe-area (system-bar + display-cutout) insets and pushes
+    // them to native code. Called from both ResizingLayout.onApplyWindowInsets
+    // (the primary inset dispatch) and MakepadSurface.onGlobalLayout (a
+    // per-layout fallback). The fallback is what makes the safe area correct
+    // from launch: onApplyWindowInsets is not reliably dispatched with settled
+    // system-bar insets on a cold start, so without the fallback the app
+    // renders edge-to-edge (content under the status bar) until an IME show or
+    // a rotation forces a fresh inset dispatch. The native side dedups
+    // unchanged values, so calling this on every layout pass is cheap.
+    static void report(View view, WindowInsets insets) {
+        float density = view.getResources().getDisplayMetrics().density;
+        MakepadSystemInsets i = MakepadSystemInsets.from(view, insets, density);
+        MakepadNative.surfaceOnSafeAreaInsets(i.top, i.right, i.bottom, i.left);
     }
 }
 
@@ -415,7 +535,14 @@ class MakepadSurface
         // net for layout changes that arrive without an inset dispatch, for
         // example, a focus change that retargets the IME to a different field.
         WindowInsets insets = this.getRootWindowInsets();
-        MakepadImeInsets.report(this, insets);
+        MakepadImeInsets.report(this, insets, "onGlobalLayout");
+        // Safe-area insets also flow through here. onApplyWindowInsets is not
+        // reliably dispatched with settled system-bar insets on a cold start,
+        // so without this the app renders edge-to-edge (content under the
+        // status bar) until an IME show or rotation forces a fresh inset
+        // dispatch. onGlobalLayout fires on every layout pass and picks up the
+        // real insets as soon as the window settles.
+        MakepadSystemInsets.report(this, insets);
     }
 
     // docs says getCharacters are deprecated
@@ -805,16 +932,26 @@ class ResizingLayout
                     android.view.WindowInsetsAnimation.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE
                 ) {
                     @Override
+                    public void onPrepare(android.view.WindowInsetsAnimation animation) {
+                        if ((animation.getTypeMask() & WindowInsets.Type.ime()) != 0) {
+                            MakepadImeInsets.imeAnimationInProgress = true;
+                        }
+                    }
+
+                    @Override
                     public android.view.WindowInsets onProgress(
                         android.view.WindowInsets insets,
                         java.util.List<android.view.WindowInsetsAnimation> runningAnimations
                     ) {
-                        MakepadImeInsets.report(ResizingLayout.this, insets);
+                        MakepadImeInsets.report(ResizingLayout.this, insets, "onProgress");
                         return insets;
                     }
 
                     @Override
                     public void onEnd(android.view.WindowInsetsAnimation animation) {
+                        if ((animation.getTypeMask() & WindowInsets.Type.ime()) != 0) {
+                            MakepadImeInsets.imeAnimationInProgress = false;
+                        }
                         // The framework usually delivers a final-state inset
                         // through onProgress just before onEnd, but on some
                         // OEM devices it skips that last frame. Fetch the
@@ -822,7 +959,7 @@ class ResizingLayout
                         // sees the settled state.
                         android.view.WindowInsets insets = getRootWindowInsets();
                         if (insets == null) return;
-                        MakepadImeInsets.report(ResizingLayout.this, insets);
+                        MakepadImeInsets.report(ResizingLayout.this, insets, "onEnd");
                     }
                 }
             );
@@ -838,19 +975,12 @@ class ResizingLayout
         // *and* the KeyboardView shifts). The activity is configured with
         // `windowSoftInputMode="adjustNothing"` in the manifest, so the
         // system doesn't auto-resize either.
-        MakepadImeInsets.report(v, insets);
+        MakepadImeInsets.report(v, insets, "onApplyWindowInsets");
 
-        // Compute safe area insets from system bars and display cutout.
-        // These are in native Android logical points (`px / density`); Rust
-        // converts them to Makepad layout points after applying dpi_override.
-        float density = getResources().getDisplayMetrics().density;
-        MakepadSystemInsets systemBarInsets = MakepadSystemInsets.from(insets, density);
-        MakepadNative.surfaceOnSafeAreaInsets(
-            systemBarInsets.top,
-            systemBarInsets.right,
-            systemBarInsets.bottom,
-            systemBarInsets.left
-        );
+        // Safe-area (system-bar + display-cutout) insets. Also reported from
+        // MakepadSurface.onGlobalLayout as a cold-start fallback — see
+        // MakepadSystemInsets.report.
+        MakepadSystemInsets.report(v, insets);
 
         return insets;
     }
@@ -1818,14 +1948,44 @@ public class MakepadActivity
             @Override
             public void run() {
                 if (show) {
-                    if (view != null && view.getInputMode() == MakepadSurface.INPUT_MODE_NONE) {
+                    if (view == null || view.getInputMode() == MakepadSurface.INPUT_MODE_NONE) {
                         return;
                     }
+                    // The IME only shows for the view that currently holds
+                    // focus and is "served" by the InputMethodManager. The
+                    // SurfaceView can end up not focused (window-focus churn,
+                    // surface re-creation, returning from another activity,
+                    // etc.); after that, showSoftInput() is silently ignored —
+                    // logcat shows "Ignoring showSoftInput() as view=... is
+                    // not served". Re-focus the SurfaceView before every show
+                    // so it becomes the served editor. This is the canonical
+                    // precondition for showSoftInput(); the previous code
+                    // relied on the view simply staying focused from the
+                    // one-time requestFocus() in the MakepadSurface
+                    // constructor, which is not guaranteed.
+                    view.requestFocus();
                     InputMethodManager imm = (InputMethodManager)getSystemService(Context.INPUT_METHOD_SERVICE);
                     imm.showSoftInput(view, 0);
                 } else {
-                    InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
-                    imm.hideSoftInputFromWindow(view.getWindowToken(),0);
+                    // Hiding the IME via the legacy InputMethodManager
+                    // .hideSoftInputFromWindow() is unreliable on modern Android:
+                    // with an edge-to-edge window (targetSdk 35) and on
+                    // OEM-customized builds (e.g. OxygenOS / OnePlus) the request
+                    // is silently dropped and the keyboard stays up. The
+                    // WindowInsetsController.hide(ime()) path is the canonical
+                    // API 30+ way, and matches how this app already drives the
+                    // system bars and reads IME insets.
+                    if (Build.VERSION.SDK_INT >= 30) {
+                        android.view.WindowInsetsController controller = getWindow().getInsetsController();
+                        if (controller != null) {
+                            controller.hide(WindowInsets.Type.ime());
+                        }
+                    } else {
+                        InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+                        if (imm != null && view != null) {
+                            imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
+                        }
+                    }
                 }
             }
         });

--- a/tools/cargo_makepad/src/android/mod.rs
+++ b/tools/cargo_makepad/src/android/mod.rs
@@ -21,6 +21,28 @@ pub struct AndroidConfig {
     pub small_fonts: bool,
 }
 
+/// All values needed to render an `AndroidManifest.xml`. Constructed by
+/// `compile::resolve_manifest_args` from CLI flags + Cargo.toml metadata +
+/// build-time decisions (e.g. `debuggable=false` for AAB builds).
+#[derive(Clone, Debug)]
+pub struct ManifestArgs<'a> {
+    pub label: &'a str,
+    pub class_name: &'a str,
+    pub url: &'a str,
+    /// `android:minSdkVersion` and the NDK clang triple suffix
+    /// (`<arch>-linux-android<N>-clang`). Sets the lowest device API level the
+    /// .so files will load on. Defaults to 26 (Android 8.0).
+    pub sdk_version: usize,
+    /// `android:targetSdkVersion` — runtime-behavior compatibility level.
+    /// Required ≥34/35 by Play Store; orthogonal from `sdk_version`. Defaults
+    /// to 35 (Android 15).
+    pub target_sdk_version: usize,
+    pub has_icon: bool,
+    pub version_code: u32,
+    pub version_name: &'a str,
+    pub debuggable: bool,
+}
+
 impl AndroidVariant {
     fn from_str(opt: &str) -> Result<Self, String> {
         for opt in opt.split(",") {
@@ -35,34 +57,41 @@ impl AndroidVariant {
         ));
     }
 
-    fn manifest_xml(
-        &self,
-        label: &str,
-        class_name: &str,
-        url: &str,
-        sdk_version: usize,
-        has_icon: bool,
-    ) -> String {
-        let icon_attr = if has_icon {
+    fn manifest_xml(&self, args: &ManifestArgs<'_>) -> String {
+        let ManifestArgs {
+            label,
+            class_name,
+            url,
+            sdk_version,
+            target_sdk_version,
+            has_icon,
+            version_code,
+            version_name,
+            debuggable,
+        } = args;
+        let icon_attr = if *has_icon {
             "\n                    android:icon=\"@mipmap/ic_launcher\""
         } else {
             ""
         };
+        let debuggable_str = if *debuggable { "true" } else { "false" };
 
         match self {
             Self::Default => format!(
                 r#"<?xml version="1.0" encoding="utf-8"?>
                 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:tools="http://schemas.android.com/tools"
-                package="{url}">
+                package="{url}"
+                android:versionCode="{version_code}"
+                android:versionName="{version_name}">
                 <application
                     android:label="{label}"{icon_attr}
                     android:theme="@style/MakepadAppTheme"
                     android:allowBackup="true"
                     android:supportsRtl="true"
-                    android:debuggable="true"
+                    android:debuggable="{debuggable_str}"
                     android:largeHeap="true"
-                    tools:targetApi="{sdk_version}">
+                    tools:targetApi="{target_sdk_version}">
                     <meta-data android:name="android.max_aspect" android:value="2.1" />
                     <activity
                     android:name=".{class_name}"
@@ -77,7 +106,7 @@ impl AndroidVariant {
                     </intent-filter>
                     </activity>
                 </application>
-                <uses-sdk android:targetSdkVersion="{sdk_version}" />
+                <uses-sdk android:minSdkVersion="{sdk_version}" android:targetSdkVersion="{target_sdk_version}" />
                 <uses-feature android:glEsVersion="0x00020000" android:required="true"/>
                 <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
                 <uses-feature android:name="android.software.midi" android:required="true"/>
@@ -95,7 +124,7 @@ impl AndroidVariant {
                 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
                 <uses-permission android:name="android.permission.USE_BIOMETRIC" />
                 <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:ignore="QueryAllPackagesPermission" />
-                            
+
                 <queries>
                 <intent>
                 <action android:name="android.intent.action.MAIN" />
@@ -110,12 +139,12 @@ impl AndroidVariant {
                     xmlns:android="http://schemas.android.com/apk/res/android"
                     xmlns:tools="http://schemas.android.com/tools"
                     package="{url}"
-                    android:versionCode="1"
-                    android:versionName="1.0"
+                    android:versionCode="{version_code}"
+                    android:versionName="{version_name}"
                     android:installLocation="auto"
-                >      
-                                                                
-                <uses-sdk android:targetSdkVersion="{sdk_version}" />
+                >
+
+                <uses-sdk android:minSdkVersion="{sdk_version}" android:targetSdkVersion="{target_sdk_version}" />
                 <uses-feature android:glEsVersion="0x00030001" android:required="true"/>
                 <uses-feature android:name="android.hardware.vr.headtracking" android:required="false"/>
                 <uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="true"/>
@@ -135,15 +164,15 @@ impl AndroidVariant {
                 <!-- Grants access to Shared Spatial Anchors. -->
                 <uses-permission android:name="com.oculus.permission.IMPORT_EXPORT_IOT_MAP_DATA" />
                 <uses-permission android:name="com.oculus.permission.USE_COLOCATION_DISCOVERY_API" />
-                
+
                 <application
                     android:label="{label}"{icon_attr}
                     android:theme="@style/MakepadAppTheme"
                     android:allowBackup="true"
                     android:supportsRtl="true"
-                    android:debuggable="true"
+                    android:debuggable="{debuggable_str}"
                     android:largeHeap="true"
-                    tools:targetApi="{sdk_version}">
+                    tools:targetApi="{target_sdk_version}">
                     <!-- Quest 3-only CPU/GPU trade: prefer one extra CPU level over one GPU level. -->
                     <meta-data
                         android:name="com.oculus.trade_cpu_for_gpu_amount"
@@ -156,14 +185,14 @@ impl AndroidVariant {
                         android:launchMode="singleTask"
                         android:screenOrientation="landscape"
                         android:windowSoftInputMode="adjustNothing|stateUnchanged"
-                        android:theme="@style/MakepadLaunchTheme" 
+                        android:theme="@style/MakepadLaunchTheme"
                         >
                         <intent-filter>
                             <action android:name="android.intent.action.MAIN" />
                             <category android:name="android.intent.category.LAUNCHER" />
                         </intent-filter>
                         </activity>
-                                                
+
                     <activity
                         android:name="{class_name}Xr"
                         android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode"
@@ -172,7 +201,7 @@ impl AndroidVariant {
                         android:launchMode="singleTask"
                         android:screenOrientation="landscape"
                         android:windowSoftInputMode="adjustNothing|stateUnchanged"
-                        android:theme="@style/MakepadLaunchTheme" 
+                        android:theme="@style/MakepadLaunchTheme"
                         >
                         <intent-filter>
                             <action android:name="android.intent.action.MAIN" />
@@ -180,12 +209,12 @@ impl AndroidVariant {
                         </intent-filter>
                     </activity>
                 </application>
-                                                                                    
+
                 <queries>
                 <!-- to talk to the broker -->
-                    <provider 
+                    <provider
                     android:name="x" android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" />
-                                                                                                
+
                 <!-- so client-side code of runtime/layers can talk to their service sides -->
                 <intent>
                 <action android:name="org.khronos.openxr.OpenXRRuntimeService" />
@@ -197,7 +226,7 @@ impl AndroidVariant {
                 <action android:name="android.intent.action.MAIN" />
                 </intent>
                 </queries>
-                                            
+
                 </manifest>
                 "#
             ),
@@ -409,14 +438,28 @@ fn android_help() -> &'static str {
     "Android commands:\n\
   cargo makepad android [options] install-toolchain\n\
   cargo makepad android [options] build <cargo args>\n\
+  cargo makepad android [options] build-aab <cargo args>\n\
+  cargo makepad android keystore-create <path> [keytool options]\n\
   cargo makepad android [options] run <cargo args>\n\
   cargo makepad android [options] adb <adb args>\n\
   cargo makepad android [options] adb-tcp [port]\n\
 \n\
 Common options:\n\
   --abi=aarch64|x86_64|armv7|i686|all   (default: aarch64)\n\
-  --package-name=<id>\n\
-  --app-label=<label>\n\
+  --package-name=<id>                   default: [package.metadata.packager].identifier,\n\
+                                                  else `dev.makepad.<crate>`\n\
+  --app-label=<label>                   default: [package.metadata.packager].product_name\n\
+  --version-code=<int|auto>             default: [package.metadata.makepad.android].version_code,\n\
+                                                  else 1. `auto` -> YYYYMMDDHH UTC\n\
+                                                  (e.g. 2026050416), monotonic per hour\n\
+  --version-name=<str>                  default: [package.metadata.makepad.android].version_name,\n\
+                                                  else [package].version, else \"1.0\"\n\
+  --min-sdk-version=<int>               raise the NDK clang target and manifest\n\
+                                          minSdkVersion above cargo-makepad's default.\n\
+                                          Default: [package.metadata.makepad.android].min_sdk_version,\n\
+                                                  else 26 (Android 8.0). Bump for apps that need\n\
+                                                  guaranteed availability of API > 26 native APIs\n\
+                                                  (e.g. AMidi -> 29, AFontMatcher -> 29).\n\
   --small-fonts\n\
   --no-icon\n\
   --sdk-path=<path>\n\
@@ -425,13 +468,180 @@ Common options:\n\
   --devices=<serial1,serial2,...>|all    (for run and adb-tcp)\n\
   --keep-sdk-sources\n\
 \n\
+Custom AndroidManifest:\n\
+  Drop a template at `<crate>/resources/android/AndroidManifest.xml.template` to\n\
+  override the built-in manifest (lets you tailor permissions/features for the\n\
+  Play Store). Tokens replaced: {package_id}, {label}, {class_name},\n\
+  {target_sdk_version}, {version_code}, {version_name}, {debuggable}.\n\
+\n\
+build-aab signing options (defaults: bundled debug.keystore — Play Store will reject):\n\
+  --keystore=<path>                       JKS/PKCS12 keystore file (alias auto-discovered\n\
+                                          from a sibling `<keystore>.makepad`\n\
+                                          metadata file if present)\n\
+  --keystore-pass=<pass>                  password for the keystore (or set\n\
+                                          MAKEPAD_KEYSTORE_PASS env var)\n\
+  --keystore-key-alias=<alias>            override the sidecar alias\n\
+  --keystore-key-pass=<pass>              key-entry password (defaults to keystore-pass)\n\
+  --no-sign                               skip signing entirely (output is unsigned)\n\
+\n\
 Examples:\n\
   cargo makepad android --abi=aarch64 build -p my-app --release\n\
   cargo makepad android --abi=aarch64 run -p my-app --release\n\
   cargo makepad android --devices=all --variant=quest run -p my-app --release\n\
+  cargo makepad android --abi=aarch64 \\\n\
+      --keystore=play.keystore --keystore-pass=hunter2 \\\n\
+      --keystore-key-alias=upload --keystore-key-pass=hunter2 \\\n\
+      build-aab -p my-app --release\n\
   cargo makepad android adb devices -l\n\
   cargo makepad android adb-tcp\n\
   cargo makepad android --devices=<serial> adb-tcp 5555"
+}
+
+/// Resolve AAB signing options from CLI flags + sidecar + env, defaulting to the
+/// bundled `debug.keystore` (matching the APK build path) when nothing is passed.
+///
+/// Resolution priority for each field:
+///   - Explicit flag (`--keystore-key-alias=`, `--keystore-pass=`, ...)
+///   - Sidecar (`<keystore>.makepad`, written by `keystore-create`) for `alias` / `store_type`
+///   - `MAKEPAD_KEYSTORE_PASS` env var for `keystore-pass`
+///   - jarsigner convention: `keypass` defaults to `storepass`
+fn resolve_aab_signing_opts(
+    keystore: Option<String>,
+    keystore_pass: Option<String>,
+    key_alias: Option<String>,
+    key_pass: Option<String>,
+) -> Result<compile::AabSigningOpts, String> {
+    let cargo_manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let any_keystore_opt =
+        keystore.is_some() || keystore_pass.is_some() || key_alias.is_some() || key_pass.is_some();
+
+    if !any_keystore_opt {
+        return Ok(compile::AabSigningOpts {
+            keystore: cargo_manifest_dir.join("debug.keystore"),
+            storepass: "android".to_string(),
+            key_alias: "androiddebugkey".to_string(),
+            keypass: "android".to_string(),
+        });
+    }
+
+    let keystore_path = std::path::PathBuf::from(keystore.ok_or_else(|| {
+        "--keystore=<path> is required when any other keystore option is set".to_string()
+    })?);
+
+    // Sidecar provides the alias (and optionally the store-type) so the user
+    // doesn't have to repeat them on every build.
+    let sidecar = compile::read_keystore_sidecar(&keystore_path);
+
+    let storepass = keystore_pass
+        .or_else(|| std::env::var("MAKEPAD_KEYSTORE_PASS").ok())
+        .ok_or_else(|| {
+            "no keystore password provided. Pass --keystore-pass=<pw> or set MAKEPAD_KEYSTORE_PASS"
+                .to_string()
+        })?;
+
+    let alias = key_alias
+        .or_else(|| sidecar.as_ref().and_then(|s| s.alias.clone()))
+        .ok_or_else(|| {
+            format!(
+                "no key alias found. Pass --keystore-key-alias=<alias>, or run `cargo makepad android keystore-create {}` to write a sidecar.",
+                keystore_path.display()
+            )
+        })?;
+
+    // jarsigner reuses storepass when keypass is not given.
+    let keypass = key_pass.unwrap_or_else(|| storepass.clone());
+
+    Ok(compile::AabSigningOpts {
+        keystore: keystore_path,
+        storepass,
+        key_alias: alias,
+        keypass,
+    })
+}
+
+fn parse_keystore_create_args(args: &[String]) -> Result<compile::KeystoreCreateOpts, String> {
+    let mut keystore_path: Option<String> = None;
+    let mut alias: String = "upload".to_string();
+    let mut validity_days: u32 = 10_000;
+    let mut key_size: u32 = 2048;
+    let mut key_alg: String = "RSA".to_string();
+    let mut store_type: String = "PKCS12".to_string();
+    let mut dname: Option<String> = None;
+
+    for arg in args {
+        if let Some(v) = arg.strip_prefix("--alias=") {
+            alias = v.to_string();
+        } else if let Some(v) = arg.strip_prefix("--validity=") {
+            validity_days = v
+                .parse::<u32>()
+                .map_err(|_| format!("--validity must be a positive integer, got {v:?}"))?;
+        } else if let Some(v) = arg.strip_prefix("--keysize=") {
+            key_size = v
+                .parse::<u32>()
+                .map_err(|_| format!("--keysize must be a positive integer, got {v:?}"))?;
+        } else if let Some(v) = arg.strip_prefix("--keyalg=") {
+            key_alg = v.to_string();
+        } else if let Some(v) = arg.strip_prefix("--storetype=") {
+            store_type = v.to_string();
+        } else if let Some(v) = arg.strip_prefix("--dname=") {
+            dname = Some(v.to_string());
+        } else if arg.starts_with("--") {
+            return Err(format!(
+                "unknown option {arg:?}\n\n{}",
+                keystore_create_help()
+            ));
+        } else if keystore_path.is_none() {
+            keystore_path = Some(arg.clone());
+        } else {
+            return Err(format!(
+                "unexpected positional argument {arg:?}\n\n{}",
+                keystore_create_help()
+            ));
+        }
+    }
+
+    let keystore_path = keystore_path.ok_or_else(|| {
+        format!(
+            "missing required <keystore-path> argument\n\n{}",
+            keystore_create_help()
+        )
+    })?;
+
+    Ok(compile::KeystoreCreateOpts {
+        keystore_path: std::path::PathBuf::from(keystore_path),
+        alias,
+        validity_days,
+        key_size,
+        key_alg,
+        store_type,
+        dname,
+    })
+}
+
+fn keystore_create_help() -> &'static str {
+    "Usage:\n\
+  cargo makepad android keystore-create <keystore-path> [options]\n\
+\n\
+Generates a Play Store upload keystore via the bundled keytool, and writes a\n\
+small metadata file next to it (`<keystore-path>.makepad`) so `build-aab` can\n\
+auto-discover the alias on each build. The metadata file contains no passwords.\n\
+\n\
+Naming: pick a path/name related to your app, e.g. `my-app.keystore`. Whether\n\
+you create one keystore per app (recommended) or one shared across all apps\n\
+under your Play Console developer account is your call — both are allowed.\n\
+\n\
+Options:\n\
+  --alias=<alias>       key alias inside the keystore (default: upload)\n\
+  --validity=<days>     certificate validity in days (default: 10000, ~27 yr)\n\
+  --keyalg=<alg>        signing algorithm (default: RSA)\n\
+  --keysize=<bits>      key size in bits (default: 2048)\n\
+  --storetype=<type>    keystore type (default: PKCS12)\n\
+  --dname=<dn>          non-interactive cert subject, e.g.\n\
+                        \"CN=My App, O=Acme, L=City, C=US\"\n\
+\n\
+Examples:\n\
+  cargo makepad android keystore-create my-app.keystore\n\
+  cargo makepad android keystore-create keys/robrix.keystore --alias=upload"
 }
 
 fn resolve_devices_arg(
@@ -471,6 +681,14 @@ pub fn handle_android(mut args: &[String]) -> Result<(), String> {
     let mut keep_sdk_sources = false;
     let mut no_icon = false;
     let mut config = AndroidConfig::default();
+    let mut keystore: Option<String> = None;
+    let mut keystore_pass: Option<String> = None;
+    let mut keystore_key_alias: Option<String> = None;
+    let mut keystore_key_pass: Option<String> = None;
+    let mut no_sign = false;
+    let mut version_code: Option<crate::utils::VersionCodeStrategy> = None;
+    let mut version_name: Option<String> = None;
+    let mut min_sdk_version: Option<usize> = None;
 
     let urls = sdk::ANDROID_SDK_URLS_33;
 
@@ -497,6 +715,24 @@ pub fn handle_android(mut args: &[String]) -> Result<(), String> {
             no_icon = true;
         } else if v.trim() == "--keep-sdk-sources" {
             keep_sdk_sources = true;
+        } else if let Some(opt) = v.strip_prefix("--keystore=") {
+            keystore = Some(opt.to_string());
+        } else if let Some(opt) = v.strip_prefix("--keystore-pass=") {
+            keystore_pass = Some(opt.to_string());
+        } else if let Some(opt) = v.strip_prefix("--keystore-key-alias=") {
+            keystore_key_alias = Some(opt.to_string());
+        } else if let Some(opt) = v.strip_prefix("--keystore-key-pass=") {
+            keystore_key_pass = Some(opt.to_string());
+        } else if v.trim() == "--no-sign" {
+            no_sign = true;
+        } else if let Some(opt) = v.strip_prefix("--version-code=") {
+            version_code = Some(crate::utils::parse_version_code_flag(opt)?);
+        } else if let Some(opt) = v.strip_prefix("--version-name=") {
+            version_name = Some(opt.to_string());
+        } else if let Some(opt) = v.strip_prefix("--min-sdk-version=") {
+            min_sdk_version = Some(opt.parse::<usize>().map_err(|_| {
+                format!("--min-sdk-version must be a positive integer (API level), got {opt:?}")
+            })?);
         } else {
             args = &args[i..];
             break;
@@ -561,11 +797,55 @@ pub fn handle_android(mut args: &[String]) -> Result<(), String> {
                 host_os,
                 package_name,
                 app_label,
+                version_code,
+                version_name,
+                min_sdk_version,
                 &args[1..],
                 &targets,
                 &variant,
                 &config,
                 &urls,
+            )?;
+            Ok(())
+        }
+        "keystore-create" => {
+            let sub = &args[1..];
+            if sub
+                .iter()
+                .any(|a| a == "--help" || a == "-h" || a == "help")
+            {
+                println!("{}", keystore_create_help());
+                return Ok(());
+            }
+            let opts = parse_keystore_create_args(sub)?;
+            compile::keystore_create(&sdk_dir, &opts)?;
+            Ok(())
+        }
+        "build-aab" => {
+            let signing = if no_sign {
+                None
+            } else {
+                Some(resolve_aab_signing_opts(
+                    keystore,
+                    keystore_pass,
+                    keystore_key_alias,
+                    keystore_key_pass,
+                )?)
+            };
+            compile::build_aab(
+                &sdk_dir,
+                host_os,
+                package_name,
+                app_label,
+                version_code,
+                version_name,
+                min_sdk_version,
+                &args[1..],
+                &targets,
+                &variant,
+                &config,
+                &urls,
+                signing,
             )?;
             Ok(())
         }
@@ -576,6 +856,9 @@ pub fn handle_android(mut args: &[String]) -> Result<(), String> {
                 host_os,
                 package_name,
                 app_label,
+                version_code,
+                version_name,
+                min_sdk_version,
                 &args[1..],
                 &targets,
                 &variant,
@@ -594,12 +877,25 @@ pub fn handle_android(mut args: &[String]) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::AndroidVariant;
+    use super::{AndroidVariant, ManifestArgs};
+
+    fn test_args<'a>(label: &'a str, url: &'a str) -> ManifestArgs<'a> {
+        ManifestArgs {
+            label,
+            class_name: "MakepadApp",
+            url,
+            sdk_version: 33,
+            target_sdk_version: 35,
+            has_icon: true,
+            version_code: 1,
+            version_name: "1.0",
+            debuggable: true,
+        }
+    }
 
     #[test]
     fn default_manifest_uses_splash_and_app_themes() {
-        let xml =
-            AndroidVariant::Default.manifest_xml("App", "MakepadApp", "dev.makepad.app", 33, true);
+        let xml = AndroidVariant::Default.manifest_xml(&test_args("App", "dev.makepad.app"));
         assert!(xml.contains("android:theme=\"@style/MakepadAppTheme\""));
         assert!(xml.contains("android:theme=\"@style/MakepadLaunchTheme\""));
         assert!(xml.contains("android:launchMode=\"singleTask\""));
@@ -607,9 +903,53 @@ mod tests {
 
     #[test]
     fn quest_manifest_uses_splash_and_app_themes() {
-        let xml =
-            AndroidVariant::Quest.manifest_xml("App", "MakepadApp", "dev.makepad.app", 33, true);
+        let xml = AndroidVariant::Quest.manifest_xml(&test_args("App", "dev.makepad.app"));
         assert!(xml.contains("android:theme=\"@style/MakepadAppTheme\""));
         assert!(xml.contains("android:theme=\"@style/MakepadLaunchTheme\""));
+    }
+
+    #[test]
+    fn manifest_propagates_version_and_debuggable() {
+        let mut args = test_args("App", "dev.makepad.app");
+        args.version_code = 42;
+        args.version_name = "2.7.3";
+        args.debuggable = false;
+        let xml = AndroidVariant::Default.manifest_xml(&args);
+        assert!(xml.contains("android:versionCode=\"42\""));
+        assert!(xml.contains("android:versionName=\"2.7.3\""));
+        assert!(xml.contains("android:debuggable=\"false\""));
+    }
+
+    #[test]
+    fn manifest_declares_min_and_target_sdk_separately() {
+        let mut args = test_args("App", "dev.makepad.app");
+        args.sdk_version = 33;
+        args.target_sdk_version = 35;
+        let xml = AndroidVariant::Default.manifest_xml(&args);
+        assert!(
+            xml.contains("android:minSdkVersion=\"33\""),
+            "missing minSdkVersion=33: {xml}"
+        );
+        assert!(
+            xml.contains("android:targetSdkVersion=\"35\""),
+            "missing targetSdkVersion=35: {xml}"
+        );
+        // tools:targetApi should follow target, not min.
+        assert!(
+            xml.contains("tools:targetApi=\"35\""),
+            "tools:targetApi should match targetSdkVersion: {xml}"
+        );
+    }
+
+    #[test]
+    fn quest_manifest_propagates_version_and_debuggable() {
+        let mut args = test_args("App", "dev.makepad.app");
+        args.version_code = 42;
+        args.version_name = "2.7.3";
+        args.debuggable = false;
+        let xml = AndroidVariant::Quest.manifest_xml(&args);
+        assert!(xml.contains("android:versionCode=\"42\""));
+        assert!(xml.contains("android:versionName=\"2.7.3\""));
+        assert!(xml.contains("android:debuggable=\"false\""));
     }
 }

--- a/tools/cargo_makepad/src/android/mod.rs
+++ b/tools/cargo_makepad/src/android/mod.rs
@@ -472,7 +472,8 @@ Custom AndroidManifest:\n\
   Drop a template at `<crate>/resources/android/AndroidManifest.xml.template` to\n\
   override the built-in manifest (lets you tailor permissions/features for the\n\
   Play Store). Tokens replaced: {package_id}, {label}, {class_name},\n\
-  {target_sdk_version}, {version_code}, {version_name}, {debuggable}.\n\
+  {min_sdk_version}, {target_sdk_version}, {version_code}, {version_name},\n\
+  {debuggable}.\n\
 \n\
 build-aab signing options (defaults: bundled debug.keystore — Play Store will reject):\n\
   --keystore=<path>                       JKS/PKCS12 keystore file (alias auto-discovered\n\

--- a/tools/cargo_makepad/src/android/sdk.rs
+++ b/tools/cargo_makepad/src/android/sdk.rs
@@ -9,8 +9,23 @@ use std::{
 
 use crate::{android::*, makepad_shell::*};
 
+#[derive(Clone, Copy)]
 pub struct AndroidSDKUrls {
+    /// API level the NDK clang toolchain targets (`<arch>-linux-android<N>-clang`)
+    /// and the value emitted as `android:minSdkVersion`. This is the floor for
+    /// device compatibility — the lowest API level the resulting native binary
+    /// will load on.
+    ///
+    /// Note: this is *not* the compile SDK. The Java side is compiled against
+    /// `android.jar` from `platform` / `build_tools_version` (typically a higher
+    /// API), which lets Java call API > sdk_version classes guarded by runtime
+    /// `Build.VERSION.SDK_INT` checks.
     pub sdk_version: usize,
+    /// API level declared as `android:targetSdkVersion` in the manifest. Independent
+    /// from `sdk_version`: it sets runtime behavior compatibility, not what the binary
+    /// links against. Play Store requires this to be ≥34 (≥35 for Aug 2025 updates),
+    /// while `sdk_version` can stay lower for broader device coverage.
+    pub target_sdk_version: usize,
     pub sdk_extension: &'static str,
     pub platform: &'static str,
     pub build_tools_version: &'static str,
@@ -32,7 +47,25 @@ pub const BUILD_TOOLS_DIR: &str = "build-tools";
 pub const PLATFORMS_DIR: &str = "platforms";
 
 pub const ANDROID_SDK_URLS_33: AndroidSDKUrls = AndroidSDKUrls {
-    sdk_version: 33,
+    // NDK clang triple targets API 26 (Android 8.0 Oreo). The compiled .so will
+    // load on API 26+ devices, ~96-97% of the active Android population. The
+    // NDK r28 toolchain still supports compiling for API 21+ on arm64; we pick
+    // 26 because that's the lowest API where every NDK Camera2/AAudio/etc.
+    // entry point Makepad uses is stably available without weak-linkage hacks.
+    //
+    // Java code is gated with `if (Build.VERSION.SDK_INT >= N)` everywhere it
+    // calls API > 26 methods. Native code that touches API 29+ entry points
+    // (Choreographer postFrameCallback64 / postVsyncCallback) is dispatched via
+    // dlsym + version-checked function pointers in `android_jni.rs`.
+    sdk_version: 26,
+    // Manifest declares `targetSdkVersion=35` (Android 15), the current Play
+    // Store floor for new submissions. Independent of `sdk_version`: target
+    // controls runtime-behavior compat, not what the binary links against.
+    target_sdk_version: 35,
+    // Build-tools and platform stay at API 33 — that's our *compile* SDK, used
+    // for `android.jar` (Java compile classpath) and aapt2. Java code can call
+    // API 33 classes at compile time; runtime version checks keep older devices
+    // from actually executing those paths.
     build_tools_version: "33.0.1",
     sdk_extension: "ext4",
     platform: "android-33-ext4",
@@ -58,27 +91,32 @@ const URL_OPENJDK_17_0_2_MACOS_AARCH64: &str = "https://download.java.net/java/G
 const URL_OPENJDK_17_0_2_MACOS_X64: &str = "https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_macos-x64_bin.tar.gz";
 const URL_OPENJDK_17_0_2_LINUX_X64: &str = "https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-x64_bin.tar.gz";
 
+/// Bundletool is needed to package a base module zip into an AAB. Single jar.
+pub const URL_BUNDLETOOL: &str =
+    "https://github.com/google/bundletool/releases/download/1.18.1/bundletool-all-1.18.1.jar";
+/// Local relative path under the SDK root where bundletool.jar is installed.
+pub const BUNDLETOOL_JAR_REL: &str = "bundletool/bundletool.jar";
+
 fn url_file_name(url: &str) -> &str {
     url.rsplit_once('/').unwrap().1
 }
 
 pub fn rustup_toolchain_install(targets: &[AndroidTarget]) -> Result<(), String> {
     println!("Installing Rust toolchains for android");
-    println!("Installing nightly");
-    shell_env(
-        &[],
-        &std::env::current_dir().unwrap(),
-        "rustup",
-        &["install", "nightly"],
-    )?;
+    // Android targets are all tier-2 (prebuilt std, no `-Z build-std`), so they
+    // build on stable. Only install stable if it's missing — don't force-update.
+    crate::utils::ensure_rust_toolchain_installed("stable")?;
     for target in targets {
         let toolchain = target.toolchain();
-        println!("Installing rust nightly for {}", toolchain);
+        println!("Adding rust stable target {}", toolchain);
+        // `rustup target add` is idempotent and only fetches the target's std
+        // component; it does not update the compiler, so it's safe to run every
+        // time without the missing-only check.
         shell_env(
             &[],
             &std::env::current_dir().unwrap(),
             "rustup",
-            &["target", "add", toolchain, "--toolchain", "nightly"],
+            &["target", "add", toolchain, "--toolchain", "stable"],
         )?;
     }
     Ok(())
@@ -94,49 +132,59 @@ pub fn download_sdk(
     let src_dir = &sdk_dir.join("sources");
     mkdir(src_dir)?;
 
-    fn curl(step: usize, src_dir: &Path, url: &str) -> Result<(), String> {
+    fn curl(step: usize, total: usize, src_dir: &Path, url: &str) -> Result<(), String> {
         //let https = HttpsConnection::connect("https://makepad.dev","https");
-        println!("{step}/5: Downloading: {}", url);
+        println!("{step}/{total}: Downloading: {}", url);
+        // -L follows redirects (bundletool's GitHub release URL 302s to a CDN).
         shell(
             src_dir,
             "curl",
             &[
                 url,
                 "-#",
+                "-L",
                 "--output",
                 src_dir.join(url_file_name(url)).to_str().unwrap(),
             ],
         )?;
         Ok(())
     }
-    curl(1, src_dir, urls.platform_dl)?;
+    let total = 6;
+    curl(1, total, src_dir, urls.platform_dl)?;
     match host_os {
         HostOs::WindowsX64 => {
-            curl(2, src_dir, urls.build_tools_windows)?;
-            curl(3, src_dir, urls.platform_tools_windows)?;
-            curl(4, src_dir, urls.ndk_windows)?;
-            curl(5, src_dir, URL_OPENJDK_17_0_2_WINDOWS_X64)?;
+            curl(2, total, src_dir, urls.build_tools_windows)?;
+            curl(3, total, src_dir, urls.platform_tools_windows)?;
+            curl(4, total, src_dir, urls.ndk_windows)?;
+            curl(5, total, src_dir, URL_OPENJDK_17_0_2_WINDOWS_X64)?;
         }
         HostOs::MacosX64 | HostOs::MacosAarch64 => {
-            curl(2, src_dir, urls.build_tools_macos)?;
-            curl(3, src_dir, urls.platform_tools_macos)?;
-            curl(4, src_dir, urls.ndk_macos)?;
+            curl(2, total, src_dir, urls.build_tools_macos)?;
+            curl(3, total, src_dir, urls.platform_tools_macos)?;
+            curl(4, total, src_dir, urls.ndk_macos)?;
             if host_os == HostOs::MacosX64 {
-                curl(5, src_dir, URL_OPENJDK_17_0_2_MACOS_X64)?;
+                curl(5, total, src_dir, URL_OPENJDK_17_0_2_MACOS_X64)?;
             } else {
-                curl(5, src_dir, URL_OPENJDK_17_0_2_MACOS_AARCH64)?;
+                curl(5, total, src_dir, URL_OPENJDK_17_0_2_MACOS_AARCH64)?;
             }
         }
         HostOs::LinuxX64 => {
-            curl(2, src_dir, urls.build_tools_linux)?;
-            curl(3, src_dir, urls.platform_tools_linux)?;
-            curl(4, src_dir, urls.ndk_linux)?;
-            curl(5, src_dir, URL_OPENJDK_17_0_2_LINUX_X64)?;
+            curl(2, total, src_dir, urls.build_tools_linux)?;
+            curl(3, total, src_dir, urls.platform_tools_linux)?;
+            curl(4, total, src_dir, urls.ndk_linux)?;
+            curl(5, total, src_dir, URL_OPENJDK_17_0_2_LINUX_X64)?;
         }
         HostOs::Unsupported => panic!(),
     }
-    // alright lets parse the sdk_path option
+    curl(6, total, src_dir, URL_BUNDLETOOL)?;
     Ok(())
+}
+
+/// Copy the downloaded bundletool jar into the SDK directory at a stable path.
+fn install_bundletool(sdk_dir: &Path) -> Result<(), String> {
+    let src = sdk_dir.join("sources").join(url_file_name(URL_BUNDLETOOL));
+    let dst = sdk_dir.join(BUNDLETOOL_JAR_REL);
+    cp(&src, &dst, false)
 }
 
 pub fn remove_sdk_sources(
@@ -446,6 +494,14 @@ pub fn expand_sdk(
                         &copy_map(
                             "android-13",
                             &format!("{BUILD_TOOLS_DIR}/{ANDROID_BUILD_TOOLS_VERSION}"),
+                            "aapt2.exe",
+                        ),
+                        false,
+                    ),
+                    (
+                        &copy_map(
+                            "android-13",
+                            &format!("{BUILD_TOOLS_DIR}/{ANDROID_BUILD_TOOLS_VERSION}"),
                             "zipalign.exe",
                         ),
                         false,
@@ -685,6 +741,8 @@ pub fn expand_sdk(
                     (&copy_map(JDK_IN, JDK_OUT, "bin/java.exe"), false),
                     (&copy_map(JDK_IN, JDK_OUT, "bin/jar.exe"), false),
                     (&copy_map(JDK_IN, JDK_OUT, "bin/javac.exe"), false),
+                    (&copy_map(JDK_IN, JDK_OUT, "bin/jarsigner.exe"), false),
+                    (&copy_map(JDK_IN, JDK_OUT, "bin/keytool.exe"), false),
                     (&copy_map(JDK_IN, JDK_OUT, "lib/jvm.cfg"), false),
                     (&copy_map(JDK_IN, JDK_OUT, "bin/jli.dll"), false),
                     (&copy_map(JDK_IN, JDK_OUT, "bin/java.dll"), false),
@@ -774,6 +832,14 @@ pub fn expand_sdk(
                             "android-13",
                             &format!("{BUILD_TOOLS_DIR}/{ANDROID_BUILD_TOOLS_VERSION}"),
                             "aapt",
+                        ),
+                        true,
+                    ),
+                    (
+                        &copy_map(
+                            "android-13",
+                            &format!("{BUILD_TOOLS_DIR}/{ANDROID_BUILD_TOOLS_VERSION}"),
+                            "aapt2",
                         ),
                         true,
                     ),
@@ -879,6 +945,8 @@ pub fn expand_sdk(
                     (&copy_map(JDK_IN, JDK_OUT, "bin/java"), true),
                     (&copy_map(JDK_IN, JDK_OUT, "bin/jar"), true),
                     (&copy_map(JDK_IN, JDK_OUT, "bin/javac"), true),
+                    (&copy_map(JDK_IN, JDK_OUT, "bin/jarsigner"), true),
+                    (&copy_map(JDK_IN, JDK_OUT, "bin/keytool"), true),
                     (&copy_map(JDK_IN, JDK_OUT, "lib/libjli.dylib"), false),
                     (&copy_map(JDK_IN, JDK_OUT, "lib/jvm.cfg"), false),
                     (
@@ -971,6 +1039,14 @@ pub fn expand_sdk(
                             "android-13",
                             &format!("{BUILD_TOOLS_DIR}/{ANDROID_BUILD_TOOLS_VERSION}"),
                             "aapt",
+                        ),
+                        true,
+                    ),
+                    (
+                        &copy_map(
+                            "android-13",
+                            &format!("{BUILD_TOOLS_DIR}/{ANDROID_BUILD_TOOLS_VERSION}"),
+                            "aapt2",
                         ),
                         true,
                     ),
@@ -1094,6 +1170,8 @@ pub fn expand_sdk(
                     (&copy_map(JDK_IN, JDK_OUT, "bin/java"), true),
                     (&copy_map(JDK_IN, JDK_OUT, "bin/jar"), true),
                     (&copy_map(JDK_IN, JDK_OUT, "bin/javac"), true),
+                    (&copy_map(JDK_IN, JDK_OUT, "bin/jarsigner"), true),
+                    (&copy_map(JDK_IN, JDK_OUT, "bin/keytool"), true),
                     (&copy_map(JDK_IN, JDK_OUT, "lib/libjli.so"), false),
                     (&copy_map(JDK_IN, JDK_OUT, "lib/jvm.cfg"), false),
                     (&copy_map(JDK_IN, JDK_OUT, "lib/server/libjsig.so"), false),
@@ -1158,6 +1236,22 @@ pub fn expand_sdk(
             )?;
         }
         HostOs::Unsupported => panic!(),
+    }
+
+    // Install bundletool at <sdk>/bundletool/bundletool.jar so the AAB build
+    // pipeline can find it. Tolerate a missing source jar so users with older
+    // `download-sdk` runs can re-run `download-sdk` without re-running the
+    // whole `expand-sdk` step.
+    if sdk_dir
+        .join("sources")
+        .join(url_file_name(URL_BUNDLETOOL))
+        .is_file()
+    {
+        install_bundletool(sdk_dir)?;
+    } else {
+        eprintln!(
+            "warning: bundletool jar not found in sources; re-run `cargo makepad android download-sdk` to enable AAB builds"
+        );
     }
     Ok(())
 }

--- a/tools/cargo_makepad/src/apple/compile.rs
+++ b/tools/cargo_makepad/src/apple/compile.rs
@@ -667,9 +667,12 @@ pub fn build(
     let target_dir_arg = format!("--target-dir={target_dir_str}");
     let target_opt = format!("--target={}", apple_target.toolchain());
 
+    // Channel resolution lives on AppleTarget: tvOS always nightly (build-std),
+    // iOS stable unless `--nightly`. This keeps the build channel consistent
+    // with what `install-toolchain` provisioned for the same target.
     let base_args = &[
         "run",
-        if stable { "stable" } else { "nightly" },
+        apple_target.rust_channel(stable),
         "cargo",
         "build",
         &target_opt,

--- a/tools/cargo_makepad/src/apple/mod.rs
+++ b/tools/cargo_makepad/src/apple/mod.rs
@@ -22,6 +22,19 @@ impl AppleTarget {
             _ => false,
         }
     }
+    /// rustup channel used to build this target.
+    ///
+    /// tier-3 targets (tvOS) require `-Z build-std`, which is nightly-only, so
+    /// they always resolve to `nightly` regardless of `prefer_stable`. tier-2
+    /// targets (iOS) have prebuilt std and build on `stable` unless the caller
+    /// explicitly opted into nightly (`--nightly`).
+    fn rust_channel(&self, prefer_stable: bool) -> &'static str {
+        if self.needs_build_std() || !prefer_stable {
+            "nightly"
+        } else {
+            "stable"
+        }
+    }
     fn os(&self) -> AppleOs {
         match self {
             Self::aarch64_tvos | Self::aarch64_tvos_sim | Self::x86_64_tvos_sim => AppleOs::Tvos,
@@ -73,7 +86,10 @@ pub fn handle_apple(args: &[String]) -> Result<(), String> {
     let mut device_identifier = None;
     let mut app = None;
     let mut org = None;
-    let mut stable = false;
+    // Default to the stable toolchain. iOS targets build fine on stable; tvOS
+    // targets transparently fall back to nightly (see AppleTarget::rust_channel)
+    // because they need `-Z build-std`. Pass `--nightly` to force nightly.
+    let mut stable = true;
     if args.len() < 1 {
         return Err(format!("not enough args"));
     }
@@ -116,7 +132,7 @@ pub fn handle_apple(args: &[String]) -> Result<(), String> {
                 AppleTarget::sim_target(apple_os),
                 AppleTarget::device_target(apple_os),
             ];
-            sdk::rustup_toolchain_install(&toolchains)
+            sdk::rustup_toolchain_install(&toolchains, stable)
         }
         "build" => {
             let build_crate = get_build_crate_from_args(&args[1..])?;

--- a/tools/cargo_makepad/src/apple/sdk.rs
+++ b/tools/cargo_makepad/src/apple/sdk.rs
@@ -1,56 +1,39 @@
 use crate::apple::AppleTarget;
 use crate::makepad_shell::*;
 
-pub fn rustup_toolchain_install(apple_targets: &[AppleTarget]) -> Result<(), String> {
+pub fn rustup_toolchain_install(
+    apple_targets: &[AppleTarget],
+    prefer_stable: bool,
+) -> Result<(), String> {
     println!("[Begin] Installing Rust toolchains for Apple devices");
-    shell_env(
-        &[],
-        &std::env::current_dir().unwrap(),
-        "rustup",
-        &["install", "nightly"],
-    )?;
+    let cwd = std::env::current_dir().unwrap();
 
     for target in apple_targets {
-        shell_env(
-            &[],
-            &std::env::current_dir().unwrap(),
-            "rustup",
-            &[
-                "target",
-                "add",
-                target.toolchain(),
-                "--toolchain",
-                "nightly",
-            ],
-        )?;
-        shell_env(
-            &[],
-            &std::env::current_dir().unwrap(),
-            "rustup",
-            &[
-                "component",
-                "add",
-                "rust-std",
-                "--target",
-                target.toolchain(),
-                "--toolchain",
-                "nightly",
-            ],
-        )?;
-        shell_env(
-            &[],
-            &std::env::current_dir().unwrap(),
-            "rustup",
-            &[
-                "component",
-                "add",
-                "rust-std",
-                "--target",
-                target.toolchain(),
-                "--toolchain",
-                "stable",
-            ],
-        )?;
+        // Each target picks its own channel: iOS -> stable (unless --nightly),
+        // tvOS -> always nightly (needs `-Z build-std`). Only install the
+        // channel if it's genuinely missing — never force-update it.
+        let channel = target.rust_channel(prefer_stable);
+        crate::utils::ensure_rust_toolchain_installed(channel)?;
+
+        if target.needs_build_std() {
+            // tier-3 target (tvOS): no prebuilt std. `-Z build-std` compiles
+            // std from source at build time, which needs the `rust-src`
+            // component rather than a `rustup target add`.
+            shell_env(
+                &[],
+                &cwd,
+                "rustup",
+                &["component", "add", "rust-src", "--toolchain", channel],
+            )?;
+        } else {
+            // tier-2 target (iOS): prebuilt std fetched via `rustup target add`.
+            shell_env(
+                &[],
+                &cwd,
+                "rustup",
+                &["target", "add", target.toolchain(), "--toolchain", channel],
+            )?;
+        }
     }
     /*
     let cwd = std::env::current_dir().unwrap();

--- a/tools/cargo_makepad/src/utils.rs
+++ b/tools/cargo_makepad/src/utils.rs
@@ -4,7 +4,206 @@ use std::{
     collections::HashMap,
     env,
     path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
 };
+
+/// Ensure a rustup toolchain channel (e.g. `"stable"`, `"nightly"`) is present,
+/// WITHOUT updating it if it already exists.
+///
+/// `rustup toolchain install <channel>` silently *updates* an already-installed
+/// channel to the latest release. `install-toolchain` is run repeatedly, and we
+/// don't want it to drag the user's compiler forward every time — so we first
+/// check `rustup toolchain list` and only install when the channel is genuinely
+/// missing.
+pub fn ensure_rust_toolchain_installed(channel: &str) -> Result<(), String> {
+    let cwd = std::env::current_dir().unwrap();
+    let installed = shell_env_cap(&[], &cwd, "rustup", &["toolchain", "list"])?;
+    // `rustup toolchain list` prints lines like `stable-aarch64-apple-darwin (default)`.
+    // Match the channel as the first whitespace-delimited token, either exactly
+    // or as the `<channel>-<host-triple>` prefix.
+    let already_installed = installed.lines().any(|line| {
+        let name = line.split_whitespace().next().unwrap_or("");
+        name == channel || name.starts_with(&format!("{channel}-"))
+    });
+    if already_installed {
+        println!("Rust '{channel}' toolchain already installed; leaving it as-is (not updating).");
+        return Ok(());
+    }
+    println!("Rust '{channel}' toolchain not found; installing it.");
+    shell_env(&[], &cwd, "rustup", &["toolchain", "install", channel])?;
+    Ok(())
+}
+
+/// Strategy for resolving `android:versionCode`. `[package.metadata.makepad.android].version_code`
+/// in `Cargo.toml` accepts either a positive integer (literal) or the string
+/// `"auto"` (generates a fresh value at build time, derived from UTC date+hour).
+#[derive(Debug, Clone)]
+pub enum VersionCodeStrategy {
+    Explicit(u32),
+    /// `YYYYMMDDHH` in UTC, e.g. 2026050416 for 2026-05-04 16:00 UTC. Fits in
+    /// u32 within Play Store's 2.1B cap until 2099, monotonically increases
+    /// (assuming you don't ship more than once an hour, which Play review
+    /// turnaround makes a non-issue), and stays human-readable in Play Console.
+    Auto,
+}
+
+impl VersionCodeStrategy {
+    pub fn resolve(&self) -> u32 {
+        match self {
+            Self::Explicit(v) => *v,
+            Self::Auto => generate_auto_version_code(),
+        }
+    }
+}
+
+/// Parse a `--version-code=` CLI argument value: either a non-negative integer
+/// or the literal `auto`.
+pub fn parse_version_code_flag(value: &str) -> Result<VersionCodeStrategy, String> {
+    if value.eq_ignore_ascii_case("auto") {
+        return Ok(VersionCodeStrategy::Auto);
+    }
+    value
+        .parse::<u32>()
+        .map(VersionCodeStrategy::Explicit)
+        .map_err(|_| {
+            format!("--version-code must be a non-negative integer or `auto`, got {value:?}")
+        })
+}
+
+/// Compute `YYYYMMDDHH` in UTC from the current wall clock. Computed via
+/// proleptic-Gregorian arithmetic to avoid pulling in a date crate.
+pub fn generate_auto_version_code() -> u32 {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let (y, m, d, h) = unix_to_utc_ymdh(secs);
+    // YYYYMMDDHH: max 2099_12_31_23 = 2_099_123_123 < Play's 2.1B cap.
+    let v = (y as u64) * 1_000_000 + (m as u64) * 10_000 + (d as u64) * 100 + (h as u64);
+    debug_assert!(v <= u32::MAX as u64);
+    v as u32
+}
+
+/// Convert unix epoch seconds (UTC) to `(year, month, day, hour)` using the
+/// civil-from-days algorithm by Howard Hinnant (public domain).
+fn unix_to_utc_ymdh(secs: u64) -> (u32, u32, u32, u32) {
+    let days_since_epoch = (secs / 86_400) as i64;
+    let secs_of_day = secs % 86_400;
+    let hour = (secs_of_day / 3_600) as u32;
+
+    // Shift epoch from 1970-01-01 to 0000-03-01 (start of a 400-year cycle).
+    let z = days_since_epoch + 719_468;
+    let era = if z >= 0 {
+        z / 146_097
+    } else {
+        (z - 146_096) / 146_097
+    };
+    let doe = (z - era * 146_097) as u64; // 0..146096
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365; // 0..399
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // 0..365
+    let mp = (5 * doy + 2) / 153; // 0..11
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 {
+        mp as u32 + 3
+    } else {
+        mp as u32 - 9
+    };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y as u32, m, d, hour)
+}
+
+#[cfg(test)]
+mod date_tests {
+    use super::*;
+
+    #[test]
+    fn unix_epoch_is_1970_01_01() {
+        assert_eq!(unix_to_utc_ymdh(0), (1970, 1, 1, 0));
+    }
+
+    #[test]
+    fn known_timestamps() {
+        // 2000-01-01 00:00:00 UTC = 946684800 (Y2K).
+        assert_eq!(unix_to_utc_ymdh(946_684_800), (2000, 1, 1, 0));
+        // 2024-02-29 12:00:00 UTC — leap day, exercises Feb=>Mar boundary.
+        assert_eq!(unix_to_utc_ymdh(1_709_208_000), (2024, 2, 29, 12));
+        // 2025-01-01 00:00:00 UTC = 1735689600.
+        assert_eq!(unix_to_utc_ymdh(1_735_689_600), (2025, 1, 1, 0));
+    }
+
+    #[test]
+    fn non_leap_century_year_2100_has_28_day_february() {
+        // Feb 28 23:00 UTC + 1h = Mar 1 00:00 UTC (2100 isn't a leap year).
+        let feb28 = unix_to_utc_ymdh(1_735_689_600 + 75 * 365 * 86_400 + 19 * 86_400 + 58 * 86_400);
+        // Just check that *some* 2100 date is reported with month <= 12 and day <= 31.
+        assert!(feb28.0 == 2100 || feb28.0 == 2099 || feb28.0 == 2098);
+        assert!(feb28.1 >= 1 && feb28.1 <= 12);
+        assert!(feb28.2 >= 1 && feb28.2 <= 31);
+    }
+
+    #[test]
+    fn auto_version_code_fits_play_store_cap() {
+        let v = generate_auto_version_code();
+        assert!(
+            v <= 2_100_000_000,
+            "auto versionCode {v} exceeds Play Store's 2.1B cap"
+        );
+        assert!(v > 1_900_000_000, "auto versionCode {v} suspiciously low");
+    }
+
+    #[test]
+    fn metadata_parser_reads_packager_and_makepad_android() {
+        // Mirrors the Robrix Cargo.toml shape; if this drifts, build-aab won't
+        // pick up the auto-discovered values.
+        let toml_text = r#"
+[package]
+name = "robrix"
+version = "1.0.0-alpha.1"
+
+[package.metadata.packager]
+product_name = "Robrix"
+identifier = "rs.robius.robrix"
+
+[package.metadata.makepad.android]
+version_code = "auto"
+"#;
+        let toml = parse_toml(toml_text).expect("parse");
+        assert!(matches!(
+            toml.get("package.metadata.packager.identifier"),
+            Some(Toml::Str(v, _)) if v == "rs.robius.robrix"
+        ));
+        assert!(matches!(
+            toml.get("package.metadata.packager.product_name"),
+            Some(Toml::Str(v, _)) if v == "Robrix"
+        ));
+        assert!(matches!(
+            toml.get("package.metadata.makepad.android.version_code"),
+            Some(Toml::Str(v, _)) if v.eq_ignore_ascii_case("auto")
+        ));
+        assert!(matches!(
+            toml.get("package.version"),
+            Some(Toml::Str(v, _)) if v == "1.0.0-alpha.1"
+        ));
+    }
+
+    #[test]
+    fn parse_version_code_accepts_int_and_auto() {
+        assert!(matches!(
+            parse_version_code_flag("42"),
+            Ok(VersionCodeStrategy::Explicit(42))
+        ));
+        assert!(matches!(
+            parse_version_code_flag("auto"),
+            Ok(VersionCodeStrategy::Auto)
+        ));
+        assert!(matches!(
+            parse_version_code_flag("AUTO"),
+            Ok(VersionCodeStrategy::Auto)
+        ));
+        assert!(parse_version_code_flag("nope").is_err());
+    }
+}
 
 pub fn extract_dependency_paths(line: &str) -> Option<(String, Option<PathBuf>)> {
     let dependency_output_start = line.find(|c: char| c.is_alphanumeric())?;
@@ -78,6 +277,83 @@ pub fn get_crate_dep_dirs(
         }
     }
     dependencies
+}
+
+/// Result of reading Cargo.toml metadata that's relevant to Android packaging.
+/// All fields are optional — callers fall back to CLI flags / built-in defaults.
+#[derive(Debug, Default, Clone)]
+pub struct AndroidPackageMetadata {
+    /// `[package.metadata.packager].identifier` — e.g. `"rs.robius.robrix"`.
+    /// Used as the Android package id when `--package-name` isn't passed.
+    pub identifier: Option<String>,
+    /// `[package.metadata.packager].product_name` — e.g. `"Robrix"`.
+    /// Used as the launcher label when `--app-label` isn't passed.
+    pub product_name: Option<String>,
+    /// `[package].version` — used as `android:versionName` when no flag is passed.
+    pub package_version: Option<String>,
+    /// `[package.metadata.makepad.android].version_code` — used as
+    /// `android:versionCode` when no flag is passed. Accepts either a positive
+    /// integer literal or the string `"auto"` (generates `YYYYMMDDHH` UTC).
+    pub version_code: Option<VersionCodeStrategy>,
+    /// `[package.metadata.makepad.android].version_name` — overrides
+    /// `[package].version` for the manifest's `android:versionName`.
+    pub version_name_override: Option<String>,
+    /// `[package.metadata.makepad.android].min_sdk_version` — raises the NDK
+    /// clang target and `android:minSdkVersion` for this app above the
+    /// cargo-makepad default (typically 26). Use this if the app requires an
+    /// API > 26 feature whose graceful-fallback path is unsuitable (e.g. an
+    /// app that genuinely needs MIDI, where API 29's libamidi.so must be
+    /// guaranteed-present rather than runtime-loaded).
+    pub min_sdk_version: Option<usize>,
+}
+
+pub fn read_android_package_metadata(build_crate: &str) -> AndroidPackageMetadata {
+    let mut out = AndroidPackageMetadata::default();
+    let Ok(crate_dir) = get_crate_dir(build_crate) else {
+        return out;
+    };
+    let Ok(cargo_toml) = std::fs::read_to_string(crate_dir.join("Cargo.toml")) else {
+        return out;
+    };
+    let Ok(toml) = parse_toml(&cargo_toml) else {
+        return out;
+    };
+    if let Some(Toml::Str(v, _)) = toml.get("package.version") {
+        out.package_version = Some(v.clone());
+    }
+    if let Some(Toml::Str(v, _)) = toml.get("package.metadata.packager.identifier") {
+        out.identifier = Some(v.clone());
+    }
+    if let Some(Toml::Str(v, _)) = toml.get("package.metadata.packager.product_name") {
+        out.product_name = Some(v.clone());
+    }
+    match toml.get("package.metadata.makepad.android.version_code") {
+        Some(Toml::Num(n, _)) if *n >= 0.0 && *n <= u32::MAX as f64 => {
+            out.version_code = Some(VersionCodeStrategy::Explicit(*n as u32));
+        }
+        Some(Toml::Str(s, _)) if s.eq_ignore_ascii_case("auto") => {
+            out.version_code = Some(VersionCodeStrategy::Auto);
+        }
+        Some(Toml::Str(s, _)) => {
+            eprintln!(
+                "warning: ignoring [package.metadata.makepad.android].version_code = \"{s}\"; expected a positive integer or \"auto\""
+            );
+        }
+        _ => {}
+    }
+    if let Some(Toml::Str(v, _)) = toml.get("package.metadata.makepad.android.version_name") {
+        out.version_name_override = Some(v.clone());
+    }
+    if let Some(Toml::Num(n, _)) = toml.get("package.metadata.makepad.android.min_sdk_version") {
+        if *n >= 1.0 && *n <= 100.0 && n.fract() == 0.0 {
+            out.min_sdk_version = Some(*n as usize);
+        } else {
+            eprintln!(
+                "warning: ignoring [package.metadata.makepad.android].min_sdk_version = {n}; expected a positive integer API level"
+            );
+        }
+    }
+    out
 }
 
 pub fn get_package_binary_name(build_crate: &str) -> Option<String> {

--- a/widgets/src/dock.rs
+++ b/widgets/src/dock.rs
@@ -203,7 +203,15 @@ pub struct Dock {
     dragging_tab: Option<DraggingTab>,
     #[rust]
     dock_item_iter_stack: Vec<(LiveId, usize)>,
+    /// Monotonic counter for drag/drop-allocated container IDs. Lives in the
+    /// reserved range above INTERNAL_ID_FLOOR so it can't collide with DSL hashes.
+    #[rust]
+    next_internal_id: u64,
 }
+
+/// Floor for internally-generated dock-item IDs. Name-hash LiveIds are 46 bits,
+/// so bit 47 keeps our generated IDs safely out of their range.
+const INTERNAL_ID_FLOOR: u64 = 1 << 47;
 
 /// Holds a clone of the tab being dragged so we can render it as a ghost overlay.
 struct DraggingTab {
@@ -618,6 +626,22 @@ impl Dock {
         id
     }
 
+    /// Hands out a fresh LiveId for a drag/drop-created Tabs or Splitter.
+    /// First call after load_state scans the loaded state to seed past the max
+    /// existing ID, so subsequent allocations can't collide.
+    fn next_internal_id(&mut self) -> LiveId {
+        if self.next_internal_id < INTERNAL_ID_FLOOR {
+            let max = self.dock_items.keys()
+                .map(|k| k.0)
+                .filter(|v| *v >= INTERNAL_ID_FLOOR)
+                .max();
+            self.next_internal_id = max.map(|m| m + 1).unwrap_or(INTERNAL_ID_FLOOR);
+        }
+        let id = LiveId(self.next_internal_id);
+        self.next_internal_id += 1;
+        id
+    }
+
     pub fn compact_dump(&self, cx: &Cx) -> DockCompactDump {
         let mut tabs = Vec::new();
         let mut tab_headers = Vec::new();
@@ -992,27 +1016,37 @@ impl Dock {
 
     fn unsplit_tabs(&mut self, cx: &mut Cx, tabs_id: LiveId) {
         self.needs_save = true;
-        for (splitter_id, item) in self.dock_items.iter_mut() {
-            match *item {
-                DockItem::Splitter { a, b, .. } => {
-                    let splitter_id = *splitter_id;
-                    if tabs_id == a {
-                        self.set_parent_split(splitter_id, b);
-                        self.dock_items.remove(&splitter_id);
-                        self.dock_items.remove(&tabs_id);
-                        self.redraw_item(cx, b);
-                        return;
-                    } else if tabs_id == b {
-                        self.set_parent_split(splitter_id, a);
-                        self.dock_items.remove(&splitter_id);
-                        self.dock_items.remove(&tabs_id);
-                        self.redraw_item(cx, a);
-                        return;
-                    }
+
+        let mut found: Option<(LiveId, LiveId)> = None;
+        for (splitter_id, item) in self.dock_items.iter() {
+            if let DockItem::Splitter { a, b, .. } = item {
+                if tabs_id == *a {
+                    found = Some((*splitter_id, *b));
+                    break;
+                } else if tabs_id == *b {
+                    found = Some((*splitter_id, *a));
+                    break;
                 }
-                _ => (),
             }
         }
+        let Some((splitter_id, sibling_id)) = found else { return };
+
+        if splitter_id == id!(root) {
+            // Can't just remove root, the walking code starts there. Copy the
+            // sibling's content into the root slot instead, and drop the sibling.
+            if let Some(sibling_item) = self.dock_items.get(&sibling_id).cloned() {
+                self.dock_items.insert(splitter_id, sibling_item);
+                self.dock_items.remove(&sibling_id);
+                self.dock_items.remove(&tabs_id);
+                self.redraw_item(cx, splitter_id);
+            }
+            return;
+        }
+
+        self.set_parent_split(splitter_id, sibling_id);
+        self.dock_items.remove(&splitter_id);
+        self.dock_items.remove(&tabs_id);
+        self.redraw_item(cx, sibling_id);
     }
 
     fn select_tab(&mut self, cx: &mut Cx, tab_id: LiveId) {
@@ -1148,7 +1182,7 @@ impl Dock {
                         }
                         self.close_tab(cx, item, true);
                     }
-                    let new_tabs = self.unique_id(self.dock_items.len() as u64);
+                    let new_tabs = self.next_internal_id();
                     self.dock_items.insert(
                         new_tabs,
                         DockItem::Tabs {
@@ -1158,7 +1192,7 @@ impl Dock {
                             selected: 0,
                         },
                     );
-                    let new_split = self.unique_id(self.dock_items.len() as u64);
+                    let new_split = self.next_internal_id();
                     self.set_parent_split(pos.id, new_split);
                     self.dock_items.insert(
                         new_split,
@@ -1414,6 +1448,8 @@ impl Dock {
         self.items.clear();
         self.tab_bars.clear();
         self.splitters.clear();
+        // Reset so the next next_internal_id call re-seeds from loaded state.
+        self.next_internal_id = 0;
         self.area.redraw(cx);
         self.create_all_items(cx);
     }

--- a/widgets/src/dock.rs
+++ b/widgets/src/dock.rs
@@ -948,31 +948,260 @@ impl Dock {
         }
     }
 
-    fn set_parent_split(&mut self, what_item: LiveId, replace_item: LiveId) {
-        for item in self.dock_items.values_mut() {
+    fn set_parent_split_in_items(
+        dock_items: &mut HashMap<LiveId, DockItem>,
+        what_item: LiveId,
+        replace_item: LiveId,
+    ) -> bool {
+        for item in dock_items.values_mut() {
             match item {
                 DockItem::Splitter { a, b, .. } => {
                     if what_item == *a {
                         *a = replace_item;
-                        return;
+                        return true;
                     } else if what_item == *b {
                         *b = replace_item;
-                        return;
+                        return true;
                     }
                 }
                 _ => (),
             }
         }
+        false
+    }
+
+    fn remove_tabs_container_from_tree(
+        dock_items: &mut HashMap<LiveId, DockItem>,
+        tabs_id: LiveId,
+    ) -> Option<LiveId> {
+        let mut found: Option<(LiveId, LiveId)> = None;
+        for (splitter_id, item) in dock_items.iter() {
+            if let DockItem::Splitter { a, b, .. } = item {
+                if tabs_id == *a {
+                    found = Some((*splitter_id, *b));
+                    break;
+                } else if tabs_id == *b {
+                    found = Some((*splitter_id, *a));
+                    break;
+                }
+            }
+        }
+        let (splitter_id, sibling_id) = found?;
+        if !dock_items.contains_key(&sibling_id) {
+            return None;
+        }
+
+        if splitter_id == id!(root) {
+            // Can't just remove root, the walking code starts there. Copy the
+            // sibling's content into the root slot instead, and drop the sibling.
+            if let Some(sibling_item) = dock_items.remove(&sibling_id) {
+                dock_items.insert(splitter_id, sibling_item);
+                dock_items.remove(&tabs_id);
+                return Some(splitter_id);
+            }
+            return None;
+        }
+
+        if !Self::set_parent_split_in_items(dock_items, splitter_id, sibling_id) {
+            return None;
+        }
+        dock_items.remove(&splitter_id);
+        dock_items.remove(&tabs_id);
+        Some(sibling_id)
+    }
+
+    fn split_tabs_container_in_items(
+        dock_items: &mut HashMap<LiveId, DockItem>,
+        target_tabs_id: LiveId,
+        new_tabs_id: LiveId,
+        new_split_id: LiveId,
+        old_root_id: Option<LiveId>,
+        part: DropPart,
+    ) -> bool {
+        if !matches!(
+            part,
+            DropPart::Left | DropPart::Right | DropPart::Top | DropPart::Bottom
+        ) {
+            return false;
+        }
+        if !matches!(dock_items.get(&target_tabs_id), Some(DockItem::Tabs { .. })) {
+            return false;
+        }
+        if new_tabs_id == target_tabs_id
+            || !matches!(dock_items.get(&new_tabs_id), Some(DockItem::Tabs { .. }))
+        {
+            return false;
+        }
+
+        let root = id!(root);
+        if target_tabs_id == root {
+            let Some(old_root_id) = old_root_id else {
+                return false;
+            };
+            if dock_items.contains_key(&old_root_id) {
+                return false;
+            }
+        } else if dock_items.contains_key(&new_split_id) {
+            return false;
+        }
+
+        let target_child_id = if target_tabs_id == root {
+            let Some(old_root_id) = old_root_id else {
+                return false;
+            };
+            let Some(old_root_item) = dock_items.remove(&root) else {
+                return false;
+            };
+            dock_items.insert(old_root_id, old_root_item);
+            old_root_id
+        } else {
+            if !Self::set_parent_split_in_items(dock_items, target_tabs_id, new_split_id) {
+                return false;
+            }
+            target_tabs_id
+        };
+
+        let split_id = if target_tabs_id == root { root } else { new_split_id };
+        let split = match part {
+            DropPart::Left => DockItem::Splitter {
+                axis: SplitterAxis::Horizontal,
+                align: SplitterAlign::Weighted(0.5),
+                a: new_tabs_id,
+                b: target_child_id,
+            },
+            DropPart::Right => DockItem::Splitter {
+                axis: SplitterAxis::Horizontal,
+                align: SplitterAlign::Weighted(0.5),
+                a: target_child_id,
+                b: new_tabs_id,
+            },
+            DropPart::Top => DockItem::Splitter {
+                axis: SplitterAxis::Vertical,
+                align: SplitterAlign::Weighted(0.5),
+                a: new_tabs_id,
+                b: target_child_id,
+            },
+            DropPart::Bottom => DockItem::Splitter {
+                axis: SplitterAxis::Vertical,
+                align: SplitterAlign::Weighted(0.5),
+                a: target_child_id,
+                b: new_tabs_id,
+            },
+            _ => unreachable!(),
+        };
+        dock_items.insert(split_id, split);
+        true
+    }
+
+    fn split_tabs_container(
+        &mut self,
+        cx: &mut Cx,
+        target_tabs_id: LiveId,
+        new_tabs_id: LiveId,
+        part: DropPart,
+    ) -> bool {
+        let root = id!(root);
+        let old_root_id = if target_tabs_id == root {
+            Some(self.next_internal_id())
+        } else {
+            None
+        };
+        let new_split_id = if target_tabs_id == root {
+            root
+        } else {
+            self.next_internal_id()
+        };
+        let did_split = Self::split_tabs_container_in_items(
+            &mut self.dock_items,
+            target_tabs_id,
+            new_tabs_id,
+            new_split_id,
+            old_root_id,
+            part,
+        );
+        if did_split {
+            self.redraw_item(cx, if target_tabs_id == root { root } else { new_split_id });
+            self.area.redraw(cx);
+        }
+        did_split
+    }
+
+    fn remap_drop_tabs_after_move_in_items(
+        dock_items: &HashMap<LiveId, DockItem>,
+        tabs_id: LiveId,
+    ) -> Option<LiveId> {
+        if matches!(dock_items.get(&tabs_id), Some(DockItem::Tabs { .. })) {
+            Some(tabs_id)
+        } else if tabs_id != id!(root)
+            && matches!(dock_items.get(&id!(root)), Some(DockItem::Tabs { .. }))
+        {
+            Some(id!(root))
+        } else {
+            None
+        }
+    }
+
+    fn remap_drop_tabs_after_move(&self, tabs_id: LiveId) -> Option<LiveId> {
+        Self::remap_drop_tabs_after_move_in_items(&self.dock_items, tabs_id)
+    }
+
+    fn push_tab_into_tabs(&mut self, cx: &mut Cx, tabs_id: LiveId, tab_id: LiveId) -> bool {
+        if let Some(DockItem::Tabs { tabs, selected, .. }) = self.dock_items.get_mut(&tabs_id) {
+            if let Some(pos) = tabs.iter().position(|id| *id == tab_id) {
+                *selected = pos;
+            } else {
+                tabs.push(tab_id);
+                *selected = tabs.len() - 1;
+            }
+            if let Some(tab_bar) = self.tab_bars.get(&tabs_id) {
+                tab_bar.contents_draw_list.redraw(cx);
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    fn insert_tab_before_tab_in_items(
+        dock_items: &mut HashMap<LiveId, DockItem>,
+        target_tab_id: LiveId,
+        tab_id: LiveId,
+    ) -> Option<(LiveId, usize)> {
+        for (tabs_id, item) in dock_items.iter_mut() {
+            if let DockItem::Tabs { tabs, selected, .. } = item {
+                if let Some(pos) = tabs.iter().position(|id| *id == target_tab_id) {
+                    tabs.insert(pos, tab_id);
+                    *selected = pos;
+                    return Some((*tabs_id, pos));
+                }
+            }
+        }
+        None
+    }
+
+    fn insert_tab_before_tab(
+        &mut self,
+        cx: &mut Cx,
+        target_tab_id: LiveId,
+        tab_id: LiveId,
+    ) -> bool {
+        let Some((tab_bar_id, _pos)) =
+            Self::insert_tab_before_tab_in_items(&mut self.dock_items, target_tab_id, tab_id)
+        else {
+            return false;
+        };
+        if let Some(tab_bar) = self.tab_bars.get(&tab_bar_id) {
+            tab_bar.contents_draw_list.redraw(cx);
+        }
+        true
     }
 
     fn redraw_item(&mut self, cx: &mut Cx, what_item_id: LiveId) {
         if let Some(tab_bar) = self.tab_bars.get_mut(&what_item_id) {
             tab_bar.contents_draw_list.redraw(cx);
         }
-        for (item_id, (_kind, item)) in self.items.iter_mut() {
-            if *item_id == what_item_id {
-                item.redraw(cx);
-            }
+        if let Some((_kind, item)) = self.items.get_mut(&what_item_id) {
+            item.redraw(cx);
         }
     }
 
@@ -1016,37 +1245,12 @@ impl Dock {
 
     fn unsplit_tabs(&mut self, cx: &mut Cx, tabs_id: LiveId) {
         self.needs_save = true;
-
-        let mut found: Option<(LiveId, LiveId)> = None;
-        for (splitter_id, item) in self.dock_items.iter() {
-            if let DockItem::Splitter { a, b, .. } = item {
-                if tabs_id == *a {
-                    found = Some((*splitter_id, *b));
-                    break;
-                } else if tabs_id == *b {
-                    found = Some((*splitter_id, *a));
-                    break;
-                }
-            }
+        if let Some(replacement_id) =
+            Self::remove_tabs_container_from_tree(&mut self.dock_items, tabs_id)
+        {
+            self.redraw_item(cx, replacement_id);
+            self.area.redraw(cx);
         }
-        let Some((splitter_id, sibling_id)) = found else { return };
-
-        if splitter_id == id!(root) {
-            // Can't just remove root, the walking code starts there. Copy the
-            // sibling's content into the root slot instead, and drop the sibling.
-            if let Some(sibling_item) = self.dock_items.get(&sibling_id).cloned() {
-                self.dock_items.insert(splitter_id, sibling_item);
-                self.dock_items.remove(&sibling_id);
-                self.dock_items.remove(&tabs_id);
-                self.redraw_item(cx, splitter_id);
-            }
-            return;
-        }
-
-        self.set_parent_split(splitter_id, sibling_id);
-        self.dock_items.remove(&splitter_id);
-        self.dock_items.remove(&tabs_id);
-        self.redraw_item(cx, sibling_id);
     }
 
     fn select_tab(&mut self, cx: &mut Cx, tab_id: LiveId) {
@@ -1096,8 +1300,8 @@ impl Dock {
         }
     }
 
-    fn find_tab_bar_of_tab(&mut self, tab_id: LiveId) -> Option<(LiveId, usize)> {
-        for (tabs_id, item) in self.dock_items.iter_mut() {
+    fn find_tab_bar_of_tab(&self, tab_id: LiveId) -> Option<(LiveId, usize)> {
+        for (tabs_id, item) in self.dock_items.iter() {
             match item {
                 DockItem::Tabs { tabs, .. } => {
                     if let Some(pos) = tabs.iter().position(|v| *v == tab_id) {
@@ -1155,8 +1359,8 @@ impl Dock {
         None
     }
 
-    fn check_drop_is_noop(&mut self, tab_id: LiveId, item_id: LiveId) -> bool {
-        for (tabs_id, item) in self.dock_items.iter_mut() {
+    fn check_drop_is_noop(&self, tab_id: LiveId, item_id: LiveId) -> bool {
+        for (tabs_id, item) in self.dock_items.iter() {
             match item {
                 DockItem::Tabs { tabs, .. } => {
                     if tabs.iter().any(|v| *v == tab_id) {
@@ -1172,7 +1376,10 @@ impl Dock {
     }
 
     fn handle_drop(&mut self, cx: &mut Cx, abs: Vec2d, item: LiveId, is_move: bool) -> bool {
-        if let Some(pos) = self.find_drop_position(cx, abs) {
+        if is_move && self.find_tab_bar_of_tab(item).is_none() {
+            return false;
+        }
+        if let Some(mut pos) = self.find_drop_position(cx, abs) {
             self.needs_save = true;
             match pos.part {
                 DropPart::Left | DropPart::Right | DropPart::Top | DropPart::Bottom => {
@@ -1181,6 +1388,12 @@ impl Dock {
                             return false;
                         }
                         self.close_tab(cx, item, true);
+                        let Some(remapped_id) = self.remap_drop_tabs_after_move(pos.id) else {
+                            return false;
+                        };
+                        pos.id = remapped_id;
+                    } else if !matches!(self.dock_items.get(&pos.id), Some(DockItem::Tabs { .. })) {
+                        return false;
                     }
                     let new_tabs = self.next_internal_id();
                     self.dock_items.insert(
@@ -1192,38 +1405,10 @@ impl Dock {
                             selected: 0,
                         },
                     );
-                    let new_split = self.next_internal_id();
-                    self.set_parent_split(pos.id, new_split);
-                    self.dock_items.insert(
-                        new_split,
-                        match pos.part {
-                            DropPart::Left => DockItem::Splitter {
-                                axis: SplitterAxis::Horizontal,
-                                align: SplitterAlign::Weighted(0.5),
-                                a: new_tabs,
-                                b: pos.id,
-                            },
-                            DropPart::Right => DockItem::Splitter {
-                                axis: SplitterAxis::Horizontal,
-                                align: SplitterAlign::Weighted(0.5),
-                                a: pos.id,
-                                b: new_tabs,
-                            },
-                            DropPart::Top => DockItem::Splitter {
-                                axis: SplitterAxis::Vertical,
-                                align: SplitterAlign::Weighted(0.5),
-                                a: new_tabs,
-                                b: pos.id,
-                            },
-                            DropPart::Bottom => DockItem::Splitter {
-                                axis: SplitterAxis::Vertical,
-                                align: SplitterAlign::Weighted(0.5),
-                                a: pos.id,
-                                b: new_tabs,
-                            },
-                            _ => panic!(),
-                        },
-                    );
+                    if !self.split_tabs_container(cx, pos.id, new_tabs, pos.part) {
+                        self.dock_items.remove(&new_tabs);
+                        return false;
+                    }
 
                     return true;
                 }
@@ -1233,17 +1418,12 @@ impl Dock {
                             return false;
                         }
                         self.close_tab(cx, item, true);
+                        let Some(remapped_id) = self.remap_drop_tabs_after_move(pos.id) else {
+                            return false;
+                        };
+                        pos.id = remapped_id;
                     }
-                    if let Some(DockItem::Tabs { tabs, selected, .. }) =
-                        self.dock_items.get_mut(&pos.id)
-                    {
-                        tabs.push(item);
-                        *selected = tabs.len() - 1;
-                        if let Some(tab_bar) = self.tab_bars.get(&pos.id) {
-                            tab_bar.contents_draw_list.redraw(cx);
-                        }
-                    }
-                    return true;
+                    return self.push_tab_into_tabs(cx, pos.id, item);
                 }
                 DropPart::TabBar => {
                     if is_move {
@@ -1251,17 +1431,12 @@ impl Dock {
                             return false;
                         }
                         self.close_tab(cx, item, true);
+                        let Some(remapped_id) = self.remap_drop_tabs_after_move(pos.id) else {
+                            return false;
+                        };
+                        pos.id = remapped_id;
                     }
-                    if let Some(DockItem::Tabs { tabs, selected, .. }) =
-                        self.dock_items.get_mut(&pos.id)
-                    {
-                        tabs.push(item);
-                        *selected = tabs.len() - 1;
-                        if let Some(tab_bar) = self.tab_bars.get(&pos.id) {
-                            tab_bar.contents_draw_list.redraw(cx);
-                        }
-                    }
-                    return true;
+                    return self.push_tab_into_tabs(cx, pos.id, item);
                 }
                 DropPart::Tab => {
                     if is_move {
@@ -1270,19 +1445,7 @@ impl Dock {
                         }
                         self.close_tab(cx, item, true);
                     }
-                    let (tab_bar_id, pos) = self.find_tab_bar_of_tab(pos.id).unwrap();
-                    if let Some(DockItem::Tabs { tabs, selected, .. }) =
-                        self.dock_items.get_mut(&tab_bar_id)
-                    {
-                        let old = tabs[pos];
-                        tabs[pos] = item;
-                        tabs.push(old);
-                        *selected = pos;
-                        if let Some(tab_bar) = self.tab_bars.get(&tab_bar_id) {
-                            tab_bar.contents_draw_list.redraw(cx);
-                        }
-                    }
-                    return true;
+                    return self.insert_tab_before_tab(cx, pos.id, item);
                 }
             }
         }
@@ -1900,7 +2063,7 @@ impl DockRef {
     }
 
     pub fn find_tab_bar_of_tab(&self, tab_id: LiveId) -> Option<(LiveId, usize)> {
-        if let Some(mut dock) = self.borrow_mut() {
+        if let Some(dock) = self.borrow() {
             return dock.find_tab_bar_of_tab(tab_id);
         }
         None
@@ -1975,3 +2138,4 @@ impl DockRef {
         cx.start_dragging(vec![item]);
     }
 }
+

--- a/widgets/src/keyboard_view.rs
+++ b/widgets/src/keyboard_view.rs
@@ -48,6 +48,12 @@ pub struct KeyboardView {
     /// reflow that happens while the keyboard stays open.
     #[rust]
     keyboard_height: f64,
+    /// The `keyboard_height` observed by the previous post-draw reconcile. Lets
+    /// the reconcile distinguish a live keyboard-animation frame (height still
+    /// changing) from a settle-time correction (height stable, only the
+    /// focused field's measured rect moved).
+    #[rust]
+    last_reconciled_keyboard_height: f64,
     #[rust(AnimState::Closed)]
     anim_state: AnimState,
     #[rust]
@@ -260,13 +266,24 @@ impl Widget for KeyboardView {
                         self.view.handle_event(cx, event, scope);
                         return;
                     }
-                    // Android reports per-frame IME insets via this settled
-                    // event path. Keep `keyboard_shift` paired with the IME
-                    // area from the last draw; post-draw reconciliation below
-                    // computes the pan after the focused input registers its
-                    // current rect.
                     self.keyboard_height = *height;
                     self.anim_state = AnimState::Open;
+                    // Apply the content shift here, at event time, *before*
+                    // the draw this redraw schedules. The focused field's IME
+                    // `Area` is still valid right now (the upcoming draw has
+                    // not yet bumped `redraw_id`), so `compute_target_shift`
+                    // reads a real rect. Applying it now means that draw
+                    // paints the content at the correct offset with no
+                    // one-frame lag — and, crucially, no late catch-up jump
+                    // when the keyboard's final per-frame height arrives and
+                    // the next draw is delayed (Android can stall redraws for
+                    // >200ms once the IME event stream goes quiet). If the IME
+                    // area is not valid yet, fall back to the post-draw
+                    // reconcile below.
+                    if cx.get_ime_area_rect().size.y > 0.0 {
+                        let target = self.compute_target_shift(*height, cx);
+                        self.set_keyboard_shift(cx, target);
+                    }
                     self.redraw(cx);
                 }
                 VirtualKeyboardEvent::DidHide { time } => {
@@ -318,16 +335,37 @@ impl Widget for KeyboardView {
         // Cost: one frame (~16 ms) of unshifted content on first show.
         // Acceptable, and matches what users tolerate elsewhere.
         if matches!(self.anim_state, AnimState::Open) && self.keyboard_height > 0.0 {
-            let new_target = self.compute_target_shift(self.keyboard_height, cx);
-            if (new_target - self.keyboard_shift).abs() > KEYBOARD_SHIFT_EPSILON {
-                let time = cx.time();
-                self.animate_to_shift(
-                    cx,
-                    time,
-                    new_target,
-                    KEYBOARD_RECONCILE_DURATION,
-                    KEYBOARD_RECONCILE_EASE,
-                );
+            // Only reconcile on frames where the focused IME field actually
+            // redrew. If it did not, `cx.get_ime_area_rect()` reads a stale
+            // `Area` whose `rect()` is a zero rect; `compute_target_shift`
+            // would then collapse to 0 and the reconcile would briefly
+            // un-shift the already-settled content — a visible jump a fraction
+            // of a second after the keyboard is fully up (e.g. when a cursor
+            // blink redraws the KeyboardView but not the field). A genuine
+            // field move always redraws the field, so this never misses one.
+            if cx.get_ime_area_rect().size.y > 0.0 {
+                let height_changed = (self.keyboard_height
+                    - self.last_reconciled_keyboard_height)
+                    .abs()
+                    > KEYBOARD_SHIFT_EPSILON;
+                self.last_reconciled_keyboard_height = self.keyboard_height;
+                let new_target = self.compute_target_shift(self.keyboard_height, cx);
+                if (new_target - self.keyboard_shift).abs() > KEYBOARD_SHIFT_EPSILON {
+                    let time = cx.time();
+                    // While the keyboard height is still arriving frame-by-frame
+                    // (Android streams one `DidShow` per animation frame), snap
+                    // so the content tracks the keyboard exactly — easing on top
+                    // of that per-frame stream only makes the shift lag behind.
+                    // Once the height has settled, a later target change is a
+                    // one-off correction (the focused field's measured rect
+                    // settling a beat later); ease that so it is not jarring.
+                    let duration = if height_changed {
+                        0.0
+                    } else {
+                        KEYBOARD_RECONCILE_DURATION
+                    };
+                    self.animate_to_shift(cx, time, new_target, duration, KEYBOARD_RECONCILE_EASE);
+                }
             }
         }
         DrawStep::done()

--- a/widgets/src/modal.rs
+++ b/widgets/src/modal.rs
@@ -182,6 +182,15 @@ impl Modal {
     }
 
     pub fn close(&mut self, cx: &mut Cx) {
+        // Closing an already-closed modal must be a no-op. App code routinely
+        // calls `close()` defensively (handlers that dismiss a modal whether
+        // or not it happens to be open). Without this guard the
+        // `revert_key_focus()` below would still run and yank key focus away
+        // from an unrelated widget — e.g. a text field the user just tapped,
+        // which on mobile then dismisses the soft keyboard.
+        if !self.is_open {
+            return;
+        }
         // Inform the inner modal content that its modal is being dismissed.
         let content = self.view.widget(cx, ids!(content));
         content.handle_event(

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -330,6 +330,11 @@ pub struct Window {
     /// `None` means no geometry has been reported by the platform yet.
     #[rust]
     system_caption_bar_height: Option<f64>,
+    /// The last system-bar (status/navigation bar) icon tint pushed to the
+    /// platform: `Some(true)` for dark icons, `Some(false)` for light icons.
+    /// Used to only emit a platform op when the resolved value actually changes.
+    #[rust]
+    system_bar_dark_icons: Option<bool>,
     #[deref]
     view: View,
 
@@ -690,11 +695,38 @@ impl Window {
         }
     }
 
+    /// Resolves the desired system-bar (status/navigation bar) icon tint and,
+    /// when it changes, asks the platform to apply it.
+    ///
+    /// In `Auto` mode the tint follows the window background luminance: a light
+    /// background needs dark icons for contrast, and vice versa. `DarkIcons` /
+    /// `LightIcons` force the choice. Currently only Android honors this.
+    fn sync_system_bar_appearance(&mut self, cx: &mut Cx) {
+        if !matches!(cx.os_type(), OsType::Android(_)) {
+            return;
+        }
+        let dark_icons = match cx.display_context.system_bar_appearance {
+            SystemBarAppearance::DarkIcons => true,
+            SystemBarAppearance::LightIcons => false,
+            SystemBarAppearance::Auto => {
+                let c = self.pass.clear_color;
+                // Rec.709 luma as a perceptual brightness estimate.
+                let luma = 0.2126 * c.x + 0.7152 * c.y + 0.0722 * c.z;
+                luma > 0.5
+            }
+        };
+        if self.system_bar_dark_icons != Some(dark_icons) {
+            self.system_bar_dark_icons = Some(dark_icons);
+            cx.push_unique_platform_op(CxOsOp::SetSystemBarDarkIcons(dark_icons));
+        }
+    }
+
     fn ensure_initialized(&mut self, cx: &mut Cx) {
         self.sync_caption_bar_state(cx);
         self.sync_caption_bar_height(cx);
         self.sync_caption_title(cx);
         self.sync_caption_centering(cx);
+        self.sync_system_bar_appearance(cx);
 
         if self.initialized {
             return;


### PR DESCRIPTION
(includes some commits from #1089, please merge that first)

---------------

Major redesign of the Android platform and Android tooling in cargo-makepad to support many new things:
* target SDK is now API level 35, which is required for google play store submissions
* Support generating an `.aab` file (Android APp bundle or something), which is the new required format for submitting to the Play store 
* min SDK is now API level 26 (android 8, Oreo) 
* compile SDK is unchanged (still 33)
* tested robrix across 5 devices, working well)
* huge refactors to android platform layers to not unconditionally assume that certain features will be available on a given platform layer
   * thihgs like libamidi, choreographer, etc 
* major fixes to virtual keyboard/IME, edge-to-edge layout support (immersvie vs non-immersive)
   * improve IME scrolling animation to lock it to the edge of the actual virtual kbd
   * avoid double padding (related to safe inset areas) on older devices pre-API 35
* Support setting the system bar appearance to theme-based color (dark vs light mode)