### PR TITLE
PortalList: make scroll-to-end reach the end, animate, and resume auto-tailing

### DIFF
--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -1746,7 +1746,14 @@ impl PortalList {
         let item_top = self.item_top_from_height_tree(target_id);
         if viewport_size > 0.0 {
             if let Some(item_top) = item_top {
-                if item_top >= 0.0 && item_top < viewport_size {
+                // Targeting the last item means "go to the bottom", and a tall
+                // last item can have its top on screen with most of it below.
+                let settled = if target_id >= self.range_end {
+                    self.at_end
+                } else {
+                    item_top >= 0.0 && item_top < viewport_size
+                };
+                if settled {
                     cx.widget_action(self.widget_uid(), PortalListAction::SmoothScrollReached);
                     return;
                 }
@@ -1808,7 +1815,8 @@ impl PortalList {
         if self.items.is_empty() {
             return;
         }
-        let speed = speed * self.range_end as f64;
+        // `speed` is a per-frame pixel delta, so it must not scale with the item
+        // count: on a long list that lands the whole way in one frame.
         self.smooth_scroll_to(cx, self.range_end, speed, max_items_to_show, 0.0);
     }
 

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -1758,6 +1758,10 @@ impl PortalList {
                     item_top >= 0.0 && item_top < viewport_size
                 };
                 if settled {
+                    // Same as arriving under animation: we're at the end, so follow it.
+                    if target_id + 1 >= self.range_end {
+                        self.detect_tail_in_draw = true;
+                    }
                     cx.widget_action(self.widget_uid(), PortalListAction::SmoothScrollReached);
                     return;
                 }
@@ -1837,8 +1841,6 @@ impl PortalList {
             max_items_to_show.or(Some(usize::MAX)),
             0.0,
         );
-        // Going to the end means staying there, so pick tailing back up on arrival.
-        self.detect_tail_in_draw = true;
     }
 
     /// Returns whether this PortalList is currently filling the viewport.
@@ -2481,6 +2483,11 @@ impl Widget for PortalList {
                     } else {
                         self.was_scrolling = false;
                         self.scroll_state = ScrollState::Stopped;
+                        // Landing on the last item means we're following the end again,
+                        // so let the next draw pick tailing back up.
+                        if target_id + 1 >= self.range_end {
+                            self.detect_tail_in_draw = true;
+                        }
                         cx.widget_action(uid, PortalListAction::SmoothScrollReached);
                     }
                 }

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -1818,6 +1818,8 @@ impl PortalList {
         // `speed` is a per-frame pixel delta, so it must not scale with the item
         // count: on a long list that lands the whole way in one frame.
         self.smooth_scroll_to(cx, self.range_end, speed, max_items_to_show, 0.0);
+        // Going to the end means staying there, so pick tailing back up on arrival.
+        self.detect_tail_in_draw = true;
     }
 
     /// Returns whether this PortalList is currently filling the viewport.
@@ -2876,7 +2878,10 @@ impl Widget for PortalList {
                     if self.grab_key_focus {
                         cx.set_key_focus(self.area);
                     }
+                    // A press that doesn't end up moving us off the end shouldn't stop
+                    // tailing, so let the next draw re-arm it like the scroll paths do.
                     self.tail_range = false;
+                    self.detect_tail_in_draw = true;
                     self.was_scrolling = match &self.scroll_state {
                         ScrollState::Drag { samples, .. } => samples.len() > 1,
                         // A press while anything moves the list (a coast, active finger

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -38,6 +38,10 @@ script_mod! {
 /// The maximum number of items that will be shown as part of a smooth scroll animation.
 const SMOOTH_SCROLL_MAXIMUM_WINDOW: usize = 20;
 
+/// How many frames a `smooth_scroll_to_end` animation takes, whatever the
+/// distance, so a long list doesn't crawl at a fixed pixels-per-frame rate.
+const SMOOTH_SCROLL_TO_END_FRAMES: f64 = 24.0;
+
 enum ScrollState {
     Stopped,
     Drag {
@@ -1748,7 +1752,7 @@ impl PortalList {
             if let Some(item_top) = item_top {
                 // Targeting the last item means "go to the bottom", and a tall
                 // last item can have its top on screen with most of it below.
-                let settled = if target_id >= self.range_end {
+                let settled = if target_id + 1 >= self.range_end {
                     self.at_end
                 } else {
                     item_top >= 0.0 && item_top < viewport_size
@@ -1815,9 +1819,24 @@ impl PortalList {
         if self.items.is_empty() {
             return;
         }
-        // `speed` is a per-frame pixel delta, so it must not scale with the item
-        // count: on a long list that lands the whole way in one frame.
-        self.smooth_scroll_to(cx, self.range_end, speed, max_items_to_show, 0.0);
+        // `range_end` is exclusive, so the last item is one before it.
+        let target_id = self.range_end.saturating_sub(1);
+        // `speed` is a per-frame pixel delta. Scale it to the distance so the
+        // animation takes the same time from anywhere in the list.
+        let speed = match self.item_top_from_height_tree(target_id) {
+            Some(item_top) => (item_top.abs() / SMOOTH_SCROLL_TO_END_FRAMES).max(speed),
+            None => speed,
+        };
+        // Pass an unbounded window so `smooth_scroll_to` doesn't teleport the anchor
+        // to the last few items first; that jump is most of the travel, and it's why
+        // this only looked smooth when you were already near the bottom.
+        self.smooth_scroll_to(
+            cx,
+            target_id,
+            speed,
+            max_items_to_show.or(Some(usize::MAX)),
+            0.0,
+        );
         // Going to the end means staying there, so pick tailing back up on arrival.
         self.detect_tail_in_draw = true;
     }


### PR DESCRIPTION
`smooth_scroll_to_end` was unreliable in three separate ways, and left tailing off
once it arrived.

* It multiplied the caller's speed by `range_end`, but that value is the per-frame
  pixel delta, so on a list of a few hundred items the whole travel landed in one
  frame. It also teleported the anchor to within `max_items_to_show` of the target
  before animating, so from further up, most of the distance was a hard jump and
  only the last few items were ever animated. It now animates the full distance,
  at a rate scaled to that distance so the duration doesn't depend on list length.
* It targeted `range_end`, which is exclusive and so names no item; the target is
  now `range_end - 1`. Relatedly, "the target's top is on screen" is not the same
  as being at the end, so scroll-to-end now settles on `at_end`.
* Tailing was left off on arrival. `Hit::FingerDown` also cleared `tail_range`
  without arming `detect_tail_in_draw`, unlike every scroll path, so any press on
  the list stopped tailing for good. Both now re-arm, the scroll on arrival rather
  than on start (the flag is one-shot and would otherwise be consumed mid-flight).
