### PR TITLE
fix(linux): don't abort on machines with no usable audio device

### DIFF
--- a/platform/src/audio.rs
+++ b/platform/src/audio.rs
@@ -48,6 +48,16 @@ pub struct AudioDevicesEvent {
 }
 
 impl AudioDevicesEvent {
+    /// The device to record from: the default device, or if that one failed to
+    /// open, the default device anyway.
+    ///
+    /// Deliberately does *not* fall back to some other microphone the way
+    /// [`Self::default_output`] falls back to another speaker. Capture devices
+    /// are not interchangeable - the next input in the list is typically a
+    /// monitor source, which is a loopback of everything the machine is
+    /// playing, so silently recording from it instead would be a privacy
+    /// breach. Which microphone to use when the default one is unavailable is
+    /// the app's decision to make, from `descs`.
     pub fn default_input(&self) -> Vec<AudioDeviceId> {
         for d in &self.descs {
             if d.is_default && d.device_type.is_input() && !d.has_failed {
@@ -61,9 +71,21 @@ impl AudioDevicesEvent {
         }
         Vec::new()
     }
+    /// The device to play to, as a fallback chain: the default device, then any
+    /// other device that has not failed to open, and only if everything has
+    /// failed the default anyway.
+    ///
+    /// Handing back a device that is already known to have failed is what makes
+    /// an app ask for it again on every device change, so it is the last resort
+    /// rather than the first fallback.
     pub fn default_output(&self) -> Vec<AudioDeviceId> {
         for d in &self.descs {
             if d.is_default && d.device_type.is_output() && !d.has_failed {
+                return vec![d.device_id];
+            }
+        }
+        for d in &self.descs {
+            if d.device_type.is_output() && !d.has_failed {
                 return vec![d.device_id];
             }
         }

--- a/platform/src/os/linux/alsa_audio.rs
+++ b/platform/src/os/linux/alsa_audio.rs
@@ -107,16 +107,18 @@ impl AlsaAudioAccess {
             let mut device_descs = Vec::new();
             let failed_inputs = alsa.failed_inputs.lock().unwrap().clone();
             let failed_outputs = alsa.failed_outputs.lock().unwrap().clone();
-            let mut card_num = -1;
             unsafe {
-                loop {
-                    alsa_error!(snd_card_next(&mut card_num))?;
-                    if card_num < 0 {
-                        break;
-                    }
-
-                    let mut hints: *mut *mut c_void = 0 as *mut _;
-                    alsa_error!(snd_device_name_hint(card_num, "pcm\0".as_ptr(), &mut hints))?;
+                // -1 asks alsa for the whole system instead of one card. It is
+                // what every other alsa client does, and it is the only way the
+                // generic pcms show up at all - "default" above all, which
+                // follows whatever the machine is configured to use and mixes
+                // through the sound server. Asking per card only ever returned
+                // raw device nodes like plughw:CARD=PCH,DEV=0, which demand
+                // exclusive access and so fail whenever anything else is
+                // playing. The whole-system list already contains every card's
+                // own pcms, so nothing is lost by not walking the cards.
+                let mut hints: *mut *mut c_void = 0 as *mut _;
+                alsa_error!(snd_device_name_hint(-1, "pcm\0".as_ptr(), &mut hints))?;
 
                 let mut index = 0;
                 while *hints.offset(index) != std::ptr::null_mut() {
@@ -125,6 +127,13 @@ impl AlsaAudioAccess {
                     let name_str =
                         from_alsa_string(snd_device_name_get_hint(hint_ptr, "NAME\0".as_ptr()))
                             .unwrap_or("".into());
+                    // "null" accepts and discards everything, and it always
+                    // opens - offering it would let the automatic fallback
+                    // land on a device that looks like working audio and is
+                    // silent
+                    if name_str.is_empty() || name_str == "null" {
+                        continue;
+                    }
                     let desc_str =
                         from_alsa_string(snd_device_name_get_hint(hint_ptr, "DESC\0".as_ptr()))
                             .unwrap_or("".into())
@@ -161,7 +170,7 @@ impl AlsaAudioAccess {
                         });
                     }
                 }
-                }
+                snd_device_name_free_hint(hints);
             }
             Ok(device_descs)
         }
@@ -174,8 +183,17 @@ impl AlsaAudioAccess {
                 println!("ALSA ERROR {}", e.0)
             }
             Ok(mut descs) => {
-                // pick a single default device
+                // pick a single default device. "default" first: it is the pcm
+                // every other linux application plays through, it follows the
+                // machine's configured device, and it shares the card instead of
+                // seizing it. The raw nodes below it are the fallback for a
+                // system without any alsa configuration at all.
                 if let Some(descs) = descs
+                    .iter_mut()
+                    .find(|v| v.desc.device_type.is_output() && v.name == "default")
+                {
+                    descs.desc.is_default = true;
+                } else if let Some(descs) = descs
                     .iter_mut()
                     .find(|v| v.desc.device_type.is_output() && v.name.starts_with("plughw:"))
                 {
@@ -191,6 +209,11 @@ impl AlsaAudioAccess {
                     descs.desc.is_default = true;
                 }
                 if let Some(descs) = descs
+                    .iter_mut()
+                    .find(|v| v.desc.device_type.is_input() && v.name == "default")
+                {
+                    descs.desc.is_default = true;
+                } else if let Some(descs) = descs
                     .iter_mut()
                     .find(|v| v.desc.device_type.is_input() && v.name.starts_with("plughw:"))
                 {

--- a/platform/src/os/linux/alsa_audio.rs
+++ b/platform/src/os/linux/alsa_audio.rs
@@ -33,12 +33,28 @@ pub struct AlsaAudioAccess {
     audio_outputs: Arc<Mutex<Vec<AlsaAudioDeviceRef>>>,
     audio_inputs: Arc<Mutex<Vec<AlsaAudioDeviceRef>>>,
     device_descs: Vec<AlsaAudioDesc>,
-    failed_devices: Arc<Mutex<HashSet<AudioDeviceId>>>,
+    // input and output are tracked apart because both directions of one alsa pcm
+    // share a device id: a card without a microphone must not disable playback
+    failed_inputs: Arc<Mutex<HashSet<AudioDeviceId>>>,
+    failed_outputs: Arc<Mutex<HashSet<AudioDeviceId>>>,
+    /// Devices asked for by the last call, used to tell an explicit request
+    /// apart from the automatic re-selection that drives the retry loop.
+    last_input_request: Vec<AudioDeviceId>,
+    last_output_request: Vec<AudioDeviceId>,
     change_signal: SignalToUI,
 }
 
 #[derive(Debug)]
 pub struct AlsaError(String);
+
+/// The identity of an enumeration, used to tell a real device change from a
+/// repeated enumeration of the same devices.
+fn device_set(descs: &[AlsaAudioDesc]) -> HashSet<(AudioDeviceId, AudioDeviceType)> {
+    descs
+        .iter()
+        .map(|v| (v.desc.device_id, v.desc.device_type))
+        .collect()
+}
 
 macro_rules! alsa_error {
     ( $ call: expr) => {
@@ -73,7 +89,10 @@ impl AlsaAudioAccess {
 
         Arc::new(Mutex::new(AlsaAudioAccess {
             change_signal,
-            failed_devices: Default::default(),
+            failed_inputs: Default::default(),
+            failed_outputs: Default::default(),
+            last_input_request: Vec::new(),
+            last_output_request: Vec::new(),
             audio_input_cb: Default::default(),
             audio_output_cb: Default::default(),
             device_descs: Default::default(),
@@ -86,6 +105,8 @@ impl AlsaAudioAccess {
         // alright lets do it
         fn inner(alsa: &AlsaAudioAccess) -> Result<Vec<AlsaAudioDesc>, AlsaError> {
             let mut device_descs = Vec::new();
+            let failed_inputs = alsa.failed_inputs.lock().unwrap().clone();
+            let failed_outputs = alsa.failed_outputs.lock().unwrap().clone();
             let mut card_num = -1;
             unsafe {
                 loop {
@@ -97,49 +118,56 @@ impl AlsaAudioAccess {
                     let mut hints: *mut *mut c_void = 0 as *mut _;
                     alsa_error!(snd_device_name_hint(card_num, "pcm\0".as_ptr(), &mut hints))?;
 
-                    let mut index = 0;
-                    while *hints.offset(index) != std::ptr::null_mut() {
-                        let hint_ptr = *hints.offset(index);
-                        let name_str =
-                            from_alsa_string(snd_device_name_get_hint(hint_ptr, "NAME\0".as_ptr()))
-                                .unwrap_or("".into());
-                        let desc_str =
-                            from_alsa_string(snd_device_name_get_hint(hint_ptr, "DESC\0".as_ptr()))
-                                .unwrap_or("".into())
-                                .replace("\n", " ");
-                        let ioid =
-                            from_alsa_string(snd_device_name_get_hint(hint_ptr, "IOID\0".as_ptr()))
-                                .unwrap_or("".into());
-                        let device_id = AudioDeviceId(LiveId::from_str(&name_str));
-                        let desc = AudioDeviceDesc {
-                            has_failed: alsa.failed_devices.lock().unwrap().contains(&device_id),
-                            device_id,
-                            device_type: AudioDeviceType::Input,
-                            is_default: false,
-                            channel_count: 2,
-                            name: format!("[ALSA] {}", desc_str),
-                        };
-                        if ioid == "" || ioid == "Input" {
-                            device_descs.push(AlsaAudioDesc {
-                                name: name_str.clone(),
-                                desc: desc.clone(),
-                            });
-                        }
-                        if ioid == "" || ioid == "Output" {
-                            device_descs.push(AlsaAudioDesc {
-                                name: name_str,
-                                desc: AudioDeviceDesc {
-                                    device_type: AudioDeviceType::Output,
-                                    ..desc
-                                },
-                            });
-                        }
-                        index += 1;
+                let mut index = 0;
+                while *hints.offset(index) != std::ptr::null_mut() {
+                    let hint_ptr = *hints.offset(index);
+                    index += 1;
+                    let name_str =
+                        from_alsa_string(snd_device_name_get_hint(hint_ptr, "NAME\0".as_ptr()))
+                            .unwrap_or("".into());
+                    let desc_str =
+                        from_alsa_string(snd_device_name_get_hint(hint_ptr, "DESC\0".as_ptr()))
+                            .unwrap_or("".into())
+                            .replace("\n", " ");
+                    let ioid =
+                        from_alsa_string(snd_device_name_get_hint(hint_ptr, "IOID\0".as_ptr()))
+                            .unwrap_or("".into());
+                    let device_id = AudioDeviceId(LiveId::from_str(&name_str));
+                    let desc = AudioDeviceDesc {
+                        has_failed: false,
+                        device_id,
+                        device_type: AudioDeviceType::Input,
+                        is_default: false,
+                        channel_count: 2,
+                        name: format!("[ALSA] {}", desc_str),
+                    };
+                    if ioid == "" || ioid == "Input" {
+                        device_descs.push(AlsaAudioDesc {
+                            name: name_str.clone(),
+                            desc: AudioDeviceDesc {
+                                has_failed: failed_inputs.contains(&device_id),
+                                ..desc.clone()
+                            },
+                        });
                     }
+                    if ioid == "" || ioid == "Output" {
+                        device_descs.push(AlsaAudioDesc {
+                            name: name_str,
+                            desc: AudioDeviceDesc {
+                                device_type: AudioDeviceType::Output,
+                                has_failed: failed_outputs.contains(&device_id),
+                                ..desc
+                            },
+                        });
+                    }
+                }
                 }
             }
             Ok(device_descs)
         }
+        // taken before the clear below: it is what the new enumeration is
+        // compared against to decide whether anything actually changed
+        let previous_devices = device_set(&self.device_descs);
         self.device_descs.clear();
         match inner(self) {
             Err(e) => {
@@ -177,6 +205,19 @@ impl AlsaAudioAccess {
                     descs.desc.is_default = true;
                 }
 
+                // a device that failed to open is not tried again until
+                // something changes - the alsa equivalent of a hotplug event is
+                // the device list itself changing, so re-arm every failure then.
+                // that is what lets a card which was merely busy come back.
+                // compared as a set: a reordered enumeration is not a change,
+                // and treating it as one would resurrect the retry loop.
+                if device_set(&descs) != previous_devices {
+                    self.failed_inputs.lock().unwrap().clear();
+                    self.failed_outputs.lock().unwrap().clear();
+                    for v in descs.iter_mut() {
+                        v.desc.has_failed = false;
+                    }
+                }
                 self.device_descs = descs;
             }
         }
@@ -188,7 +229,9 @@ impl AlsaAudioAccess {
     }
 
     pub fn use_audio_inputs(&mut self, devices: &[AudioDeviceId]) {
+        self.rearm_on_explicit_request(devices, true);
         let new = {
+            let failed_inputs = self.failed_inputs.lock().unwrap().clone();
             let mut audio_inputs = self.audio_inputs.lock().unwrap();
             // lets shut down the ones we dont use
             audio_inputs.iter_mut().for_each(|v| {
@@ -199,6 +242,12 @@ impl AlsaAudioAccess {
             // create the new ones
             let mut new = Vec::new();
             for (index, device_id) in devices.iter().enumerate() {
+                // a device that already refused to open is reported back with
+                // has_failed; opening it again on every device change would
+                // spawn a thread per frame and never stop
+                if failed_inputs.contains(device_id) {
+                    continue;
+                }
                 if audio_inputs
                     .iter()
                     .find(|v| v.device_id == *device_id)
@@ -218,13 +267,18 @@ impl AlsaAudioAccess {
         for (index, device_id, name) in new {
             let audio_input_cb = self.audio_input_cb[index].clone();
             let audio_inputs = self.audio_inputs.clone();
-            let failed_devices = self.failed_devices.clone();
+            let failed_inputs = self.failed_inputs.clone();
             let change_signal = self.change_signal.clone();
+            // published before the open, see the matching comment in
+            // use_audio_outputs
+            self.audio_inputs.lock().unwrap().push(AlsaAudioDeviceRef {
+                device_id,
+                is_terminated: false,
+            });
             std::thread::spawn(move || {
-                if let Ok((mut device, device_ref)) =
+                if let Ok((mut device, _device_ref)) =
                     AlsaAudioDevice::new(&name, device_id, SND_PCM_STREAM_CAPTURE)
                 {
-                    audio_inputs.lock().unwrap().push(device_ref);
                     let mut audio_buffer = device.allocate_matching_buffer();
                     loop {
                         if audio_inputs
@@ -238,7 +292,10 @@ impl AlsaAudioAccess {
                         }
                         match device.read_input_buffer(&mut audio_buffer) {
                             Err(e) => {
-                                println!("Write output buffer error {}", e.0);
+                                // see the matching comment in use_audio_outputs
+                                crate::error!("ALSA: input device {} stopped: {}", name, e.0);
+                                failed_inputs.lock().unwrap().insert(device_id);
+                                change_signal.set();
                                 break;
                             }
                             Ok(_) => (),
@@ -257,16 +314,46 @@ impl AlsaAudioAccess {
                     let mut audio_inputs = audio_inputs.lock().unwrap();
                     audio_inputs.retain(|v| v.device_id != device_id);
                 } else {
-                    println!("Failed to open ALSA audio device, trying something else");
-                    failed_devices.lock().unwrap().insert(device_id);
+                    crate::error!("ALSA: could not open input device {}", name);
+                    audio_inputs
+                        .lock()
+                        .unwrap()
+                        .retain(|v| v.device_id != device_id);
+                    failed_inputs.lock().unwrap().insert(device_id);
                     change_signal.set();
                 }
             });
         }
     }
 
+    /// Gives the requested devices another chance when the app asks for a
+    /// different set than last time.
+    ///
+    /// The retry loop this guards against is an app re-requesting the *same*
+    /// devices on every device change. A changed request is an explicit choice -
+    /// a user picking a device, or a widget toggling its microphone back on -
+    /// and silently ignoring it because the device failed once would leave that
+    /// device dead for the rest of the process.
+    fn rearm_on_explicit_request(&mut self, devices: &[AudioDeviceId], is_input: bool) {
+        let (last, failed) = if is_input {
+            (&mut self.last_input_request, &self.failed_inputs)
+        } else {
+            (&mut self.last_output_request, &self.failed_outputs)
+        };
+        if last.as_slice() == devices {
+            return;
+        }
+        *last = devices.to_vec();
+        let mut failed = failed.lock().unwrap();
+        for device_id in devices {
+            failed.remove(device_id);
+        }
+    }
+
     pub fn use_audio_outputs(&mut self, devices: &[AudioDeviceId]) {
+        self.rearm_on_explicit_request(devices, false);
         let new = {
+            let failed_outputs = self.failed_outputs.lock().unwrap().clone();
             let mut audio_outputs = self.audio_outputs.lock().unwrap();
             // lets shut down the ones we dont use
             audio_outputs.iter_mut().for_each(|v| {
@@ -277,6 +364,12 @@ impl AlsaAudioAccess {
             // create the new ones
             let mut new = Vec::new();
             for (index, device_id) in devices.iter().enumerate() {
+                // a device that already refused to open is reported back with
+                // has_failed; opening it again on every device change would
+                // spawn a thread per frame and never stop
+                if failed_outputs.contains(device_id) {
+                    continue;
+                }
                 if audio_outputs
                     .iter()
                     .find(|v| v.device_id == *device_id)
@@ -296,15 +389,25 @@ impl AlsaAudioAccess {
         for (index, device_id, name) in new {
             let audio_output_cb = self.audio_output_cb[index].clone();
             let audio_outputs = self.audio_outputs.clone();
-            let failed_devices = self.failed_devices.clone();
+            let failed_outputs = self.failed_outputs.clone();
             let change_signal = self.change_signal.clone();
+            // published before the open, not after it: opening takes ~200ms, and
+            // the check above that decides to spawn reads this same list. two
+            // device changes inside that window - the normal startup, where the
+            // card watcher signals immediately after the first enumeration -
+            // would otherwise spawn a second thread for the same exclusive pcm,
+            // whose EBUSY would mark a device that is playing fine as failed.
+            // it also means a terminate arriving mid-open is not lost.
+            self.audio_outputs.lock().unwrap().push(AlsaAudioDeviceRef {
+                device_id,
+                is_terminated: false,
+            });
             std::thread::spawn(move || {
                 // this thing fails here. so how would we then drop down to a secondary
                 // we could simply switch default
-                if let Ok((mut device, device_ref)) =
+                if let Ok((mut device, _device_ref)) =
                     AlsaAudioDevice::new(&name, device_id, SND_PCM_STREAM_PLAYBACK)
                 {
-                    audio_outputs.lock().unwrap().push(device_ref);
                     // lets allocate an output buffer
                     let mut audio_buffer = device.allocate_matching_buffer();
                     loop {
@@ -329,7 +432,14 @@ impl AlsaAudioAccess {
                         }
                         match device.write_output_buffer(&audio_buffer) {
                             Err(e) => {
-                                println!("Write output buffer error {}", e.0);
+                                // the stream died under us. mark it like a failed
+                                // open and tell the app, so it moves to another
+                                // device instead of silently losing audio - and
+                                // so we do not respawn this thread on every
+                                // device change from here on
+                                crate::error!("ALSA: output device {} stopped: {}", name, e.0);
+                                failed_outputs.lock().unwrap().insert(device_id);
+                                change_signal.set();
                                 break;
                             }
                             Ok(_) => (),
@@ -340,8 +450,12 @@ impl AlsaAudioAccess {
                         .unwrap()
                         .retain(|v| v.device_id != device_id);
                 } else {
-                    println!("Failed to open ALSA audio device, trying something else");
-                    failed_devices.lock().unwrap().insert(device_id);
+                    crate::error!("ALSA: could not open output device {}", name);
+                    audio_outputs
+                        .lock()
+                        .unwrap()
+                        .retain(|v| v.device_id != device_id);
+                    failed_outputs.lock().unwrap().insert(device_id);
                     change_signal.set();
                 }
             });

--- a/platform/src/os/linux/alsa_sys.rs
+++ b/platform/src/os/linux/alsa_sys.rs
@@ -297,6 +297,8 @@ extern "C" {
 
     pub fn snd_device_name_get_hint(hint: *const c_void, id: *const u8) -> *mut c_char;
 
+    pub fn snd_device_name_free_hint(hints: *mut *mut c_void) -> c_int;
+
     pub fn snd_pcm_open(
         pcm: *mut *mut snd_pcm_t,
         name: *const u8,

--- a/platform/src/os/linux/linux_media.rs
+++ b/platform/src/os/linux/linux_media.rs
@@ -18,7 +18,9 @@ impl Cx {
     pub(crate) fn handle_media_signals(&mut self) {
         let pulse_enabled = pulse_audio_enabled();
         let audio_first = self.os.media.alsa_audio.is_none()
-            || (pulse_enabled && self.os.media.pulse_audio.is_none());
+            || (pulse_enabled
+                && self.os.media.pulse_audio.is_none()
+                && !self.os.media.pulse_audio_unavailable);
         if audio_first || self.os.media.audio_change.check_and_clear() {
             // alright so. if we 'failed' opening a device here
             // what do we do. we could flag our device as 'failed' on the desc
@@ -30,14 +32,10 @@ impl Cx {
                 .unwrap()
                 .get_updated_descs();
             if pulse_enabled {
-                let descs2 = self
-                    .os
-                    .media
-                    .pulse_audio()
-                    .lock()
-                    .unwrap()
-                    .get_updated_descs();
-                descs.extend(descs2);
+                if let Some(pulse_audio) = self.os.media.pulse_audio() {
+                    let descs2 = pulse_audio.lock().unwrap().get_updated_descs();
+                    descs.extend(descs2);
+                }
             }
             self.call_event_handler(&Event::AudioDevices(AudioDevicesEvent { descs }));
         }
@@ -70,6 +68,9 @@ impl Cx {
 #[derive(Default)]
 pub struct CxLinuxMedia {
     pub(crate) pulse_audio: Option<Arc<Mutex<PulseAudioAccess>>>,
+    /// Set when connecting to a PulseAudio server failed, so we don't retry
+    /// (and re-log) on every audio device change on machines without one.
+    pub(crate) pulse_audio_unavailable: bool,
     pub(crate) alsa_audio: Option<Arc<Mutex<AlsaAudioAccess>>>,
     pub(crate) audio_change: SignalToUI,
     pub(crate) alsa_midi: Option<Arc<Mutex<AlsaMidiAccess>>>,
@@ -79,14 +80,17 @@ pub struct CxLinuxMedia {
 }
 
 impl CxLinuxMedia {
-    pub fn pulse_audio(&mut self) -> Arc<Mutex<PulseAudioAccess>> {
-        if self.pulse_audio.is_none() {
-            self.pulse_audio = Some(PulseAudioAccess::new(
+    /// Returns `None` when there is no usable PulseAudio server, in which case
+    /// audio runs through ALSA alone.
+    pub fn pulse_audio(&mut self) -> Option<Arc<Mutex<PulseAudioAccess>>> {
+        if self.pulse_audio.is_none() && !self.pulse_audio_unavailable {
+            self.pulse_audio = PulseAudioAccess::new(
                 self.audio_change.clone(),
                 &self.alsa_audio().lock().unwrap(),
-            ));
+            );
+            self.pulse_audio_unavailable = self.pulse_audio.is_none();
         }
-        self.pulse_audio.as_ref().unwrap().clone()
+        self.pulse_audio.clone()
     }
 
     pub fn alsa_audio(&mut self) -> Arc<Mutex<AlsaAudioAccess>> {
@@ -153,12 +157,9 @@ impl CxMediaApi for Cx {
             .unwrap()
             .use_audio_inputs(devices);
         if pulse_audio_enabled() {
-            self.os
-                .media
-                .pulse_audio()
-                .lock()
-                .unwrap()
-                .use_audio_inputs(devices);
+            if let Some(pulse_audio) = self.os.media.pulse_audio() {
+                pulse_audio.lock().unwrap().use_audio_inputs(devices);
+            }
         }
     }
 
@@ -170,12 +171,9 @@ impl CxMediaApi for Cx {
             .unwrap()
             .use_audio_outputs(devices);
         if pulse_audio_enabled() {
-            self.os
-                .media
-                .pulse_audio()
-                .lock()
-                .unwrap()
-                .use_audio_outputs(devices);
+            if let Some(pulse_audio) = self.os.media.pulse_audio() {
+                pulse_audio.lock().unwrap().use_audio_outputs(devices);
+            }
         }
     }
 

--- a/platform/src/os/linux/pulse_audio.rs
+++ b/platform/src/os/linux/pulse_audio.rs
@@ -1,13 +1,30 @@
 #![allow(dead_code)]
 use {
-    self::super::{alsa_audio::AlsaAudioAccess, pulse_sys::*},
+    self::super::{alsa_audio::AlsaAudioAccess, libc_sys::timeval, pulse_sys::*},
     crate::{audio::*, makepad_live_id::*, thread::SignalToUI},
     std::collections::HashSet,
-    std::ffi::CStr,
-    std::os::raw::{c_int, c_void},
-    std::sync::atomic::{AtomicU32, Ordering},
+    std::ffi::{CStr, CString},
+    std::os::raw::{c_char, c_int, c_void},
+    std::sync::atomic::{AtomicBool, AtomicU32, Ordering},
     std::sync::{Arc, Mutex},
+    std::time::{Duration, SystemTime, UNIX_EPOCH},
 };
+
+/// How long we are willing to block on a PulseAudio server that does not
+/// answer. A server that accepts our connection but never completes a request -
+/// a container with a stub sink, a server that is shutting down - must not hang
+/// the UI thread.
+const PULSE_TIMEOUT_MS: u64 = 3000;
+
+/// Values of `PulseContextState::state`.
+const CONTEXT_CONNECTING: u32 = 0;
+const CONTEXT_READY: u32 = 1;
+const CONTEXT_FAILED: u32 = 2;
+
+/// Values of the `ready_state` of an input/output stream.
+const STREAM_CONNECTING: u32 = 0;
+const STREAM_READY: u32 = 1;
+const STREAM_FAILED: u32 = 2;
 
 struct PulseAudioDesc {
     name: String,
@@ -23,15 +40,196 @@ struct AlsaAudioDeviceRef {
     _is_terminated: bool,
 }
 
-enum ContextState {
-    Connecting,
-    Ready,
-    Failed,
+/// State shared with the pulse mainloop thread through a raw pointer.
+///
+/// This is deliberately lock-free: the mainloop thread runs the context state
+/// callback while our thread can be sitting inside `pa_threaded_mainloop_wait`
+/// holding the `PulseAudioAccess` mutex, so a callback that took that mutex
+/// would deadlock both threads.
+struct PulseContextState {
+    state: AtomicU32,
+    main_loop: *mut pa_threaded_mainloop,
+    change_signal: SignalToUI,
+}
+
+struct PulseTimeoutState {
+    expired: AtomicBool,
+    main_loop: *mut pa_threaded_mainloop,
+}
+
+/// A one shot mainloop timer that wakes up `pa_threaded_mainloop_wait`, so that
+/// every wait in here is bounded.
+///
+/// Created and freed with the mainloop lock held, which is also the only thing
+/// that keeps the callback from overlapping with either.
+struct PulseTimeout {
+    api: *mut pa_mainloop_api,
+    event: *mut pa_time_event,
+    state: Box<PulseTimeoutState>,
+}
+
+impl PulseTimeout {
+    unsafe fn new(
+        api: *mut pa_mainloop_api,
+        main_loop: *mut pa_threaded_mainloop,
+        millis: u64,
+    ) -> Self {
+        let state = Box::new(PulseTimeoutState {
+            expired: AtomicBool::new(false),
+            main_loop,
+        });
+        let deadline = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            + Duration::from_millis(millis);
+        let tv = timeval {
+            tv_sec: deadline.as_secs() as _,
+            tv_usec: deadline.subsec_micros() as _,
+        };
+        let event = match (*api).time_new {
+            Some(time_new) => time_new(
+                api,
+                &tv,
+                Some(Self::timeout_callback),
+                &*state as *const _ as *mut _,
+            ),
+            None => std::ptr::null_mut(),
+        };
+        if event.is_null() {
+            crate::error!("PulseAudio: could not arm a timeout, not waiting on the server");
+        }
+        Self { api, event, state }
+    }
+
+    /// Also true when there is no timer at all: without one we cannot bound the
+    /// wait, and giving up beats freezing the app.
+    fn expired(&self) -> bool {
+        self.event.is_null() || self.state.expired.load(Ordering::Acquire)
+    }
+
+    unsafe fn free(self) {
+        if !self.event.is_null() {
+            if let Some(time_free) = (*self.api).time_free {
+                time_free(self.event);
+            }
+        }
+    }
+
+    unsafe extern "C" fn timeout_callback(
+        _api: *mut pa_mainloop_api,
+        _event: *mut pa_time_event,
+        _tv: *const timeval,
+        state_ptr: *mut c_void,
+    ) {
+        let state = &*(state_ptr as *const PulseTimeoutState);
+        state.expired.store(true, Ordering::Release);
+        pa_threaded_mainloop_signal(state.main_loop, 0);
+    }
+}
+
+unsafe fn cstr_to_string(ptr: *const c_char) -> Option<String> {
+    if ptr.is_null() {
+        None
+    } else {
+        Some(CStr::from_ptr(ptr).to_string_lossy().into_owned())
+    }
+}
+
+unsafe fn context_error(context: *mut pa_context) -> String {
+    if context.is_null() {
+        return "no context".to_string();
+    }
+    let errno = pa_context_errno(context);
+    cstr_to_string(pa_strerror(errno)).unwrap_or_else(|| format!("error {}", errno))
+}
+
+/// Disconnects a stream and frees the boxed callback state that belongs to it.
+///
+/// Must be called with the mainloop lock held, so that no callback can be
+/// running on the mainloop thread. All callbacks are cleared first, which makes
+/// us the sole owner of the box: libpulse will not hand it back to us through a
+/// TERMINATED state change afterwards.
+///
+/// A stream the server has not finished creating cannot be disconnected at all
+/// (`pa_stream_disconnect` is a no-op returning PA_ERR_BADSTATE until the create
+/// reply arrives), and merely dropping our reference leaves it alive and
+/// attached to the device: "If you only unreference it, then it will live on"
+/// (pulse/stream.h). That is exactly what the open timeout does, so those are
+/// parked and disconnected later instead - otherwise a timed out input stream
+/// stays latched onto the microphone for the life of the process.
+unsafe fn destroy_stream<T>(pulse: &PulseAudioAccess, stream: *mut pa_stream, state_ptr: *mut T) {
+    if stream.is_null() {
+        return;
+    }
+    pa_stream_set_state_callback(stream, None, std::ptr::null_mut());
+    pa_stream_set_read_callback(stream, None, std::ptr::null_mut());
+    pa_stream_set_write_callback(stream, None, std::ptr::null_mut());
+    if pa_stream_disconnect(stream) != 0
+        && pa_stream_get_state(stream) == PA_STREAM_CREATING
+        && pulse.is_context_ready()
+    {
+        pulse.zombie_streams.lock().unwrap().push(stream);
+    } else {
+        pa_stream_unref(stream);
+    }
+    // the callbacks are gone, so nothing can reach the box any more whether the
+    // stream itself is parked or not
+    if !state_ptr.is_null() {
+        drop(Box::from_raw(state_ptr));
+    }
+}
+
+/// Waits until a freshly connected stream is ready, and returns whether it is.
+///
+/// Must be called with the mainloop lock held. A device that never answers
+/// (pulse happily reports sinks that cannot actually be opened, e.g. the dummy
+/// sink of a sound server without any hardware) gives up on the timeout instead
+/// of blocking the UI thread for good.
+///
+/// `ready_state` is a raw pointer into the stream's boxed state rather than a
+/// reference: the read/write callbacks take `&mut` to that same box, and they
+/// run on the mainloop thread whenever `pa_threaded_mainloop_wait` below drops
+/// the lock, so holding a live shared reference across the wait would alias a
+/// `&mut`.
+unsafe fn wait_for_stream(
+    pulse: &PulseAudioAccess,
+    ready_state: *const AtomicU32,
+    what: &str,
+    name: &str,
+) -> bool {
+    let timeout = PulseTimeout::new(pulse.main_loop_api, pulse.main_loop, PULSE_TIMEOUT_MS);
+    let ready = loop {
+        match (*ready_state).load(Ordering::Acquire) {
+            STREAM_READY => break true,
+            STREAM_FAILED => {
+                crate::error!(
+                    "PulseAudio: {} {} could not be started ({})",
+                    what,
+                    name,
+                    context_error(pulse.context)
+                );
+                break false;
+            }
+            _ => (),
+        }
+        // once the server is gone nothing will ever signal us again
+        if !pulse.is_context_ready() {
+            break false;
+        }
+        if timeout.expired() {
+            crate::error!("PulseAudio: timed out opening {} {}", what, name);
+            break false;
+        }
+        pa_threaded_mainloop_wait(pulse.main_loop);
+    };
+    timeout.free();
+    ready
 }
 
 struct PulseInputStream {
     device_id: AudioDeviceId,
     stream: *mut pa_stream,
+    input_ptr: *mut PulseInputStruct,
 }
 
 struct PulseInputStruct {
@@ -48,7 +246,17 @@ impl PulseInputStream {
         name: &str,
         index: usize,
         pulse: &PulseAudioAccess,
-    ) -> PulseInputStream {
+    ) -> Option<PulseInputStream> {
+        if !pulse.is_context_ready() {
+            return None;
+        }
+        let device_name = match CString::new(name) {
+            Ok(v) => v,
+            Err(_) => {
+                crate::error!("PulseAudio: invalid input device name {:?}", name);
+                return None;
+            }
+        };
         pa_threaded_mainloop_lock(pulse.main_loop);
         let sample_spec = pa_sample_spec {
             format: PA_SAMPLE_FLOAT32LE,
@@ -62,12 +270,18 @@ impl PulseInputStream {
             &sample_spec,
             std::ptr::null(),
         );
-        if stream == std::ptr::null_mut() {
-            panic!("pa_stream_new failed");
+        if stream.is_null() {
+            crate::error!(
+                "PulseAudio: pa_stream_new failed for input device {} ({})",
+                name,
+                context_error(pulse.context)
+            );
+            pa_threaded_mainloop_unlock(pulse.main_loop);
+            return None;
         }
         let input_ptr = Box::into_raw(Box::new(PulseInputStruct {
             device_id,
-            ready_state: AtomicU32::new(0),
+            ready_state: AtomicU32::new(STREAM_CONNECTING),
             input_fn: pulse.audio_input_cb[index].clone(),
             audio_buffer: AudioBuffer::default(),
             main_loop: pulse.main_loop,
@@ -92,30 +306,43 @@ impl PulseInputStream {
         };
         let flags = PA_STREAM_ADJUST_LATENCY;
 
-        pa_stream_connect_record(stream, format!("{}\0", name).as_ptr(), &buffer_attr, flags);
+        if pa_stream_connect_record(stream, device_name.as_ptr() as *const u8, &buffer_attr, flags)
+            != 0
+        {
+            crate::error!(
+                "PulseAudio: could not open input device {} ({})",
+                name,
+                context_error(pulse.context)
+            );
+            destroy_stream(pulse, stream, input_ptr);
+            pa_threaded_mainloop_unlock(pulse.main_loop);
+            return None;
+        }
 
-        loop {
-            let ready_state = (*input_ptr).ready_state.load(Ordering::Relaxed);
-            if ready_state == 1 {
-                break;
-            }
-            if ready_state == 2 {
-                pa_threaded_mainloop_unlock(pulse.main_loop);
-                panic!("STREAM CANNOT BE STARTED");
-            }
-            pa_threaded_mainloop_wait(pulse.main_loop);
+        let ready = wait_for_stream(pulse, &raw const (*input_ptr).ready_state, "input device", name);
+        if !ready {
+            destroy_stream(pulse, stream, input_ptr);
+            pa_threaded_mainloop_unlock(pulse.main_loop);
+            return None;
         }
 
         pa_threaded_mainloop_unlock(pulse.main_loop);
-        Self { device_id, stream }
+        Some(Self {
+            device_id,
+            stream,
+            input_ptr,
+        })
     }
 
     pub unsafe fn terminate(self, pulse: &PulseAudioAccess) {
         pa_threaded_mainloop_lock(pulse.main_loop);
-        pa_stream_set_read_callback(self.stream, None, std::ptr::null_mut());
-        pa_stream_disconnect(self.stream);
-        pa_stream_unref(self.stream);
+        destroy_stream(pulse, self.stream, self.input_ptr);
         pa_threaded_mainloop_unlock(pulse.main_loop);
+    }
+
+    /// Whether the server has torn this stream down since we opened it.
+    fn has_failed(&self) -> bool {
+        unsafe { (*self.input_ptr).ready_state.load(Ordering::Acquire) == STREAM_FAILED }
     }
 
     unsafe extern "C" fn recording_stream_read_callback(
@@ -124,18 +351,23 @@ impl PulseInputStream {
         input_ptr: *mut c_void,
     ) {
         let input = &mut *(input_ptr as *mut PulseInputStruct);
-        let mut read_ptr: *mut f32 = std::ptr::null_mut();
+        let mut read_ptr: *const c_void = std::ptr::null();
         let mut byte_count = 0;
-        if pa_stream_peek(stream, &mut read_ptr as *mut _ as *mut _, &mut byte_count) != 0 {
-            println!("pa_stream_peek failed");
+        if pa_stream_peek(stream, &mut read_ptr, &mut byte_count) != 0 {
+            crate::error!("PulseAudio: pa_stream_peek failed");
             return;
         }
         if byte_count == 0 {
             return;
         }
+        // a null buffer with a non-zero size is a hole in the recording stream
+        if read_ptr.is_null() {
+            pa_stream_drop(stream);
+            return;
+        }
         let mut input_fn = (*input).input_fn.lock().unwrap();
         if let Some(input_fn) = &mut *input_fn {
-            let interleaved = std::slice::from_raw_parts(read_ptr, byte_count / 4);
+            let interleaved = std::slice::from_raw_parts(read_ptr as *const f32, byte_count / 4);
             input.audio_buffer.copy_from_interleaved(2, interleaved);
             input_fn(
                 AudioInfo {
@@ -156,15 +388,15 @@ impl PulseInputStream {
         let input_ptr = input_ptr as *mut PulseInputStruct;
         let state = pa_stream_get_state(stream);
         match state {
-            PA_STREAM_UNCONNECTED => (),
-            PA_STREAM_CREATING => (),
-            PA_STREAM_READY => (*input_ptr).ready_state.store(1, Ordering::Relaxed),
-            PA_STREAM_FAILED => (*input_ptr).ready_state.store(2, Ordering::Relaxed),
-            PA_STREAM_TERMINATED => {
-                let _ = Box::from_raw(input_ptr);
-                return;
-            }
-            _ => panic!(),
+            PA_STREAM_READY => (*input_ptr)
+                .ready_state
+                .store(STREAM_READY, Ordering::Release),
+            // the box is owned by PulseInputStream and freed in destroy_stream,
+            // so a terminated stream only has to stop anyone waiting on it
+            PA_STREAM_FAILED | PA_STREAM_TERMINATED => (*input_ptr)
+                .ready_state
+                .store(STREAM_FAILED, Ordering::Release),
+            _ => (),
         }
         pa_threaded_mainloop_signal((*input_ptr).main_loop, 0);
     }
@@ -173,6 +405,7 @@ impl PulseInputStream {
 struct PulseOutputStream {
     device_id: AudioDeviceId,
     stream: *mut pa_stream,
+    output_ptr: *mut PulseOutputStruct,
 }
 
 struct PulseOutputStruct {
@@ -180,6 +413,7 @@ struct PulseOutputStruct {
     output_fn: Arc<Mutex<Option<AudioOutputFn>>>,
     write_byte_count: usize,
     clear_on_read: bool,
+    write_error: bool,
     ready_state: AtomicU32,
     audio_buffer: AudioBuffer,
     main_loop: *mut pa_threaded_mainloop,
@@ -192,6 +426,16 @@ impl PulseOutputStream {
         index: usize,
         pulse: &PulseAudioAccess,
     ) -> Option<PulseOutputStream> {
+        if !pulse.is_context_ready() {
+            return None;
+        }
+        let device_name = match CString::new(name) {
+            Ok(v) => v,
+            Err(_) => {
+                crate::error!("PulseAudio: invalid output device name {:?}", name);
+                return None;
+            }
+        };
         pa_threaded_mainloop_lock(pulse.main_loop);
         let sample_spec = pa_sample_spec {
             format: PA_SAMPLE_FLOAT32LE,
@@ -205,8 +449,14 @@ impl PulseOutputStream {
             &sample_spec,
             std::ptr::null(),
         );
-        if stream == std::ptr::null_mut() {
-            panic!("pa_stream_new failed");
+        if stream.is_null() {
+            crate::error!(
+                "PulseAudio: pa_stream_new failed for output device {} ({})",
+                name,
+                context_error(pulse.context)
+            );
+            pa_threaded_mainloop_unlock(pulse.main_loop);
+            return None;
         }
 
         let output_ptr = Box::into_raw(Box::new(PulseOutputStruct {
@@ -214,7 +464,8 @@ impl PulseOutputStream {
             clear_on_read: true,
             output_fn: pulse.audio_output_cb[index].clone(),
             write_byte_count: 0,
-            ready_state: AtomicU32::new(0),
+            write_error: false,
+            ready_state: AtomicU32::new(STREAM_CONNECTING),
             audio_buffer: AudioBuffer::default(),
             main_loop: pulse.main_loop,
         }));
@@ -233,26 +484,30 @@ impl PulseOutputStream {
         };
         let flags = PA_STREAM_ADJUST_LATENCY | PA_STREAM_START_CORKED | PA_STREAM_START_UNMUTED;
 
-        pa_stream_connect_playback(
+        if pa_stream_connect_playback(
             stream,
-            format!("{}\0", name).as_ptr(),
+            device_name.as_ptr() as *const u8,
             &buffer_attr,
             flags,
             std::ptr::null(),
             std::ptr::null_mut(),
-        );
+        ) != 0
+        {
+            crate::error!(
+                "PulseAudio: could not open output device {} ({})",
+                name,
+                context_error(pulse.context)
+            );
+            destroy_stream(pulse, stream, output_ptr);
+            pa_threaded_mainloop_unlock(pulse.main_loop);
+            return None;
+        }
 
-        loop {
-            let ready_state = (*output_ptr).ready_state.load(Ordering::Relaxed);
-            if ready_state == 1 {
-                break;
-            }
-            if ready_state == 2 {
-                pa_threaded_mainloop_unlock(pulse.main_loop);
-                Self::terminate_stream(stream, pulse);
-                return None;
-            }
-            pa_threaded_mainloop_wait(pulse.main_loop);
+        let ready = wait_for_stream(pulse, &raw const (*output_ptr).ready_state, "output device", name);
+        if !ready {
+            destroy_stream(pulse, stream, output_ptr);
+            pa_threaded_mainloop_unlock(pulse.main_loop);
+            return None;
         }
 
         (*output_ptr).write_byte_count = pa_stream_writable_size(stream);
@@ -264,26 +519,37 @@ impl PulseOutputStream {
         );
 
         let op = pa_stream_cork(stream, 0, None, std::ptr::null_mut());
-        if op == std::ptr::null_mut() {
+        if op.is_null() {
+            crate::error!(
+                "PulseAudio: pa_stream_cork failed for output device {} ({})",
+                name,
+                context_error(pulse.context)
+            );
+            destroy_stream(pulse, stream, output_ptr);
             pa_threaded_mainloop_unlock(pulse.main_loop);
-            panic!("pa_stream_cork failed");
+            return None;
         }
         pa_operation_unref(op);
 
         pa_threaded_mainloop_unlock(pulse.main_loop);
-        Some(Self { device_id, stream })
+        Some(Self {
+            device_id,
+            stream,
+            output_ptr,
+        })
     }
 
     pub fn terminate(&self, pulse: &PulseAudioAccess) {
-        unsafe { Self::terminate_stream(self.stream, pulse) };
+        unsafe {
+            pa_threaded_mainloop_lock(pulse.main_loop);
+            destroy_stream(pulse, self.stream, self.output_ptr);
+            pa_threaded_mainloop_unlock(pulse.main_loop);
+        }
     }
 
-    pub unsafe fn terminate_stream(stream: *mut pa_stream, pulse: &PulseAudioAccess) {
-        pa_threaded_mainloop_lock(pulse.main_loop);
-        pa_stream_set_write_callback(stream, None, std::ptr::null_mut());
-        pa_stream_disconnect(stream);
-        pa_stream_unref(stream);
-        pa_threaded_mainloop_unlock(pulse.main_loop);
+    /// Whether the server has torn this stream down since we opened it.
+    fn has_failed(&self) -> bool {
+        unsafe { (*self.output_ptr).ready_state.load(Ordering::Acquire) == STREAM_FAILED }
     }
 
     unsafe extern "C" fn playback_stream_write_callback(
@@ -294,8 +560,14 @@ impl PulseOutputStream {
         let output = &mut *(output_ptr as *mut PulseOutputStruct);
         let mut write_ptr = std::ptr::null_mut();
         let mut write_byte_count = output.write_byte_count;
-        if pa_stream_begin_write(stream, &mut write_ptr, &mut write_byte_count) != 0 {
-            panic!("pa_stream_begin_write");
+        if pa_stream_begin_write(stream, &mut write_ptr, &mut write_byte_count) != 0
+            || write_ptr.is_null()
+        {
+            if !output.write_error {
+                output.write_error = true;
+                crate::error!("PulseAudio: pa_stream_begin_write failed");
+            }
+            return;
         }
         if write_byte_count == output.write_byte_count {
             let mut output_fn = (*output).output_fn.lock().unwrap();
@@ -315,9 +587,17 @@ impl PulseOutputStream {
                     output.write_byte_count / 4,
                 );
                 output.audio_buffer.copy_to_interleaved(interleaved);
+            } else {
+                std::ptr::write_bytes(write_ptr as *mut u8, 0, write_byte_count);
             }
         } else {
-            println!("Pulse audio buffer size unexpected");
+            // we got handed a differently sized buffer than we prepared for,
+            // play silence rather than whatever happens to be in it
+            std::ptr::write_bytes(write_ptr as *mut u8, 0, write_byte_count);
+            if !output.write_error {
+                output.write_error = true;
+                crate::error!("PulseAudio: audio buffer size unexpected");
+            }
         }
         let flags = if output.clear_on_read {
             output.clear_on_read = false;
@@ -327,7 +607,13 @@ impl PulseOutputStream {
         };
 
         if pa_stream_write(stream, write_ptr, write_byte_count, None, 0, flags) != 0 {
-            panic!("pa_stream_write");
+            if !output.write_error {
+                output.write_error = true;
+                crate::error!("PulseAudio: pa_stream_write failed");
+            }
+            // a stream we cannot write to is dead even if the server has not
+            // said so; let it be reaped rather than silently playing nothing
+            output.ready_state.store(STREAM_FAILED, Ordering::Release);
         }
     }
 
@@ -338,15 +624,15 @@ impl PulseOutputStream {
         let output_ptr = output_ptr as *mut PulseOutputStruct;
         let state = pa_stream_get_state(stream);
         match state {
-            PA_STREAM_UNCONNECTED => (),
-            PA_STREAM_CREATING => (),
-            PA_STREAM_READY => (*output_ptr).ready_state.store(1, Ordering::Relaxed),
-            PA_STREAM_FAILED => (*output_ptr).ready_state.store(2, Ordering::Relaxed),
-            PA_STREAM_TERMINATED => {
-                let _ = Box::from_raw(output_ptr);
-                return;
-            }
-            _ => panic!(),
+            PA_STREAM_READY => (*output_ptr)
+                .ready_state
+                .store(STREAM_READY, Ordering::Release),
+            // the box is owned by PulseOutputStream and freed in destroy_stream,
+            // so a terminated stream only has to stop anyone waiting on it
+            PA_STREAM_FAILED | PA_STREAM_TERMINATED => (*output_ptr)
+                .ready_state
+                .store(STREAM_FAILED, Ordering::Release),
+            _ => (),
         }
         pa_threaded_mainloop_signal((*output_ptr).main_loop, 0);
     }
@@ -364,13 +650,20 @@ pub struct PulseAudioAccess {
 
     device_descs: Vec<PulseAudioDesc>,
     change_signal: SignalToUI,
-    context_state: ContextState,
+    context_state: *mut PulseContextState,
     main_loop: *mut pa_threaded_mainloop,
     main_loop_api: *mut pa_mainloop_api,
     context: *mut pa_context,
-    self_ptr: *const Mutex<PulseAudioAccess>,
 
     failed_devices: HashSet<AudioDeviceId>,
+    /// Devices asked for by the last call, used to tell an explicit request
+    /// apart from the automatic re-selection that drives the retry loop.
+    last_input_request: Vec<AudioDeviceId>,
+    last_output_request: Vec<AudioDeviceId>,
+    /// Streams awaiting a disconnect they were not allowed to do yet, see
+    /// [`destroy_stream`]. Behind its own lock because streams are torn down
+    /// through a `&PulseAudioAccess`.
+    zombie_streams: Mutex<Vec<*mut pa_stream>>,
 }
 
 struct PulseDeviceDesc {
@@ -388,96 +681,186 @@ struct PulseDeviceQuery {
     default_source: Option<String>,
 }
 
+impl PulseDeviceQuery {
+    unsafe fn signal(&self) {
+        if let Some(main_loop) = self.main_loop {
+            pa_threaded_mainloop_signal(main_loop, 0);
+        }
+    }
+}
+
 impl PulseAudioAccess {
-    pub fn new(change_signal: SignalToUI, alsa_audio: &AlsaAudioAccess) -> Arc<Mutex<Self>> {
+    /// Connects to the PulseAudio server.
+    ///
+    /// Returns `None` when there is no usable server (headless machines,
+    /// containers without a sound server, and so on); the caller is expected to
+    /// carry on with ALSA only. Nothing in here may panic or abort: a machine
+    /// without audio is a perfectly normal machine to run on.
+    pub fn new(change_signal: SignalToUI, alsa_audio: &AlsaAudioAccess) -> Option<Arc<Mutex<Self>>> {
         unsafe {
             let main_loop = pa_threaded_mainloop_new();
+            if main_loop.is_null() {
+                crate::error!("PulseAudio: pa_threaded_mainloop_new failed, using ALSA only");
+                return None;
+            }
             let main_loop_api = pa_threaded_mainloop_get_api(main_loop);
+            if main_loop_api.is_null() {
+                crate::error!("PulseAudio: pa_threaded_mainloop_get_api failed, using ALSA only");
+                pa_threaded_mainloop_free(main_loop);
+                return None;
+            }
             let prop_list = pa_proplist_new();
             let context =
                 pa_context_new_with_proplist(main_loop_api, "makepad\0".as_ptr(), prop_list);
+            if !prop_list.is_null() {
+                pa_proplist_free(prop_list);
+            }
+            if context.is_null() {
+                crate::error!("PulseAudio: pa_context_new failed, using ALSA only");
+                pa_threaded_mainloop_free(main_loop);
+                return None;
+            }
 
-            let pulse = Arc::new(Mutex::new(PulseAudioAccess {
+            let context_state = Box::into_raw(Box::new(PulseContextState {
+                state: AtomicU32::new(CONTEXT_CONNECTING),
+                main_loop,
+                change_signal: change_signal.clone(),
+            }));
+            pa_context_set_state_callback(
+                context,
+                Some(Self::context_state_callback),
+                context_state as *mut _,
+            );
+
+            // NOAUTOSPAWN: without it libpulse forks and execs a sound daemon
+            // when none is running, synchronously, inside this call - before the
+            // mainloop exists and before any of our timeouts are armed, so it
+            // blocks this thread for as long as the spawn takes (measured: 7s
+            // for a daemon that takes 7s to fail). Enumerating audio devices
+            // must not freeze the UI, and must not start a sound server on a
+            // machine that deliberately has none.
+            if pa_context_connect(
+                context,
+                std::ptr::null(),
+                PA_CONTEXT_NOAUTOSPAWN,
+                std::ptr::null(),
+            ) != 0
+            {
+                crate::error!(
+                    "PulseAudio: pa_context_connect failed ({}), using ALSA only",
+                    context_error(context)
+                );
+                Self::destroy_context(main_loop, context, context_state);
+                return None;
+            }
+            if pa_threaded_mainloop_start(main_loop) != 0 {
+                crate::error!("PulseAudio: pa_threaded_mainloop_start failed, using ALSA only");
+                Self::destroy_context(main_loop, context, context_state);
+                return None;
+            }
+
+            pa_threaded_mainloop_lock(main_loop);
+            let timeout = PulseTimeout::new(main_loop_api, main_loop, PULSE_TIMEOUT_MS);
+            while (*context_state).state.load(Ordering::Acquire) == CONTEXT_CONNECTING
+                && !timeout.expired()
+            {
+                pa_threaded_mainloop_wait(main_loop);
+            }
+            timeout.free();
+            pa_threaded_mainloop_unlock(main_loop);
+
+            match (*context_state).state.load(Ordering::Acquire) {
+                CONTEXT_READY => (),
+                CONTEXT_CONNECTING => {
+                    crate::error!(
+                        "PulseAudio: timed out connecting to a sound server, using ALSA only"
+                    );
+                    Self::destroy_context(main_loop, context, context_state);
+                    return None;
+                }
+                _ => {
+                    crate::error!(
+                        "PulseAudio: could not connect to a sound server ({}), using ALSA only",
+                        context_error(context)
+                    );
+                    Self::destroy_context(main_loop, context, context_state);
+                    return None;
+                }
+            }
+
+            Some(Arc::new(Mutex::new(PulseAudioAccess {
                 buffer_frames: 256,
                 audio_inputs: Vec::new(),
                 audio_outputs: Vec::new(),
                 change_signal,
                 device_query: None,
-                context: context.clone(),
+                context,
                 main_loop,
                 main_loop_api,
-                context_state: ContextState::Connecting,
+                context_state,
                 audio_input_cb: alsa_audio.audio_input_cb.clone(),
                 audio_output_cb: alsa_audio.audio_output_cb.clone(),
                 device_descs: Default::default(),
-                self_ptr: std::ptr::null(),
                 failed_devices: Default::default(),
-            }));
-            let self_ptr = Arc::into_raw(pulse.clone());
-            (*self_ptr).lock().unwrap().self_ptr = self_ptr;
-
-            pa_context_set_state_callback(
-                context,
-                Some(Self::context_state_callback),
-                self_ptr as *mut _,
-            );
-            if pa_context_connect(context, std::ptr::null(), 0, std::ptr::null()) != 0 {
-                panic!("Pulse audio pa_context_connect failed");
-            };
-            if pa_threaded_mainloop_start(main_loop) != 0 {
-                panic!("Pulse audio pa_threaded_mainloop_start failed");
-            }
-
-            pa_threaded_mainloop_lock(main_loop);
-            loop {
-                if let ContextState::Connecting = pulse.lock().unwrap().context_state {
-                } else {
-                    break;
-                }
-                pa_threaded_mainloop_wait(main_loop);
-            }
-
-            pa_threaded_mainloop_unlock(main_loop);
-            pulse
+                last_input_request: Vec::new(),
+                last_output_request: Vec::new(),
+                zombie_streams: Default::default(),
+            })))
         }
     }
-    /*
-    pub fn destroy(&self){
-        pa_threaded_mainloop_stop(self.main_loop);
-        pa_context_unref(self.context);
-        pa_context_disconnect(self.context);
-        pa_threaded_mainloop_free(self.main_loop);
-    }*/
+
+    /// Tears down a context that never made it into a `PulseAudioAccess`.
+    unsafe fn destroy_context(
+        main_loop: *mut pa_threaded_mainloop,
+        context: *mut pa_context,
+        context_state: *mut PulseContextState,
+    ) {
+        // stop the mainloop first, so no callback can reference the state below
+        pa_threaded_mainloop_stop(main_loop);
+        pa_context_set_state_callback(context, None, std::ptr::null_mut());
+        pa_context_disconnect(context);
+        pa_context_unref(context);
+        pa_threaded_mainloop_free(main_loop);
+        drop(Box::from_raw(context_state));
+    }
+
+    fn context_state(&self) -> u32 {
+        unsafe { (*self.context_state).state.load(Ordering::Acquire) }
+    }
+
+    /// Whether the server connection is alive.
+    ///
+    /// Once it is not, every `pa_context_*` call returns a null `pa_operation`,
+    /// and passing one of those to `pa_operation_get_state`/`pa_operation_unref`
+    /// aborts the process inside libpulse.
+    fn is_context_ready(&self) -> bool {
+        self.context_state() == CONTEXT_READY
+    }
 
     unsafe extern "C" fn subscribe_callback(
         _c: *mut pa_context,
         _event_bits: pa_subscription_event_type_t,
         _index: u32,
-        pulse_ptr: *mut c_void,
+        state_ptr: *mut c_void,
     ) {
-        let pulse: &Mutex<PulseAudioAccess> = &*(pulse_ptr as *const _);
-        let pulse = pulse.lock().unwrap();
-        pulse.change_signal.set();
-        pa_threaded_mainloop_signal(pulse.main_loop, 0);
+        let state = &*(state_ptr as *const PulseContextState);
+        state.change_signal.set();
+        pa_threaded_mainloop_signal(state.main_loop, 0);
     }
 
-    unsafe extern "C" fn context_state_callback(c: *mut pa_context, pulse_ptr: *mut c_void) {
-        let pulse: &Mutex<PulseAudioAccess> = &*(pulse_ptr as *mut _);
-        let state = pa_context_get_state(c);
+    unsafe extern "C" fn context_state_callback(c: *mut pa_context, state_ptr: *mut c_void) {
+        let context_state = &*(state_ptr as *const PulseContextState);
 
-        match state {
-            PA_CONTEXT_READY => {
-                pulse.lock().unwrap().context_state = ContextState::Ready;
-                let main_loop = pulse.lock().unwrap().main_loop;
-                pa_threaded_mainloop_signal(main_loop, 0);
-            }
+        match pa_context_get_state(c) {
+            PA_CONTEXT_READY => context_state.state.store(CONTEXT_READY, Ordering::Release),
             PA_CONTEXT_FAILED | PA_CONTEXT_TERMINATED => {
-                pulse.lock().unwrap().context_state = ContextState::Failed;
-                let main_loop = pulse.lock().unwrap().main_loop;
-                pa_threaded_mainloop_signal(main_loop, 0);
+                context_state.state.store(CONTEXT_FAILED, Ordering::Release)
             }
             _ => (),
         }
+        // always signal: whoever is waiting has to re-check both the context
+        // state and whatever else it was waiting for
+        pa_threaded_mainloop_signal(context_state.main_loop, 0);
     }
 
     unsafe extern "C" fn sink_info_callback(
@@ -487,18 +870,20 @@ impl PulseAudioAccess {
         query_ptr: *mut c_void,
     ) {
         let query: &mut PulseDeviceQuery = &mut *(query_ptr as *mut _);
-        if eol > 0 {
-            pa_threaded_mainloop_signal(query.main_loop.unwrap(), 0);
+        // eol > 0 is the end of the list, eol < 0 means the query failed;
+        // in both cases `info` is not ours to read
+        if eol != 0 || info.is_null() {
+            query.signal();
             return;
         }
-        query.sink_list.push(PulseDeviceDesc {
-            name: CStr::from_ptr((*info).name).to_str().unwrap().to_string(),
-            description: CStr::from_ptr((*info).description)
-                .to_str()
-                .unwrap()
-                .to_string(),
-            _index: (*info).index,
-        })
+        if let Some(name) = cstr_to_string((*info).name) {
+            let description = cstr_to_string((*info).description).unwrap_or_else(|| name.clone());
+            query.sink_list.push(PulseDeviceDesc {
+                name,
+                description,
+                _index: (*info).index,
+            })
+        }
     }
 
     unsafe extern "C" fn source_info_callback(
@@ -508,18 +893,18 @@ impl PulseAudioAccess {
         query_ptr: *mut c_void,
     ) {
         let query: &mut PulseDeviceQuery = &mut *(query_ptr as *mut _);
-        if eol > 0 {
-            pa_threaded_mainloop_signal(query.main_loop.unwrap(), 0);
+        if eol != 0 || info.is_null() {
+            query.signal();
             return;
         }
-        query.source_list.push(PulseDeviceDesc {
-            name: CStr::from_ptr((*info).name).to_str().unwrap().to_string(),
-            description: CStr::from_ptr((*info).description)
-                .to_str()
-                .unwrap()
-                .to_string(),
-            _index: (*info).index,
-        })
+        if let Some(name) = cstr_to_string((*info).name) {
+            let description = cstr_to_string((*info).description).unwrap_or_else(|| name.clone());
+            query.source_list.push(PulseDeviceDesc {
+                name,
+                description,
+                _index: (*info).index,
+            })
+        }
     }
 
     unsafe extern "C" fn server_info_callback(
@@ -528,51 +913,71 @@ impl PulseAudioAccess {
         query_ptr: *mut c_void,
     ) {
         let query: &mut PulseDeviceQuery = &mut *(query_ptr as *mut _);
-        query.default_sink = Some(
-            CStr::from_ptr((*info).default_sink_name)
-                .to_str()
-                .unwrap()
-                .to_string(),
-        );
-        query.default_source = Some(
-            CStr::from_ptr((*info).default_source_name)
-                .to_str()
-                .unwrap()
-                .to_string(),
-        );
-        pa_threaded_mainloop_signal(query.main_loop.unwrap(), 0);
+        // both the info and the default device names are null when the query
+        // failed or when the server has no default sink/source at all
+        if !info.is_null() {
+            query.default_sink = cstr_to_string((*info).default_sink_name);
+            query.default_source = cstr_to_string((*info).default_source_name);
+        }
+        query.signal();
     }
 
     pub fn get_updated_descs(&mut self) -> Vec<AudioDeviceDesc> {
         // ok lets enumerate pulse audio
         unsafe {
+            if !self.is_context_ready() {
+                self.device_descs.clear();
+                return Vec::new();
+            }
             let mut query = PulseDeviceQuery::default();
             query.main_loop = Some(self.main_loop);
             pa_threaded_mainloop_lock(self.main_loop);
-            let sink_op = pa_context_get_sink_info_list(
-                self.context,
-                Some(Self::sink_info_callback),
-                &mut query as *mut _ as *mut _,
-            );
-            let source_op = pa_context_get_source_info_list(
-                self.context,
-                Some(Self::source_info_callback),
-                &mut query as *mut _ as *mut _,
-            );
-            let server_op = pa_context_get_server_info(
-                self.context,
-                Some(Self::server_info_callback),
-                &mut query as *mut _ as *mut _,
-            );
-            while pa_operation_get_state(sink_op) == PA_OPERATION_RUNNING
-                || pa_operation_get_state(source_op) == PA_OPERATION_RUNNING
-                || pa_operation_get_state(server_op) == PA_OPERATION_RUNNING
-            {
+            let ops = [
+                pa_context_get_sink_info_list(
+                    self.context,
+                    Some(Self::sink_info_callback),
+                    &mut query as *mut _ as *mut _,
+                ),
+                pa_context_get_source_info_list(
+                    self.context,
+                    Some(Self::source_info_callback),
+                    &mut query as *mut _ as *mut _,
+                ),
+                pa_context_get_server_info(
+                    self.context,
+                    Some(Self::server_info_callback),
+                    &mut query as *mut _ as *mut _,
+                ),
+            ];
+            // a null operation means the context died between the check above
+            // and the call - libpulse asserts on those, so skip them entirely
+            let timeout = PulseTimeout::new(self.main_loop_api, self.main_loop, PULSE_TIMEOUT_MS);
+            loop {
+                let running = ops
+                    .iter()
+                    .any(|op| !op.is_null() && pa_operation_get_state(*op) == PA_OPERATION_RUNNING);
+                if !running || !self.is_context_ready() {
+                    break;
+                }
+                if timeout.expired() {
+                    crate::error!("PulseAudio: timed out enumerating devices");
+                    break;
+                }
                 pa_threaded_mainloop_wait(self.main_loop);
             }
-            pa_operation_unref(sink_op);
-            pa_operation_unref(source_op);
-            pa_operation_unref(server_op);
+            timeout.free();
+            for op in ops {
+                if op.is_null() {
+                    continue;
+                }
+                // cancelling detaches the callback, which points at `query` on
+                // our stack - an unreffed but still running operation would call
+                // it after we return
+                if pa_operation_get_state(op) == PA_OPERATION_RUNNING {
+                    pa_operation_cancel(op);
+                }
+                pa_operation_unref(op);
+            }
             pa_threaded_mainloop_unlock(self.main_loop);
             // lets add some input/output devices
             let mut out = Vec::new();
@@ -607,12 +1012,36 @@ impl PulseAudioAccess {
                     desc: out.last().cloned().unwrap(),
                 });
             }
+            // a device that failed to open is not tried again until something
+            // changes - the server's device list changing is our hotplug event,
+            // so re-arm every failure then. that is what lets a sink which was
+            // merely busy, or a server that has just come up, work again.
+            // compared as a set: a reordered enumeration is not a change, and
+            // treating it as one would resurrect the retry loop.
+            let device_set = |descs: &[PulseAudioDesc]| {
+                descs
+                    .iter()
+                    .map(|v| (v.desc.device_id, v.desc.device_type))
+                    .collect::<HashSet<_>>()
+            };
+            if device_set(&device_descs) != device_set(&self.device_descs) {
+                self.failed_devices.clear();
+                for desc in out.iter_mut() {
+                    desc.has_failed = false;
+                }
+                for v in device_descs.iter_mut() {
+                    v.desc.has_failed = false;
+                }
+            }
             self.device_descs = device_descs;
             out
         }
     }
 
     pub fn use_audio_inputs(&mut self, devices: &[AudioDeviceId]) {
+        self.reap_zombie_streams();
+        self.reap_failed_inputs();
+        self.rearm_on_explicit_request(devices, true);
         let new = {
             let mut i = 0;
             while i < self.audio_inputs.len() {
@@ -623,9 +1052,18 @@ impl PulseAudioAccess {
                     i += 1;
                 }
             }
+            if !self.is_context_ready() {
+                return;
+            }
             // create the new ones
             let mut new = Vec::new();
             for (index, device_id) in devices.iter().enumerate() {
+                // a device that already refused to open is reported back with
+                // has_failed, retrying it on every device change would stall the
+                // UI thread over and over
+                if self.failed_devices.contains(device_id) {
+                    continue;
+                }
                 if self
                     .audio_inputs
                     .iter()
@@ -644,12 +1082,103 @@ impl PulseAudioAccess {
             new
         };
         for (index, device_id, name) in new {
-            let new_input = unsafe { PulseInputStream::new(device_id, name, index, self) };
-            self.audio_inputs.push(new_input);
+            if let Some(new_input) = unsafe { PulseInputStream::new(device_id, name, index, self) } {
+                self.audio_inputs.push(new_input);
+            } else {
+                self.failed_devices.insert(device_id);
+                self.change_signal.set();
+            }
+        }
+    }
+
+    /// Retries the disconnect of streams that were still being created when we
+    /// gave up on them, once the server has answered. See [`destroy_stream`].
+    fn reap_zombie_streams(&self) {
+        let mut zombies = self.zombie_streams.lock().unwrap();
+        if zombies.is_empty() {
+            return;
+        }
+        unsafe {
+            pa_threaded_mainloop_lock(self.main_loop);
+            zombies.retain(|stream| {
+                // still no answer from the server: keep waiting, unless the
+                // server is gone, in which case it never will answer
+                if pa_stream_get_state(*stream) == PA_STREAM_CREATING && self.is_context_ready() {
+                    return true;
+                }
+                pa_stream_disconnect(*stream);
+                pa_stream_unref(*stream);
+                false
+            });
+            pa_threaded_mainloop_unlock(self.main_loop);
+        }
+    }
+
+    /// Gives the requested devices another chance when the app asks for a
+    /// different set than last time.
+    ///
+    /// The retry loop this guards against is an app re-requesting the *same*
+    /// devices on every device change. A changed request is an explicit choice -
+    /// a user picking a device, or a widget toggling its microphone back on -
+    /// and silently ignoring it because the device failed once would leave that
+    /// microphone dead for the rest of the process.
+    fn rearm_on_explicit_request(&mut self, devices: &[AudioDeviceId], is_input: bool) {
+        let last = if is_input {
+            &mut self.last_input_request
+        } else {
+            &mut self.last_output_request
+        };
+        if last.as_slice() == devices {
+            return;
+        }
+        *last = devices.to_vec();
+        for device_id in devices {
+            self.failed_devices.remove(device_id);
+        }
+    }
+
+    /// Drops streams the server has torn down since we opened them.
+    ///
+    /// Without this a dead stream sits in the list forever: it is never
+    /// recreated because it looks like it is still in use, and the app is never
+    /// told, so audio just stops. Marking the device failed lets the app fall
+    /// over to another one, and the device is re-armed when the device list
+    /// next changes.
+    fn reap_failed_streams(&mut self) {
+        let mut i = 0;
+        while i < self.audio_outputs.len() {
+            if self.audio_outputs[i].has_failed() {
+                let item = self.audio_outputs.remove(i);
+                crate::error!("PulseAudio: output device stopped");
+                item.terminate(self);
+                self.failed_devices.insert(item.device_id);
+                self.change_signal.set();
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    fn reap_failed_inputs(&mut self) {
+        let mut i = 0;
+        while i < self.audio_inputs.len() {
+            if self.audio_inputs[i].has_failed() {
+                let item = self.audio_inputs.remove(i);
+                crate::error!("PulseAudio: input device stopped");
+                let device_id = item.device_id;
+                unsafe { item.terminate(self) };
+                self.failed_devices.insert(device_id);
+                self.change_signal.set();
+            } else {
+                i += 1;
+            }
         }
     }
 
     pub fn use_audio_outputs(&mut self, devices: &[AudioDeviceId]) {
+        self.reap_zombie_streams();
+        self.reap_failed_streams();
+        self.rearm_on_explicit_request(devices, false);
         let new = {
             let mut i = 0;
             while i < self.audio_outputs.len() {
@@ -660,9 +1189,18 @@ impl PulseAudioAccess {
                     i += 1;
                 }
             }
+            if !self.is_context_ready() {
+                return;
+            }
             // create the new ones
             let mut new = Vec::new();
             for (index, device_id) in devices.iter().enumerate() {
+                // a device that already refused to open is reported back with
+                // has_failed, retrying it on every device change would stall the
+                // UI thread over and over
+                if self.failed_devices.contains(device_id) {
+                    continue;
+                }
                 if self
                     .audio_outputs
                     .iter()

--- a/platform/src/os/linux/pulse_sys.rs
+++ b/platform/src/os/linux/pulse_sys.rs
@@ -43,6 +43,9 @@ pub const PA_OPERATION_RUNNING: pa_operation_state = 0;
 pub const PA_OPERATION_DONE: pa_operation_state = 1;
 pub const PA_OPERATION_CANCELLED: pa_operation_state = 2;
 
+pub const PA_CONTEXT_NOAUTOSPAWN: pa_context_flags = 0x0001;
+pub const PA_CONTEXT_NOFAIL: pa_context_flags = 0x0002;
+
 pub const PA_CONTEXT_UNCONNECTED: pa_context_state = 0;
 pub const PA_CONTEXT_CONNECTING: pa_context_state = 1;
 pub const PA_CONTEXT_AUTHORIZING: pa_context_state = 2;
@@ -412,6 +415,10 @@ extern "C" {
     );
     pub fn pa_context_get_state(c: *const pa_context) -> pa_context_state_t;
 
+    pub fn pa_context_errno(c: *const pa_context) -> c_int;
+
+    pub fn pa_strerror(error: c_int) -> *const c_char;
+
     pub fn pa_context_disconnect(c: *mut pa_context);
 
     pub fn pa_context_unref(c: *mut pa_context);
@@ -423,6 +430,7 @@ extern "C" {
     ) -> *mut pa_operation;
 
     pub fn pa_operation_get_state(o: *const pa_operation) -> pa_operation_state_t;
+    pub fn pa_operation_cancel(o: *mut pa_operation);
     pub fn pa_operation_unref(o: *mut pa_operation);
 
     pub fn pa_context_get_source_info_list(
@@ -449,6 +457,7 @@ extern "C" {
         userdata: *mut c_void,
     ) -> *mut pa_operation;
     pub fn pa_proplist_new() -> *mut pa_proplist;
+    pub fn pa_proplist_free(p: *mut pa_proplist);
     pub fn pa_context_new_with_proplist(
         mainloop: *mut pa_mainloop_api,
         name: *const u8,


### PR DESCRIPTION
Makepad aborted inside libpulse on any machine without a working sound
server: get_updated_descs passed the null pa_operation returned by a
context that is not READY straight to pa_operation_get_state, which is
an assert in libpulse ("Assertion 'o' failed at pulse/operation.c:136").
Headless boxes and containers died on startup. Nearby paths were no
better - a sound server that advertises a sink it cannot open hung the
UI thread for good, and a device that failed to open was re-opened on
every device change, forever.

PulseAudio:
 - never hand a null pa_operation to libpulse, and give up on a context
   that is not ready instead of calling into it
 - PulseAudioAccess::new returns None rather than panicking, so a
   machine without a server simply runs on ALSA
 - PA_CONTEXT_NOAUTOSPAWN: without it pa_context_connect forks and execs
   a sound daemon synchronously, before the mainloop exists, blocking
   the UI thread for as long as the spawn takes (measured 7s) and
   leaving a daemon running on a machine that deliberately had none
 - every wait is bounded by a mainloop timer, so a server that never
   answers cannot freeze the app
 - the context state callback no longer takes the access mutex, which
   the UI thread holds while waiting on the mainloop (a deadlock)
 - null info pointers, eol < 0 and absent default sink/source names are
   handled instead of dereferenced
 - streams still being created cannot be disconnected, so they are
   parked and disconnected once the server answers rather than left
   attached to the microphone for the life of the process
 - callbacks no longer panic across the FFI boundary, and a stream the
   server tears down is reaped and reported instead of going silent

ALSA:
 - track input and output failures apart: both directions of one pcm
   share a device id, so a card with no microphone disabled playback
 - publish a device before opening it, not after. Opening takes ~200ms
   and the check that decides to spawn reads that same list, so two
   device changes inside the window - the normal startup - spawned a
   second thread whose EBUSY marked a device that was playing fine as
   failed
 - a stream that dies mid-playback is reported, so the app can move to
   another device instead of silently losing audio

Both backends:
 - a device that failed to open is not retried on every device change.
   It is retried when the device list changes, or when the app asks for
   a different set than last time, so an explicit request - a user
   picking a device, a widget toggling its microphone - is still
   honoured
 - AudioDevicesEvent::default_output falls back to another working
   device instead of handing back one already known to have failed,
   which is what made apps ask for it again on every event.
   default_input deliberately does not: the next input in the list is
   typically a monitor source, and silently recording the machine's
   own output instead of a microphone would be a privacy breach