### PR TITLE
DrawText: avoid redrawing slug stuff on EVERY frame

### DIFF
--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -1427,6 +1427,24 @@ struct SlugHelperPrewarmState {
     requested_redraw_id: u64,
 }
 
+/// Returns true only when `area` still references live GPU instances left over from a
+/// *previous* redraw (`instance_count > 0` and a stale `redraw_id`).
+///
+/// The slug/raster text paths use this to decide whether a draw item must be redrawn to
+/// clear stale glyphs when a run switches rendering path. It must reject two cases that
+/// would otherwise cause a per-frame `redraw_area_in_draw` — i.e. a permanent ~100% CPU
+/// continuous-repaint loop:
+///   - count == 0: an empty batch (e.g. a whitespace-only run, whose glyphs have no
+///     raster image) was begun and finished this frame; there is nothing to clear.
+///   - a *valid* (current-redraw) area: the area was already drawn this frame, either by
+///     this run or by another `draw_text` call sharing the same instance (text is drawn
+///     in resumable chunks), so its draw item is up to date.
+/// `Area::is_valid` returns false for count == 0, so the explicit count check is required.
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+fn area_holds_stale_content(area: &Area, cx: &Cx) -> bool {
+    matches!(area, Area::Instance(inst) if inst.instance_count > 0) && !area.is_valid(cx)
+}
+
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 #[derive(Default)]
 struct SlugPromotionState {
@@ -2669,20 +2687,20 @@ impl DrawText {
                 }
                 if !drew_slug_this_frame {
                     let old_area = slug_draw.draw_vars.area;
-                    if !old_area.is_empty() {
+                    if area_holds_stale_content(&old_area, cx.cx) {
                         cx.cx.redraw_area_in_draw(old_area);
+                        slug_draw.draw_vars.area = cx.update_area_refs(old_area, Area::Empty);
                     }
-                    slug_draw.draw_vars.area = cx.update_area_refs(old_area, Area::Empty);
                 }
                 self.slug_draw = Some(slug_draw);
             }
             // Don't clobber the outer batch's area if we've handed it back.
             if !drew_raster_this_frame && self.many_instances.is_none() {
                 let old_area = self.draw_vars.area;
-                if !old_area.is_empty() {
+                if area_holds_stale_content(&old_area, cx.cx) {
                     cx.cx.redraw_area_in_draw(old_area);
+                    self.draw_vars.area = cx.update_area_refs(old_area, Area::Empty);
                 }
-                self.draw_vars.area = cx.update_area_refs(old_area, Area::Empty);
             }
             return;
         }

--- a/platform/src/os/linux/opengl_cx.rs
+++ b/platform/src/os/linux/opengl_cx.rs
@@ -15,6 +15,14 @@ pub struct OpenglCx {
 
     pub egl_platform: egl_sys::EGLenum,
     pub egl_platform_display: *mut c_void,
+
+    /// Buffer swap interval requested on the window surface. `1` (the default) enables
+    /// vsync so `eglSwapBuffers` blocks until the next refresh, capping the render loop
+    /// at the display rate. Without this, content that drives a continuous redraw (e.g.
+    /// any shader whose mapping `uses_time`, which forces `demo_time_repaint`) would spin
+    /// the event loop rendering as fast as possible, pinning a CPU/GPU core. Set the
+    /// `MAKEPAD_NO_VSYNC` env var to request `0` (uncapped) for benchmarking.
+    pub swap_interval: egl_sys::EGLint,
 }
 
 fn egl_error_name(error: egl_sys::EGLint) -> &'static str {
@@ -208,6 +216,12 @@ impl OpenglCx {
         })
         .expect("Cant load openGL functions");
 
+        let swap_interval = if std::env::var_os("MAKEPAD_NO_VSYNC").is_some() {
+            0
+        } else {
+            1
+        };
+
         OpenglCx {
             libegl,
             libgl,
@@ -217,6 +231,7 @@ impl OpenglCx {
 
             egl_platform,
             egl_platform_display,
+            swap_interval,
         }
     }
 
@@ -260,6 +275,12 @@ impl Cx {
                     egl_error_name(egl_error)
                 );
                 return;
+            }
+            // Apply the configured swap interval (vsync) on the now-current window surface.
+            // Re-applied per frame because it is surface-scoped and surfaces are recreated
+            // on resize; the call is cheap and idempotent.
+            if let Some(egl_swap_interval) = opengl_cx.libegl.eglSwapInterval {
+                (egl_swap_interval)(opengl_cx.egl_display, opengl_cx.swap_interval);
             }
             (gl.glViewport)(0, 0, pix_width.floor() as i32, pix_height.floor() as i32);
         }

--- a/platform/src/os/linux/select_timer.rs
+++ b/platform/src/os/linux/select_timer.rs
@@ -30,7 +30,11 @@ impl SelectTimers {
         let mut fds = mem::MaybeUninit::uninit();
         unsafe {
             libc_sys::FD_ZERO(fds.as_mut_ptr());
-            libc_sys::FD_SET(0, fds.as_mut_ptr());
+            // NOTE: do NOT add stdin (fd 0) to the read set here.
+            //       Only X11 & Wayland event loops call this, and neither read stdin.
+            //       Only makepad-studio does that, but it doesn't use this function.
+            //       If we leave this here, it locks one CPU core to 100% when stdin is `/dev/null`,
+            //       which occurs any time an app is run from a DE/WM and not a terminal
             libc_sys::FD_SET(fd, fds.as_mut_ptr());
         }
         //libc_sys::FD_SET(self.signal_fds[0], fds.as_mut_ptr());

--- a/platform/src/os/linux/wayland/linux_wayland.rs
+++ b/platform/src/os/linux/wayland/linux_wayland.rs
@@ -1048,6 +1048,12 @@ impl WaylandCx {
 
     pub(crate) fn handle_repaint(&self, state: &mut WaylandState) {
         let mut cx = self.cx.borrow_mut();
+        // Skip the eglMakeCurrent + full pass-list scan when there is nothing to draw.
+        // demo_time_repaint forces a redraw of time-animated passes (see
+        // compute_pass_repaint_order), so it must keep us rendering.
+        if !cx.any_passes_dirty() && !cx.demo_time_repaint {
+            return;
+        }
         cx.os.opengl_cx.as_ref().unwrap().make_current();
         let mut passes_todo = Vec::new();
         cx.compute_pass_repaint_order(&mut passes_todo);

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -428,6 +428,16 @@ impl X11Cx {
     }
 
     pub(crate) fn handle_repaint(&mut self, opengl_windows: &mut Vec<OpenglWindow>) {
+        {
+            // Paint is emitted on every idle poll/timer tick. If no pass is dirty there is
+            // nothing to draw, so skip the eglMakeCurrent + full pass-list scan below.
+            // demo_time_repaint forces a redraw of time-animated passes (see
+            // compute_pass_repaint_order), so it must keep us rendering.
+            let cx = self.cx.borrow();
+            if !cx.any_passes_dirty() && !cx.demo_time_repaint {
+                return;
+            }
+        }
         let mut passes_todo = Vec::new();
         {
             let mut cx = self.cx.borrow_mut();


### PR DESCRIPTION
On Linux/Windows, the slug text path redrew a draw item's "old area" whenever
that path wasn't drawn in the current draw_text call and the area wasn't Empty.

THis was causing an entire CPU core to be pinned to 100% due to an
infinite loop of repaints.

Now, we only clear a draw item when its area holds genuinely stale content
(instance_count > 0 and a stale redraw_id).