### PR TITLE
SVG: allow replacing and re-loading the SVG "doc"

### DIFF
--- a/draw/src/shader/draw_svg.rs
+++ b/draw/src/shader/draw_svg.rs
@@ -129,8 +129,10 @@ pub struct DrawSvg {
     pub svg: Option<ScriptHandleRef>,
     #[rust]
     pub svg_doc: Option<SvgDocument>,
+    // The svg handle currently parsed into `svg_doc`,
+    // so we can detect when the svg has been changed and reload it.
     #[rust]
-    pub svg_loaded: bool,
+    loaded_handle: Option<ScriptHandle>,
     // Content bounding box after viewbox transform at 1:1 scale.
     // This is the actual extent of rendered geometry.
     #[rust]
@@ -321,16 +323,16 @@ impl DrawSvg {
     }
 
     fn load_svg(&mut self, cx: &mut Cx) {
-        if self.svg_loaded {
+        let current_handle = self.svg.as_ref().map(|h| h.as_handle());
+        // Do nothing if the SVG handle hasn't changed since it was last loaded.
+        if self.loaded_handle == current_handle {
             return;
         }
 
-        let Some(ref handle_ref) = self.svg else {
-            self.svg_loaded = true;
+        let Some(handle) = current_handle else {
+            self.loaded_handle = None;
             return;
         };
-
-        let handle = handle_ref.as_handle();
 
         let data = if let Some(data) = cx.get_resource(handle) {
             data
@@ -338,13 +340,13 @@ impl DrawSvg {
             cx.load_script_resource(handle);
             match cx.get_resource(handle) {
                 Some(data) => data,
-                // Resource not yet available (may be loading via HTTP) - don't
-                // set svg_loaded so we retry on next draw after data arrives.
+                // Resource isn't yet available (may be loading via HTTP),
+                // so don't set loaded_handle to ensure we retry on the next draw after data arrives.
                 None => return,
             }
         };
 
-        self.svg_loaded = true;
+        self.loaded_handle = Some(handle);
 
         let svg_str = match std::str::from_utf8(&data) {
             Ok(s) => s,
@@ -363,7 +365,8 @@ impl DrawSvg {
         self.set_doc_bounds(&doc);
         self.has_animations = doc.has_animations();
         self.svg_doc = Some(doc);
-        self.svg_loaded = true;
+        // Loaded from a raw string, so the doc corresponds to no svg handle.
+        self.loaded_handle = None;
         self.cache_valid = false;
     }
 


### PR DESCRIPTION
Without this, once you load an SVG for the first time, you can never change it. This meant that you couldn't change a buttton's icon, for example, at runtime, even using a script apply.

Now that works, at no cost too, since we track which SVG body/"doc" has been loaded to ensure we're not re-loading it on every draw (which was already there, it was just too strict).