### PR TITLE
Add `Event::ClearHover`, and expose the pointer's claim and capture areas

### DIFF
--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -156,6 +156,7 @@ pub struct Cx {
 
     /// `WindowGeomChange` events queued up during an event dispatch.
     pub(crate) pending_window_geom_changes: Vec<WindowGeomChangeEvent>,
+    pub(crate) clear_hover_queued: bool,
 
     pub debug: Debug,
 
@@ -501,6 +502,7 @@ impl Cx {
             pending_script_reapply: false,
             pending_live_edit_request: false,
             pending_window_geom_changes: Default::default(),
+            clear_hover_queued: false,
 
             widget_tree_dump_requests: Default::default(),
             widget_snapshot_requests: Default::default(),

--- a/platform/src/event/event.rs
+++ b/platform/src/event/event.rs
@@ -162,6 +162,9 @@ pub enum Event {
     WindowGeomChange(WindowGeomChangeEvent),
     VirtualKeyboard(VirtualKeyboardEvent),
     ClearAtlasses,
+    /// Clear all hover/pressed visual state, e.g. after an overlay that
+    /// swallowed the hover-outs (a context menu) has closed.
+    ClearHover,
 
     /// The raw event that occurs when the user presses a mouse button down.
     ///
@@ -300,6 +303,7 @@ impl Event {
             17 => "WindowGeomChange",
             18 => "VirtualKeyboard",
             19 => "ClearAtlasses",
+            72 => "ClearHover",
 
             20 => "MouseDown",
             21 => "MouseMove",
@@ -389,6 +393,7 @@ impl Event {
             Self::WindowGeomChange(_) => 17,
             Self::VirtualKeyboard(_) => 18,
             Self::ClearAtlasses => 19,
+            Self::ClearHover => 72,
             Self::PopupDismissed(_) => 61,
 
             Self::MouseDown(_) => 20,

--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -882,6 +882,21 @@ impl Event {
             _ => (),
         }
     }
+
+    /// The area that has claimed this pointer event so far (hover, mouse press, or touch start).
+    /// Snapshot it before dispatching a subtree: a claim appearing across that dispatch came from within.
+    pub fn pointer_claimed_area(&self) -> Area {
+        match self {
+            Event::MouseMove(e) => e.handled.get(),
+            Event::MouseDown(e) => e.handled.get(),
+            Event::TouchUpdate(e) => e
+                .touches
+                .iter()
+                .find(|t| t.state == TouchState::Start)
+                .map_or(Area::Empty, |t| t.handled.get()),
+            _ => Area::Empty,
+        }
+    }
 }
 
 impl Event {

--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -438,6 +438,13 @@ impl CxFingers {
         self.captures.iter().find(|v| v.area == area).is_some()
     }
 
+    /// The area that captured the touch with the given uid, if any.
+    /// Lets a raw `Event::LongPress` handler check which widget owns the press.
+    pub fn touch_capture_area(&self, uid: u64) -> Option<Area> {
+        let digit_id: DigitId = live_id_num!(touch, uid).into();
+        self.captures.iter().find(|v| v.digit_id == digit_id).map(|v| v.area)
+    }
+
     pub fn any_areas_captured(&self) -> bool {
         self.captures.len() > 0
     }

--- a/platform/src/os/cx_shared.rs
+++ b/platform/src/os/cx_shared.rs
@@ -860,6 +860,21 @@ impl Cx {
         }
     }
 
+    /// Requests an `Event::ClearHover` dispatch once the current event
+    /// (and its follow-up actions) finish, so every widget can drop
+    /// hover/pressed visuals an overlay kept from clearing normally.
+    pub fn queue_clear_hover(&mut self) {
+        self.clear_hover_queued = true;
+    }
+
+    pub(crate) fn handle_pending_clear_hover(&mut self) {
+        if self.clear_hover_queued {
+            self.clear_hover_queued = false;
+            self.inner_call_event_handler(&Event::ClearHover);
+            self.handle_actions();
+        }
+    }
+
     pub(crate) fn call_event_handler(&mut self, event: &Event) {
         if let Event::PermissionResult(result) = event {
             self.handle_camera_permission_result(result);
@@ -880,6 +895,7 @@ impl Cx {
         self.inner_key_focus_change();
         self.handle_triggers();
         self.handle_actions();
+        self.handle_pending_clear_hover();
     }
 
     #[allow(dead_code)]

--- a/platform/src/os/cx_shared.rs
+++ b/platform/src/os/cx_shared.rs
@@ -860,10 +860,10 @@ impl Cx {
         }
     }
 
-    /// Requests an `Event::ClearHover` dispatch once the current event
-    /// (and its follow-up actions) finish, so every widget can drop
-    /// hover/pressed visuals an overlay kept from clearing normally.
-    pub fn queue_clear_hover(&mut self) {
+    /// Clears all widgets' hover/pressed visuals by dispatching one
+    /// `Event::ClearHover` once the current event and its actions finish,
+    /// for when an overlay kept the normal hover-outs from arriving.
+    pub fn clear_all_hovers(&mut self) {
         self.clear_hover_queued = true;
     }
 

--- a/widgets/src/button.rs
+++ b/widgets/src/button.rs
@@ -497,6 +497,10 @@ impl Widget for Button {
             self.draw_bg.redraw(cx);
         }
 
+        if let Event::ClearHover = event {
+            self.animator_cut(cx, ids!(hover.off));
+        }
+
         // The button only handles hits when it's visible and enabled.
         // If it's not enabled, we still show the button, but we set
         // the NotAllowed mouse cursor upon hover instead of the Hand cursor.

--- a/widgets/src/callout_tooltip.rs
+++ b/widgets/src/callout_tooltip.rs
@@ -199,6 +199,10 @@ impl Widget for CalloutTooltip {
             }
         }
 
+        if let Event::ClearHover = event {
+            self.hide(cx);
+        }
+
         // Auto-process `TooltipAction`s emitted by other widgets in the
         // action batch via the `WidgetMatchEvent` impl below.
         self.widget_match_event(cx, event, scope);

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -1113,6 +1113,9 @@ impl WidgetMatchEvent for HtmlLink {
 
 impl Widget for HtmlLink {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        if let Event::ClearHover = event {
+            self.animator_cut(cx, ids!(hover.off));
+        }
         if self.animator_handle_event(cx, event).must_redraw() {
             if let Some(tf) = scope.data.get_mut::<TextFlow>() {
                 tf.redraw(cx);

--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -791,6 +791,12 @@ impl Widget for View {
                 return;
             }
         }
+        if let Event::ClearHover = event {
+            if self.animator.is_defined {
+                self.animator_play(cx, ids!(hover.off));
+                self.animator_play(cx, ids!(down.off));
+            }
+        }
         // A press that catches an in-progress momentum fling stops the scroll and is consumed:
         // it must not also activate a child widget under the finger, as on iOS, Android, and
         // macOS. So when the scroll bars report a caught fling, skip dispatching this press to


### PR DESCRIPTION
Widgets had no way to drop stale hover state, or to tell whether a pointer claim
came from their own subtree. Apps were left hand-resetting each widget type.

* `Cx::clear_all_hovers()` dispatches a one-shot `Event::ClearHover` after the
  current event, for use when an overlay closes and swallowed the hover-out.
  `View`, `Button`, `HtmlLink` and `CalloutTooltip` reset themselves on it.
* `Event::pointer_claimed_area()` exposes the current claim, so a widget can
  snapshot it on entry to `handle_event`: a claim appearing during its own dispatch
  came from it or a child, one that predates it means an overlay owns the pointer.
* `CxFingers::touch_capture_area(uid)` returns which area captured a touch, so a
  raw `Event::LongPress` handler can tell whether the press was ever its own.
