### PR TITLE
Linux: cache GL shaders to the local fs

### DIFF
--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -313,12 +313,40 @@ impl OsType {
     }
 
     pub fn get_cache_dir(&self) -> Option<String> {
-        if let OsType::Android(params) = self {
-            Some(params.cache_path.clone())
-        } else if let OsType::OpenHarmony(params) = self {
-            Some(params.cache_dir.clone())
-        } else {
-            None
+        match self {
+            OsType::Android(params) => Some(params.cache_path.clone()),
+            OsType::OpenHarmony(params) => Some(params.cache_dir.clone()),
+            // Desktop Linux (windowed or DRM/direct): persist the GL program-binary cache
+            // under the XDG cache directory so compiled shaders survive across launches.
+            // Computed once and memoized (env lookup + directory creation).
+            //
+            // Note: the Windows backend is D3D11 and caches its compiled DXBC separately
+            // via `shader_cache_dir()` in `os/windows/d3d11.rs`, so it does not rely on
+            // this. macOS/iOS use Metal libraries and likewise do not use this path.
+            OsType::LinuxWindow(_) | OsType::LinuxDirect => {
+                use std::sync::OnceLock;
+                static DIR: OnceLock<Option<String>> = OnceLock::new();
+                DIR.get_or_init(|| {
+                    // Resolve the XDG cache base the same way the XDG Base Directory spec
+                    // (and the `robius-directories` crate) do: honor $XDG_CACHE_HOME only
+                    // when it is an *absolute* path, otherwise fall back to $HOME/.cache.
+                    // A relative or empty value is ignored per spec.
+                    let base = std::env::var_os("XDG_CACHE_HOME")
+                        .map(std::path::PathBuf::from)
+                        .filter(|p| p.is_absolute())
+                        .or_else(|| {
+                            std::env::var_os("HOME")
+                                .map(std::path::PathBuf::from)
+                                .filter(|p| p.is_absolute())
+                                .map(|home| home.join(".cache"))
+                        })?;
+                    let dir = base.join("makepad");
+                    std::fs::create_dir_all(&dir).ok()?;
+                    Some(dir.to_string_lossy().into_owned())
+                })
+                .clone()
+            }
+            _ => None,
         }
     }
 

--- a/platform/src/os/linux/opengl.rs
+++ b/platform/src/os/linux/opengl.rs
@@ -1313,10 +1313,16 @@ impl GlShader {
                                             program as usize,
                                             "",
                                         ) {
-                                            crate::error!(
-                                                "ERROR::SHADER::CACHE::PROGRAM_BINARY_FAILED\n{}",
+                                            // A cached program binary that no longer loads is
+                                            // expected and recoverable (e.g. after a GPU driver
+                                            // update changes the binary format). The caller falls
+                                            // back to compiling from source and overwrites this
+                                            // stale entry, so warn rather than error.
+                                            crate::warning!(
+                                                "Ignoring stale shader cache entry (will recompile): SHADER::CACHE::PROGRAM_BINARY_FAILED\n{}",
                                                 error
                                             );
+                                            (gl.glDeleteProgram)(program);
                                             return None;
                                         }
                                         return Some(program);


### PR DESCRIPTION
Previously, `get_cache_dir()` returned None for Linux (X11, Wayland, Direct) so there was no shader caching happening like there was on android and windows.

Now we cache it and also handle removal of stale shader binaries