### PR TITLE
Honor X & Y align values for deferred Fill child widgets

### DIFF
--- a/draw/src/turtle.rs
+++ b/draw/src/turtle.rs
@@ -1272,6 +1272,40 @@ pub struct FinishedWalk {
     metrics: Metrics,
 }
 
+/// The horizontal shift that centers a `Flow::Right` row's actually-drawn content
+/// within its inner width, per `align.x`.
+///
+/// Deferred fills are given all the slack up front, so the normal align path skips
+/// align.x when any exist. But a fill that draws narrower than its slot (an image
+/// that aspect-fits, say) leaves genuine slack, and this reclaims it. Returns 0 when
+/// the content fills the row or the inner width is unknown.
+fn row_align_x_shift(turtle: &Turtle, walks: &[FinishedWalk]) -> f64 {
+    let align_x = turtle.align().x;
+    let inner_width = turtle.inner_width();
+    if align_x == 0.0 || walks.is_empty() || inner_width.is_nan() {
+        return 0.0;
+    }
+    let spacing = turtle.spacing() * walks.len().saturating_sub(1) as f64;
+    let used: f64 = walks.iter().map(|w| w.outer_size.x).sum::<f64>() + spacing;
+    align_x * (inner_width - used).max(0.0)
+}
+
+/// The vertical counterpart of [`row_align_x_shift`] for a `Flow::Down` column.
+///
+/// A `height: Fill` child that draws shorter than its slot leaves genuine slack;
+/// this reclaims it for `align.y`. Returns 0 when the column fills, `align.y` is 0,
+/// or the inner height is unknown.
+fn col_align_y_shift(turtle: &Turtle, walks: &[FinishedWalk]) -> f64 {
+    let align_y = turtle.align().y;
+    let inner_height = turtle.inner_height();
+    if align_y == 0.0 || walks.is_empty() || inner_height.is_nan() {
+        return 0.0;
+    }
+    let spacing = turtle.spacing() * walks.len().saturating_sub(1) as f64;
+    let used: f64 = walks.iter().map(|w| w.outer_size.y).sum::<f64>() + spacing;
+    align_y * (inner_height - used).max(0.0)
+}
+
 impl<'a, 'b> Cx2d<'a, 'b> {
     /// Returns a reference to the current turtle.
     pub fn turtle(&self) -> &Turtle {
@@ -1518,14 +1552,23 @@ impl<'a, 'b> Cx2d<'a, 'b> {
                     // vertical alignment is applied to each walk individually.
                     let inner_effective_height = turtle.inner_effective_height();
 
+                    // A fill normally eats all the horizontal slack, but one that draws
+                    // narrower than its slot (e.g. an image that aspect-fits) leaves real
+                    // slack. Honor align.x over whatever's genuinely left after drawing.
+                    let extra_dx = row_align_x_shift(
+                        turtle,
+                        &self.finished_walks[turtle_walks_start..],
+                    );
+
                     for finished_walk_index in turtle_walks_start..self.finished_walks.len() {
                         let finished_walk = &self.finished_walks[finished_walk_index];
 
                         let inner_unused_height =
                             (inner_effective_height - finished_walk.outer_size.y).max(0.0);
 
-                        let dx =
-                            turtle.total_resolved_length_to(finished_walk.deferred_before_count);
+                        let dx = turtle
+                            .total_resolved_length_to(finished_walk.deferred_before_count)
+                            + extra_dx;
                         let dy = turtle.align().y * inner_unused_height;
 
                         let align_list_start = finished_walk.align_list_start;
@@ -1620,6 +1663,13 @@ impl<'a, 'b> Cx2d<'a, 'b> {
                     // unused height is distributed over the deferred walks.
                     let inner_effective_width = turtle.effective_inner_width();
 
+                    // Mirror of the Flow::Right case: a height:Fill child that draws
+                    // shorter than its slot leaves slack that align.y should still honor.
+                    let extra_dy = col_align_y_shift(
+                        turtle,
+                        &self.finished_walks[turtle_walks_start..],
+                    );
+
                     for finished_walk_index in turtle_walks_start..self.finished_walks.len() {
                         let finished_walk = &self.finished_walks[finished_walk_index];
 
@@ -1627,8 +1677,9 @@ impl<'a, 'b> Cx2d<'a, 'b> {
                             (inner_effective_width - finished_walk.outer_size.x).max(0.0);
 
                         let dx = turtle.align().x * inner_unused_width;
-                        let dy =
-                            turtle.total_resolved_length_to(finished_walk.deferred_before_count);
+                        let dy = turtle
+                            .total_resolved_length_to(finished_walk.deferred_before_count)
+                            + extra_dy;
 
                         let align_list_start = finished_walk.align_list_start;
                         let align_list_end = self.finished_walk_align_list_end(finished_walk_index);

--- a/examples/uizoo/src/tab_layout.rs
+++ b/examples/uizoo/src/tab_layout.rs
@@ -21,6 +21,10 @@ script_mod! {
         align: Align{x: 0.5}
     }
 
+    let RedBox = Box{ draw_bg +: { color: #xD8483C } }
+    let GreenBox = Box{ draw_bg +: { color: #x3CA83C } }
+    let BlueBox = Box{ draw_bg +: { color: #x4A6ED8 } }
+
     mod.widgets.DemoLayout = UIZooTabLayout_B{
         desc +: {
             Markdown{body: "# Layout\n\nLayout demos show width, height, margin, padding, spacing, flow, and alignment."}
@@ -162,6 +166,58 @@ script_mod! {
                 Box{height: 100 width: 50.}
                 Box{height: 20 width: 50.}
                 Box{height: 50 width: 50.}
+            }
+
+            Hr{}
+            H4{text: "Align x of an under-filling Fill child"}
+            // A `width: Fill{max}` child that caps below the row width leaves slack.
+            // align.x must position that slack. These three should read left / center /
+            // right; before the Flow::Right deferred-fill fix they all anchored left.
+            Pbold{text: "flow: Right, align: {x: 0.},  child width: Fill{max: 120.}"}
+            UIZooRowH{
+                align: Align{x: 0. y: 0.5}
+                RedBox{height: 50 width: Fill{max: 120.}
+                    BoxLabel{text: "Fill{max: 120.}"}
+                }
+            }
+            Pbold{text: "flow: Right, align: {x: 0.5}, child width: Fill{max: 120.}"}
+            UIZooRowH{
+                align: Align{x: 0.5 y: 0.5}
+                GreenBox{height: 50 width: Fill{max: 120.}
+                    BoxLabel{text: "Fill{max: 120.}"}
+                }
+            }
+            Pbold{text: "flow: Right, align: {x: 1.0}, child width: Fill{max: 120.}"}
+            UIZooRowH{
+                align: Align{x: 1.0 y: 0.5}
+                BlueBox{height: 50 width: Fill{max: 120.}
+                    BoxLabel{text: "Fill{max: 120.}"}
+                }
+            }
+
+            Hr{}
+            H4{text: "Align y of an under-filling Fill child"}
+            // The Flow::Down mirror: a `height: Fill{max}` child caps below the column
+            // height, and align.y positions the slack. These read top / center / bottom.
+            // The faint outer box is the full column; the colored box is the Fill child.
+            UIZooRowH{
+                height: 180.
+                spacing: 20.
+                Box{width: 140. height: Fill flow: Down align: Align{y: 0.}
+                    RedBox{width: Fill height: Fill{max: 60.}
+                        BoxLabel{text: "align y: 0."}
+                    }
+                }
+                Box{width: 140. height: Fill flow: Down align: Align{y: 0.5}
+                    GreenBox{width: Fill height: Fill{max: 60.}
+                        BoxLabel{text: "align y: 0.5"}
+                    }
+                }
+                Box{width: 140. height: Fill flow: Down align: Align{y: 1.0}
+                    BlueBox{width: Fill height: Fill{max: 60.}
+                        BoxLabel{text: "align y: 1.0"}
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
A `Fill` child under Flow::Right (or `height: Fill` under Flow::Down) is deferred and given the row's full slack up front, so end_turtle's align step takes the deferred branch, which distributes width/height to fills and drops main-axis align entirely. That's correct when a fill consumes its whole slot, but a fill that draws narrower than its slot (e.g. an Image that aspect-fits, or `Fill{max: N}` capped below the container) leaves real slack that then anchors to the start regardless of align.

Add row_align_x_shift / col_align_y_shift: reclaim align * (inner - actually_drawn) in each deferred branch. They early-return 0 when align is 0, the inner size is unknown, or the content fills, so the only behavior change is deferred-flow containers that set main-axis align and hold an under-filling Fill child.

Add examples to the uizoo "Layout Demos" tab that proves they boht work.