### PR TITLE
Run script-VM gc in the desktop and mobile event loops, not just macOS

### DIFF
--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -781,6 +781,16 @@ impl Cx {
                 }
                 // ok here we send out to all our childprocesses
                 self.handle_repaint(metal_cx);
+
+                // Run script-VM garbage collection at a safe point after paint, matching
+                // the macOS backend, so the script object heap doesn't grow without bound:
+                // every `eval` / `script_apply_eval!` allocates script objects that are
+                // only reclaimed by `gc()`. `needs_gc()` gates the actual sweep.
+                self.with_vm(|vm| {
+                    if vm.heap().needs_gc() {
+                        vm.gc();
+                    }
+                });
             }
             IosEvent::TouchUpdate(mut e) => {
                 let window = &self.windows[e.window_id];

--- a/platform/src/os/linux/direct/linux_direct.rs
+++ b/platform/src/os/linux/direct/linux_direct.rs
@@ -136,6 +136,14 @@ impl Cx {
                 //let p = profile_start();
                 self.handle_repaint(direct_app);
                 //profile_end("paint openGL", p);
+
+                // Run script-VM garbage collection at a safe point after paint, matching
+                // the macOS backend, so the script object heap doesn't grow without bound.
+                self.with_vm(|vm| {
+                    if vm.heap().needs_gc() {
+                        vm.gc();
+                    }
+                });
             }
             DirectEvent::MouseDown(mut e) => {
                 self.dpi_override_scale(&mut e.abs, e.window_id);

--- a/platform/src/os/linux/wayland/linux_wayland.rs
+++ b/platform/src/os/linux/wayland/linux_wayland.rs
@@ -290,6 +290,19 @@ impl WaylandCx {
                 // ok here we send out to all our childprocesses
 
                 self.handle_repaint(state);
+
+                // Run script-VM garbage collection at a safe point after paint, matching
+                // the macOS backend. Without this the script object heap grows without
+                // bound: every `eval` / `script_apply_eval!` allocates script objects
+                // that are only reclaimed by `gc()`. `needs_gc()` gates the actual sweep.
+                {
+                    let mut cx = self.cx.borrow_mut();
+                    cx.with_vm(|vm| {
+                        if vm.heap().needs_gc() {
+                            vm.gc();
+                        }
+                    });
+                }
             }
             XlibEvent::MouseMove(mut e) => {
                 let mut cx = self.cx.borrow_mut();

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -194,6 +194,20 @@ impl X11Cx {
                 // ok here we send out to all our childprocesses
 
                 self.handle_repaint(opengl_windows);
+
+                // Run script-VM garbage collection at a safe point after paint, matching
+                // the macOS backend. Without this the script object heap grows without
+                // bound on Linux: every `eval` / `script_apply_eval!` allocates script
+                // objects that are only reclaimed by `gc()`. `needs_gc()` gates this so
+                // it only runs once the heap has grown past its threshold (~2x).
+                {
+                    let mut cx = self.cx.borrow_mut();
+                    cx.with_vm(|vm| {
+                        if vm.heap().needs_gc() {
+                            vm.gc();
+                        }
+                    });
+                }
             }
             XlibEvent::MouseDown(mut e) => {
                 let mut cx = self.cx.borrow_mut();

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -261,6 +261,16 @@ impl Cx {
                 // ok here we send out to all our childprocesses
 
                 self.handle_repaint(d3d11_windows, d3d11_cx);
+
+                // Run script-VM garbage collection at a safe point after paint, matching
+                // the macOS backend, so the script object heap doesn't grow without bound:
+                // every `eval` / `script_apply_eval!` allocates script objects that are
+                // only reclaimed by `gc()`. `needs_gc()` gates the actual sweep.
+                self.with_vm(|vm| {
+                    if vm.heap().needs_gc() {
+                        vm.gc();
+                    }
+                });
             }
             Win32Event::MouseDown(mut e) => {
                 self.dpi_override_scale(&mut e.abs, e.window_id);


### PR DESCRIPTION
Only macOS was calling the script VM's garbage collector. Now we call it everywhere, based on the original implementation in macOS.