### PR TITLE
Fix subtle layout bug that ignored padding for text wrapping calc

### DIFF
--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -2120,12 +2120,7 @@ impl DrawText {
     }
 
     pub fn draw_walk(&mut self, cx: &mut Cx2d, walk: Walk, align: Align, text: &str) -> Rect {
-        let turtle_rect = cx.turtle().inner_rect();
-        let mut max_width_in_lpxs = if !turtle_rect.size.x.is_nan() {
-            Some(turtle_rect.size.x as f32)
-        } else {
-            None
-        };
+        let mut max_width_in_lpxs = self.max_layout_width_for_walk(cx, walk);
 
         // For Fit-width containers with a max bound, resolve the bound so that
         // ellipsis truncation and max_lines clamping can work. Without this, Fit
@@ -2150,6 +2145,15 @@ impl DrawText {
 
         let text = self.layout(cx, 0.0, 0.0, max_width_in_lpxs, wrap, align, text);
         self.draw_walk_laidout(cx, walk, &text)
+    }
+
+    fn max_layout_width_for_walk(&self, cx: &mut Cx2d, walk: Walk) -> Option<f32> {
+        let width = cx.turtle().max_width(walk).or_else(|| {
+            let turtle_rect = cx.turtle().inner_rect();
+            (!turtle_rect.size.x.is_nan()).then_some(turtle_rect.size.x)
+        })?;
+
+        Some((width.max(0.0) as f32) / self.font_scale.max(0.0001))
     }
 
     pub fn draw_walk_laidout(

--- a/draw/src/text/layouter.rs
+++ b/draw/src/text/layouter.rs
@@ -564,6 +564,7 @@ impl LayoutContext {
 struct Fitter {
     text: Substr,
     font_family: Rc<FontFamily>,
+    font_size_in_lpxs: f32,
     lens: Vec<usize>,
     widths_in_lpxs: Vec<f32>,
 }
@@ -600,6 +601,7 @@ impl Fitter {
         Self {
             text,
             font_family,
+            font_size_in_lpxs,
             lens,
             widths_in_lpxs,
         }
@@ -626,16 +628,20 @@ impl Fitter {
                 max_count = mid_count;
             }
         }
-        if let Some(best_count) = best_count {
-            let best_len = self.lens[..best_count].iter().sum();
-            let best_text = self.font_family.get_or_shape(self.text.substr(0..best_len));
-            self.lens.drain(..best_count);
-            self.widths_in_lpxs.drain(..best_count);
-            self.text = self.text.substr(best_len..);
-            Some(best_text)
-        } else {
-            None
+        if let Some(mut best_count) = best_count {
+            while best_count > 0 {
+                let best_len = self.lens[..best_count].iter().sum();
+                let best_text = self.font_family.get_or_shape(self.text.substr(0..best_len));
+                if best_text.width_in_ems * self.font_size_in_lpxs <= wrap_width_in_lpxs {
+                    self.lens.drain(..best_count);
+                    self.widths_in_lpxs.drain(..best_count);
+                    self.text = self.text.substr(best_len..);
+                    return Some(best_text);
+                }
+                best_count -= 1;
+            }
         }
+        None
     }
 
     fn can_fit(&self, count: usize, wrap_width_in_lpxs: f32) -> bool {
@@ -645,10 +651,8 @@ impl Fitter {
         // cumulative substrings are unique and always miss the shaper cache,
         // making each call a full HarfBuzz shape operation.
         //
-        // The sum of individual segment widths is a close approximation of the
-        // actual shaped width (it doesn't account for inter-word kerning, but
-        // that's negligible for wrap-width decisions). The final shaped text
-        // in `fit()` uses get_or_shape() for the exact result.
+        // The final candidate is shaped and checked exactly in `fit()` before it
+        // is accepted, so this estimate can never allow an overflowing row.
         let estimated_width_in_lpxs: f32 = self.widths_in_lpxs[..count].iter().sum();
         estimated_width_in_lpxs <= wrap_width_in_lpxs
     }


### PR DESCRIPTION
Padding wasn't properly being factored in to the layout calculation for text wrapping, which led to subtle errors like this where text got cut off. 

<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/f9c8a632-dd0d-46b4-82c2-92a549dc158c" />
