### PR TITLE
PortalList: allow setting layout `flow` at runtime; AdaptiveView fixes

### DIFF
--- a/platform/src/display_context.rs
+++ b/platform/src/display_context.rs
@@ -41,6 +41,12 @@ impl DisplayContext {
         self.screen_size.x >= DEFAULT_MIN_DESKTOP_WIDTH
     }
 
+    /// Whether the given width qualifies as the wide "desktop" layout.
+    /// Useful as a fallback signal when `screen_size` isn't known yet.
+    pub fn is_desktop_width(&self, width: f64) -> bool {
+        width >= DEFAULT_MIN_DESKTOP_WIDTH
+    }
+
     pub fn is_screen_size_known(&self) -> bool {
         self.screen_size.x != 0.0 && self.screen_size.y != 0.0
     }

--- a/widgets/src/adaptive_view.rs
+++ b/widgets/src/adaptive_view.rs
@@ -331,11 +331,24 @@ impl AdaptiveView {
         self.should_reapply_selector = true;
     }
 
+    /// The template id of the currently-active variant (e.g. `Desktop`/`Mobile`),
+    /// or `None` before the first selection. Read this after `draw_walk` to keep
+    /// dependent styling in lockstep with the variant that's actually shown.
+    pub fn active_variant(&self) -> Option<LiveId> {
+        self.active_widget.as_ref().map(|w| w.template_id)
+    }
+
     pub fn set_default_variant_selector(&mut self) {
-        // TODO(Julian): setup a more comprehensive default, currently defaults to Desktop even if the screen size is unknown
-        // (happens on startup for macOS due to a regression, first few WindowGeomChange events report size 0)
-        self.set_variant_selector(|cx, _parent_size| {
-            if cx.display_context.is_desktop() || !cx.display_context.is_screen_size_known() {
+        // When the screen size isn't known yet (e.g. the first few macOS startup
+        // geom events report size 0), fall back to `parent_size`, the actual layout
+        // size handed to this view, which is reliable during draw.
+        self.set_variant_selector(|cx, parent_size| {
+            let is_desktop = if cx.display_context.is_screen_size_known() {
+                cx.display_context.is_desktop()
+            } else {
+                cx.display_context.is_desktop_width(parent_size.x)
+            };
+            if is_desktop {
                 live_id!(Desktop)
             } else {
                 live_id!(Mobile)

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -1653,6 +1653,18 @@ impl PortalList {
         self.tail_range = tail_range;
     }
 
+    /// Sets the flow direction, e.g. to switch a list between a vertical
+    /// (`Flow::Down`) and horizontal (`Flow::right()`) layout at runtime.
+    pub fn set_flow(&mut self, cx: &mut Cx, flow: Flow) {
+        if self.layout.flow != flow {
+            self.layout.flow = flow;
+            // `vec_index` is the axis the list actually lays out along; it's normally
+            // derived from `flow` in `on_after_apply`, so keep it in sync here too.
+            self.vec_index = if let Flow::Down = flow { Vec2Index::Y } else { Vec2Index::X };
+            self.redraw(cx);
+        }
+    }
+
     /// Sets the first visible item and scroll offset.
     pub fn set_first_id_and_scroll(&mut self, first_id: usize, first_scroll: f64) {
         self.first_id = first_id;
@@ -3171,6 +3183,13 @@ impl PortalListRef {
     pub fn set_tail_range(&self, tail_range: bool) {
         if let Some(mut inner) = self.borrow_mut() {
             inner.tail_range = tail_range;
+        }
+    }
+
+    /// See [`PortalList::set_flow`].
+    pub fn set_flow(&self, cx: &mut Cx, flow: Flow) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_flow(cx, flow);
         }
     }
 

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -1260,9 +1260,13 @@ impl Widget for Window {
                         _ => (),
                     }
 
-                    // Update the display context if the screen size has changed
+                    // Update the display context if the screen size has changed.
+                    // Some platforms send spurious zero-size geometry at startup (notably macOS);
+                    // don't let it clobber a good size and flip adaptive layouts to their fallback.
                     let old_insets = cx.display_context.safe_area_insets;
-                    cx.display_context.screen_size = ev.new_geom.inner_size;
+                    if ev.new_geom.inner_size.x > 0.0 && ev.new_geom.inner_size.y > 0.0 {
+                        cx.display_context.screen_size = ev.new_geom.inner_size;
+                    }
                     cx.display_context.safe_area_insets = ev.new_geom.safe_area_insets;
                     cx.display_context.updated_on_event_id = cx.event_id();
 


### PR DESCRIPTION
* PortalList: add `set_flow(cx, flow)` to switch a list between vertical and horizontal layout flow at runtime. Much faster than using `script_apply_eval`, and always fully correct because it updates the `vec_index` axis. It also avoids a full ScriptReapply sequence, which is potentially expensive across all of an app's widgets.
* AdaptiveView: add `active_variant()` getter so that widgets using AdaptiveView   do not have to separately track which variant it should be in.   Removes all ambiguity and possibility of divergence... finally!
  * Also fixes long-standing TODO item in AdaptiveView about properly handling
    weird window geom events, e.g., on macOS sometimes it spits out a 0-width
    window update which is total b.s.
* DisplayContext: add `is_desktop_width()` helper.
* Window: ignore spurious zero-size window geom events.