### PR TITLE
fix: hot reload broken when file contains script_apply_eval! calls

### DIFF
--- a/platform/src/live_reload.rs
+++ b/platform/src/live_reload.rs
@@ -313,6 +313,14 @@ fn collect_compiled_sites_for_file(
         let ScriptSource::Mod(script_mod) = &body.source else {
             continue;
         };
+        // `script_apply_eval!` bodies are tagged with `__script_source__` as the
+        // first token of their code. They are Rust-driven runtime evals, not static
+        // DSL blocks, so the file extractor cannot match them. Skip them here so
+        // the compiled-site count only reflects `script_mod!` blocks, which the
+        // extractor does understand.
+        if script_mod.code.trim_start().starts_with("__script_source__") {
+            continue;
+        }
         let Some(compiled_file_name) = resolve_matching_script_mod_file(script_mod, file_name)
         else {
             continue;


### PR DESCRIPTION
## Problem

`script_apply_eval!` expands to a `ScriptMod { file, line, column, code: "__script_source__{...}", ... }` literal, which `vm.add_script_mod` registers as a persistent body just like `script_mod!` does.

`collect_compiled_sites_for_file` counts **all** `ScriptSource::Mod` bodies for a file, so a file with `M` `script_mod!` blocks and `N` `script_apply_eval!` calls reports `M + N` compiled sites.

`extract_script_mods_from_rust_file` only scans for the `script_mod!` macro pattern and finds `M`.

Result:
```
hot reload could not match script_mod! blocks for <file>: runtime has M+N, file has M
```

Hot reload is completely disabled for any file that mixes `script_mod!` with `script_apply_eval!`.

## Fix

Skip bodies whose `code` field starts with `__script_source__` in `collect_compiled_sites_for_file`. The `__script_source__` prefix is the internal marker that `script_apply_eval!` injects (see `script_apply_eval_impl` in `platform/script/derive/src/script.rs`). These bodies are Rust-driven runtime evals — their DSL content is not static text in the file, so the extractor cannot match them and hot reload cannot update them anyway.

## Testing

Verified against a Makepad 2.0 app (`chami`) that uses `script_mod!` alongside multiple `script_apply_eval!` calls in the same file. Before the fix: immediate hot reload error on any file save. After: hot reload watches 66 source files cleanly with no mismatch errors.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)