### PR TITLE
android: don't make the surface invisible, that destroys it

### DIFF
--- a/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
+++ b/tools/cargo_makepad/src/android/java/dev/makepad/android/MakepadActivity.java
@@ -1630,9 +1630,8 @@ public class MakepadActivity
         mSurfaceRecoveryOverlayVisible = true;
         cacheWarmResumeSurfaceSnapshot(mLatestSurfaceSnapshot);
         updateSurfaceSnapshotBackdrop();
-        if (view != null) {
-            view.setVisibility(View.INVISIBLE);
-        }
+        // Don't hide the SurfaceView or make it invisible. That destroys its surface
+        // and causes visual flashing behind any system overlay (like a share sheet).
         showSurfaceRecoverySnapshotIfAvailable();
         refreshSurfaceSnapshotCache();
     }


### PR DESCRIPTION
Setting MakepadSurface to be `INVISIBLE` in the pause path will destroy that surface and cause system overlays to flash/flicker for a moment.