### PR TITLE
TextFlow: fix inline `<code>` spans that are too low (beneath text baseline)

### DIFF
--- a/draw/src/shader/draw_text.rs
+++ b/draw/src/shader/draw_text.rs
@@ -1292,6 +1292,11 @@ pub struct DrawText {
     #[live]
     pub temp_y_shift: f32,
 
+    /// Centering height (in unscaled lpxs) for RowAlign::Center; TextFlow sets
+    /// this to the line style's height so mixed-font runs stay baseline-aligned.
+    #[rust]
+    pub align_row_height: Option<f32>,
+
     /// Per-row horizontal alignment applied by the text layouter when the
     /// text does not fill the full `max_width_in_lpxs`. `x: 0.0` = left,
     /// `0.5` = center, `1.0` = right. `y` is currently unused by the
@@ -2404,12 +2409,15 @@ impl DrawText {
 
                 // Emit a per-row FinishedWalk covering this row's glyphs +
                 // callback rect-areas.
-                cx.emit_turtle_walk(
+                cx.emit_turtle_walk_with_align_height(
                     Rect {
                         pos: dvec2(row_origin.x as f64, row_top_y),
                         size: dvec2((row.width_in_lpxs * self.font_scale) as f64, row_h),
                     },
                     row_als,
+                    Metrics::default(),
+                    self.align_row_height
+                        .map(|h| (h * self.font_scale) as f64),
                 );
             }
 
@@ -2487,7 +2495,9 @@ impl DrawText {
                 }
             }
 
-            cx.emit_turtle_walk(
+            // Only pass the centering height for single-row runs; a multi-row
+            // walk here spans the whole block, which centering already skips.
+            cx.emit_turtle_walk_with_align_height(
                 Rect {
                     pos: new_turtle_pos,
                     size: dvec2(
@@ -2496,6 +2506,10 @@ impl DrawText {
                     ),
                 },
                 align_list_start,
+                Metrics::default(),
+                self.align_row_height
+                    .filter(|_| text.rows.len() == 1)
+                    .map(|h| (h * self.font_scale) as f64),
             );
         }
 

--- a/draw/src/turtle.rs
+++ b/draw/src/turtle.rs
@@ -1270,6 +1270,11 @@ pub struct FinishedWalk {
     outer_size: Vec2d,
 
     metrics: Metrics,
+
+    /// Height to center by under `RowAlign::Center` instead of `outer_size.y`.
+    /// Text runs pass their line's height here so mixed-font runs on a row all
+    /// get the same shift and keep their relative baselines.
+    align_height: Option<f64>,
 }
 
 /// The horizontal shift that centers a `Flow::Right` row's actually-drawn content
@@ -1929,6 +1934,7 @@ impl<'a, 'b> Cx2d<'a, 'b> {
                 deferred_before_count: 0,
                 outer_size: size + walk.margin.size(),
                 metrics: walk.metrics,
+                align_height: None,
             });
 
             let origin = outer_origin + walk.margin.left_top();
@@ -1979,6 +1985,7 @@ impl<'a, 'b> Cx2d<'a, 'b> {
                 deferred_before_count: defer_index,
                 outer_size,
                 metrics: walk.metrics,
+                align_height: None,
             });
 
             let origin = outer_origin + walk.margin.left_top();
@@ -2160,12 +2167,25 @@ impl<'a, 'b> Cx2d<'a, 'b> {
         align_list_start: usize,
         metrics: Metrics,
     ) {
+        self.emit_turtle_walk_with_align_height(rect, align_list_start, metrics, None)
+    }
+
+    /// Like [`emit_turtle_walk_with_metrics`] but also sets the walk's
+    /// centering height for `RowAlign::Center` (see `FinishedWalk::align_height`).
+    pub fn emit_turtle_walk_with_align_height(
+        &mut self,
+        rect: Rect,
+        align_list_start: usize,
+        metrics: Metrics,
+        align_height: Option<f64>,
+    ) {
         let turtle = self.turtles.last().unwrap();
         self.finished_walks.push(FinishedWalk {
             align_list_start,
             deferred_before_count: turtle.deferred_fills.len(),
             outer_size: rect.size,
             metrics,
+            align_height,
         });
     }
 
@@ -2361,7 +2381,10 @@ impl<'a, 'b> Cx2d<'a, 'b> {
         let finished_walks_end = self.finished_walks.len();
 
         for finished_walk_index in finished_walks_start..finished_walks_end {
-            let finished_walk_height = self.finished_walks[finished_walk_index].outer_size.y;
+            let finished_walk = &self.finished_walks[finished_walk_index];
+            let finished_walk_height = finished_walk
+                .align_height
+                .unwrap_or(finished_walk.outer_size.y);
             let shift = (current_row_height - finished_walk_height) * 0.5;
 
             if shift <= 0.0 {

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -383,8 +383,7 @@ impl Html {
                 trim_whitespace_in_text = TrimWhitespaceInText::Trim;
             }
             some_id!(code) => {
-                const FIXED_FONT_SIZE_SCALE: f64 = 0.85;
-                tf.push_size_rel_scale(FIXED_FONT_SIZE_SCALE);
+                tf.push_size_rel_scale(tf.fixed_font_size_scale);
                 tf.combine_spaces.push(false);
                 tf.fixed.push();
                 tf.inline_code.push();

--- a/widgets/src/markdown.rs
+++ b/widgets/src/markdown.rs
@@ -405,8 +405,7 @@ impl Markdown {
                         self.in_code_block = true;
                         self.code_block_string.clear();
                     } else {
-                        const FIXED_FONT_SIZE_SCALE: f64 = 0.85;
-                        tf.push_size_rel_scale(FIXED_FONT_SIZE_SCALE);
+                        tf.push_size_rel_scale(tf.fixed_font_size_scale);
                         tf.combine_spaces.push(false);
                         tf.fixed.push();
                         tf.begin_code(cx);
@@ -452,8 +451,7 @@ impl Markdown {
                 }
                 // Inline code
                 MdEvent::Code(text) => {
-                    const FIXED_FONT_SIZE_SCALE: f64 = 0.85;
-                    tf.push_size_rel_scale(FIXED_FONT_SIZE_SCALE);
+                    tf.push_size_rel_scale(tf.fixed_font_size_scale);
                     tf.fixed.push();
                     tf.inline_code.push();
                     tf.draw_text(cx, &text);
@@ -471,8 +469,7 @@ impl Markdown {
                         });
                     } else {
                         // Fallback: render as inline code style
-                        const FIXED_FONT_SIZE_SCALE: f64 = 0.85;
-                        tf.push_size_rel_scale(FIXED_FONT_SIZE_SCALE);
+                        tf.push_size_rel_scale(tf.fixed_font_size_scale);
                         tf.fixed.push();
                         tf.inline_code.push();
                         tf.draw_text(cx, &text);

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -9,6 +9,8 @@ use crate::{
 };
 use std::rc::Rc;
 
+const LPXS_PER_PT: f32 = 96.0 / 72.0;
+
 script_mod! {
     use mod.prelude.widgets_internal.*
     use mod.widgets.*
@@ -667,12 +669,12 @@ pub struct TextFlow {
     #[rust]
     pub inline_code: StackCounter,
 
-    /// Ascender in ems per style slot (normal/bold/italic/bold_italic/fixed),
-    /// probed lazily via a tiny layout call. Used to baseline-align mixed
-    /// runs: a 0.85x inline-code run must sit ON the line's baseline, not
-    /// hang from its top.
+    /// (Ascender, descender) in ems per style slot (normal/bold/italic/
+    /// bold_italic/fixed), probed lazily via a tiny layout call. Used to
+    /// baseline-align mixed runs: a 0.85x inline-code run must sit ON the
+    /// line's baseline, not hang from its top.
     #[rust]
-    style_ascender_em: [Option<f32>; 5],
+    style_metrics_em: [Option<(f32, f32)>; 5],
     #[rust]
     pub item_counter: u64,
     #[rust]
@@ -1190,11 +1192,11 @@ impl TextFlow {
             .push(self.font_sizes.last().unwrap_or(&self.font_size) * (scale as f32));
     }
 
-    /// Ascender (in ems) of one of the five run styles, probed once via a
-    /// tiny layout call and cached. Slots: 0 normal, 1 bold, 2 italic,
-    /// 3 bold-italic, 4 fixed.
-    fn ascender_em(&mut self, cx: &mut Cx2d, slot: usize) -> f32 {
-        if let Some(v) = self.style_ascender_em[slot] {
+    /// (Ascender, descender) in ems (descender positive) of one of the five
+    /// run styles, probed once via a tiny layout call and cached. Slots:
+    /// 0 normal, 1 bold, 2 italic, 3 bold-italic, 4 fixed.
+    fn style_metrics_em(&mut self, cx: &mut Cx2d, slot: usize) -> (f32, f32) {
+        if let Some(v) = self.style_metrics_em[slot] {
             return v;
         }
         let style = match slot {
@@ -1205,20 +1207,22 @@ impl TextFlow {
             _ => self.text_style_normal.clone(),
         };
         const PROBE_PT: f32 = 100.0;
-        const LPXS_PER_PT: f32 = 96.0 / 72.0;
         let saved = self.draw_text.text_style.clone();
         self.draw_text.text_style = style;
         self.draw_text.text_style.font_size = PROBE_PT;
-        let asc_lpxs = self
+        let (asc_lpxs, desc_lpxs) = self
             .draw_text
             .layout(cx, 0.0, 0.0, None, false, Align::default(), "Ag")
             .rows
             .first()
-            .map(|row| row.ascender_in_lpxs)
-            .unwrap_or(PROBE_PT * LPXS_PER_PT * 0.9);
+            .map(|row| (row.ascender_in_lpxs, -row.descender_in_lpxs))
+            .unwrap_or((PROBE_PT * LPXS_PER_PT * 0.9, PROBE_PT * LPXS_PER_PT * 0.3));
         self.draw_text.text_style = saved;
-        let em = asc_lpxs / (PROBE_PT * LPXS_PER_PT);
-        self.style_ascender_em[slot] = Some(em);
+        let em = (
+            asc_lpxs / (PROBE_PT * LPXS_PER_PT),
+            desc_lpxs / (PROBE_PT * LPXS_PER_PT),
+        );
+        self.style_metrics_em[slot] = Some(em);
         em
     }
 
@@ -1891,27 +1895,40 @@ impl TextFlow {
                 (self.text_style_normal.clone(), 0)
             };
 
+            let run_size = *self.font_sizes.last().unwrap_or(&self.font_size);
+            let y_shift_scale = self.y_shift_scales.last().copied().unwrap_or(0.0);
+            // A code or sub/superscript run pushed its own scaled size; the
+            // entry below it (or the base size) is the surrounding line's.
+            let line_size = if style_slot == 4 || y_shift_scale != 0.0 {
+                if self.font_sizes.len() >= 2 {
+                    self.font_sizes[self.font_sizes.len() - 2]
+                } else {
+                    self.font_size
+                }
+            } else {
+                run_size
+            };
+
             // Baseline-align mixed runs: a fixed/code run scaled to 0.85x of
             // the surrounding text must sit ON the line's baseline — without
             // this shift it hangs from the row top and inline code floats
             // above the prose. Shift = (line ascender − run ascender), in
             // multiples of the run's own font size (temp_y_shift units).
             // Probe BEFORE the run style is applied (the probe clobbers it).
-            let run_size = *self.font_sizes.last().unwrap_or(&self.font_size);
             let baseline_shift = if style_slot == 4 && run_size > 0.0 {
-                // The code run's size was pushed relative to the surrounding
-                // text; the entry below it (or the base size) is the line.
-                let line_size = if self.font_sizes.len() >= 2 {
-                    self.font_sizes[self.font_sizes.len() - 2]
-                } else {
-                    self.font_size
-                };
-                let line_asc = self.ascender_em(cx, 0);
-                let run_asc = self.ascender_em(cx, 4);
+                let (line_asc, _) = self.style_metrics_em(cx, 0);
+                let (run_asc, _) = self.style_metrics_em(cx, 4);
                 (line_asc * line_size - run_asc * run_size) / run_size
             } else {
                 0.0
             };
+
+            // RowAlign::Center centers each walk by its own height, which
+            // would undo baseline_shift for shorter runs; hand every run the
+            // line's height instead so they all get the same centering shift.
+            let (line_asc, line_desc) = self.style_metrics_em(cx, 0);
+            self.draw_text.align_row_height =
+                Some((line_asc + line_desc) * line_size * LPXS_PER_PT);
 
             // Apply the text style to the single draw_text instance
             let top_drop = text_style.top_drop;
@@ -1920,7 +1937,6 @@ impl TextFlow {
             let font_color = self.font_colors.last().unwrap_or(&self.font_color);
             self.draw_text.text_style.font_size = *font_size as _;
             self.draw_text.color = *font_color;
-            let y_shift_scale = self.y_shift_scales.last().copied().unwrap_or(0.0);
             self.draw_text.temp_y_shift = top_drop + y_shift_scale + baseline_shift;
             self.draw_text.layout_align = Align {
                 x: self.cell_text_align_x,

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -739,6 +739,9 @@ pub struct TextFlow {
     pub inline_code_padding: Inset,
     #[live]
     pub inline_code_margin: Inset,
+    /// Font-size scale for fixed/code runs relative to the surrounding text.
+    #[live(0.85)]
+    pub fixed_font_size_scale: f64,
     #[live(Inset{top:0.5,bottom:0.5,left:0.0,right:0.0})]
     pub heading_margin: Inset,
     #[live(Inset{top:0.5,bottom:0.5,left:0.0,right:0.0})]


### PR DESCRIPTION
I thought this had been fixed, but it looks like there was a regression at some point in the last few months. Here are some examples of the alignment being wrong:
<img width="599" height="149" alt="image" src="https://github.com/user-attachments/assets/6552ba33-e91f-4f8c-bc3a-3109e4bd8433" />
<img width="590" height="363" alt="image" src="https://github.com/user-attachments/assets/530ddc8a-2cf9-4140-8461-c2cbeb86bfc7" />


all of that has now been fixed, and the size scaling factor (to shrink down or enlarge fixed-width fonts compared to normal fonts) is now configurable too.

Details belwow:

* finish_row_center centered every walk by its own height, so a code run's
shorter walk got a larger downward shift than the surrounding prose under
`RowAlign.Center`. That undid TextFlow's baseline_shift: inline `<code>`
spans sat a few px below the line's baseline, and their descenders poked
out of the bottom of the code box.

* FinishedWalk now carries an optional `align_height` that text runs set
  to their line style's height, so every text run on a row receives the
  same centering shift and stays on the baseline. Also fixes sub- and
  superscripts drifting under `RowAlign.Center`.
* The per-style metrics probe now caches descenders too, since we need
  the full line height (ascender + descender) to compute `align_height`.
  
*  Replaces the hardcoded 0.85 `FIXED_FONT_SIZE_SCALE` consts with a
`fixed_font_size_scale` live property on TextFlow (default 0.85), so
apps can tune how much smaller `<code>` text renders than the prose.