### PR TITLE
Fix modal behavior: prevent scroll behind it, make `Fit{max}` scrollable

### DIFF
--- a/draw/src/turtle.rs
+++ b/draw/src/turtle.rs
@@ -1708,7 +1708,9 @@ impl<'a, 'b> Cx2d<'a, 'b> {
                     let max = max.eval_width(self);
                     turtle = self.turtles.last_mut().unwrap();
                     if let Some(max) = max {
-                        turtle.width = turtle.width.min(max);
+                        // take the margin into account when calculating a Fit bound
+                        // with a relative-to-parent max value.
+                        turtle.width = turtle.width.min(max - turtle.walk.margin.width());
                     }
                 }
             }
@@ -1734,7 +1736,8 @@ impl<'a, 'b> Cx2d<'a, 'b> {
                     let max = max.eval_height(self);
                     turtle = self.turtles.last_mut().unwrap();
                     if let Some(max) = max {
-                        turtle.height = turtle.height.min(max);
+                        // See the width branch above, account for the margin in max calculations.
+                        turtle.height = turtle.height.min(max - turtle.walk.margin.height());
                     }
                 }
             }

--- a/widgets/derive_widget/src/derive_widget.rs
+++ b/widgets/derive_widget/src/derive_widget.rs
@@ -148,6 +148,9 @@ pub fn derive_widget_node_impl(input: TokenStream) -> TokenStream {
             tb.add("    fn redraw(&mut self, cx:&mut Cx) { self.")
                 .ident(wrap_field)
                 .add(".redraw(cx)}");
+            tb.add("    fn set_scroll_pos(&mut self, cx:&mut Cx, v:Vec2d) { self.")
+                .ident(wrap_field)
+                .add(".set_scroll_pos(cx, v)}");
             tb.add("    fn visible(&self)->bool{ self.")
                 .ident(wrap_field)
                 .add(".visible()}");
@@ -249,6 +252,11 @@ pub fn derive_widget_node_impl(input: TokenStream) -> TokenStream {
                     "Need either a field marked redraw or deref or wrap to find redraw method",
                 );
             }
+            if let Some(deref_field) = &deref_field {
+                tb.add("    fn set_scroll_pos(&mut self, cx:&mut Cx, v:Vec2d) { self.")
+                    .ident(deref_field)
+                    .add(".set_scroll_pos(cx, v)}");
+            }
             if !find_fields.is_empty() {
                 tb.add("    fn children(&self, visit:&mut dyn FnMut(LiveId, WidgetRef)){");
                 for find_field in &find_fields {
@@ -312,6 +320,13 @@ pub fn derive_widget_node_impl(input: TokenStream) -> TokenStream {
                         .add(".selection_get_full_text(); if !v.is_empty() { return v; } }");
                 }
                 tb.add("        String::new() }");
+                if deref_field.is_none() {
+                    tb.add("    fn set_scroll_pos(&mut self, cx:&mut Cx, v:Vec2d) {");
+                    for find_field in &find_fields {
+                        tb.add("        self.").ident(find_field).add(".set_scroll_pos(cx, v);");
+                    }
+                    tb.add("    }");
+                }
             } else if let Some(deref_field) = &deref_field {
                 tb.add("   fn children(&self, visit:&mut dyn FnMut(LiveId, WidgetRef)){");
                 tb.add("       self.")

--- a/widgets/src/modal.rs
+++ b/widgets/src/modal.rs
@@ -115,19 +115,17 @@ impl Widget for Modal {
 
             // Close the modal if any of the following conditions occur:
             // * If the back navigational action/gesture was triggered (e.g., on Android),
-            // * If the Escape key was pressed while either the `bg_view` or `content` has key focus,
-            // * If there was a click/press in the background area, outside of the inner `content` view.
+            // * If the Escape key was released while `content` has key focus.
+            //   We look for KeyUp (not KeyDown) to match the FingerUp dismissal,
+            //   which also prevents a widget behind the modal from handling that Escape keypress.
+            // * If there was a click/tap in the background area, outside of the inner `content` view.
             let should_close = event.back_pressed()
                 || match bg_area_hit {
-                    Hit::KeyDown(KeyEvent {
-                        key_code: KeyCode::Escape,
-                        ..
-                    }) => true,
                     Hit::FingerUp(fe) => !content.area().rect(cx).contains(fe.abs),
                     _ => false,
                 }
                 || match content_area_hit {
-                    Hit::KeyDown(KeyEvent {
+                    Hit::KeyUp(KeyEvent {
                         key_code: KeyCode::Escape,
                         ..
                     }) => true,
@@ -158,11 +156,10 @@ impl Widget for Modal {
         cx.end_pass_sized_turtle();
         self.draw_list.as_mut().unwrap().end(cx);
 
-        // After drawing the modal content, its area may have changed,
-        // so we need to update that area as a scrolling-allowed area bound.
+        // We must re-set the blocked scrolling area, as it might've changed after each draw.
         if self.is_open {
-            let content = self.view.widget(cx, ids!(content));
-            cx.block_scrolling_except_within(content.area());
+            let content_area = self.view.widget(cx, ids!(content)).area();
+            cx.block_scrolling_except_within(content_area);
         }
         DrawStep::done()
     }
@@ -179,6 +176,7 @@ impl Modal {
         self.draw_bg.redraw(cx);
         let content = self.view.widget(cx, ids!(content));
         cx.set_key_focus(content.area());
+        content.set_scroll_pos(cx, Vec2d { x: 0.0, y: 0.0 });
     }
 
     pub fn close(&mut self, cx: &mut Cx) {

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -2216,7 +2216,9 @@ impl Widget for PortalList {
                             });
                             self.update_item_selections(cx);
                         }
-                    } else if self.drag_scrolling && fe.is_primary_hit() {
+                    } else if self.drag_scrolling && fe.is_primary_hit()
+                        && cx.is_scrolling_allowed_within(&self.area)
+                    {
                         // Always enter drag state to enable drag-to-scroll even over
                         // interactive widgets (buttons, links, etc.). The drag threshold
                         // prevents micro-scrolling during taps/clicks, and child widgets

--- a/widgets/src/scroll_bar.rs
+++ b/widgets/src/scroll_bar.rs
@@ -530,6 +530,12 @@ impl ScrollBar {
             return;
         }
 
+        // Don't start or continue a touch-based drag scroll if scrolling is blocked.
+        if !cx.is_scrolling_allowed_within(&scroll_area) {
+            self.scroll_state = ScrollState::Stopped;
+            return;
+        }
+
         // Check if scroll bar handle is not captured
         if self.is_area_captured(cx) {
             self.scroll_state = ScrollState::Stopped;

--- a/widgets/src/scroll_bars.rs
+++ b/widgets/src/scroll_bars.rs
@@ -323,11 +323,29 @@ impl ScrollBars {
         let view_total = cx.turtle().used();
         let mut rect_now = cx.turtle().rect();
 
+        // The turtle's rect might be `NaN` if either size dimension is `Fit`,
+        // so we look at each dimension's max value to ensure that it can be scrollable.
         if rect_now.size.y.is_nan() {
-            rect_now.size.y = view_total.y;
+            let height = cx.turtle().walk().height;
+            // `Fit { max }` bounds the OUTER height (incl. margin), matching
+            // Turtle::compute_final_size, so subtract the margin for the visible height.
+            let margin = cx.turtle().walk().margin.height();
+            rect_now.size.y = match height {
+                Size::Fit { max: Some(max), .. } => {
+                    max.eval_height(cx).map_or(view_total.y, |m| view_total.y.min(m - margin))
+                }
+                _ => view_total.y,
+            };
         }
         if rect_now.size.x.is_nan() {
-            rect_now.size.x = view_total.x;
+            let width = cx.turtle().walk().width;
+            let margin = cx.turtle().walk().margin.width();
+            rect_now.size.x = match width {
+                Size::Fit { max: Some(max), .. } => {
+                    max.eval_width(cx).map_or(view_total.x, |m| view_total.x.min(m - margin))
+                }
+                _ => view_total.x,
+            };
         }
 
         if self.show_scroll_x {
@@ -337,7 +355,6 @@ impl ScrollBars {
             self.set_scroll_x(cx, scroll_pos);
         }
         if self.show_scroll_y {
-            //println!("SET SCROLLBAR {} {}", rect_now.h, view_total.y);
             let scroll_pos =
                 self.scroll_bar_y
                     .draw_scroll_bar(cx, ScrollAxis::Vertical, rect_now, view_total);

--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -589,6 +589,10 @@ impl WidgetNode for View {
         self.area
     }
 
+    fn set_scroll_pos(&mut self, cx: &mut Cx, v: Vec2d) {
+        self.set_scroll_pos(cx, v);
+    }
+
     fn redraw(&mut self, cx: &mut Cx) {
         self.area.redraw(cx);
         if let Some(draw_list) = &self.draw_list {

--- a/widgets/src/widget.rs
+++ b/widgets/src/widget.rs
@@ -159,6 +159,7 @@ pub trait WidgetNode: ScriptApply {
     fn walk(&mut self, _cx: &mut Cx) -> Walk;
     fn area(&self) -> Area; //{return Area::Empty;}
     fn redraw(&mut self, _cx: &mut Cx);
+    fn set_scroll_pos(&mut self, _cx: &mut Cx, _v: Vec2d) {}
     fn set_action_data(&mut self, _data: Arc<dyn ActionTrait>) {}
     fn action_data(&self) -> Option<Arc<dyn ActionTrait>> {
         None
@@ -1074,6 +1075,12 @@ impl WidgetRef {
     pub fn redraw(&self, cx: &mut Cx) {
         if let Some(inner) = self.0.borrow_mut().as_mut() {
             return inner.widget.redraw(cx);
+        }
+    }
+
+    pub fn set_scroll_pos(&self, cx: &mut Cx, v: Vec2d) {
+        if let Some(inner) = self.0.borrow_mut().as_mut() {
+            return inner.widget.set_scroll_pos(cx, v);
         }
     }
 


### PR DESCRIPTION
* Ensure that a view that specifies Fit with a max value can be scrolled.
* Turtle: include a view's outer maring in the size calc for a `Fit{max}` bound.
* Modal: dismiss on Escape KeyUp (not KeyDown) so the release can't leak to a background widget behind the modal.
* Modal: allow scrolling, and reset the scroll to the top when showing it.
* Touch-baased dragging for views (ScrollBar) and PortalList now respect the blocked scrolling areas, not just the mouse wheel / trackpad scroll.
* Forward the `set_scroll_pos()` through the widget derive traits so that we don't have to hook it up for each specific widget.