### PR TITLE
Windows: overlapped main window

### DIFF
--- a/libs/windows/windows-rs/src/Windows/mod.rs
+++ b/libs/windows/windows-rs/src/Windows/mod.rs
@@ -47174,6 +47174,9 @@ impl IRecordInfo_Vtbl {
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
 impl windows_core::RuntimeName for IRecordInfo {}
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PARAMFLAGS(pub u16);
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -47181,24 +47184,21 @@ pub struct PARAMDESC {
     pub pparamdescex: *mut PARAMDESCEX,
     pub wParamFlags: PARAMFLAGS,
 }
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct PARAMFLAGS(pub u16);
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
 pub struct PARAMDESCEX {
     pub cBytes: u32,
     pub varDefaultValue: super::Variant::VARIANT,
 }
+impl PARAMFLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
 impl Default for PARAMDESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl PARAMFLAGS {
-    pub const fn contains(&self, other: Self) -> bool {
-        self.0 & other.0 == other.0
     }
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
@@ -48857,6 +48857,7 @@ pub const SM_CXICON: SYSTEM_METRICS_INDEX = SYSTEM_METRICS_INDEX(11i32);
 pub const SM_CXSMICON: SYSTEM_METRICS_INDEX = SYSTEM_METRICS_INDEX(49i32);
 pub const SM_CYICON: SYSTEM_METRICS_INDEX = SYSTEM_METRICS_INDEX(12i32);
 pub const SM_CYSMICON: SYSTEM_METRICS_INDEX = SYSTEM_METRICS_INDEX(50i32);
+pub const SWP_FRAMECHANGED: SET_WINDOW_POS_FLAGS = SET_WINDOW_POS_FLAGS(32u32);
 pub const SWP_NOACTIVATE: SET_WINDOW_POS_FLAGS = SET_WINDOW_POS_FLAGS(16u32);
 pub const SWP_NOMOVE: SET_WINDOW_POS_FLAGS = SET_WINDOW_POS_FLAGS(2u32);
 pub const SWP_NOSIZE: SET_WINDOW_POS_FLAGS = SET_WINDOW_POS_FLAGS(1u32);

--- a/libs/windows/windows-rs/src/Windows/mod.rs
+++ b/libs/windows/windows-rs/src/Windows/mod.rs
@@ -29649,17 +29649,30 @@ pub unsafe fn DwmSetWindowAttribute(hwnd: super::super::Foundation::HWND, dwattr
     windows_core::link!("dwmapi.dll" "system" fn DwmSetWindowAttribute(hwnd : super::super::Foundation:: HWND, dwattribute : u32, pvattribute : *const core::ffi::c_void, cbattribute : u32) -> windows_core::HRESULT);
     unsafe { DwmSetWindowAttribute(hwnd, dwattribute.0 as _, pvattribute, cbattribute).ok() }
 }
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct DWMNCRENDERINGPOLICY(pub i32);
+pub const DWMNCRP_ENABLED: DWMNCRENDERINGPOLICY = DWMNCRENDERINGPOLICY(2i32);
 pub const DWMSBT_MAINWINDOW: DWM_SYSTEMBACKDROP_TYPE = DWM_SYSTEMBACKDROP_TYPE(2i32);
 pub const DWMSBT_NONE: DWM_SYSTEMBACKDROP_TYPE = DWM_SYSTEMBACKDROP_TYPE(1i32);
 pub const DWMSBT_TABBEDWINDOW: DWM_SYSTEMBACKDROP_TYPE = DWM_SYSTEMBACKDROP_TYPE(4i32);
 pub const DWMSBT_TRANSIENTWINDOW: DWM_SYSTEMBACKDROP_TYPE = DWM_SYSTEMBACKDROP_TYPE(3i32);
+pub const DWMWA_BORDER_COLOR: DWMWINDOWATTRIBUTE = DWMWINDOWATTRIBUTE(34i32);
+pub const DWMWA_COLOR_NONE: u32 = 4294967294u32;
+pub const DWMWA_NCRENDERING_POLICY: DWMWINDOWATTRIBUTE = DWMWINDOWATTRIBUTE(2i32);
 pub const DWMWA_SYSTEMBACKDROP_TYPE: DWMWINDOWATTRIBUTE = DWMWINDOWATTRIBUTE(38i32);
+pub const DWMWA_WINDOW_CORNER_PREFERENCE: DWMWINDOWATTRIBUTE = DWMWINDOWATTRIBUTE(33i32);
+pub const DWMWCP_ROUND: DWM_WINDOW_CORNER_PREFERENCE = DWM_WINDOW_CORNER_PREFERENCE(2i32);
+pub const DWMWCP_ROUNDSMALL: DWM_WINDOW_CORNER_PREFERENCE = DWM_WINDOW_CORNER_PREFERENCE(3i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DWMWINDOWATTRIBUTE(pub i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DWM_SYSTEMBACKDROP_TYPE(pub i32);
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct DWM_WINDOW_CORNER_PREFERENCE(pub i32);
 }
 pub mod Dxgi{
 #[inline]
@@ -47163,24 +47176,24 @@ impl IRecordInfo_Vtbl {
 impl windows_core::RuntimeName for IRecordInfo {}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
-pub struct PARAMDESCEX {
-    pub cBytes: u32,
-    pub varDefaultValue: super::Variant::VARIANT,
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PARAMDESC {
+    pub pparamdescex: *mut PARAMDESCEX,
+    pub wParamFlags: PARAMFLAGS,
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PARAMFLAGS(pub u16);
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct PARAMDESC {
-    pub pparamdescex: *mut PARAMDESCEX,
-    pub wParamFlags: PARAMFLAGS,
+pub struct PARAMDESCEX {
+    pub cBytes: u32,
+    pub varDefaultValue: super::Variant::VARIANT,
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
-impl Clone for PARAMDESCEX {
-    fn clone(&self) -> Self {
-        unsafe { core::mem::transmute_copy(self) }
+impl Default for PARAMDESC {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
     }
 }
 impl PARAMFLAGS {
@@ -47189,21 +47202,21 @@ impl PARAMFLAGS {
     }
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
-impl Default for PARAMDESC {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
-impl Default for PARAMDESCEX {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
+impl Clone for PARAMDESCEX {
+    fn clone(&self) -> Self {
+        unsafe { core::mem::transmute_copy(self) }
     }
 }
 impl core::ops::BitOr for PARAMFLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
         Self(self.0 | other.0)
+    }
+}
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
+impl Default for PARAMDESCEX {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
     }
 }
 impl core::ops::BitAnd for PARAMFLAGS {
@@ -48353,6 +48366,11 @@ pub struct PSC_STATE(pub i32);
 }
 pub mod WindowsAndMessaging{
 #[inline]
+pub unsafe fn AdjustWindowRectEx(lprect: *mut super::super::Foundation::RECT, dwstyle: WINDOW_STYLE, bmenu: bool, dwexstyle: WINDOW_EX_STYLE) -> windows_core::Result<()> {
+    windows_core::link!("user32.dll" "system" fn AdjustWindowRectEx(lprect : *mut super::super::Foundation:: RECT, dwstyle : WINDOW_STYLE, bmenu : windows_core::BOOL, dwexstyle : WINDOW_EX_STYLE) -> windows_core::BOOL);
+    unsafe { AdjustWindowRectEx(lprect as _, dwstyle, bmenu.into(), dwexstyle).ok() }
+}
+#[inline]
 pub unsafe fn CreateWindowExW<P1, P2>(dwexstyle: WINDOW_EX_STYLE, lpclassname: P1, lpwindowname: P2, dwstyle: WINDOW_STYLE, x: i32, y: i32, nwidth: i32, nheight: i32, hwndparent: Option<super::super::Foundation::HWND>, hmenu: Option<HMENU>, hinstance: Option<super::super::Foundation::HINSTANCE>, lpparam: Option<*const core::ffi::c_void>) -> windows_core::Result<super::super::Foundation::HWND>
 where
     P1: windows_core::Param<windows_core::PCWSTR>,
@@ -48558,6 +48576,7 @@ pub const CW_USEDEFAULT: i32 = -2147483648i32;
 pub struct GDI_IMAGE_TYPE(pub u32);
 pub const GWLP_USERDATA: WINDOW_LONG_PTR_INDEX = WINDOW_LONG_PTR_INDEX(-21i32);
 pub const GWL_EXSTYLE: WINDOW_LONG_PTR_INDEX = WINDOW_LONG_PTR_INDEX(-20i32);
+pub const GWL_STYLE: WINDOW_LONG_PTR_INDEX = WINDOW_LONG_PTR_INDEX(-16i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCURSOR(pub *mut core::ffi::c_void);
@@ -48746,6 +48765,17 @@ pub struct MSG {
     pub time: u32,
     pub pt: super::super::Foundation::POINT,
 }
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct NCCALCSIZE_PARAMS {
+    pub rgrc: [super::super::Foundation::RECT; 3],
+    pub lppos: *mut WINDOWPOS,
+}
+impl Default for NCCALCSIZE_PARAMS {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PEEK_MESSAGE_REMOVE_TYPE(pub u32);
@@ -48885,6 +48915,17 @@ impl core::ops::Not for WINDOWPLACEMENT_FLAGS {
     fn not(self) -> Self {
         Self(self.0.not())
     }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct WINDOWPOS {
+    pub hwnd: super::super::Foundation::HWND,
+    pub hwndInsertAfter: super::super::Foundation::HWND,
+    pub x: i32,
+    pub y: i32,
+    pub cx: i32,
+    pub cy: i32,
+    pub flags: SET_WINDOW_POS_FLAGS,
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -49045,6 +49086,8 @@ impl core::ops::Not for WNDCLASS_STYLES {
     }
 }
 pub type WNDPROC = Option<unsafe extern "system" fn(param0: super::super::Foundation::HWND, param1: u32, param2: super::super::Foundation::WPARAM, param3: super::super::Foundation::LPARAM) -> super::super::Foundation::LRESULT>;
+pub const WS_BORDER: WINDOW_STYLE = WINDOW_STYLE(8388608u32);
+pub const WS_CAPTION: WINDOW_STYLE = WINDOW_STYLE(12582912u32);
 pub const WS_CLIPCHILDREN: WINDOW_STYLE = WINDOW_STYLE(33554432u32);
 pub const WS_CLIPSIBLINGS: WINDOW_STYLE = WINDOW_STYLE(67108864u32);
 pub const WS_EX_ACCEPTFILES: WINDOW_EX_STYLE = WINDOW_EX_STYLE(16u32);
@@ -49053,11 +49096,9 @@ pub const WS_EX_LAYERED: WINDOW_EX_STYLE = WINDOW_EX_STYLE(524288u32);
 pub const WS_EX_TOOLWINDOW: WINDOW_EX_STYLE = WINDOW_EX_STYLE(128u32);
 pub const WS_EX_TOPMOST: WINDOW_EX_STYLE = WINDOW_EX_STYLE(8u32);
 pub const WS_EX_WINDOWEDGE: WINDOW_EX_STYLE = WINDOW_EX_STYLE(256u32);
-pub const WS_MAXIMIZEBOX: WINDOW_STYLE = WINDOW_STYLE(65536u32);
-pub const WS_MINIMIZEBOX: WINDOW_STYLE = WINDOW_STYLE(131072u32);
+pub const WS_OVERLAPPEDWINDOW: WINDOW_STYLE = WINDOW_STYLE(13565952u32);
 pub const WS_POPUP: WINDOW_STYLE = WINDOW_STYLE(2147483648u32);
-pub const WS_SIZEBOX: WINDOW_STYLE = WINDOW_STYLE(262144u32);
-pub const WS_SYSMENU: WINDOW_STYLE = WINDOW_STYLE(524288u32);
+pub const WS_THICKFRAME: WINDOW_STYLE = WINDOW_STYLE(262144u32);
 }
 }
 }

--- a/platform/src/gpu_texture.rs
+++ b/platform/src/gpu_texture.rs
@@ -35,12 +35,17 @@ use std::{
 };
 
 use crate::{
-    texture::{
-        CxTexturePool, Texture, TextureAlloc, TextureCategory, TextureFormat, TextureId,
-        TexturePixel,
-    },
+    texture::{Texture, TextureAlloc, TextureCategory, TextureFormat, TexturePixel},
     Cx,
 };
+
+#[cfg(any(
+    target_os = "windows",
+    all(target_os = "linux", not(any(target_env = "ohos", linux_direct))),
+    target_os = "macos",
+    target_os = "ios",
+))]
+use crate::texture::{CxTexturePool, TextureId};
 
 /// Serializes hard-decode / media GPU work with Makepad present copies on the
 /// shared D3D11 device. Recursive so the same thread may nest lock calls

--- a/platform/src/gpu_texture.rs
+++ b/platform/src/gpu_texture.rs
@@ -309,6 +309,7 @@ impl Drop for MetalNv12PresentCache {
 #[cfg(target_os = "windows")]
 mod windows_api {
     use super::*;
+    use crate::os::windows::d3d11_texture;
     use windows::{
         core::Interface,
         Win32::Graphics::{
@@ -424,11 +425,15 @@ mod windows_api {
                         .map_err(|e| format!("adopt_d3d11_bgra: cast to resource failed: {e}"))?;
                     let mut out: Option<ID3D11ShaderResourceView> = None;
                     unsafe {
-                        device
-                            .CreateShaderResourceView(&resource, None, Some(&mut out))
-                            .map_err(|e| {
-                                format!("adopt_d3d11_bgra: CreateShaderResourceView failed: {e:?}")
-                            })?;
+                        d3d11_texture::create_shader_resource_view(
+                            &device,
+                            &resource,
+                            None,
+                            Some(&mut out),
+                        )
+                        .map_err(|e| {
+                            format!("adopt_d3d11_bgra: CreateShaderResourceView failed: {e:?}")
+                        })?;
                     }
                     out.ok_or_else(|| {
                         "adopt_d3d11_bgra: CreateShaderResourceView returned null".to_string()
@@ -508,7 +513,7 @@ mod windows_api {
     ) -> Result<ID3D11ShaderResourceView, String> {
         let mut tex_desc = D3D11_TEXTURE2D_DESC::default();
         unsafe {
-            texture.GetDesc(&mut tex_desc);
+            d3d11_texture::texture2d_get_desc(texture, &mut tex_desc);
         }
         if tex_desc.Format != DXGI_FORMAT_NV12 {
             return Err(format!(
@@ -546,9 +551,13 @@ mod windows_api {
 
         let mut out: Option<ID3D11ShaderResourceView> = None;
         unsafe {
-            device
-                .CreateShaderResourceView(&resource, Some(&desc), Some(&mut out))
-                .map_err(|e| format!("NV12 plane SRV: CreateShaderResourceView failed: {e:?}"))?;
+            d3d11_texture::create_shader_resource_view(
+                device,
+                &resource,
+                Some(&desc),
+                Some(&mut out),
+            )
+            .map_err(|e| format!("NV12 plane SRV: CreateShaderResourceView failed: {e:?}"))?;
         }
         out.ok_or_else(|| "NV12 plane SRV: null".into())
     }
@@ -563,7 +572,7 @@ mod windows_api {
     ) -> Result<ID3D11ShaderResourceView, String> {
         let mut tex_desc = D3D11_TEXTURE2D_DESC::default();
         unsafe {
-            texture.GetDesc(&mut tex_desc);
+            d3d11_texture::texture2d_get_desc(texture, &mut tex_desc);
         }
         if tex_desc.Format != DXGI_FORMAT_NV12 {
             return Err(format!(
@@ -603,11 +612,13 @@ mod windows_api {
 
         let mut out: Option<ID3D11ShaderResourceView> = None;
         unsafe {
-            device
-                .CreateShaderResourceView(&resource, Some(&desc), Some(&mut out))
-                .map_err(|e| {
-                    format!("NV12 array SRV: CreateShaderResourceView failed: {e:?}")
-                })?;
+            d3d11_texture::create_shader_resource_view(
+                device,
+                &resource,
+                Some(&desc),
+                Some(&mut out),
+            )
+            .map_err(|e| format!("NV12 array SRV: CreateShaderResourceView failed: {e:?}"))?;
         }
         out.ok_or_else(|| "NV12 array SRV: null".into())
     }
@@ -645,8 +656,7 @@ mod windows_api {
             };
             let mut tex: Option<ID3D11Texture2D> = None;
             unsafe {
-                device
-                    .CreateTexture2D(&desc, None, Some(&mut tex))
+                d3d11_texture::create_texture_2d(device, &desc, None, Some(&mut tex))
                     .map_err(|e| format!("NV12 present: CreateTexture2D failed: {e:?}"))?;
             }
             *slot = Some(tex.ok_or_else(|| "NV12 present: null texture".to_string())?);
@@ -668,7 +678,7 @@ mod windows_api {
     ) -> Result<(ID3D11Texture2D, ID3D11Texture2D), String> {
         let mut src_desc = D3D11_TEXTURE2D_DESC::default();
         unsafe {
-            src.GetDesc(&mut src_desc);
+            d3d11_texture::texture2d_get_desc(src, &mut src_desc);
         }
         if src_desc.Format != DXGI_FORMAT_NV12 {
             return Err(format!(
@@ -702,7 +712,7 @@ mod windows_api {
         let y_tex = ensure_nv12_present_tex(device, &mut present.y_slots[write], copy_w, copy_h)?;
         let uv_tex = ensure_nv12_present_tex(device, &mut present.uv_slots[write], copy_w, copy_h)?;
 
-        let context = unsafe { device.GetImmediateContext() }
+        let context = unsafe { d3d11_texture::device_get_immediate_context(device) }
             .map_err(|e| format!("NV12 present: GetImmediateContext failed: {e:?}"))?;
 
         let src_res: ID3D11Resource = src
@@ -726,7 +736,8 @@ mod windows_api {
         let src_sub = array_slice;
         // Hold the shared media lock so present copies do not race decoder GPU work.
         with_media_d3d11_lock(|| unsafe {
-            context.CopySubresourceRegion(
+            d3d11_texture::copy_subresource_region(
+                &context,
                 &y_res,
                 0,
                 0,
@@ -736,7 +747,8 @@ mod windows_api {
                 src_sub,
                 Some(&src_box as *const _),
             );
-            context.CopySubresourceRegion(
+            d3d11_texture::copy_subresource_region(
+                &context,
                 &uv_res,
                 0,
                 0,
@@ -872,7 +884,7 @@ mod windows_api {
     ) -> Result<(), String> {
         let mut desc = D3D11_TEXTURE2D_DESC::default();
         unsafe {
-            texture.GetDesc(&mut desc);
+            d3d11_texture::texture2d_get_desc(texture, &mut desc);
         }
         if desc.Format != DXGI_FORMAT_NV12 {
             return Err(format!(

--- a/platform/src/os/linux/mod.rs
+++ b/platform/src/os/linux/mod.rs
@@ -28,6 +28,7 @@ pub mod egl_sys;
 #[macro_use]
 pub mod gl_sys;
 pub(crate) mod gl_video_upload;
+#[cfg(not(any(target_env = "ohos", target_os = "android")))]
 pub(crate) mod va_dmabuf_modifier;
 pub mod libc_sys;
 pub mod module_loader;

--- a/platform/src/os/linux/openxr.rs
+++ b/platform/src/os/linux/openxr.rs
@@ -171,11 +171,14 @@ impl Cx {
     pub(crate) fn openxr_handle_repaint(
         &mut self,
         frame: &CxOpenXrFrame,
+        #[cfg_attr(not(use_vulkan), allow(unused_variables))]
         xr_cpu: &mut XrFrameCpuBreakdown,
     ) {
         //opengl_cx.make_current();
         let mut passes_todo = Vec::new();
+        #[cfg(use_vulkan)]
         let mut xr_render_cpu_ms = 0.0f64;
+        #[cfg(use_vulkan)]
         let mut saw_xr_vulkan_pass = false;
         self.compute_pass_repaint_order(&mut passes_todo);
         self.repaint_id += 1;
@@ -240,7 +243,14 @@ impl Cx {
                 }
             }
         }
-        self.os.xr_render_cpu_time_ms = saw_xr_vulkan_pass.then_some(xr_render_cpu_ms);
+        #[cfg(use_vulkan)]
+        {
+            self.os.xr_render_cpu_time_ms = saw_xr_vulkan_pass.then_some(xr_render_cpu_ms);
+        }
+        #[cfg(not(use_vulkan))]
+        {
+            self.os.xr_render_cpu_time_ms = None;
+        }
     }
 
     pub(crate) fn openxr_handle_drawing(&mut self) {

--- a/platform/src/os/windows/d3d11_texture.rs
+++ b/platform/src/os/windows/d3d11_texture.rs
@@ -1,0 +1,64 @@
+//! Thin D3D11 texture helpers for cross-platform GPU texture code.
+//!
+//! COM method call sites live here so `windows_strip` (which scans
+//! `os/windows/*.rs`) keeps the corresponding vendored methods.
+
+use windows::{
+    core::Result as WinResult,
+    Win32::Graphics::Direct3D11::{
+        ID3D11Device, ID3D11DeviceContext, ID3D11Resource, ID3D11ShaderResourceView,
+        ID3D11Texture2D, D3D11_BOX, D3D11_SHADER_RESOURCE_VIEW_DESC, D3D11_SUBRESOURCE_DATA,
+        D3D11_TEXTURE2D_DESC,
+    },
+};
+
+pub unsafe fn texture2d_get_desc(texture: &ID3D11Texture2D, out: &mut D3D11_TEXTURE2D_DESC) {
+    texture.GetDesc(out);
+}
+
+pub unsafe fn copy_subresource_region(
+    context: &ID3D11DeviceContext,
+    dst: &ID3D11Resource,
+    dst_subresource: u32,
+    dst_x: u32,
+    dst_y: u32,
+    dst_z: u32,
+    src: &ID3D11Resource,
+    src_subresource: u32,
+    src_box: Option<*const D3D11_BOX>,
+) {
+    context.CopySubresourceRegion(
+        dst,
+        dst_subresource,
+        dst_x,
+        dst_y,
+        dst_z,
+        src,
+        src_subresource,
+        src_box,
+    );
+}
+
+pub unsafe fn create_texture_2d(
+    device: &ID3D11Device,
+    desc: &D3D11_TEXTURE2D_DESC,
+    initial_data: Option<*const D3D11_SUBRESOURCE_DATA>,
+    texture_out: Option<*mut Option<ID3D11Texture2D>>,
+) -> WinResult<()> {
+    device.CreateTexture2D(desc, initial_data, texture_out)
+}
+
+pub unsafe fn create_shader_resource_view(
+    device: &ID3D11Device,
+    resource: &ID3D11Resource,
+    desc: Option<*const D3D11_SHADER_RESOURCE_VIEW_DESC>,
+    srv_out: Option<*mut Option<ID3D11ShaderResourceView>>,
+) -> WinResult<()> {
+    device.CreateShaderResourceView(resource, desc, srv_out)
+}
+
+pub unsafe fn device_get_immediate_context(
+    device: &ID3D11Device,
+) -> WinResult<ID3D11DeviceContext> {
+    device.GetImmediateContext()
+}

--- a/platform/src/os/windows/mod.rs
+++ b/platform/src/os/windows/mod.rs
@@ -20,6 +20,7 @@ pub mod winrt_midi;
 //pub mod com_sys;
 pub mod angle;
 pub mod d3d11;
+pub mod d3d11_texture;
 pub mod windows;
 pub mod windows_game_input;
 pub mod windows_stdin;

--- a/platform/src/os/windows/win32_app.rs
+++ b/platform/src/os/windows/win32_app.rs
@@ -255,6 +255,7 @@ impl Win32App {
             hInstance: unsafe { GetModuleHandleW(None).unwrap().into() },
             hIcon: hicon_big,
             hIconSm: hicon_small,
+            hCursor: unsafe { LoadCursorW(None, IDC_ARROW).unwrap_or_default() },
             lpszClassName: PCWSTR(window_class_name.as_ptr()),
             hbrBackground: unsafe { CreateSolidBrush(COLORREF(0x3f3f3f3f)) },
             ..Default::default()
@@ -758,6 +759,13 @@ type SetProcessDpiAwareness = unsafe extern "system" fn(value: PROCESS_DPI_AWARE
 type SetProcessDpiAwarenessContext =
     unsafe extern "system" fn(value: DPI_AWARENESS_CONTEXT) -> BOOL;
 type GetDpiForWindow = unsafe extern "system" fn(hwnd: HWND) -> u32;
+type AdjustWindowRectExForDpi = unsafe extern "system" fn(
+    lp_rect: *mut crate::windows::Win32::Foundation::RECT,
+    dw_style: u32,
+    b_menu: BOOL,
+    dw_ex_style: u32,
+    dpi: u32,
+) -> BOOL;
 type GetDpiForMonitor = unsafe extern "system" fn(
     hmonitor: HMONITOR,
     dpi_type: MONITOR_DPI_TYPE,
@@ -812,6 +820,7 @@ pub fn post_signal_to_hwnd(hwnd:HWND, signal:Signal){
 */
 pub struct DpiFunctions {
     get_dpi_for_window: Option<GetDpiForWindow>,
+    adjust_window_rect_ex_for_dpi: Option<AdjustWindowRectExForDpi>,
     get_dpi_for_monitor: Option<GetDpiForMonitor>,
     enable_nonclient_dpi_scaling: Option<EnableNonClientDpiScaling>,
     set_process_dpi_awareness_context: Option<SetProcessDpiAwarenessContext>,
@@ -825,6 +834,7 @@ impl DpiFunctions {
     fn new() -> DpiFunctions {
         DpiFunctions {
             get_dpi_for_window: get_function!("user32.dll", GetDpiForWindow),
+            adjust_window_rect_ex_for_dpi: get_function!("user32.dll", AdjustWindowRectExForDpi),
             get_dpi_for_monitor: get_function!("shcore.dll", GetDpiForMonitor),
             enable_nonclient_dpi_scaling: get_function!("user32.dll", EnableNonClientDpiScaling),
             set_process_dpi_awareness_context: get_function!(
@@ -864,6 +874,36 @@ impl DpiFunctions {
             if let Some(enable_nonclient_dpi_scaling) = self.enable_nonclient_dpi_scaling {
                 let _ = enable_nonclient_dpi_scaling(hwnd);
             }
+        }
+    }
+
+    /// DPI-aware frame insets for a zero client rect when available (Win10 1607+).
+    /// Falls back to `AdjustWindowRectEx` on older systems.
+    pub fn adjust_window_rect_ex(
+        &self,
+        hwnd: HWND,
+        style: u32,
+        ex_style: u32,
+        rect: &mut crate::windows::Win32::Foundation::RECT,
+    ) {
+        unsafe {
+            if let (Some(adjust), Some(get_dpi)) = (
+                self.adjust_window_rect_ex_for_dpi,
+                self.get_dpi_for_window,
+            ) {
+                let dpi = match get_dpi(hwnd) {
+                    0 => BASE_DPI,
+                    d => d,
+                };
+                let _ = adjust(rect, style, FALSE, ex_style, dpi);
+                return;
+            }
+            let _ = crate::windows::Win32::UI::WindowsAndMessaging::AdjustWindowRectEx(
+                rect,
+                crate::windows::Win32::UI::WindowsAndMessaging::WINDOW_STYLE(style),
+                false,
+                crate::windows::Win32::UI::WindowsAndMessaging::WINDOW_EX_STYLE(ex_style),
+            );
         }
     }
 

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -23,9 +23,11 @@ use {
                 },
                 Graphics::{
                     Dwm::{
-                        DwmExtendFrameIntoClientArea, DwmSetWindowAttribute, DWMSBT_MAINWINDOW,
-                        DWMSBT_NONE, DWMSBT_TABBEDWINDOW, DWMSBT_TRANSIENTWINDOW,
-                        DWMWA_SYSTEMBACKDROP_TYPE,
+                        DwmExtendFrameIntoClientArea, DwmSetWindowAttribute, DWMNCRP_ENABLED,
+                        DWMSBT_MAINWINDOW, DWMSBT_NONE, DWMSBT_TABBEDWINDOW,
+                        DWMSBT_TRANSIENTWINDOW, DWMWA_BORDER_COLOR, DWMWA_COLOR_NONE,
+                        DWMWA_NCRENDERING_POLICY, DWMWA_SYSTEMBACKDROP_TYPE,
+                        DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_ROUND, DWMWCP_ROUNDSMALL,
                     },
                     Gdi::ScreenToClient,
                 },
@@ -72,24 +74,25 @@ use {
                         },
                     },
                     WindowsAndMessaging::{
-                        CreateWindowExW, DefWindowProcW, DestroyWindow, GetClientRect,
-                        GetWindowLongPtrW, GetWindowPlacement, GetWindowRect, MoveWindow,
-                        PostMessageW, SetLayeredWindowAttributes, SetWindowLongPtrW, SetWindowPos,
-                        ShowWindow, CW_USEDEFAULT, GWLP_USERDATA, GWL_EXSTYLE, HTBOTTOM,
-                        HTBOTTOMLEFT, HTBOTTOMRIGHT, HTCAPTION, HTCLIENT, HTLEFT, HTRIGHT,
-                        HTSYSMENU, HTTOP, HTTOPLEFT, HTTOPRIGHT, HWND_NOTOPMOST, HWND_TOPMOST,
-                        LWA_ALPHA, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER,
-                        SW_MAXIMIZE, SW_MINIMIZE, SW_RESTORE,
-                        SW_SHOW, WA_ACTIVE, WINDOWPLACEMENT, WM_ACTIVATE, WM_CHAR, WM_CLOSE,
-                        WM_DESTROY, WM_DPICHANGED, WM_ENTERSIZEMOVE, WM_ERASEBKGND,
-                        WM_EXITSIZEMOVE, WM_IME_COMPOSITION, WM_IME_ENDCOMPOSITION,
-                        WM_IME_STARTCOMPOSITION, WM_KEYDOWN, WM_KEYUP,
-                        WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEMOVE,
-                        WM_MOUSEWHEEL, WM_NCCALCSIZE, WM_NCHITTEST, WM_RBUTTONDOWN, WM_RBUTTONUP,
-                        WM_SIZE, WM_SYSKEYDOWN, WM_SYSKEYUP, WM_XBUTTONDOWN, WM_XBUTTONUP,
-                        WS_CLIPCHILDREN, WS_CLIPSIBLINGS, WS_EX_ACCEPTFILES, WS_EX_APPWINDOW,
-                        WS_EX_LAYERED, WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_EX_WINDOWEDGE,
-                        WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_POPUP, WS_SIZEBOX, WS_SYSMENU,
+                        AdjustWindowRectEx, CreateWindowExW, DefWindowProcW, DestroyWindow,
+                        GetClientRect, GetWindowLongPtrW, GetWindowPlacement, GetWindowRect,
+                        MoveWindow, PostMessageW, SetLayeredWindowAttributes, SetWindowLongPtrW,
+                        SetWindowPos, ShowWindow, CW_USEDEFAULT, GWLP_USERDATA, GWL_EXSTYLE,
+                        GWL_STYLE, HTBOTTOM, HTBOTTOMLEFT, HTBOTTOMRIGHT, HTCAPTION, HTCLIENT,
+                        HTLEFT, HTRIGHT, HTSYSMENU, HTTOP, HTTOPLEFT, HTTOPRIGHT, HWND_NOTOPMOST,
+                        HWND_TOPMOST, LWA_ALPHA, NCCALCSIZE_PARAMS, SWP_NOACTIVATE, SWP_NOMOVE,
+                        SWP_NOSIZE, SWP_NOZORDER, SW_MAXIMIZE, SW_MINIMIZE, SW_RESTORE, SW_SHOW,
+                        WA_ACTIVE, WINDOWPLACEMENT, WM_ACTIVATE, WM_CHAR, WM_CLOSE, WM_DESTROY,
+                        WM_DPICHANGED, WM_ENTERSIZEMOVE, WM_ERASEBKGND, WM_EXITSIZEMOVE,
+                        WM_IME_COMPOSITION, WM_IME_ENDCOMPOSITION, WM_IME_STARTCOMPOSITION,
+                        WM_KEYDOWN, WM_KEYUP, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN,
+                        WM_MBUTTONUP, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_NCCALCSIZE, WM_NCHITTEST,
+                        WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SIZE, WM_SYSKEYDOWN, WM_SYSKEYUP,
+                        WM_XBUTTONDOWN, WM_XBUTTONUP, WS_BORDER, WS_CAPTION, WS_CLIPCHILDREN,
+                        WS_CLIPSIBLINGS, WS_EX_ACCEPTFILES, WS_EX_APPWINDOW, WS_EX_LAYERED,
+                        WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_EX_WINDOWEDGE,
+                        WS_OVERLAPPEDWINDOW, WS_POPUP, WS_THICKFRAME, WINDOW_EX_STYLE,
+                        WINDOW_STYLE,
                     },
                 },
             },
@@ -210,6 +213,143 @@ pub struct Win32Window {
 }
 
 impl Win32Window {
+    /// Opt into Win11 rounded corners for overlapped custom-chrome windows.
+    /// No-ops on older Windows (DwmSetWindowAttribute returns an error).
+    fn apply_win11_window_shape(hwnd: HWND, small_radius: bool) {
+        let preference = if small_radius {
+            DWMWCP_ROUNDSMALL
+        } else {
+            DWMWCP_ROUND
+        };
+        unsafe {
+            let _ = DwmSetWindowAttribute(
+                hwnd,
+                DWMWA_WINDOW_CORNER_PREFERENCE,
+                &preference as *const _ as *const c_void,
+                std::mem::size_of_val(&preference) as u32,
+            );
+            let border = DWMWA_COLOR_NONE;
+            let _ = DwmSetWindowAttribute(
+                hwnd,
+                DWMWA_BORDER_COLOR,
+                &border as *const _ as *const c_void,
+                std::mem::size_of_val(&border) as u32,
+            );
+        }
+    }
+
+    fn set_nc_rendering_enabled(hwnd: HWND) {
+        let policy = DWMNCRP_ENABLED;
+        unsafe {
+            let _ = DwmSetWindowAttribute(
+                hwnd,
+                DWMWA_NCRENDERING_POLICY,
+                &policy as *const _ as *const c_void,
+                std::mem::size_of_val(&policy) as u32,
+            );
+        }
+    }
+
+    fn get_style(&self) -> WINDOW_STYLE {
+        unsafe { WINDOW_STYLE(GetWindowLongPtrW(self.hwnd, GWL_STYLE) as u32) }
+    }
+
+    fn get_ex_style(&self) -> WINDOW_EX_STYLE {
+        unsafe { WINDOW_EX_STYLE(GetWindowLongPtrW(self.hwnd, GWL_EXSTYLE) as u32) }
+    }
+
+    /// Frame insets via `AdjustWindowRectEx` on a zero client rect.
+    /// `left`/`top` are negative; `right`/`bottom` are positive.
+    fn frame_border_thickness(style: WINDOW_STYLE, ex_style: WINDOW_EX_STYLE) -> RECT {
+        let mut thickness = RECT {
+            left: 0,
+            top: 0,
+            right: 0,
+            bottom: 0,
+        };
+        unsafe {
+            let _ = AdjustWindowRectEx(&mut thickness, style, false, ex_style);
+        }
+        thickness
+    }
+
+    /// Expand the client into the caption while keeping resize borders outside
+    /// the client. Mutates `NCCALCSIZE_PARAMS.rgrc[0]`.
+    unsafe fn apply_extended_client_nccalcsize(&self, lparam: LPARAM) {
+        let params = &mut *(lparam.0 as *mut NCCALCSIZE_PARAMS);
+        let rect = &mut params.rgrc[0];
+
+        let style = self.get_style();
+        let ex_style = self.get_ex_style();
+        let maximized = self.get_is_maximized();
+
+        let border = if (style.0 & WS_CAPTION.0) == WS_CAPTION.0 {
+            if maximized {
+                // Caption is drawn into the client; keep only border+thickframe for work-area.
+                Self::frame_border_thickness(
+                    WINDOW_STYLE((style.0 & !WS_CAPTION.0) | WS_BORDER.0 | WS_THICKFRAME.0),
+                    ex_style,
+                )
+            } else {
+                let mut b = Self::frame_border_thickness(style, ex_style);
+                // Caption already includes the top border — extend client into it.
+                b.top = 0;
+                b
+            }
+        } else if (style.0 & WS_BORDER.0) != 0 {
+            Self::frame_border_thickness(style, ex_style)
+        } else {
+            Self::frame_border_thickness(style, ex_style)
+        };
+
+        // `rgrc[0]` arrives as the proposed *window* rect. `AdjustWindowRectEx` on a
+        // zero client yields negative left/top; subtracting those insets converts
+        // window → client while leaving thickframe resize borders outside.
+        rect.left -= border.left;
+        rect.top -= border.top;
+        rect.right -= border.right;
+        rect.bottom -= border.bottom;
+    }
+
+    fn extend_frame_for_custom_chrome(&self) {
+        // Opaque custom chrome: zero margins (no 1px glass hairline). DWM still
+        // paints NC shadows/corners because NCRP is ENABLED.
+        let margins = MARGINS {
+            cxLeftWidth: 0,
+            cxRightWidth: 0,
+            cyTopHeight: 0,
+            cyBottomHeight: 0,
+        };
+        unsafe {
+            let _ = DwmExtendFrameIntoClientArea(self.hwnd, &margins);
+        }
+        Self::set_nc_rendering_enabled(self.hwnd);
+        Self::apply_win11_window_shape(self.hwnd, self.is_popup);
+    }
+
+    /// Physical-pixel frame insets (left, top, right, bottom) for converting
+    /// window rect <-> client size under extended-client chrome.
+    fn client_frame_insets_px(&self) -> (i32, i32, i32, i32) {
+        let style = self.get_style();
+        let ex_style = self.get_ex_style();
+        let maximized = self.get_is_maximized();
+        let border = if (style.0 & WS_CAPTION.0) == WS_CAPTION.0 {
+            if maximized {
+                Self::frame_border_thickness(
+                    WINDOW_STYLE((style.0 & !WS_CAPTION.0) | WS_BORDER.0 | WS_THICKFRAME.0),
+                    ex_style,
+                )
+            } else {
+                let mut b = Self::frame_border_thickness(style, ex_style);
+                b.top = 0;
+                b
+            }
+        } else {
+            Self::frame_border_thickness(style, ex_style)
+        };
+        (-border.left, -border.top, border.right, border.bottom)
+    }
+
     // 2-stage initialization (new and init) to connect GWLP_USERDATA
 
     // create window structure and register drag/drop
@@ -221,13 +361,9 @@ impl Win32Window {
     ) -> Win32Window {
         let title = encode_wide(title);
 
-        let style = WS_SIZEBOX
-            | WS_MAXIMIZEBOX
-            | WS_MINIMIZEBOX
-            | WS_POPUP
-            | WS_CLIPSIBLINGS
-            | WS_CLIPCHILDREN
-            | WS_SYSMENU;
+        // Overlapped top-level window. Client is extended into the caption via
+        // WM_NCCALCSIZE; chrome stays app-drawn.
+        let style = WS_OVERLAPPEDWINDOW | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
 
         let style_ex = WS_EX_WINDOWEDGE | WS_EX_APPWINDOW | WS_EX_ACCEPTFILES;
 
@@ -254,6 +390,8 @@ impl Win32Window {
             )
             .unwrap()
         };
+        Self::apply_win11_window_shape(hwnd, false);
+        Self::set_nc_rendering_enabled(hwnd);
 
         // create DropTarget object that accesses the same data object, convert to COM and give to Microsoft
         let drop_target: IDropTarget = DropTarget {
@@ -314,6 +452,7 @@ impl Win32Window {
             )
             .unwrap()
         };
+        Self::apply_win11_window_shape(hwnd, true);
 
         Win32Window {
             window_id,
@@ -337,13 +476,14 @@ impl Win32Window {
         }
     }
 
-    // initialize GWLP_USERDATA and registration of global stuff, and set outer size
+    // initialize GWLP_USERDATA and registration of global stuff, and set inner size
     pub fn init(&mut self, size: Vec2d) {
         unsafe { SetWindowLongPtrW(self.hwnd, GWLP_USERDATA, self as *const _ as isize) };
 
         with_win32_app(|app| app.dpi_functions.enable_non_client_dpi_scaling(self.hwnd));
         with_win32_app(|app| app.all_windows.push(self.hwnd));
-        self.set_outer_size(size);
+        // `size` is the desired client (inner) size from CreateWindow.
+        self.set_inner_size(size);
         if self.is_fullscreen {
             self.maximize();
         }
@@ -412,18 +552,17 @@ impl Win32Window {
                 }
             }
             WM_NCCALCSIZE => {
-                // check if we are maximised
-                if window.get_is_maximized() {
-                    return DefWindowProcW(hwnd, msg, wparam, lparam);
-                }
                 if wparam == WPARAM(1) {
-                    let margins = MARGINS {
-                        cxLeftWidth: 0,
-                        cxRightWidth: 0,
-                        cyTopHeight: 0,
-                        cyBottomHeight: 1,
-                    };
-                    DwmExtendFrameIntoClientArea(hwnd, &margins).unwrap();
+                    if window.is_popup {
+                        // Popups stay fully client-sized.
+                        return LRESULT(0);
+                    }
+                    // Extend client into caption; keep thickframe resize borders
+                    // outside the client rect.
+                    unsafe {
+                        window.apply_extended_client_nccalcsize(lparam);
+                    }
+                    window.extend_frame_for_custom_chrome();
                     return LRESULT(0);
                 }
             }
@@ -1093,11 +1232,7 @@ impl Win32Window {
         const BUTTON_H: f64 = 29.0;
         const BUTTON_COUNT: f64 = 3.0;
         const BUTTONS_W: f64 = BUTTON_W * BUTTON_COUNT;
-        let inner_size = if self.get_is_maximized() {
-            self.get_outer_size()
-        } else {
-            self.get_inner_size()
-        };
+        let inner_size = self.get_inner_size();
         WindowGeom {
             xr_is_presenting: false,
             can_fullscreen: false,
@@ -1280,6 +1415,13 @@ impl Win32Window {
             DwmExtendFrameIntoClientArea(self.hwnd, &margins).unwrap();
         }
 
+        if !self.is_popup {
+            Self::set_nc_rendering_enabled(self.hwnd);
+            Self::apply_win11_window_shape(self.hwnd, false);
+        } else {
+            Self::apply_win11_window_shape(self.hwnd, true);
+        }
+
         let hr = unsafe {
             DwmSetWindowAttribute(
                 self.hwnd,
@@ -1392,15 +1534,19 @@ impl Win32Window {
     /// the empty-edge gap that appears when growing the window.
     pub fn send_sizing_event(&mut self, proposed_rect: &RECT) {
         let dpi = self.get_dpi_factor();
-        let proposed_size = Vec2d {
+        let outer_size = Vec2d {
             x: (proposed_rect.right - proposed_rect.left) as f64 / dpi,
             y: (proposed_rect.bottom - proposed_rect.top) as f64 / dpi,
         };
+        let (l, t, r, b) = self.client_frame_insets_px();
+        let inner_size = Vec2d {
+            x: ((proposed_rect.right - proposed_rect.left) - l - r).max(0) as f64 / dpi,
+            y: ((proposed_rect.bottom - proposed_rect.top) - t - b).max(0) as f64 / dpi,
+        };
 
         let mut new_geom = self.last_window_geom.clone();
-        // For custom chrome, inner size == outer size.
-        new_geom.inner_size = proposed_size;
-        new_geom.outer_size = proposed_size;
+        new_geom.inner_size = inner_size;
+        new_geom.outer_size = outer_size;
         new_geom.position = Vec2d {
             x: proposed_rect.left as f64,
             y: proposed_rect.top as f64,
@@ -1411,7 +1557,7 @@ impl Win32Window {
             return; // Size didn't change (e.g. just a move), nothing to pre-render.
         }
         // Skip degenerate sizes — ResizeBuffers rejects zero dimensions.
-        if proposed_size.x < 1.0 || proposed_size.y < 1.0 {
+        if inner_size.x < 1.0 || inner_size.y < 1.0 {
             return;
         }
         self.last_window_geom = new_geom.clone();

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -74,25 +74,24 @@ use {
                         },
                     },
                     WindowsAndMessaging::{
-                        AdjustWindowRectEx, CreateWindowExW, DefWindowProcW, DestroyWindow,
-                        GetClientRect, GetWindowLongPtrW, GetWindowPlacement, GetWindowRect,
-                        MoveWindow, PostMessageW, SetLayeredWindowAttributes, SetWindowLongPtrW,
-                        SetWindowPos, ShowWindow, CW_USEDEFAULT, GWLP_USERDATA, GWL_EXSTYLE,
-                        GWL_STYLE, HTBOTTOM, HTBOTTOMLEFT, HTBOTTOMRIGHT, HTCAPTION, HTCLIENT,
-                        HTLEFT, HTRIGHT, HTSYSMENU, HTTOP, HTTOPLEFT, HTTOPRIGHT, HWND_NOTOPMOST,
-                        HWND_TOPMOST, LWA_ALPHA, NCCALCSIZE_PARAMS, SWP_NOACTIVATE, SWP_NOMOVE,
+                        CreateWindowExW, DefWindowProcW, DestroyWindow, GetClientRect,
+                        GetWindowLongPtrW, GetWindowRect, MoveWindow, PostMessageW,
+                        SetLayeredWindowAttributes, SetWindowLongPtrW, SetWindowPos, ShowWindow,
+                        CW_USEDEFAULT, GWLP_USERDATA, GWL_EXSTYLE, GWL_STYLE, HTBOTTOM,
+                        HTBOTTOMLEFT, HTBOTTOMRIGHT, HTCAPTION, HTCLIENT, HTLEFT, HTRIGHT,
+                        HTSYSMENU, HTTOP, HTTOPLEFT, HTTOPRIGHT, HWND_NOTOPMOST, HWND_TOPMOST,
+                        LWA_ALPHA, NCCALCSIZE_PARAMS, SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOMOVE,
                         SWP_NOSIZE, SWP_NOZORDER, SW_MAXIMIZE, SW_MINIMIZE, SW_RESTORE, SW_SHOW,
-                        WA_ACTIVE, WINDOWPLACEMENT, WM_ACTIVATE, WM_CHAR, WM_CLOSE, WM_DESTROY,
-                        WM_DPICHANGED, WM_ENTERSIZEMOVE, WM_ERASEBKGND, WM_EXITSIZEMOVE,
-                        WM_IME_COMPOSITION, WM_IME_ENDCOMPOSITION, WM_IME_STARTCOMPOSITION,
-                        WM_KEYDOWN, WM_KEYUP, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN,
-                        WM_MBUTTONUP, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_NCCALCSIZE, WM_NCHITTEST,
-                        WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SIZE, WM_SYSKEYDOWN, WM_SYSKEYUP,
-                        WM_XBUTTONDOWN, WM_XBUTTONUP, WS_BORDER, WS_CAPTION, WS_CLIPCHILDREN,
-                        WS_CLIPSIBLINGS, WS_EX_ACCEPTFILES, WS_EX_APPWINDOW, WS_EX_LAYERED,
-                        WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_EX_WINDOWEDGE,
-                        WS_OVERLAPPEDWINDOW, WS_POPUP, WS_THICKFRAME, WINDOW_EX_STYLE,
-                        WINDOW_STYLE,
+                        WA_ACTIVE, WM_ACTIVATE, WM_CHAR, WM_CLOSE, WM_DESTROY, WM_DPICHANGED,
+                        WM_ENTERSIZEMOVE, WM_ERASEBKGND, WM_EXITSIZEMOVE, WM_IME_COMPOSITION,
+                        WM_IME_ENDCOMPOSITION, WM_IME_STARTCOMPOSITION, WM_KEYDOWN, WM_KEYUP,
+                        WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEMOVE,
+                        WM_MOUSEWHEEL, WM_NCCALCSIZE, WM_NCHITTEST, WM_RBUTTONDOWN, WM_RBUTTONUP,
+                        WM_SIZE, WM_SYSKEYDOWN, WM_SYSKEYUP, WM_XBUTTONDOWN, WM_XBUTTONUP,
+                        WS_BORDER, WS_CAPTION, WS_CLIPCHILDREN, WS_CLIPSIBLINGS, WS_EX_ACCEPTFILES,
+                        WS_EX_APPWINDOW, WS_EX_LAYERED, WS_EX_TOOLWINDOW, WS_EX_TOPMOST,
+                        WS_EX_WINDOWEDGE, WS_OVERLAPPEDWINDOW, WS_POPUP, WS_THICKFRAME,
+                        WINDOW_EX_STYLE, WINDOW_STYLE,
                     },
                 },
             },
@@ -258,53 +257,62 @@ impl Win32Window {
         unsafe { WINDOW_EX_STYLE(GetWindowLongPtrW(self.hwnd, GWL_EXSTYLE) as u32) }
     }
 
-    /// Frame insets via `AdjustWindowRectEx` on a zero client rect.
+    /// Frame insets via DPI-aware `AdjustWindowRectEx*` on a zero client rect.
     /// `left`/`top` are negative; `right`/`bottom` are positive.
-    fn frame_border_thickness(style: WINDOW_STYLE, ex_style: WINDOW_EX_STYLE) -> RECT {
+    fn frame_border_thickness(&self, style: WINDOW_STYLE, ex_style: WINDOW_EX_STYLE) -> RECT {
         let mut thickness = RECT {
             left: 0,
             top: 0,
             right: 0,
             bottom: 0,
         };
-        unsafe {
-            let _ = AdjustWindowRectEx(&mut thickness, style, false, ex_style);
-        }
+        with_win32_app(|app| {
+            app.dpi_functions.adjust_window_rect_ex(
+                self.hwnd,
+                style.0,
+                ex_style.0,
+                &mut thickness,
+            );
+        });
         thickness
     }
 
-    /// Expand the client into the caption while keeping resize borders outside
-    /// the client. Mutates `NCCALCSIZE_PARAMS.rgrc[0]`.
+    /// Non-client insets for custom chrome.
+    ///
+    /// Restored (non-maximized) mains use a **fully client-sized** frame: no
+    /// thickframe strip outside the swap chain. That strip was showing as a
+    /// light/white edge while resizing because D3D only paints the client.
+    /// Resize is emulated via `WM_NCHITTEST` `HT*` returns instead.
+    ///
+    /// Maximized windows still keep border+thickframe insets so the client
+    /// matches the monitor work area.
+    fn extended_client_border_thickness(&self) -> RECT {
+        let style = self.get_style();
+        let ex_style = self.get_ex_style();
+        if (style.0 & WS_CAPTION.0) == WS_CAPTION.0 && self.get_is_maximized() {
+            // Caption is drawn into the client; keep only border+thickframe for work-area.
+            self.frame_border_thickness(
+                WINDOW_STYLE((style.0 & !WS_CAPTION.0) | WS_BORDER.0 | WS_THICKFRAME.0),
+                ex_style,
+            )
+        } else {
+            RECT {
+                left: 0,
+                top: 0,
+                right: 0,
+                bottom: 0,
+            }
+        }
+    }
+
+    /// Expand the client for custom chrome. Mutates `NCCALCSIZE_PARAMS.rgrc[0]`.
     unsafe fn apply_extended_client_nccalcsize(&self, lparam: LPARAM) {
         let params = &mut *(lparam.0 as *mut NCCALCSIZE_PARAMS);
         let rect = &mut params.rgrc[0];
+        let border = self.extended_client_border_thickness();
 
-        let style = self.get_style();
-        let ex_style = self.get_ex_style();
-        let maximized = self.get_is_maximized();
-
-        let border = if (style.0 & WS_CAPTION.0) == WS_CAPTION.0 {
-            if maximized {
-                // Caption is drawn into the client; keep only border+thickframe for work-area.
-                Self::frame_border_thickness(
-                    WINDOW_STYLE((style.0 & !WS_CAPTION.0) | WS_BORDER.0 | WS_THICKFRAME.0),
-                    ex_style,
-                )
-            } else {
-                let mut b = Self::frame_border_thickness(style, ex_style);
-                // Caption already includes the top border — extend client into it.
-                b.top = 0;
-                b
-            }
-        } else if (style.0 & WS_BORDER.0) != 0 {
-            Self::frame_border_thickness(style, ex_style)
-        } else {
-            Self::frame_border_thickness(style, ex_style)
-        };
-
-        // `rgrc[0]` arrives as the proposed *window* rect. `AdjustWindowRectEx` on a
-        // zero client yields negative left/top; subtracting those insets converts
-        // window → client while leaving thickframe resize borders outside.
+        // `rgrc[0]` arrives as the proposed *window* rect. Subtracting
+        // `AdjustWindowRectEx` insets converts window → client.
         rect.left -= border.left;
         rect.top -= border.top;
         rect.right -= border.right;
@@ -328,26 +336,158 @@ impl Win32Window {
     }
 
     /// Physical-pixel frame insets (left, top, right, bottom) for converting
-    /// window rect <-> client size under extended-client chrome.
+    /// window rect <-> client size under custom chrome.
     fn client_frame_insets_px(&self) -> (i32, i32, i32, i32) {
-        let style = self.get_style();
-        let ex_style = self.get_ex_style();
-        let maximized = self.get_is_maximized();
-        let border = if (style.0 & WS_CAPTION.0) == WS_CAPTION.0 {
-            if maximized {
-                Self::frame_border_thickness(
-                    WINDOW_STYLE((style.0 & !WS_CAPTION.0) | WS_BORDER.0 | WS_THICKFRAME.0),
-                    ex_style,
-                )
-            } else {
-                let mut b = Self::frame_border_thickness(style, ex_style);
-                b.top = 0;
-                b
-            }
-        } else {
-            Self::frame_border_thickness(style, ex_style)
-        };
+        let border = self.extended_client_border_thickness();
         (-border.left, -border.top, border.right, border.bottom)
+    }
+
+    /// Force a `WM_NCCALCSIZE` pass now that `GWLP_USERDATA` is set so our
+    /// extended-client handler runs (CreateWindow still used DefWindowProc).
+    fn force_frame_change(&self) {
+        unsafe {
+            let _ = SetWindowPos(
+                self.hwnd,
+                None,
+                0,
+                0,
+                0,
+                0,
+                SWP_NOMOVE
+                    | SWP_NOSIZE
+                    | SWP_NOZORDER
+                    | SWP_NOACTIVATE
+                    | SWP_FRAMECHANGED,
+            );
+        }
+    }
+
+    /// Logical-pixel resize hit band for fully-client custom chrome / popups.
+    fn resize_edge_logical(&self) -> f64 {
+        // Thick enough to grab reliably; not so thick it steals caption clicks.
+        const EDGE: f64 = 8.0;
+        EDGE
+    }
+
+    /// Same geometry as `WindowGeom.window_chrome_buttons` (logical, client-relative).
+    fn chrome_buttons_rect_logical(&self) -> Rect {
+        const BUTTON_W: f64 = 46.0;
+        const BUTTON_H: f64 = 29.0;
+        const BUTTON_COUNT: f64 = 3.0;
+        let inner = self.get_inner_size();
+        Rect {
+            pos: dvec2(inner.x - BUTTON_W * BUTTON_COUNT, 0.0),
+            size: dvec2(BUTTON_W * BUTTON_COUNT, BUTTON_H),
+        }
+    }
+
+    /// `HTTOP` / `HTLEFT` / … for a fully client-sized window. Returns `None`
+    /// when the cursor is outside the resize band, over caption buttons, or
+    /// when maximized.
+    fn hit_test_client_resize_edge(&self, lparam: LPARAM) -> Option<LRESULT> {
+        if self.get_is_maximized() {
+            return None;
+        }
+        let dpi = self.get_dpi_factor();
+        let edge = self.resize_edge_logical();
+        let abs = self.get_mouse_pos_from_lparam(lparam);
+        let mut window_rect = RECT {
+            left: 0,
+            top: 0,
+            bottom: 0,
+            right: 0,
+        };
+        unsafe {
+            GetWindowRect(self.hwnd, &mut window_rect).unwrap();
+        }
+        let origin = dvec2(window_rect.left as f64 / dpi, window_rect.top as f64 / dpi);
+        let size = dvec2(
+            (window_rect.right - window_rect.left) as f64 / dpi,
+            (window_rect.bottom - window_rect.top) as f64 / dpi,
+        );
+        let local = abs - origin;
+
+        // Don't steal hits from the system-style caption buttons (close/max/min).
+        if !self.is_popup && self.chrome_buttons_rect_logical().contains(local) {
+            return None;
+        }
+
+        let on_left = abs.x < origin.x + edge;
+        let on_right = abs.x > origin.x + size.x - edge;
+        let on_top = abs.y < origin.y + edge;
+        let on_bottom = abs.y > origin.y + size.y - edge;
+
+        let hit = match (on_left, on_right, on_top, on_bottom) {
+            (true, _, true, _) => HTTOPLEFT,
+            (true, _, _, true) => HTBOTTOMLEFT,
+            (_, true, true, _) => HTTOPRIGHT,
+            (_, true, _, true) => HTBOTTOMRIGHT,
+            (true, _, _, _) => HTLEFT,
+            (_, true, _, _) => HTRIGHT,
+            (_, _, true, _) => HTTOP,
+            (_, _, _, true) => HTBOTTOM,
+            _ => return None,
+        };
+        Some(LRESULT(hit as isize))
+    }
+
+    /// Caption / client hit-test for the custom-chrome client area.
+    fn hit_test_extended_client(&mut self, lparam: LPARAM) -> LRESULT {
+        let dpi = self.get_dpi_factor();
+        let mut window_rect = RECT {
+            left: 0,
+            top: 0,
+            bottom: 0,
+            right: 0,
+        };
+        unsafe {
+            GetWindowRect(self.hwnd, &mut window_rect).unwrap();
+        }
+        let origin = dvec2(window_rect.left as f64 / dpi, window_rect.top as f64 / dpi);
+
+        // Dedupe: return the cached WindowDragQuery result for a repeated cursor
+        // position (the loop is vsync-paced, so the OS sends several same-position
+        // hit-tests/frame).
+        let response_val = match self.nc_dq_cache.get() {
+            Some((lp, rv)) if lp == lparam.0 => rv,
+            _ => {
+                // Snapshot the cache generation: dispatching WindowDragQuery can
+                // reenter the window proc (nested SendMessage) and invalidate the
+                // cache mid-flight; if it does, we must NOT write our now-stale
+                // result back over that invalidation.
+                let gen = self.nc_dq_gen.get();
+                let response = Rc::new(Cell::new(WindowDragQueryResponse::NoAnswer));
+                self.do_callback(Win32Event::WindowDragQuery(WindowDragQueryEvent {
+                    window_id: self.window_id,
+                    abs: self.get_mouse_pos_from_lparam(lparam) - origin,
+                    response: response.clone(),
+                }));
+                let rv = response.get();
+                if self.nc_dq_gen.get() == gen {
+                    self.nc_dq_cache.set(Some((lparam.0, rv)));
+                }
+                rv
+            }
+        };
+        match response_val {
+            WindowDragQueryResponse::Caption => {
+                with_win32_app(|app| app.set_mouse_cursor(MouseCursor::Default));
+                LRESULT(HTCAPTION as isize)
+            }
+            WindowDragQueryResponse::SysMenu => {
+                with_win32_app(|app| app.set_mouse_cursor(MouseCursor::Default));
+                LRESULT(HTSYSMENU as isize)
+            }
+            WindowDragQueryResponse::Client | WindowDragQueryResponse::NoAnswer => {
+                // Caption already restores Default above. Client must too: after
+                // HTLEFT/HTRIGHT the system size cursor sticks otherwise, and the
+                // window class cursor alone is not enough once we cleared
+                // `current_cursor` on the resize edge. Widgets re-apply Text/etc.
+                // on the following WM_MOUSEMOVE.
+                with_win32_app(|app| app.set_mouse_cursor(MouseCursor::Default));
+                LRESULT(HTCLIENT as isize)
+            }
+        }
     }
 
     // 2-stage initialization (new and init) to connect GWLP_USERDATA
@@ -361,8 +501,8 @@ impl Win32Window {
     ) -> Win32Window {
         let title = encode_wide(title);
 
-        // Overlapped top-level window. Client is extended into the caption via
-        // WM_NCCALCSIZE; chrome stays app-drawn.
+        // Overlapped top-level window with app-drawn chrome. Restored size is
+        // fully client-sized (WM_NCCALCSIZE); maximize keeps work-area insets.
         let style = WS_OVERLAPPEDWINDOW | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
 
         let style_ex = WS_EX_WINDOWEDGE | WS_EX_APPWINDOW | WS_EX_ACCEPTFILES;
@@ -390,6 +530,8 @@ impl Win32Window {
             )
             .unwrap()
         };
+        // DWM chrome is applied in `init` after USERDATA is set (so NCCALCSIZE
+        // can use our handler). Shape/NCRP here only covers the CreateWindow gap.
         Self::apply_win11_window_shape(hwnd, false);
         Self::set_nc_rendering_enabled(hwnd);
 
@@ -476,13 +618,21 @@ impl Win32Window {
         }
     }
 
-    // initialize GWLP_USERDATA and registration of global stuff, and set inner size
+    // initialize GWLP_USERDATA and registration of global stuff, then set inner size
     pub fn init(&mut self, size: Vec2d) {
         unsafe { SetWindowLongPtrW(self.hwnd, GWLP_USERDATA, self as *const _ as isize) };
 
         with_win32_app(|app| app.dpi_functions.enable_non_client_dpi_scaling(self.hwnd));
         with_win32_app(|app| app.all_windows.push(self.hwnd));
-        // `size` is the desired client (inner) size from CreateWindow.
+
+        if !self.is_popup {
+            // CreateWindow ran NCCALCSIZE via DefWindowProc (no USERDATA yet).
+            // Apply DWM chrome, then force our extended-client frame before sizing.
+            self.extend_frame_for_custom_chrome();
+            self.force_frame_change();
+        }
+
+        // `size` is the app's desired client (inner) size (`create_inner_size`).
         self.set_inner_size(size);
         if self.is_fullscreen {
             self.maximize();
@@ -557,105 +707,24 @@ impl Win32Window {
                         // Popups stay fully client-sized.
                         return LRESULT(0);
                     }
-                    // Extend client into caption; keep thickframe resize borders
-                    // outside the client rect.
+                    // Custom chrome: restored = fully client-sized; maximized keeps
+                    // work-area insets. DWM extend/shape is done in init / visuals.
                     unsafe {
                         window.apply_extended_client_nccalcsize(lparam);
                     }
-                    window.extend_frame_for_custom_chrome();
                     return LRESULT(0);
                 }
             }
             WM_NCHITTEST => {
-                let abs = window.get_mouse_pos_from_lparam(lparam);
-                let mut rect = RECT {
-                    left: 0,
-                    top: 0,
-                    bottom: 0,
-                    right: 0,
-                };
-                const EDGE: f64 = 4.0;
-                // WM_NCHITTEST is OS-sent on every mouse move (uncoalesced); `get_dpi_factor()` is
-                // now cached so this (and the two calls inside `get_mouse_pos_from_lparam`) no
-                // longer syscall `GetDeviceCaps` per move.
-                let dpi = window.get_dpi_factor();
-                GetWindowRect(hwnd, &mut rect).unwrap();
-                let rect = Rect {
-                    pos: dvec2(rect.left as f64 / dpi, rect.top as f64 / dpi),
-                    size: dvec2(
-                        (rect.right - rect.left) as f64 / dpi,
-                        (rect.bottom - rect.top) as f64 / dpi,
-                    ),
-                };
-                if abs.x < rect.pos.x + EDGE {
-                    if abs.y < rect.pos.y + EDGE {
-                        with_win32_app(|app| app.set_mouse_cursor(MouseCursor::NwseResize));
-                        return LRESULT(HTTOPLEFT as isize);
-                    }
-                    if abs.y > rect.pos.y + rect.size.y - EDGE {
-                        with_win32_app(|app| app.set_mouse_cursor(MouseCursor::NeswResize));
-                        return LRESULT(HTBOTTOMLEFT as isize);
-                    }
-                    with_win32_app(|app| app.set_mouse_cursor(MouseCursor::EwResize));
-                    return LRESULT(HTLEFT as isize);
+                // Fully-client custom chrome (restored mains + popups): emulate
+                // resize borders with HT* hits. Returning system sizing codes
+                // still starts a resize drag; WM_SETCURSOR owns the cursor so we
+                // only clear our cached cursor (avoids stuck resize arrows).
+                if let Some(resize_hit) = window.hit_test_client_resize_edge(lparam) {
+                    with_win32_app(|app| app.current_cursor = None);
+                    return resize_hit;
                 }
-                if abs.x > rect.pos.x + rect.size.x - EDGE {
-                    if abs.y < rect.pos.y + EDGE {
-                        with_win32_app(|app| app.set_mouse_cursor(MouseCursor::NeswResize));
-                        return LRESULT(HTTOPRIGHT as isize);
-                    }
-                    if abs.y > rect.pos.y + rect.size.y - EDGE {
-                        with_win32_app(|app| app.set_mouse_cursor(MouseCursor::NwseResize));
-                        return LRESULT(HTBOTTOMRIGHT as isize);
-                    }
-                    with_win32_app(|app| app.set_mouse_cursor(MouseCursor::EwResize));
-                    return LRESULT(HTRIGHT as isize);
-                }
-                if abs.y < rect.pos.y + EDGE {
-                    with_win32_app(|app| app.set_mouse_cursor(MouseCursor::NsResize));
-                    return LRESULT(HTTOP as isize);
-                }
-                if abs.y > rect.pos.y + rect.size.y - EDGE {
-                    with_win32_app(|app| app.set_mouse_cursor(MouseCursor::NsResize));
-                    return LRESULT(HTBOTTOM as isize);
-                }
-                // Dedupe: return the cached WindowDragQuery result for a repeated cursor position
-                // (the loop is vsync-paced, so the OS sends several same-position hit-tests/frame).
-                let response_val = match window.nc_dq_cache.get() {
-                    Some((lp, rv)) if lp == lparam.0 => rv,
-                    _ => {
-                        // Snapshot the cache generation: dispatching WindowDragQuery can reenter the
-                        // window proc (nested SendMessage) and invalidate the cache mid-flight; if it
-                        // does, we must NOT write our now-stale result back over that invalidation.
-                        let gen = window.nc_dq_gen.get();
-                        let response = Rc::new(Cell::new(WindowDragQueryResponse::NoAnswer));
-                        window.do_callback(Win32Event::WindowDragQuery(WindowDragQueryEvent {
-                            window_id: window.window_id,
-                            abs: window.get_mouse_pos_from_lparam(lparam) - rect.pos,
-                            response: response.clone(),
-                        }));
-                        let rv = response.get();
-                        if window.nc_dq_gen.get() == gen {
-                            window.nc_dq_cache.set(Some((lparam.0, rv)));
-                        }
-                        rv
-                    }
-                };
-                match response_val {
-                    WindowDragQueryResponse::Client => {
-                        return LRESULT(HTCLIENT as isize);
-                    }
-                    WindowDragQueryResponse::Caption => {
-                        with_win32_app(|app| app.set_mouse_cursor(MouseCursor::Default));
-                        return LRESULT(HTCAPTION as isize);
-                    }
-                    WindowDragQueryResponse::SysMenu => {
-                        with_win32_app(|app| app.set_mouse_cursor(MouseCursor::Default));
-                        return LRESULT(HTSYSMENU as isize);
-                    }
-                    _ => (),
-                }
-                return LRESULT(HTCLIENT as isize);
+                return window.hit_test_extended_client(lparam);
             }
             WM_ERASEBKGND => return LRESULT(1),
             WM_MOUSEMOVE => {
@@ -1257,16 +1326,10 @@ impl Win32Window {
     }
 
     pub fn get_is_maximized(&self) -> bool {
-        unsafe {
-            let wp: mem::MaybeUninit<WINDOWPLACEMENT> = mem::MaybeUninit::uninit();
-            let mut wp = wp.assume_init();
-            wp.length = mem::size_of::<WINDOWPLACEMENT>() as u32;
-            GetWindowPlacement(self.hwnd, &mut wp).unwrap();
-            if wp.showCmd == SW_MAXIMIZE.0 as u32 {
-                return true;
-            }
-            return false;
-        }
+        // Prefer the live WS_MAXIMIZE style bit — more accurate during
+        // WM_NCCALCSIZE than WINDOWPLACEMENT while maximize/restore is in flight.
+        const WS_MAXIMIZE: u32 = 0x0100_0000;
+        (self.get_style().0 & WS_MAXIMIZE) != 0
     }
 
     pub fn time_now(&self) -> f64 {
@@ -1466,24 +1529,17 @@ impl Win32Window {
                 right: 0,
             };
             GetWindowRect(self.hwnd, &mut window_rect).unwrap();
-            let mut client_rect = RECT {
-                left: 0,
-                top: 0,
-                bottom: 0,
-                right: 0,
-            };
-            GetClientRect(self.hwnd, &mut client_rect).unwrap();
             let dpi = self.get_dpi_factor();
+            // Use the same inset model as WM_NCCALCSIZE / send_sizing_event so
+            // we do not depend on the current client rect (which may still be
+            // DefWindowProc-sized before the first FRAMECHANGED).
+            let (l, t, r, b) = self.client_frame_insets_px();
             MoveWindow(
                 self.hwnd,
                 window_rect.left,
                 window_rect.top,
-                (size.x * dpi) as i32
-                    + ((window_rect.right - window_rect.left)
-                        - (client_rect.right - client_rect.left)),
-                (size.y * dpi) as i32
-                    + ((window_rect.bottom - window_rect.top)
-                        - (client_rect.bottom - client_rect.top)),
+                (size.x * dpi) as i32 + l + r,
+                (size.y * dpi) as i32 + t + b,
                 false,
             )
             .unwrap();


### PR DESCRIPTION
## Summary

- Main top-level windows use `WS_OVERLAPPEDWINDOW` instead of `WS_POPUP`.
- Popups stay `WS_POPUP` (tool / overlay behavior unchanged).
- Client area is extended into the caption via `WM_NCCALCSIZE`; chrome stays app-drawn.
- DWM NC rendering stays enabled so shadows (and Win11 rounded corners when available) still work.

Primary code: `platform/src/os/windows/win32_window.rs`.

## Motivation

Makepad draws its own window chrome (caption bar, buttons, etc.). The previous main-window style was effectively a decorated `WS_POPUP`: full client, custom hit-testing, little reliance on the system frame.

That works for “everything is client,” but it fights how Windows expects a normal app window to behave. Overlapped windows are the platform’s first-class top-level style; popups are for transient UI. Mixing those roles on the main window caused recurring friction around shadows, snap/maximize, and frame geometry.

## Design

| Window kind | Style | Client / frame |
|-------------|--------|----------------|
| Main (restored) | `WS_OVERLAPPEDWINDOW` (+ clip styles) | Fully client-sized; app paints everything; resize via `WM_NCHITTEST` |
| Main (maximized) | same | Client inset by border+thickframe to match work area |
| Popup | `WS_POPUP` | Fully client-sized; same resize-edge hit-test |

Custom chrome path (main only):

1. `WM_NCCALCSIZE`: restored windows are **fully client-sized** (no thickframe strip outside the swap chain — that strip caused light/white edges while resizing). Maximized windows keep border+thickframe insets for the monitor work area.
2. Resize is emulated by returning `HTLEFT` / `HTTOP` / … from `WM_NCHITTEST` on an ~8px edge band (caption-button rect excluded so close/max/min stay clickable).
3. `DwmExtendFrameIntoClientArea` with zero margins (opaque chrome, no 1px glass hairline).
4. `DWMWA_NCRENDERING_POLICY = DWMNCRP_ENABLED` so DWM still paints shadows / corners.
5. Optional Win11 attrs (`DWMWA_WINDOW_CORNER_PREFERENCE`, `DWMWA_BORDER_COLOR`) — fail quietly on older OS.
6. Maximized work-area insets use `AdjustWindowRectExForDpi` when available (fallback `AdjustWindowRectEx`).

`init` sets `GWLP_USERDATA`, applies DWM chrome, forces `SWP_FRAMECHANGED`, then sizes with the same inset model as `NCCALCSIZE` / `WM_SIZING` so the first client size matches `create_inner_size`.

## Benefits vs `WS_POPUP` main windows

### System window behavior

- **Snap / Aero Snap / Win+Arrow** work more reliably as a normal overlapped window.
- **Maximize / restore / minimize** use the standard overlapped path (`WS_MAXIMIZEBOX` / `WS_MINIMIZEBOX` / `WS_THICKFRAME` via `WS_OVERLAPPEDWINDOW`).
- **Alt+Space system menu** and other shell integrations expect overlapped + `WS_SYSMENU`, not a naked popup.

### DWM visuals

- **Drop shadows** on Windows 10/11: overlapped + `DWMNCRP_ENABLED` gets the normal DWM shadow. Popup mains often had weak or missing shadows.
- **Win11 rounded corners / border color**: optional; ignored on Windows 10. Win10 keeps rectangular chrome with classic DWM shadow.

### Geometry semantics

- Clear **inner (client) vs outer (window)** sizes. `set_inner_size`, `get_window_geom`, and `WM_SIZING` pre-render all use the same extended-client insets.
- Avoids the old “maximized ⇒ pretend inner == outer” hack that existed because popup + full-client made those sizes collapse together.

### Separation of concerns

- **Main window** = app shell (taskbar, snap, shadow, lifetime).
- **Popup** = floating / transient UI (`WS_EX_TOPMOST` / `WS_EX_TOOLWINDOW` as today), still full-client and dismissible — no need to pretend it is a captioned frame.

### Alignment with common desktop practice

This matches the usual pattern used by custom-chrome desktop toolkits: overlapped top-level + extend client into non-client, rather than a permanent `WS_POPUP` main frame.

## What did not change

- App-drawn caption and chrome hit-testing (`WM_NCHITTEST`, caption drag, custom buttons) remain in Makepad.
- Popup creation API and `WS_POPUP` styling are unchanged.
- No requirement for Win11-only APIs; Win10 is supported with the overlapped + DWM shadow path.