### PR TITLE
cargo_makepad: fix iOS icon behavior to not override app-specific icon bundles

### DIFF
--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -261,7 +261,8 @@ pub enum CxOsOp {
     SetWindowVisuals(WindowId, WindowVisuals),
     ShowInDock(bool),
     /// Tints the system bar (status/navigation bar) icons: `true` requests
-    /// dark icons, `false` requests light icons. Currently only Android.
+    /// dark icons, `false` requests light icons. Honored on Android and iOS
+    /// (iOS only has a status bar).
     SetSystemBarDarkIcons(bool),
 
     ShowTextIME(Area, Vec2d, TextInputConfig),

--- a/platform/src/display_context.rs
+++ b/platform/src/display_context.rs
@@ -4,7 +4,8 @@ use crate::Vec2d;
 const DEFAULT_MIN_DESKTOP_WIDTH: f64 = 860.;
 
 /// Controls how the system bars (status bar and navigation bar) icons and
-/// text are tinted, on platforms that support it (currently Android only).
+/// text are tinted, on platforms that support it (currently Android and iOS;
+/// iOS only has a status bar).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum SystemBarAppearance {
     /// Pick dark or light system-bar icons automatically based on the

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -1377,6 +1377,9 @@ impl Cx {
                 CxOsOp::StartDragging(items) => {
                     self.os.internal_drag_items = Some(Arc::new(items));
                 }
+                CxOsOp::SetSystemBarDarkIcons(dark_icons) => {
+                    IosApp::set_status_bar_dark_icons(dark_icons);
+                }
                 e => {
                     crate::error!("Not implemented on this platform: CxOsOp::{:?}", e);
                 }

--- a/platform/src/os/apple/ios/ios_app.rs
+++ b/platform/src/os/apple/ios/ios_app.rs
@@ -263,6 +263,8 @@ impl IosApp {
             let view_ctrl_obj: ObjcId = msg_send![view_ctrl_obj, init];
             (*view_ctrl_obj).set_ivar::<BOOL>("_prefersStatusBarHidden", NO);
             (*view_ctrl_obj).set_ivar::<BOOL>("_prefersHomeIndicatorAutoHidden", NO);
+            // 0 = UIStatusBarStyleDefault (system-managed light/dark).
+            (*view_ctrl_obj).set_ivar::<i64>("_preferredStatusBarStyle", 0);
 
             let () = msg_send![view_ctrl_obj, setView: mtk_view_obj];
 
@@ -1074,6 +1076,31 @@ impl IosApp {
                 (*vc).set_ivar::<BOOL>("_prefersHomeIndicatorAutoHidden", val);
                 let () = msg_send![vc, setNeedsStatusBarAppearanceUpdate];
                 let () = msg_send![vc, setNeedsUpdateOfHomeIndicatorAutoHidden];
+            }
+        }
+    }
+
+    /// Sets the iOS status bar icon/text tint: `true` requests dark icons
+    /// (for light backgrounds), `false` requests light icons (for dark
+    /// backgrounds). iOS has no separate navigation bar.
+    pub fn set_status_bar_dark_icons(dark_icons: bool) {
+        // Same re-entrancy guard as set_fullscreen: borrow briefly to grab the
+        // view controller, then make UIKit calls outside the borrow.
+        let vc = IOS_APP
+            .try_with(|app| {
+                app.try_borrow()
+                    .ok()
+                    .and_then(|app_ref| app_ref.as_ref()?.view_controller)
+            })
+            .ok()
+            .flatten();
+
+        if let Some(vc) = vc {
+            // UIStatusBarStyleDarkContent = 3 (iOS 13+), UIStatusBarStyleLightContent = 1.
+            let style: i64 = if dark_icons { 3 } else { 1 };
+            unsafe {
+                (*vc).set_ivar::<i64>("_preferredStatusBarStyle", style);
+                let () = msg_send![vc, setNeedsStatusBarAppearanceUpdate];
             }
         }
     }

--- a/platform/src/os/apple/ios/ios_delegates.rs
+++ b/platform/src/os/apple/ios/ios_delegates.rs
@@ -41,6 +41,8 @@ pub fn define_makepad_view_controller() -> *const Class {
 
     decl.add_ivar::<BOOL>("_prefersStatusBarHidden");
     decl.add_ivar::<BOOL>("_prefersHomeIndicatorAutoHidden");
+    // UIStatusBarStyle raw value: 0 = Default, 1 = LightContent, 3 = DarkContent.
+    decl.add_ivar::<i64>("_preferredStatusBarStyle");
 
     extern "C" fn prefers_status_bar_hidden(this: &Object, _: Sel) -> BOOL {
         unsafe { *this.get_ivar("_prefersStatusBarHidden") }
@@ -48,6 +50,10 @@ pub fn define_makepad_view_controller() -> *const Class {
 
     extern "C" fn prefers_home_indicator_auto_hidden(this: &Object, _: Sel) -> BOOL {
         unsafe { *this.get_ivar("_prefersHomeIndicatorAutoHidden") }
+    }
+
+    extern "C" fn preferred_status_bar_style(this: &Object, _: Sel) -> i64 {
+        unsafe { *this.get_ivar("_preferredStatusBarStyle") }
     }
 
     // Called by iOS when the safe area insets change (e.g., device rotation).
@@ -73,6 +79,10 @@ pub fn define_makepad_view_controller() -> *const Class {
         decl.add_method(
             sel!(prefersHomeIndicatorAutoHidden),
             prefers_home_indicator_auto_hidden as extern "C" fn(&Object, Sel) -> BOOL,
+        );
+        decl.add_method(
+            sel!(preferredStatusBarStyle),
+            preferred_status_bar_style as extern "C" fn(&Object, Sel) -> i64,
         );
         decl.add_method(
             sel!(viewSafeAreaInsetsDidChange),

--- a/tools/cargo_makepad/src/apple/compile.rs
+++ b/tools/cargo_makepad/src/apple/compile.rs
@@ -448,12 +448,30 @@ impl Scent {
     }
 }
 
-/// Generate and compile an Asset Catalog with AppIcon from the crate's
-/// `resources/` directory.  Requires a 1024×1024 PNG at minimum
-/// (`icon_1024.png`).  Smaller sizes are optional; iOS will scale down
-/// from the largest available.
+/// Generate and compile an Asset Catalog with AppIcon for iOS.
+///
+/// Two sources are supported, in priority order:
+/// 1. A project-supplied catalog at `<crate>/packaging/ios/icons/Assets.xcassets/`
+///    with an `AppIcon.appiconset/` inside. This is preferred because iOS
+///    icons must be fully opaque with no baked-in rounded corners — the
+///    macOS-style `resources/icon_1024.png` (transparent corners, baked
+///    squircle, drop shadow) renders with a black border on iOS.
+/// 2. Fallback: synthesize a catalog from `resources/icon_1024.png`.
 fn generate_app_icon_xcassets(app_dir: &Path, build_crate: &str) -> Result<bool, String> {
     let crate_dir = get_crate_dir(build_crate)?;
+
+    let project_xcassets = crate_dir
+        .join("packaging")
+        .join("ios")
+        .join("icons")
+        .join("Assets.xcassets");
+    if project_xcassets.join("AppIcon.appiconset").is_dir() {
+        let xcassets = app_dir.join("Assets.xcassets");
+        cp_all(&project_xcassets, &xcassets, false)?;
+        copy_loose_iphone_icons(&xcassets.join("AppIcon.appiconset"), app_dir)?;
+        return compile_xcassets(&xcassets, app_dir);
+    }
+
     let res = crate_dir.join("resources");
     let icon_1024 = res.join("icon_1024.png");
     if !icon_1024.is_file() {
@@ -600,7 +618,35 @@ fn generate_app_icon_xcassets(app_dir: &Path, build_crate: &str) -> Result<bool,
         r#"{"info":{"author":"cargo-makepad","version":1}}"#,
     )?;
 
-    // Compile with actool
+    compile_xcassets(&xcassets, app_dir)
+}
+
+/// Copy the iPhone/iPad primary icon PNGs from a project-supplied
+/// AppIcon.appiconset into the bundle root with iOS's conventional
+/// `<basename>@<scale>x[~ipad].png` filenames. These act as a fallback for
+/// the CFBundleIcons entries actool merges into Info.plist, so iOS can
+/// still find an icon if `Assets.car` is missing, stale, or unreadable.
+/// Source filenames not present are silently skipped.
+fn copy_loose_iphone_icons(appiconset: &Path, app_dir: &Path) -> Result<(), String> {
+    let pairs: &[(&str, &str)] = &[
+        ("AppIcon120x120.png", "AppIcon60x60@2x.png"),
+        ("AppIcon180x180.png", "AppIcon60x60@3x.png"),
+        ("AppIcon152x152.png", "AppIcon76x76@2x~ipad.png"),
+        ("AppIcon167x167.png", "AppIcon83.5x83.5@2x~ipad.png"),
+    ];
+    for (src_name, dst_name) in pairs {
+        let src = appiconset.join(src_name);
+        if src.is_file() {
+            cp(&src, &app_dir.join(dst_name), false)?;
+        }
+    }
+    Ok(())
+}
+
+/// Invoke `actool` to compile an Assets.xcassets directory into `Assets.car`
+/// inside `app_dir`, then merge actool's partial Info.plist (which contains
+/// the CFBundleIcons keys iOS 15 expects) into the app's main Info.plist.
+fn compile_xcassets(xcassets: &Path, app_dir: &Path) -> Result<bool, String> {
     let cwd = std::env::current_dir().unwrap();
     shell_env_cap(
         &[],
@@ -622,12 +668,9 @@ fn generate_app_icon_xcassets(app_dir: &Path, build_crate: &str) -> Result<bool,
         ],
     )?;
 
-    // Merge actool's partial Info.plist (contains CFBundleIcons for iOS 15)
-    // into the main Info.plist.
     let actool_plist = app_dir.join("actool-Info.plist");
     if actool_plist.is_file() {
         let main_plist = app_dir.join("Info.plist");
-        // PlistBuddy Merge copies all keys from source into destination
         shell_env_cap(
             &[],
             &cwd,

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -714,9 +714,10 @@ impl Window {
     ///
     /// In `Auto` mode the tint follows the window background luminance: a light
     /// background needs dark icons for contrast, and vice versa. `DarkIcons` /
-    /// `LightIcons` force the choice. Currently only Android honors this.
+    /// `LightIcons` force the choice. Honored on Android and iOS (iOS has no
+    /// separate navigation bar, so only the status bar is affected).
     fn sync_system_bar_appearance(&mut self, cx: &mut Cx) {
-        if !matches!(cx.os_type(), OsType::Android(_)) {
+        if !matches!(cx.os_type(), OsType::Android(_) | OsType::Ios(_)) {
             return;
         }
         let dark_icons = match cx.display_context.system_bar_appearance {


### PR DESCRIPTION
Please merge #1098 first

Icons need to not be modified by cargo_makepad if they're already in the proper iOS-expected format, otherwise they'll end up with some kind of extra black border around the icon, which looks bad.