### PR TITLE
Area: don't panic on a stale `Area::Rect`

### DIFF
--- a/platform/src/area.rs
+++ b/platform/src/area.rs
@@ -241,7 +241,14 @@ impl Area {
             Area::Rect(ra) => {
                 // we need to clip this drawlist too
                 let draw_list = &cx.draw_lists[ra.draw_list_id];
-                let rect_area = &draw_list.rect_areas[ra.rect_id];
+                // A stale area outlives the draw that made it, and its rect_id
+                // can then be past the end of a shorter list.
+                if draw_list.redraw_id != ra.redraw_id {
+                    return Rect::default();
+                }
+                let Some(rect_area) = draw_list.rect_areas.get(ra.rect_id) else {
+                    return Rect::default();
+                };
                 if draw_list.draw_list_has_clip {
                     let p3 = dvec2(
                         draw_list.draw_list_uniforms.view_clip.x as f64,
@@ -307,8 +314,9 @@ impl Area {
             Area::Rect(ra) => {
                 let draw_list = &cx.draw_lists[ra.draw_list_id];
                 if draw_list.redraw_id == ra.redraw_id {
-                    let rect_area = &draw_list.rect_areas[ra.rect_id];
-                    return rect_area.rect;
+                    if let Some(rect_area) = draw_list.rect_areas.get(ra.rect_id) {
+                        return rect_area.rect;
+                    }
                 }
                 Rect::default()
             }
@@ -344,7 +352,12 @@ impl Area {
             }
             Area::Rect(ra) => {
                 let draw_list = &cx.draw_lists[ra.draw_list_id];
-                let rect_area = &draw_list.rect_areas[ra.rect_id];
+                if draw_list.redraw_id != ra.redraw_id {
+                    return abs;
+                }
+                let Some(rect_area) = draw_list.rect_areas.get(ra.rect_id) else {
+                    return abs;
+                };
                 Vec2d {
                     x: abs.x - rect_area.rect.pos.x,
                     y: abs.y - rect_area.rect.pos.y,
@@ -404,8 +417,12 @@ impl Area {
             }
             Area::Rect(ra) => {
                 let draw_list = &mut cx.draw_lists[ra.draw_list_id];
-                let rect_area = &mut draw_list.rect_areas[ra.rect_id];
-                rect_area.rect = *rect
+                if draw_list.redraw_id != ra.redraw_id {
+                    return;
+                }
+                if let Some(rect_area) = draw_list.rect_areas.get_mut(ra.rect_id) {
+                    rect_area.rect = *rect
+                }
             }
             _ => (),
         }


### PR DESCRIPTION
`Area::Rect` holds a `rect_id` into its draw list's `rect_areas`, plus the `redraw_id` of the draw that created it. A widget that hands out its area and is then redrawn with fewer rect areas leaves that id past the end, so `clipped_rect()` panicked with an out-of-bounds index (seen from robrix as "the len is 105 but the index is 173" while hit-testing a message's children).

`rect()` already guarded this with `redraw_id`; `clipped_rect()`, `abs_to_rel()` and `set_rect()` did not. All four now check the generation first and use `get`/`get_mut` instead of indexing, falling back to the same values they already return for an unknown area.