### PR TITLE
Avoid redrawing for simple text-based widgets

### DIFF
--- a/widgets/src/button.rs
+++ b/widgets/src/button.rs
@@ -605,6 +605,7 @@ impl Widget for Button {
     }
 
     fn set_text(&mut self, cx: &mut Cx, v: &str) {
+        if self.text.as_ref() == v { return }
         self.text.as_mut_empty().push_str(v);
         self.redraw(cx);
     }

--- a/widgets/src/check_box.rs
+++ b/widgets/src/check_box.rs
@@ -564,6 +564,7 @@ impl Widget for CheckBox {
     }
 
     fn set_text(&mut self, cx: &mut Cx, v: &str) {
+        if self.text.as_ref() == v { return }
         self.text.as_mut_empty().push_str(v);
         self.redraw(cx);
     }

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -1213,6 +1213,7 @@ impl Widget for HtmlLink {
     }
 
     fn set_text(&mut self, cx: &mut Cx, v: &str) {
+        if self.text.as_ref() == v { return }
         self.text.as_mut_empty().push_str(v);
         self.redraw(cx);
     }

--- a/widgets/src/radio_button.rs
+++ b/widgets/src/radio_button.rs
@@ -446,6 +446,7 @@ impl Widget for RadioButton {
     }
 
     fn set_text(&mut self, cx: &mut Cx, v: &str) {
+        if self.text.as_ref() == v { return }
         self.text.as_mut_empty().push_str(v);
         self.redraw(cx);
     }

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -2410,6 +2410,7 @@ impl Widget for TextFlowLink {
     }
 
     fn set_text(&mut self, cx: &mut Cx, v: &str) {
+        if self.text.as_ref() == v { return }
         self.text.as_mut_empty().push_str(v);
         self.redraw(cx);
     }


### PR DESCRIPTION
redrawing is significantly more expensive than text comparisons, and doing this outside of each widget is difficult and less efficient.

this helped avoid a bunch of redraw cycles in robrix, so it's probably worth doing for all widgets, especially since setting text or another basic property now does an auto-redraw (it didn't used to be like that)