### PR TITLE
cargo_makepad: link `std` statically for shippable android builds

### DIFF
--- a/tools/cargo_makepad/src/android/compile.rs
+++ b/tools/cargo_makepad/src/android/compile.rs
@@ -753,8 +753,8 @@ fn rust_build(
 
 /// Builds the `RUSTFLAGS` value for an Android `cargo rustc` invocation.
 ///
-/// `prefer_dynamic`: APK/dev builds pass `true` (dynamically linked `std`
-/// keeps incremental relinks fast). AAB builds pass `false` — `prefer-dynamic`
+/// `prefer_dynamic`: debug builds pass `true` (dynamically linked `std` keeps
+/// incremental relinks fast). Release and AAB builds pass `false` — `prefer-dynamic`
 /// makes Rust ship `std` as a separate `libstd-<hash>.so`, and the toolchain's
 /// prebuilt copy of that library is only 4 KB-page aligned, which fails Google
 /// Play's 16 KB page-size requirement for apps targeting Android 15+. Static
@@ -2754,8 +2754,9 @@ pub fn build(
         android_targets,
         variant,
         urls,
-        // APK/dev builds keep `-C prefer-dynamic` for faster incremental relinks.
-        true,
+        // Only debug builds keep `-C prefer-dynamic`, for faster incremental
+        // relinks. Nobody ships a debug apk, and anything else might be shipped.
+        get_profile_from_args(args) == "debug",
     )?;
     // For APK builds, debuggable matches the cargo profile: release -> false,
     // anything else -> true (matches the historical behavior of `cargo makepad


### PR DESCRIPTION
Android apks built by `cargo makepad android build` can't load on the 16 KB-page devices Android 15 allows, which Google Play requires for apps targeting API 35+.

## Cause

`build()` passed `-C prefer-dynamic` unconditionally, so Rust shipped `std` as a separate `libstd-<hash>.so`. That file is a rustup prebuilt, and its LOAD segments are only 4 KB-page aligned:

```
$ llvm-readelf -l libstd-66f124bcab4e42e0.so
  LOAD  0x000000 ... R   0x1000
  LOAD  0x07c8e8 ... R E 0x1000
```

`libmakepad.so` itself was already fine at `0x4000`, so the bundled `std` was the only thing holding the apk back. The aab path already passed `prefer_dynamic: false` for exactly this reason.

## Fix

Only debug builds keep `prefer-dynamic`, where the faster incremental relink is worth having and nothing gets shipped. Everything else links `std` statically, which removes the separate library entirely.

## Verified

Built `makepad-example-counter` for android with `--release`:

* no `libstd-*.so` in the apk, `libmakepad.so` is the only native library
* all four LOAD segments at `p_align 0x4000`
* apksigner v2 + v3 still verify, `zipalign -c 4` passes

## Size

Measured on a real app (a Matrix client, ~1,170 crates), holding everything else constant:

| | native code in the apk |
| --- | --- |
| dynamic `std` | 92,664,096 B (`libmakepad.so` 87,046,608 + `libstd` 5,617,488) |
| static `std` | 87,497,608 B (single library) |
| | **-5,166,488 B (-5.6%)** |

Linking `std` in added only 451 KB to `libmakepad.so`, against a 5.6 MB dylib removed, because `--gc-sections` drops the parts of `std` the app never calls while a dylib has to carry all of it. The apk shrank 1.2 MB and the installed footprint 6.1 MB.

## Build time

Measured on the same app, one `cargo-makepad` binary with `RUSTFLAGS` toggling `prefer-dynamic` so it is the only variable, separate cold target dirs, runs strictly sequential:

| | cold build | incremental (touch crate root) |
| --- | --- | --- |
| dynamic `std` | 264 s | 101 s |
| static `std` | 265 s | 88 s |

Cold builds are unchanged. The incremental case is faster rather than slower, which I did not expect. Static linking more than halves the PLT relocations (12,768 -> 5,496 bytes) since `std` calls stop going through the PLT, and packaging has one fewer 5.6 MB library to copy and deflate into the apk. These timings cover the whole `cargo makepad android build` including packaging, so the win is not attributable to the linker alone.

The one real cost is that updating to this commit forces a full rebuild, since `RUSTFLAGS` is part of cargo's fingerprint.

Debug builds are unaffected and keep `prefer-dynamic`.
