### PR TITLE
Linux: derive window app id from the binary name, or app override

### DIFF
--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -577,6 +577,7 @@ impl X11Cx {
                         window.create_inner_size.unwrap_or(dvec2(800., 600.)),
                         window.create_position,
                         &window.create_title,
+                        &window.create_app_id,
                         window.is_fullscreen,
                     );
                     let window = &mut cx.windows[window_id];

--- a/platform/src/os/linux/x11/opengl_x11.rs
+++ b/platform/src/os/linux/x11/opengl_x11.rs
@@ -345,6 +345,7 @@ impl OpenglWindow {
         inner_size: Vec2d,
         position: Option<Vec2d>,
         title: &str,
+        app_id: &str,
         is_fullscreen: bool,
     ) -> OpenglWindow {
         // Checked "downcast" of the EGL platform display to a X11 display.
@@ -389,6 +390,7 @@ impl OpenglWindow {
         let custom_window_chrome = false;
         xlib_window.init(
             title,
+            app_id,
             inner_size,
             position,
             is_fullscreen,

--- a/platform/src/os/linux/x11/xlib_window.rs
+++ b/platform/src/os/linux/x11/xlib_window.rs
@@ -3,7 +3,7 @@ use {
     crate::{area::Area, cursor::MouseCursor, event::*, makepad_math::{Rect, Vec2d}, window::WindowId},
     std::{
         cell::Cell,
-        ffi::{CStr, CString, OsStr},
+        ffi::{CStr, CString},
         mem,
         os::raw::{c_char, c_int, c_long, c_ulong, c_void},
         ptr,
@@ -68,6 +68,7 @@ impl XlibWindow {
     pub fn init(
         &mut self,
         title: &str,
+        app_id: &str,
         size: Vec2d,
         position: Option<Vec2d>,
         is_fullscreen: bool,
@@ -195,14 +196,11 @@ impl XlibWindow {
             // Set the WM_CLASS before mapping the window.
             // Based on <https://www.x.org/releases/X11R7.5/doc/man/man3/XSetWMProperties.3.html>
             {
-                // Use the binary name by default (the first arg).
-                let class = std::env::args_os()
-                    .next()
-                    .as_ref()
-                    .and_then(|arg0| std::path::Path::new(arg0).file_name())
-                    .and_then(OsStr::to_str)
-                    .map(ToOwned::to_owned)
-                    .unwrap_or_else(|| String::from("Makepad"));
+                let class = if app_id.is_empty() {
+                    crate::window::default_app_id()
+                } else {
+                    app_id.to_string()
+                };
                 let instance = std::env::var("RESOURCE_NAME")
                     .ok()
                     .unwrap_or_else(|| class.clone());

--- a/platform/src/window.rs
+++ b/platform/src/window.rs
@@ -316,6 +316,18 @@ impl ScriptApply for WindowHandle {
     }
 }
 
+/// Linux desktops match a window to its `.desktop` file by app id, and packagers
+/// name that file after the binary, so that's the best default we have.
+pub(crate) fn default_app_id() -> String {
+    std::env::args_os()
+        .next()
+        .as_ref()
+        .and_then(|arg0| std::path::Path::new(arg0).file_name())
+        .and_then(|name| name.to_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| "Makepad".to_string())
+}
+
 impl WindowHandle {
     pub fn new(cx: &mut Cx) -> Self {
         let window = cx.windows.alloc();
@@ -324,7 +336,7 @@ impl WindowHandle {
         cxwindow.create_title = "Makepad".to_string();
         cxwindow.create_inner_size = None;
         cxwindow.create_position = None;
-        cxwindow.create_app_id = "Makepad".to_string();
+        cxwindow.create_app_id = default_app_id();
         cxwindow.is_popup = false;
         cxwindow.popup_parent = None;
         cxwindow.popup_position = None;
@@ -350,7 +362,7 @@ impl WindowHandle {
             cxwindow.create_title = "Makepad Popup".to_string();
             cxwindow.create_inner_size = Some(size);
             cxwindow.create_position = Some(position);
-            cxwindow.create_app_id = "Makepad".to_string();
+            cxwindow.create_app_id = default_app_id();
             cxwindow.is_popup = true;
             cxwindow.popup_parent = Some(parent);
             cxwindow.popup_position = Some(position);
@@ -375,6 +387,10 @@ pub struct ScriptWindowHandle {
     pub handle: WindowHandle,
     #[live]
     pub title: String,
+    /// Wayland `app_id` and X11 WM_CLASS; must match the installed `.desktop`
+    /// file's basename or desktops can't find the app's icon. Defaults to argv[0].
+    #[live]
+    pub app_id: String,
     #[live]
     pub inner_size: Option<Vec2d>,
     #[live]
@@ -421,6 +437,9 @@ impl ScriptHook for ScriptWindowHandle {
         let window_id = self.handle.window_id();
         if !self.title.is_empty() {
             cx.windows[window_id].create_title = self.title.clone();
+        }
+        if !self.app_id.is_empty() {
+            cx.windows[window_id].create_app_id = self.app_id.clone();
         }
         if self.inner_size.is_some() {
             cx.windows[window_id].create_inner_size = self.inner_size;
@@ -996,6 +1015,7 @@ mod tests {
         let mut script_window = ScriptWindowHandle {
             handle,
             title: "Floating Panel".to_string(),
+            app_id: "floating-panel".to_string(),
             inner_size: Some(dvec2(320.0, 80.0)),
             position: Some(dvec2(40.0, 50.0)),
             kind_id: 7,
@@ -1013,6 +1033,7 @@ mod tests {
         let cx = vm.cx_mut();
         let cx_window = &cx.windows[window_id];
         assert_eq!(cx_window.create_title, "Floating Panel");
+        assert_eq!(cx_window.create_app_id, "floating-panel");
         assert_eq!(cx_window.create_inner_size, Some(dvec2(320.0, 80.0)));
         assert_eq!(cx_window.create_position, Some(dvec2(40.0, 50.0)));
         assert_eq!(cx_window.kind_id, 7);


### PR DESCRIPTION
Every window hardcoded `create_app_id = "Makepad"`. GNOME Shell matches Wayland toplevels to their `.desktop` file by app id, so packaged apps looked for `Makepad.desktop`, missed, and lost their icon. X11 was unaffected, having always used argv[0] for WM_CLASS.

* Default `create_app_id` to the argv[0] basename via `window::default_app_id()`.
* Add a `window.app_id` DSL field to override it, for rDNS packaging like Flatpak.
* Route X11's WM_CLASS through `create_app_id` too, replacing its own inline copy of the argv[0] chain, so both identities come from one field.