### PR TITLE
iOS: log panics to NSLog, and don't abort when one escapes

### DIFF
--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -52,6 +52,7 @@ use {
     std::{
         cell::RefCell,
         collections::HashMap,
+        panic::{catch_unwind, resume_unwind, AssertUnwindSafe},
         rc::Rc,
         sync::{
             mpsc::{channel, Receiver, Sender},
@@ -419,8 +420,47 @@ impl Drop for IosNativeCameraPreview {
     }
 }
 
+fn ios_panic_summary(info: &std::panic::PanicHookInfo<'_>) -> String {
+    let payload = if let Some(payload) = info.payload().downcast_ref::<&str>() {
+        (*payload).to_string()
+    } else if let Some(payload) = info.payload().downcast_ref::<String>() {
+        payload.clone()
+    } else {
+        "non-string panic payload".to_string()
+    };
+    let location = info
+        .location()
+        .map(|location| {
+            format!(
+                "{}:{}:{}",
+                location.file(),
+                location.line(),
+                location.column()
+            )
+        })
+        .unwrap_or_else(|| "<unknown>".to_string());
+    let thread = std::thread::current();
+    let thread_name = thread.name().unwrap_or("<unnamed>");
+    let backtrace = std::backtrace::Backtrace::force_capture();
+    format!(
+        "iOS panic hook: thread={thread_name} location={location} payload={payload}\n{backtrace}"
+    )
+}
+
+/// The default hook writes to stderr, which goes nowhere on a device, so route
+/// panics through `error!` (NSLog) while the panicking frame is still on the stack.
+fn install_ios_panic_hook() {
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        crate::error!("{}", ios_panic_summary(info));
+        previous_hook(info);
+    }));
+}
+
 impl Cx {
     pub fn event_loop(cx: Rc<RefCell<Cx>>) {
+        install_ios_panic_hook();
+
         let data_path = IosApp::get_ios_directory_paths();
 
         // Get device info
@@ -459,9 +499,15 @@ impl Cx {
                     let event_flow = cx_ref.ios_event_callback(event, &mut metal_cx);
                     let executor = cx_ref.executor.take().unwrap();
                     drop(cx_ref);
-                    executor.run_until_stalled();
+                    // Put the executor back even if a spawned task panics, so
+                    // the `take` above can't hand a `None` to the next event.
+                    let stalled = catch_unwind(AssertUnwindSafe(|| executor.run_until_stalled()));
                     let mut cx_ref = cx.borrow_mut();
                     cx_ref.executor = Some(executor);
+                    drop(cx_ref);
+                    if let Err(payload) = stalled {
+                        resume_unwind(payload);
+                    }
                     event_flow
                 }
             }),

--- a/platform/src/os/apple/ios/ios_app.rs
+++ b/platform/src/os/apple/ios/ios_app.rs
@@ -14,6 +14,7 @@ use {
         cell::{Cell, RefCell},
         collections::HashMap,
         ffi::c_void,
+        panic::{catch_unwind, AssertUnwindSafe},
         rc::Rc,
         time::Instant,
     },
@@ -1097,7 +1098,13 @@ impl IosApp {
     pub fn do_callback(event: IosEvent) -> bool {
         let cb = with_ios_app(|app| app.event_callback.take());
         if let Some(mut callback) = cb {
-            let event_flow = callback(event);
+            // Every caller of this reaches us from an ObjC callback, so a panic
+            // escaping the app would unwind across `extern "C"` and abort.
+            let event_flow = catch_unwind(AssertUnwindSafe(|| callback(event)))
+                .unwrap_or_else(|_| {
+                    crate::error!("Caught a panic while handling an iOS event, dropped it.");
+                    EventFlow::Poll
+                });
             let mtk_view = with_ios_app(|app| app.mtk_view.unwrap());
             with_ios_app(|app| app.event_flow = event_flow);
 


### PR DESCRIPTION
A Rust panic raised while handling an iOS event unwinds out of the `extern "C"` ObjC callback that delivered it, so the process aborts with a bare SIGABRT. Phase-2 unwinding pops every frame between the panic and that callback, and the default panic hook writes to stderr, which goes nowhere on a device.

The result is that nothing about the panic survives. This is the entire app-side stack from the TestFlight report that prompted this:

```
2   libsystem_c      abort + 148
3   <app>            0x...          <- std::panicking / abort_internal
...
11  <app>            0x...
12  <app>            0x...          <- the extern "C" touch IMP
13  UIKitCore        -[UIWindow _sendTouchesForEvent:] + 904
```

No message, no panic site, and no frames from the code that actually panicked.

### Changes

* Install an iOS panic hook in `Cx::event_loop`, mirroring the Android one at `os/linux/android/android.rs:109-144`, that logs payload, location, thread and backtrace through `error!` (already routed to `NSLog` on iOS by `log.rs`). Hooks run at the panic site before unwinding starts, so this captures the location the abort would otherwise erase.

* Wrap the app callback in `IosApp::do_callback` in `catch_unwind`. That's the one choke point every ObjC callback funnels through, so it covers touches, presses, timers, draws and text input at once, rather than patching each of the ~20 IMPs in `ios_delegates.rs`. It also has to be that spot specifically: `do_callback` `take()`s `event_callback` and only restores it on the normal path, so catching any further out would leave the app alive but permanently inert.

* Restore `Cx::executor` in `event_loop`'s callback even when a spawned task panics. It's `take()`n the same way, so without this the catch above would turn one abort into an `unwrap` panic on every later event. The panic still propagates once the executor is back.

macOS and tvOS take the executor the same way, but neither catches, so the process dies either way and there's nothing to restore it for. Left alone.

### Testing

`cargo check`/`cargo clippy -p makepad-platform --target aarch64-apple-ios` are clean with no new warnings, and the host build is unaffected. The behaviour change is on an iOS-device-only path.