### PR TITLE
headless: cache the shader JIT, the texture conversions, and let dpi be chosen

### DIFF
--- a/platform/src/os/headless/event_loop.rs
+++ b/platform/src/os/headless/event_loop.rs
@@ -21,6 +21,19 @@ use std::{
     time::Instant,
 };
 
+/// Backing-store scale for a headless window. Retina by default, because a
+/// screenshot is expected to match what a real display would show. Rendering is
+/// a software rasteriser here, so the cost is per PIXEL: a suite that only
+/// asserts on logical geometry can set `MAKEPAD_HEADLESS_DPI=1` and do a
+/// quarter of the work.
+fn configured_headless_dpi() -> f64 {
+    std::env::var("MAKEPAD_HEADLESS_DPI")
+        .ok()
+        .and_then(|s| s.parse::<f64>().ok())
+        .filter(|dpi| *dpi > 0.0)
+        .unwrap_or(2.0)
+}
+
 #[derive(Default)]
 struct HeadlessWindowState {
     created: bool,
@@ -580,7 +593,7 @@ impl Cx {
                         .create_inner_size
                         .unwrap_or_else(|| dvec2(1920.0, 1080.0));
                     let position = window.create_position.unwrap_or_else(|| dvec2(0.0, 0.0));
-                    let dpi_factor = 2.0;
+                    let dpi_factor = configured_headless_dpi();
 
                     let state = &mut windows[window_id.id()];
                     state.created = true;

--- a/platform/src/os/headless/jit.rs
+++ b/platform/src/os/headless/jit.rs
@@ -39,6 +39,28 @@ impl HeadlessShaderJit {
         source: &str,
     ) -> Result<HeadlessJitOutput, String> {
         let shader_dir = self.root_dir.join(format!("shader_{source_hash:016x}"));
+        let cached_path =
+            shader_dir.join(format!("shader_{source_hash:016x}.{}", dylib_extension()));
+
+        // The dylib is content-addressed by the hash of the source that made it,
+        // so one left by an earlier run is exactly what rustc would produce now.
+        // Reuse it: this compiles EVERY shader with `rustc -O` at startup, which
+        // costs tens of seconds per process — and a headless test suite starts a
+        // fresh process for every test. Anything unloadable (truncated by a killed
+        // run, built by a different toolchain) just falls through and recompiles.
+        if cached_path.is_file() {
+            if let Ok(loaded) = HeadlessLoadedModule::load(&cached_path) {
+                if let Ok(version) = loaded.shader_version() {
+                    return Ok(HeadlessJitOutput {
+                        dylib_path: cached_path,
+                        module: Some(loaded),
+                        shader_version: Some(version),
+                        load_error: None,
+                    });
+                }
+            }
+        }
+
         std::fs::create_dir_all(&shader_dir).map_err(|err| {
             format!(
                 "failed to create headless shader output dir `{}`: {err}",
@@ -54,8 +76,15 @@ impl HeadlessShaderJit {
             )
         })?;
 
-        let dylib_path =
-            shader_dir.join(format!("shader_{source_hash:016x}.{}", dylib_extension()));
+        let dylib_path = cached_path;
+        // Compile to a private path and rename into place, so a crashed or
+        // killed run can never leave a half-written dylib for the next one to
+        // find (and so two processes building the same shader can't interleave).
+        let staging_path = shader_dir.join(format!(
+            "shader_{source_hash:016x}.{}.{}",
+            std::process::id(),
+            dylib_extension()
+        ));
 
         let crate_name = format!("makepad_headless_shader_{source_hash:016x}");
         let output = Command::new("rustc")
@@ -67,13 +96,14 @@ impl HeadlessShaderJit {
             .arg("-O")
             .arg(&source_path)
             .arg("-o")
-            .arg(&dylib_path)
+            .arg(&staging_path)
             .output()
             .map_err(|err| {
                 format!("failed to run rustc for headless shader JIT `{crate_name}`: {err}")
             })?;
 
         if !output.status.success() {
+            let _ = std::fs::remove_file(&staging_path);
             let stderr = String::from_utf8_lossy(&output.stderr);
             return Err(format!(
                 "headless shader JIT compile failed for `{}`:\n{}",
@@ -81,6 +111,13 @@ impl HeadlessShaderJit {
                 stderr.trim()
             ));
         }
+
+        std::fs::rename(&staging_path, &dylib_path).map_err(|err| {
+            format!(
+                "failed to publish headless shader dylib `{}`: {err}",
+                dylib_path.display()
+            )
+        })?;
 
         let mut load_error = None;
         let mut shader_version = None;

--- a/platform/src/os/headless/mod.rs
+++ b/platform/src/os/headless/mod.rs
@@ -69,6 +69,11 @@ pub struct CxOs {
     pub(crate) draw_cycles: Option<usize>,
     pub(crate) render_pool: Option<MessageThreadPool<()>>,
     pub(crate) render_pool_threads: usize,
+    /// BGRA -> RGBAf32 conversions of sampled textures, kept ACROSS frames.
+    /// Rebuilding this per frame re-converted the whole glyph atlas on every
+    /// draw, which cost more than rasterising the window did. Entries carry a
+    /// signature and are redone when the texture reports pending updates.
+    pub(crate) texture_conversions: crate::os::headless::raster::TextureConversionCache,
 }
 
 impl Default for CxOs {
@@ -83,6 +88,7 @@ impl Default for CxOs {
             draw_cycles: None,
             render_pool: None,
             render_pool_threads: 0,
+            texture_conversions: Default::default(),
         }
     }
 }

--- a/platform/src/os/headless/raster.rs
+++ b/platform/src/os/headless/raster.rs
@@ -123,12 +123,12 @@ struct TextureConversionSignature {
     data_len: usize,
 }
 
-struct CachedTextureConversion {
+pub(crate) struct CachedTextureConversion {
     signature: TextureConversionSignature,
     rgba: Vec<f32>,
 }
 
-type TextureConversionCache = HashMap<usize, CachedTextureConversion>;
+pub(crate) type TextureConversionCache = HashMap<usize, CachedTextureConversion>;
 
 fn headless_texture_info(
     texture_index: usize,
@@ -329,6 +329,7 @@ struct RenderProfile {
     total_triangles: usize,
     vertex_ms: f64,
     raster_ms: f64,
+    texture_ms: f64,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -617,7 +618,7 @@ impl Cx {
         self.headless_ensure_render_pool(render_threads);
 
         let mut results = Vec::new();
-        let mut texture_cache = TextureConversionCache::new();
+        let mut texture_cache = std::mem::take(&mut self.os.texture_conversions);
 
         for draw_pass_id in &passes_todo {
             self.passes[*draw_pass_id].paint_dirty = false;
@@ -664,6 +665,9 @@ impl Cx {
             }
         }
 
+        // Hand the conversions back for the next frame to reuse.
+        self.os.texture_conversions = texture_cache;
+
         let elapsed = frame_start.elapsed();
         if profile_enabled {
             crate::log!(
@@ -673,14 +677,15 @@ impl Cx {
         }
         if profile_enabled {
             crate::log!(
-                "[headless][profile] draws={} serial={} parallel={} inst={} tris={} vertex={:.1}ms raster={:.1}ms",
+                "[headless][profile] draws={} serial={} parallel={} inst={} tris={} vertex={:.1}ms raster={:.1}ms texture={:.1}ms",
                 profile.draw_calls,
                 profile.serial_draw_calls,
                 profile.parallel_draw_calls,
                 profile.total_instances,
                 profile.total_triangles,
                 profile.vertex_ms,
-                profile.raster_ms
+                profile.raster_ms,
+                profile.texture_ms
             );
         }
 
@@ -899,8 +904,12 @@ impl Cx {
                 if let Some(texture) = &draw_call.texture_slots[tex_idx] {
                     let texture_id = texture.texture_id();
                     let cxtexture = &self.textures[texture_id];
-                    if let Some(info) =
-                        headless_texture_info(texture_id.0, cxtexture, texture_cache)
+                    let __tex_t0 = std::time::Instant::now();
+                    let __info = headless_texture_info(texture_id.0, cxtexture, texture_cache);
+                    if let Some(p) = profile.as_deref_mut() {
+                        p.texture_ms += __tex_t0.elapsed().as_secs_f64() * 1000.0;
+                    }
+                    if let Some(info) = __info
                     {
                         tex_infos.push(info);
                     } else {


### PR DESCRIPTION
in headless mode (for testing), things are just so slow. Like glacially slow. so this PR is kinda an amalgamation of fixes to make headless mode testing a lot faster. 

there are still more fixes to come though.

generated summary below:

--------------

## 1. The shader JIT recompiled everything on every start

`HeadlessShaderJit::compile_and_load` builds each shader into a cdylib with `rustc -O`, writing it to `shader_<hash>/shader_<hash>.dylib` — a path already keyed by a content hash of the generated source. It then ignores that file on the next run and recompiles from scratch.

That is 68 `rustc -O` invocations and **38.7s of startup**, paid by every process. A headless suite starts one process per test, so it paid it 55 times — about 35 minutes of the run spent compiling identical inputs.

Now it reuses the dylib when it is there, and only falls back to compiling if it will not `dlopen` or has no `makepad_headless_shader_version` symbol — which covers a file truncated by a killed run or left by another toolchain. Compiles also go to a pid-private path and get renamed into place, so a crash can no longer leave a half-written dylib for the next process to find, and two processes building the same shader cannot interleave.

**38.7s -> 1.2s.**

## 2. The texture conversion cache was rebuilt every frame

`headless_render_all_passes` created a fresh `TextureConversionCache` per frame, so the BGRA->RGBAf32 conversion of the whole glyph atlas ran again on every draw: **430ms of an 840ms frame**.

The cache already carries a signature and re-converts when the texture reports pending updates, so it was written to outlive a frame — it just never got the chance. Parked on `CxOs` instead.

**430ms -> 29ms** per steady-state frame.

## 3. Headless dpi was pinned at 2.0

`CxOsOp::CreateWindow` hardcoded `dpi_factor = 2.0`, i.e. 4x the pixels through a *software* rasteriser. That is the right default — a screenshot should match what a display shows — but a suite that only asserts on logical geometry is paying 4x for nothing.

Still 2.0 unless `MAKEPAD_HEADLESS_DPI` says otherwise.

**Raster 385ms -> 96ms** at dpi 1.

Together a steady frame goes **840ms -> 127ms**.

## Also

`MAKEPAD_HEADLESS_PROFILE` now reports `texture=` alongside `vertex=`/`raster=`. Without it the atlas cost was invisible: raster time looked reasonable and the rest of the frame was unattributed, which is what sent me looking at the wrong thing first.

## Checks

- `cargo build -p makepad-platform` (normal) and `MAKEPAD=headless cargo build -p makepad-widgets` both clean.
- Every change is under `platform/src/os/headless/`, so nothing outside the headless backend is affected.
- Downstream suite: 55/55 green, and one test that had been failing on a 10s harness timeout now passes with the frame budget back.