### PR TITLE
Play and Pause fix in Video

### DIFF
--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -1607,10 +1607,12 @@ impl Cx {
     }
 
     pub fn pause_video_playback(&mut self, video_id: LiveId) {
+        eprintln!("[VID-DBG] Cx::pause_video_playback id={:?} (enqueueing CxOsOp::PauseVideoPlayback)", video_id);
         self.platform_ops.push(CxOsOp::PauseVideoPlayback(video_id));
     }
 
     pub fn resume_video_playback(&mut self, video_id: LiveId) {
+        eprintln!("[VID-DBG] Cx::resume_video_playback id={:?} (enqueueing CxOsOp::ResumeVideoPlayback)", video_id);
         self.platform_ops
             .push(CxOsOp::ResumeVideoPlayback(video_id));
     }

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -1607,12 +1607,10 @@ impl Cx {
     }
 
     pub fn pause_video_playback(&mut self, video_id: LiveId) {
-        eprintln!("[VID-DBG] Cx::pause_video_playback id={:?} (enqueueing CxOsOp::PauseVideoPlayback)", video_id);
         self.platform_ops.push(CxOsOp::PauseVideoPlayback(video_id));
     }
 
     pub fn resume_video_playback(&mut self, video_id: LiveId) {
-        eprintln!("[VID-DBG] Cx::resume_video_playback id={:?} (enqueueing CxOsOp::ResumeVideoPlayback)", video_id);
         self.platform_ops
             .push(CxOsOp::ResumeVideoPlayback(video_id));
     }

--- a/platform/src/os/apple/apple_video_playback.rs
+++ b/platform/src/os/apple/apple_video_playback.rs
@@ -40,7 +40,14 @@ pub struct AppleVideoPlayer {
     texture_id: TextureId,
     is_prepared: bool,
     prepare_notified: bool,
+    /// "Start playback as soon as the asset is ready." One-shot intent consumed
+    /// in `check_prepared`. Do NOT use to drive stall recovery in `poll_frame` —
+    /// once a user-initiated pause has occurred, autoplay must not resurrect playback.
     autoplay: bool,
+    /// Tracks the most recent user/widget play-vs-pause command. `poll_frame`
+    /// uses this (not `autoplay`) to decide whether a rate-0 AVPlayer should be
+    /// nudged back into playing, so a user-initiated pause sticks.
+    should_play: bool,
     is_looping: bool,
     temp_file_path: Option<std::path::PathBuf>,
 }
@@ -118,6 +125,7 @@ impl AppleVideoPlayer {
                 is_prepared: false,
                 prepare_notified: false,
                 autoplay,
+                should_play: autoplay,
                 is_looping,
                 temp_file_path,
             }
@@ -361,9 +369,12 @@ impl AppleVideoPlayer {
         }
 
         unsafe {
-            // Force play if rate dropped to 0 (e.g. AVPlayer stalled or was never started)
+            // Nudge rate=0 back to playing only when the most recent command was
+            // play/resume; never when the user has paused. Using `autoplay` here
+            // ignored user pause intent and made `[AVPlayer pause]` immediately
+            // overridden by the next poll.
             let rate: f32 = msg_send![self.player.as_id(), rate];
-            if rate == 0.0 && self.autoplay {
+            if rate == 0.0 && self.should_play {
                 let _: () = msg_send![self.player.as_id(), play];
             }
 
@@ -461,19 +472,21 @@ impl AppleVideoPlayer {
         }
     }
 
-    pub fn play(&self) {
+    pub fn play(&mut self) {
+        self.should_play = true;
         unsafe {
             let _: () = msg_send![self.player.as_id(), play];
         }
     }
 
-    pub fn pause(&self) {
+    pub fn pause(&mut self) {
+        self.should_play = false;
         unsafe {
             let _: () = msg_send![self.player.as_id(), pause];
         }
     }
 
-    pub fn resume(&self) {
+    pub fn resume(&mut self) {
         self.play();
     }
 

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -505,12 +505,11 @@ impl ScriptHook for Video {
         _scope: &mut Scope,
         _value: ScriptValue,
     ) {
-        // Gate the side-effects in on_after_apply so they don't run for animator-driven applies. E.g. Mouse hover in.
-        // If not, apply_thumbnail_settings will flush the thumbnail texture when mouse hover in.
-        eprintln!("[VID-DBG] on_after_apply id={:?} apply={:?} state={:?} autoplay={} show_idle_thumbnail={} should_prepare_playback={}",
-            self.id, apply, self.playback_state, self.autoplay, self.show_idle_thumbnail, self.should_prepare_playback);
+        // Skip widget-level side effects for animator-driven applies (hover/seek
+        // indicator transitions fire one apply per frame). Otherwise
+        // apply_thumbnail_settings would re-decode the PNG/JPG thumbnail and
+        // allocate a fresh GPU texture on every animator frame.
         if apply.is_animate() {
-            eprintln!("[VID-DBG]   -> EARLY RETURN on Apply::Animate (gate active)");
             return;
         }
         vm.with_cx_mut(|cx| {
@@ -1043,7 +1042,10 @@ impl Video {
 
     fn apply_thumbnail_settings(&mut self, cx: &mut Cx) {
         self.lazy_create_image_cache(cx);
-        //self.thumbnail_texture = Some(Texture::new(cx));
+        // Don't pre-allocate an empty thumbnail texture here: load_thumbnail_image
+        // (via load_png_from_data / load_jpg_from_data) already calls set_texture
+        // with a fresh GPU texture containing the decoded image. Allocating a
+        // throwaway Texture::new(cx) first was just churning GPU resources.
 
         let target_w = self.walk.width.to_fixed().unwrap_or(0.0);
         let target_h = self.walk.height.to_fixed().unwrap_or(0.0);
@@ -1244,14 +1246,11 @@ impl Video {
                 }
             }
             Hit::FingerUp(fe) if fe.is_primary_hit() => {
-                eprintln!("[VID-DBG] FingerUp abs={:?} dragging={} should_show_center_play={} interactable={} state={:?}",
-                    fe.abs, self.is_dragging_progress, self.should_show_center_play(), self.controls_interactable(), self.playback_state);
                 if self.is_dragging_progress {
                     self.is_dragging_progress = false;
                     self.seek_to_position_from_x(cx, fe.abs.x);
                 } else if self.should_show_center_play() && fe.tap_count < 2 {
                     // Center play button is showing — tap anywhere to start playback
-                    eprintln!("[VID-DBG]   FingerUp -> center play branch");
                     self.toggle_play_pause(cx);
                 } else if self.controls_interactable() && self.hit_test_controls_click(cx, fe.abs) {
                     // Control click handled
@@ -1376,24 +1375,16 @@ impl Video {
     }
 
     fn pause_playback(&mut self, cx: &mut Cx) {
-        eprintln!("[VID-DBG] pause_playback ENTER id={:?} state={:?}", self.id, self.playback_state);
         if self.playback_state != PlaybackState::Paused {
             cx.pause_video_playback(self.id);
             self.playback_state = PlaybackState::Paused;
-            eprintln!("[VID-DBG] pause_playback POSTED CxOsOp::PauseVideoPlayback({:?}), state now Paused", self.id);
-        } else {
-            eprintln!("[VID-DBG] pause_playback SKIPPED (already Paused)");
         }
     }
 
     fn resume_playback(&mut self, cx: &mut Cx) {
-        eprintln!("[VID-DBG] resume_playback ENTER id={:?} state={:?}", self.id, self.playback_state);
         if self.playback_state == PlaybackState::Paused {
             cx.resume_video_playback(self.id);
             self.playback_state = PlaybackState::Playing;
-            eprintln!("[VID-DBG] resume_playback POSTED CxOsOp::ResumeVideoPlayback({:?}), state now Playing", self.id);
-        } else {
-            eprintln!("[VID-DBG] resume_playback SKIPPED (state != Paused)");
         }
     }
 
@@ -1806,18 +1797,13 @@ impl Video {
     }
 
     fn hit_test_controls_click(&mut self, cx: &mut Cx, abs: Vec2d) -> bool {
-        let in_controls = self.hit_test_controls(cx, abs);
-        eprintln!("[VID-DBG] hit_test_controls_click abs={:?} in_controls={} interactable={} controls_hover={} controls_visible={}",
-            abs, in_controls, self.controls_interactable(), self.controls_hover, self.controls_visible);
-        if !in_controls {
+        if !self.hit_test_controls(cx, abs) {
             return false;
         }
 
         // Play/pause button — use the draw area from layout
         let play_rect = self.draw_play_icon.area().rect(cx);
-        eprintln!("[VID-DBG]   play_rect={:?} click_x={}", play_rect, abs.x);
         if abs.x >= play_rect.pos.x && abs.x <= play_rect.pos.x + play_rect.size.x {
-            eprintln!("[VID-DBG]   -> play/pause button hit, calling toggle_play_pause");
             self.toggle_play_pause(cx);
             return true;
         }
@@ -1852,7 +1838,6 @@ impl Video {
     }
 
     fn toggle_play_pause(&mut self, cx: &mut Cx) {
-        eprintln!("[VID-DBG] toggle_play_pause id={:?} state={:?}", self.id, self.playback_state);
         match self.playback_state {
             PlaybackState::Playing => self.pause_playback(cx),
             PlaybackState::Paused => self.resume_playback(cx),

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -507,7 +507,12 @@ impl ScriptHook for Video {
     ) {
         // Gate the side-effects in on_after_apply so they don't run for animator-driven applies. E.g. Mouse hover in.
         // If not, apply_thumbnail_settings will flush the thumbnail texture when mouse hover in.
-        if apply.is_animate() { return; }
+        eprintln!("[VID-DBG] on_after_apply id={:?} apply={:?} state={:?} autoplay={} show_idle_thumbnail={} should_prepare_playback={}",
+            self.id, apply, self.playback_state, self.autoplay, self.show_idle_thumbnail, self.should_prepare_playback);
+        if apply.is_animate() {
+            eprintln!("[VID-DBG]   -> EARLY RETURN on Apply::Animate (gate active)");
+            return;
+        }
         vm.with_cx_mut(|cx| {
             self.ensure_primary_texture(cx);
             self.apply_thumbnail_settings(cx);
@@ -1038,7 +1043,7 @@ impl Video {
 
     fn apply_thumbnail_settings(&mut self, cx: &mut Cx) {
         self.lazy_create_image_cache(cx);
-        self.thumbnail_texture = Some(Texture::new(cx));
+        //self.thumbnail_texture = Some(Texture::new(cx));
 
         let target_w = self.walk.width.to_fixed().unwrap_or(0.0);
         let target_h = self.walk.height.to_fixed().unwrap_or(0.0);
@@ -1239,11 +1244,14 @@ impl Video {
                 }
             }
             Hit::FingerUp(fe) if fe.is_primary_hit() => {
+                eprintln!("[VID-DBG] FingerUp abs={:?} dragging={} should_show_center_play={} interactable={} state={:?}",
+                    fe.abs, self.is_dragging_progress, self.should_show_center_play(), self.controls_interactable(), self.playback_state);
                 if self.is_dragging_progress {
                     self.is_dragging_progress = false;
                     self.seek_to_position_from_x(cx, fe.abs.x);
                 } else if self.should_show_center_play() && fe.tap_count < 2 {
                     // Center play button is showing — tap anywhere to start playback
+                    eprintln!("[VID-DBG]   FingerUp -> center play branch");
                     self.toggle_play_pause(cx);
                 } else if self.controls_interactable() && self.hit_test_controls_click(cx, fe.abs) {
                     // Control click handled
@@ -1368,16 +1376,24 @@ impl Video {
     }
 
     fn pause_playback(&mut self, cx: &mut Cx) {
+        eprintln!("[VID-DBG] pause_playback ENTER id={:?} state={:?}", self.id, self.playback_state);
         if self.playback_state != PlaybackState::Paused {
             cx.pause_video_playback(self.id);
             self.playback_state = PlaybackState::Paused;
+            eprintln!("[VID-DBG] pause_playback POSTED CxOsOp::PauseVideoPlayback({:?}), state now Paused", self.id);
+        } else {
+            eprintln!("[VID-DBG] pause_playback SKIPPED (already Paused)");
         }
     }
 
     fn resume_playback(&mut self, cx: &mut Cx) {
+        eprintln!("[VID-DBG] resume_playback ENTER id={:?} state={:?}", self.id, self.playback_state);
         if self.playback_state == PlaybackState::Paused {
             cx.resume_video_playback(self.id);
             self.playback_state = PlaybackState::Playing;
+            eprintln!("[VID-DBG] resume_playback POSTED CxOsOp::ResumeVideoPlayback({:?}), state now Playing", self.id);
+        } else {
+            eprintln!("[VID-DBG] resume_playback SKIPPED (state != Paused)");
         }
     }
 
@@ -1790,13 +1806,18 @@ impl Video {
     }
 
     fn hit_test_controls_click(&mut self, cx: &mut Cx, abs: Vec2d) -> bool {
-        if !self.hit_test_controls(cx, abs) {
+        let in_controls = self.hit_test_controls(cx, abs);
+        eprintln!("[VID-DBG] hit_test_controls_click abs={:?} in_controls={} interactable={} controls_hover={} controls_visible={}",
+            abs, in_controls, self.controls_interactable(), self.controls_hover, self.controls_visible);
+        if !in_controls {
             return false;
         }
 
         // Play/pause button — use the draw area from layout
         let play_rect = self.draw_play_icon.area().rect(cx);
+        eprintln!("[VID-DBG]   play_rect={:?} click_x={}", play_rect, abs.x);
         if abs.x >= play_rect.pos.x && abs.x <= play_rect.pos.x + play_rect.size.x {
+            eprintln!("[VID-DBG]   -> play/pause button hit, calling toggle_play_pause");
             self.toggle_play_pause(cx);
             return true;
         }
@@ -1831,6 +1852,7 @@ impl Video {
     }
 
     fn toggle_play_pause(&mut self, cx: &mut Cx) {
+        eprintln!("[VID-DBG] toggle_play_pause id={:?} state={:?}", self.id, self.playback_state);
         match self.playback_state {
             PlaybackState::Playing => self.pause_playback(cx),
             PlaybackState::Paused => self.resume_playback(cx),


### PR DESCRIPTION
After this PR https://github.com/makepad/makepad/pull/1092,

The play and pause does not seem to work in the play control. This PR fixes the wrong behavior.