### PR TITLE
Linux: fix desktop close/terminate lifecycle handling

### DIFF
--- a/platform/src/os/linux/wayland/linux_wayland.rs
+++ b/platform/src/os/linux/wayland/linux_wayland.rs
@@ -246,29 +246,10 @@ impl WaylandCx {
                 cx.call_event_handler(&Event::WindowGeomChange(re));
             }
             XlibEvent::WindowClosed(wc) => {
-                let window_id = wc.window_id;
-                self.close_popup_children(state, window_id);
-
-                let mut cx = self.cx.borrow_mut();
-                cx.call_event_handler(&Event::WindowClosed(wc));
-                // lets remove the window from the set
-                cx.windows[window_id].is_created = false;
-                if state.pointer_window == Some(window_id) {
-                    state.pointer_window = None;
-                }
-                if state.keyboard_window == Some(window_id) {
-                    state.keyboard_window = None;
-                }
-                if let Some(index) = state.windows.iter().position(|w| w.window_id == window_id) {
-                    state.windows.remove(index);
-                    if state.windows.len() == 0 {
-                        cx.call_event_handler(&Event::Shutdown);
-                        return EventFlow::Exit;
-                    }
-                } else if let Some(index) =
-                    state.popups.iter().position(|w| w.window_id == window_id)
-                {
-                    state.popups.remove(index);
+                if let EventFlow::Exit = self.handle_window_closed(state, wc) {
+                    let mut cx = self.cx.borrow_mut();
+                    cx.call_event_handler(&Event::Shutdown);
+                    return EventFlow::Exit;
                 }
             }
             XlibEvent::PopupDismissed(event) => {
@@ -338,9 +319,20 @@ impl WaylandCx {
                 cx.call_event_handler(&Event::WindowDragQuery(e))
             }
             XlibEvent::WindowCloseRequested(e) => {
+                let window_id = e.window_id;
+                let accept_close = e.accept_close.clone();
                 let mut cx = self.cx.borrow_mut();
-                state.windows.retain_mut(|win| win.window_id != e.window_id);
-                cx.call_event_handler(&Event::WindowCloseRequested(e))
+                cx.call_event_handler(&Event::WindowCloseRequested(e));
+                if accept_close.get() {
+                    drop(cx);
+                    if let EventFlow::Exit =
+                        self.handle_window_closed(state, WindowClosedEvent { window_id })
+                    {
+                        let mut cx = self.cx.borrow_mut();
+                        cx.call_event_handler(&Event::Shutdown);
+                        return EventFlow::Exit;
+                    }
+                }
             }
             XlibEvent::TextInput(e) => {
                 let mut cx = self.cx.borrow_mut();
@@ -495,6 +487,16 @@ impl WaylandCx {
                 }
 
                 cx.run_live_edit_if_needed("linux-wayland");
+                let has_platform_ops = !cx.platform_ops.is_empty();
+                drop(cx);
+                if has_platform_ops {
+                    if let EventFlow::Exit = self.handle_platform_ops(state) {
+                        let mut cx = self.cx.borrow_mut();
+                        cx.call_event_handler(&Event::Shutdown);
+                        state.event_loop_running = false;
+                        return EventFlow::Exit;
+                    }
+                }
                 return EventFlow::Wait;
             }
         }
@@ -543,6 +545,39 @@ impl WaylandCx {
         if let Some(index) = state.popups.iter().position(|w| w.window_id == window_id) {
             state.popups.remove(index);
         }
+    }
+
+    fn handle_window_closed(
+        &self,
+        state: &mut WaylandState,
+        event: WindowClosedEvent,
+    ) -> EventFlow {
+        let window_id = event.window_id;
+        if !state.windows.iter().any(|w| w.window_id == window_id)
+            && !state.popups.iter().any(|w| w.window_id == window_id)
+        {
+            return EventFlow::Poll;
+        }
+        self.close_popup_children(state, window_id);
+
+        let mut cx = self.cx.borrow_mut();
+        cx.call_event_handler(&Event::WindowClosed(event));
+        cx.windows[window_id].is_created = false;
+        if state.pointer_window == Some(window_id) {
+            state.pointer_window = None;
+        }
+        if state.keyboard_window == Some(window_id) {
+            state.keyboard_window = None;
+        }
+        if let Some(index) = state.windows.iter().position(|w| w.window_id == window_id) {
+            state.windows.remove(index);
+            if state.windows.is_empty() {
+                return EventFlow::Exit;
+            }
+        } else if let Some(index) = state.popups.iter().position(|w| w.window_id == window_id) {
+            state.popups.remove(index);
+        }
+        EventFlow::Poll
     }
 
     fn close_popup_children(&self, state: &mut WaylandState, parent_window_id: WindowId) {
@@ -649,9 +684,9 @@ impl WaylandCx {
                     }
                 }
                 CxOsOp::CloseWindow(window_id) => {
-                    self.close_popup_children(state, window_id);
+                    drop(cx);
                     if state.popups.iter().any(|w| w.window_id == window_id) {
-                        drop(cx);
+                        self.close_popup_children(state, window_id);
                         self.close_popup_window(state, window_id, None);
                         cx = self.cx.borrow_mut();
                         if state.windows.is_empty() {
@@ -660,15 +695,13 @@ impl WaylandCx {
                         continue;
                     }
 
-                    cx.call_event_handler(&Event::WindowClosed(WindowClosedEvent { window_id }));
-                    let windows = &mut state.windows;
-                    if let Some(index) = windows.iter().position(|w| w.window_id == window_id) {
-                        cx.windows[window_id].is_created = false;
-                        windows.remove(index);
-                        if windows.len() == 0 {
-                            ret = EventFlow::Exit
-                        }
+                    if let EventFlow::Exit =
+                        self.handle_window_closed(state, WindowClosedEvent { window_id })
+                    {
+                        ret = EventFlow::Exit;
+                        break;
                     }
+                    cx = self.cx.borrow_mut();
                 }
                 CxOsOp::Quit => ret = EventFlow::Exit,
                 CxOsOp::MinimizeWindow(window_id) => {

--- a/platform/src/os/linux/wayland/wayland_state.rs
+++ b/platform/src/os/linux/wayland/wayland_state.rs
@@ -445,8 +445,10 @@ impl Dispatch<xdg_toplevel::XdgToplevel, WindowId> for WaylandState {
                 }
             }
             xdg_toplevel::Event::Close => {
-                state.do_callback(XlibEvent::WindowClosed(WindowClosedEvent {
+                let accept_close = Rc::new(Cell::new(true));
+                state.do_callback(XlibEvent::WindowCloseRequested(WindowCloseRequestedEvent {
                     window_id: *window_id,
+                    accept_close,
                 }))
             }
             _ => {}

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -425,6 +425,15 @@ impl X11Cx {
                 }
 
                 cx.run_live_edit_if_needed("linux-x11");
+                let has_platform_ops = !cx.platform_ops.is_empty();
+                drop(cx);
+                if has_platform_ops {
+                    if let EventFlow::Exit = self.handle_platform_ops(opengl_windows, xlib_app) {
+                        let mut cx = self.cx.borrow_mut();
+                        cx.call_event_handler(&Event::Shutdown);
+                        return EventFlow::Exit;
+                    }
+                }
                 return EventFlow::Wait;
             }
         }

--- a/platform/src/os/linux/x11/xlib_app.rs
+++ b/platform/src/os/linux/x11/xlib_app.rs
@@ -227,21 +227,26 @@ impl XlibApp {
                 x11_sys::DestroyNotify => {
                     // our window got destroyed
                     let destroy_window = event.xdestroywindow;
-                    if let Some(window_ptr) = self.window_map.get(&destroy_window.window) {
-                        let window = &mut (**window_ptr);
+                    if let Some(window_ptr) = self.window_map.remove(&destroy_window.window) {
+                        let window = &mut (*window_ptr);
                         if self.active_popup == Some(destroy_window.window) {
                             self.release_popup_grab(destroy_window.window);
                         }
+                        window.window = None;
+                        let window_id = window.window_id;
                         window.do_callback(XlibEvent::WindowClosed(WindowClosedEvent {
-                            window_id: window.window_id,
+                            window_id,
                         }));
+                        if !self.event_loop_running {
+                            return;
+                        }
                     }
                 }
                 x11_sys::ConfigureNotify => {
                     let cfg = event.xconfigure;
                     if let Some(window_ptr) = self.window_map.get(&cfg.window) {
                         let window = &mut (**window_ptr);
-                        if cfg.window == window.window.unwrap() {
+                        if window.window == Some(cfg.window) {
                             window.send_change_event();
                         }
                     }
@@ -637,10 +642,21 @@ impl XlibApp {
                 }
                 x11_sys::ClientMessage => {
                     let event = event.xclient;
-                    if event.message_type == self.atoms.wm_protocols {
-                        if let Some(window_ptr) = self.window_map.get(&event.window) {
-                            let window = &mut (**window_ptr);
-                            window.close_window();
+                    if event.message_type == self.atoms.wm_protocols
+                        && event.data.l[0] as c_ulong == self.atoms.wm_delete_window
+                    {
+                        if let Some(window_ptr) = self.window_map.get(&event.window).copied() {
+                            let window = &mut (*window_ptr);
+                            let window_id = window.window_id;
+                            if window.send_close_requested_event() {
+                                window.close_window();
+                                window.do_callback(XlibEvent::WindowClosed(WindowClosedEvent {
+                                    window_id,
+                                }));
+                                if !self.event_loop_running {
+                                    return;
+                                }
+                            }
                         }
                     }
                     if event.message_type == self.dnd.atoms.enter {
@@ -705,7 +721,9 @@ impl XlibApp {
                 _ => {}
             }
         }
-        self.do_callback(XlibEvent::Paint);
+        if self.event_loop_running && !self.display.is_null() {
+            self.do_callback(XlibEvent::Paint);
+        }
     }
 
     pub fn event_loop(&mut self) {

--- a/platform/src/os/linux/x11/xlib_window.rs
+++ b/platform/src/os/linux/x11/xlib_window.rs
@@ -437,10 +437,15 @@ impl XlibWindow {
     }
 
     pub fn close_window(&mut self) {
-        unsafe {
-            x11_sys::XDestroyWindow(get_xlib_app_global().display, self.window.unwrap());
-            self.window = None;
-            // lets remove us from the mapping
+        if let Some(window) = self.window.take() {
+            unsafe {
+                let xlib_app = get_xlib_app_global();
+                if xlib_app.active_popup == Some(window) {
+                    xlib_app.release_popup_grab(window);
+                }
+                xlib_app.window_map.remove(&window);
+                x11_sys::XDestroyWindow(xlib_app.display, window);
+            }
         }
     }
 

--- a/platform/src/os/termination_signal.rs
+++ b/platform/src/os/termination_signal.rs
@@ -2,9 +2,13 @@ use {
     crate::{log, thread::SignalToUI},
     std::sync::atomic::{AtomicBool, Ordering},
 };
+#[cfg(target_os = "linux")]
+use std::sync::atomic::AtomicUsize;
 
 static INSTALLED: AtomicBool = AtomicBool::new(false);
 static REQUESTED: AtomicBool = AtomicBool::new(false);
+#[cfg(target_os = "linux")]
+static SIGNAL_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 pub(crate) fn install() {
     if INSTALLED.swap(true, Ordering::AcqRel) {
@@ -12,6 +16,10 @@ pub(crate) fn install() {
     }
 
     if let Err(err) = ctrlc::set_handler(move || {
+        #[cfg(target_os = "linux")]
+        if SIGNAL_COUNT.fetch_add(1, Ordering::AcqRel) > 0 {
+            std::process::exit(130);
+        }
         REQUESTED.store(true, Ordering::Release);
         SignalToUI::set_ui_signal();
     }) {

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -633,6 +633,7 @@ impl Win32Window {
             }
             WM_DESTROY => {
                 // window actively destroyed
+                SetWindowLongPtrW(hwnd, GWLP_USERDATA, 0);
                 window.do_callback(Win32Event::WindowClosed(WindowClosedEvent {
                     window_id: window.window_id,
                 }));


### PR DESCRIPTION
This avoids a strange case where Linux (both X11 and wayland but in different ways) failed to properly shut down cleanly.

* Fix X11 close handling by removing destroyed windows from the map, which helps avoid delivering duplicate window closed events.
* Restructure how close handling happens on Wayland too, and allow the app to respond to a close request just like other platforms.
* Add a Linux second-signal hard exit so that repeated Ctrl+C or `kill` comands can actually terminate a failed/hung shutdown.
* Also a tiny fix to windows too: clear Win32 `GWLP_USERDATA` during `WM_DESTROY` to avoid accessing an old window pointer.