### PR TITLE
Windows: resize swap chain on DPI change

### DIFF
--- a/platform/src/os/windows/d3d11.rs
+++ b/platform/src/os/windows/d3d11.rs
@@ -854,7 +854,12 @@ pub struct D3d11Window {
     pub win32_window: Box<Win32Window>,
     pub render_target_view: Option<ID3D11RenderTargetView>,
     pub swap_texture: Option<ID3D11Texture2D>,
+    /// Logical inner size the swap-chain buffers were last allocated for.
+    /// Compared together with `alloc_dpi`: a DPI-only change (cross-monitor)
+    /// keeps logical size stable but still needs ResizeBuffers for physical pixels.
     pub alloc_size: Vec2d,
+    /// DPI factor the swap-chain buffers were last allocated for.
+    pub alloc_dpi: f64,
     pub first_draw: bool,
     pub swap_chain: IDXGISwapChain1,
     /// The DXGI frame-latency waitable object for this swap chain, used to pace
@@ -953,6 +958,7 @@ impl D3d11Window {
                 is_in_resize: false,
                 window_id: window_id,
                 alloc_size: wg.inner_size,
+                alloc_dpi: wg.dpi_factor,
                 window_geom: wg,
                 win32_window: win32_window,
                 swap_texture: Some(swap_texture),
@@ -1019,6 +1025,7 @@ impl D3d11Window {
                 is_in_resize: false,
                 window_id,
                 alloc_size: wg.inner_size,
+                alloc_dpi: wg.dpi_factor,
                 window_geom: wg,
                 win32_window,
                 swap_texture: Some(swap_texture),
@@ -1041,7 +1048,10 @@ impl D3d11Window {
     // switch back to swapchain
     pub fn stop_resize(&mut self) {
         self.is_in_resize = false;
+        // Force ResizeBuffers on the next paint (logical size and/or DPI may have
+        // changed while the user was dragging across monitors).
         self.alloc_size = Vec2d::default();
+        self.alloc_dpi = 0.0;
         // Live-resize presents without vsync and skips the frame-latency wait, but
         // every retired Present still credits the waitable semaphore. Drain the
         // accumulated credits here so the per-frame wait in draw_pass_to_window
@@ -1071,8 +1081,19 @@ impl D3d11Window {
         }
     }
 
+    fn clear_alloc_size(&mut self) {
+        self.alloc_size = Vec2d::default();
+        self.alloc_dpi = 0.0;
+    }
+
     pub fn resize_buffers(&mut self, d3d11_cx: &D3d11Cx) {
-        if self.alloc_size == self.window_geom.inner_size {
+        // Buffers are sized in physical pixels (inner_size * dpi_factor). A
+        // cross-monitor move can change DPI while keeping logical size the same;
+        // skipping ResizeBuffers then leaves DXGI_SCALING_NONE presenting a
+        // mismatched buffer (blank/letterboxed until something else forces resize).
+        if self.alloc_size == self.window_geom.inner_size
+            && self.alloc_dpi == self.window_geom.dpi_factor
+        {
             return;
         }
         let inner = self.window_geom.inner_size;
@@ -1081,6 +1102,7 @@ impl D3d11Window {
             return; // ResizeBuffers rejects zero dimensions.
         }
         self.alloc_size = self.window_geom.inner_size;
+        self.alloc_dpi = self.window_geom.dpi_factor;
         // ResizeBuffers requires all references to the old backbuffers released first.
         self.swap_texture = None;
         self.render_target_view = None;
@@ -1111,7 +1133,7 @@ impl D3d11Window {
                     self.resize_error_logged = true;
                     crate::error!("IDXGISwapChain::ResizeBuffers failed: {}", e);
                 }
-                self.alloc_size = Vec2d::default();
+                self.clear_alloc_size();
                 resize_ok = false;
                 // Fall through: re-acquire the old-size backbuffer so we keep presenting.
             }
@@ -1123,7 +1145,7 @@ impl D3d11Window {
                         self.resize_error_logged = true;
                         crate::error!("IDXGISwapChain::GetBuffer failed: {}", e);
                     }
-                    self.alloc_size = Vec2d::default();
+                    self.clear_alloc_size();
                     return;
                 }
             };
@@ -1137,7 +1159,7 @@ impl D3d11Window {
                     self.resize_error_logged = true;
                     crate::error!("CreateRenderTargetView failed: {}", e);
                 }
-                self.alloc_size = Vec2d::default();
+                self.clear_alloc_size();
                 return;
             }
 

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -136,8 +136,11 @@ impl Cx {
 
                     window.window_geom = re.new_geom.clone();
                     self.windows[re.window_id].window_geom = re.new_geom.clone();
-                    // redraw just this windows root draw list
-                    if re.old_geom.inner_size != re.new_geom.inner_size {
+                    // redraw just this windows root draw list (size or DPI — DPI-only
+                    // changes still need a pass rebuild at the new physical scale)
+                    if re.old_geom.inner_size != re.new_geom.inner_size
+                        || re.old_geom.dpi_factor != re.new_geom.dpi_factor
+                    {
                         if let Some(main_pass_id) = self.windows[re.window_id].main_pass_id {
                             self.redraw_pass_and_child_passes(main_pass_id);
                         }


### PR DESCRIPTION
## Summary

- Cross-monitor moves that change DPI (e.g. 150% → 125%) can leave the window blank until a later force-resize.
- Root cause: `D3d11Window::resize_buffers` only compared logical `inner_size`, so a DPI-only change skipped `IDXGISwapChain::ResizeBuffers`.
- Fix: track `alloc_dpi` alongside `alloc_size`, and resize whenever either differs from current `window_geom`.
- Also mark the window’s main pass dirty on DPI-only `WindowGeomChange` (desktop path now matches stdin).

Primary code: `platform/src/os/windows/d3d11.rs`, `platform/src/os/windows/windows.rs`.

## Symptom

Dragging a window from a higher-DPI monitor to a lower-DPI one (or the reverse) for the first time often shows a blank / solid-background client for a while. Content returns after the drag ends or after some later size change.

Typical case: primary at 150%, secondary at 125%.

## Cause

Makepad sizes DXGI swap-chain buffers in **physical** pixels:

```text
buffer_w = inner_size.x * dpi_factor
buffer_h = inner_size.y * dpi_factor
```

`WM_DPICHANGED` asks the app to adopt the OS-suggested rect, which is meant to keep **logical** size stable while physical size changes with the new scale. The window then publishes a `WindowGeomChange` with a new `dpi_factor`.

Previously, `resize_buffers` early-out was:

```rust
if self.alloc_size == self.window_geom.inner_size {
    return;
}
```

So when only DPI changed:

1. Logical `inner_size` stayed the same → early return.
2. Backbuffers stayed at the old physical size.
3. Swap chains are created with `DXGI_SCALING_NONE`, so a mismatch between buffer and HWND client is not scaled away; gaps use the swap-chain background color (looks blank).
4. Recovery often waited for `stop_resize()` (clears `alloc_size`) or an unrelated logical-size nudge that finally called `ResizeBuffers`.

First-time moves feel worse because fonts / atlases / pass resources also rebuild at the new scale; the stale buffer makes that stall look like a full blank.

## Fix

### `D3d11Window` allocation identity

Store both values used to size the buffers:

| Field | Meaning |
|-------|---------|
| `alloc_size` | Logical inner size last used for `ResizeBuffers` |
| `alloc_dpi` | DPI factor last used for `ResizeBuffers` |

`resize_buffers` now returns early only when **both** match current `window_geom`. Error / `stop_resize` paths clear both via `clear_alloc_size()` so the next paint retries.

### Pass redraw on DPI-only geom change

In `windows.rs`, redraw the window’s main pass when either `inner_size` or `dpi_factor` changes (same rule as `windows_stdin.rs`). Logical size alone was insufficient for DPI transitions.

## What did not change

- `WM_DPICHANGED` handling in `win32_window.rs` (invalidate DPI cache, `SetWindowPos` to suggested rect, nested `WM_SIZE` / `send_change_event`).
- Swap-chain creation flags (`DXGI_SCALING_NONE`, flip discard, waitable latency object).
- Per-monitor DPI awareness / `DpiFunctions` lookup path.