### PR TITLE
Splash: a host-services bridge for mini-apps, plus three VM/parser fixes

### DIFF
--- a/platform/script/src/function.rs
+++ b/platform/script/src/function.rs
@@ -45,6 +45,14 @@ impl ScriptRefOptionExt for Option<ScriptFnRef> {
     }
 }
 
+/// The `index`-th DECLARED parameter of a fn/scope object: its named vec
+/// entries, in order. NIL-keyed entries are varargs (`unnamed_fn_arg`) — a
+/// closure captures the scope it was minted in, so those can appear ahead of
+/// real parameters and must never be mistaken for one.
+fn declared_arg(object: &ScriptObjectData, index: usize) -> Option<&ScriptVecValue> {
+    object.vec.iter().filter(|kv| !kv.key.is_nil()).nth(index)
+}
+
 impl ScriptHeap {
     // Functions
 
@@ -95,9 +103,10 @@ impl ScriptHeap {
 
         if let Some(ptr) = object.proto.as_object() {
             let proto_object = &self.objects[ptr];
-            if let Some(kv) = proto_object.vec.get(index) {
+            // Declared parameters only, same reason as `push_all_fn_args`.
+            if let Some(kv) = declared_arg(proto_object, index) {
                 let key = kv.key;
-                if let Some(def) = object.vec.get(index) {
+                if let Some(def) = declared_arg(&self.objects[top_ptr], index) {
                     if !def.value.is_nil()
                         && def.value.value_type().to_redux() != value.value_type().to_redux()
                     {
@@ -170,22 +179,28 @@ impl ScriptHeap {
         if let Some(ptr) = object.proto.as_object() {
             for (index, value) in args.iter().enumerate() {
                 let object = &self.objects[ptr];
-                if let Some(v1) = object.vec.get(index) {
+                // Positional args bind to the DECLARED parameters in order.
+                // Skip NIL-keyed entries: those are varargs (see
+                // `unnamed_fn_arg`), and a closure minted inside a call
+                // captures its scope — including any varargs that call
+                // received. Indexing the raw vec let such a leftover shadow
+                // the closure's own first parameter, so a timer handing a
+                // time to a `||` closure broke every callback created in it
+                // (typecheck against the leftover, then a bind under its NIL
+                // key that left the real parameter unset).
+                if let Some(v1) = declared_arg(object, index) {
                     let key = v1.key;
-                    // typecheck against default arg
-                    if let Some(def) = object.vec.get(index) {
-                        if !def.value.is_nil()
-                            && def.value.value_type().to_redux() != value.value_type().to_redux()
-                        {
-                            return script_err_type_mismatch!(
-                                trap,
-                                "arg {} ({:?}) type mismatch: expected {}, got {}",
-                                index,
-                                key,
-                                format_value_type(self, def.value),
-                                format_value_type(self, *value)
-                            );
-                        }
+                    if !v1.value.is_nil()
+                        && v1.value.value_type().to_redux() != value.value_type().to_redux()
+                    {
+                        return script_err_type_mismatch!(
+                            trap,
+                            "arg {} ({:?}) type mismatch: expected {}, got {}",
+                            index,
+                            key,
+                            format_value_type(self, v1.value),
+                            format_value_type(self, *value)
+                        );
                     }
                     self.objects[top_ptr].map_insert(key, *value);
                 } else {

--- a/platform/script/src/heap.rs
+++ b/platform/script/src/heap.rs
@@ -726,6 +726,19 @@ impl ScriptHeap {
     }
 
     pub fn to_json_inner(&self, value: ScriptValue, out: &mut String) {
+        self.to_json_depth(value, out, 0);
+    }
+
+    fn to_json_depth(&self, value: ScriptValue, out: &mut String, depth: usize) {
+        // A cyclic object/array graph recurses forever here (scripts can
+        // build one, and hosts serialize script-supplied values); a depth cap
+        // turns both cycles and absurd nesting into a null leaf instead of a
+        // host stack overflow.
+        const MAX_JSON_DEPTH: usize = 24;
+        if depth > MAX_JSON_DEPTH {
+            out.push_str("null");
+            return;
+        }
         fn escape_str(inp: &str, out: &mut String) {
             for c in inp.chars() {
                 match c {
@@ -733,8 +746,12 @@ impl ScriptHeap {
                     '\x0c' => out.push_str("\\f"),
                     '\n' => out.push_str("\\n"),
                     '\r' => out.push_str("\\r"),
+                    '\t' => out.push_str("\\t"),
                     '"' => out.push_str("\\\""),
-                    '\\' => out.push_str("\\"),
+                    '\\' => out.push_str("\\\\"),
+                    c if (c as u32) < 0x20 => {
+                        write!(out, "\\u{:04x}", c as u32).ok();
+                    }
                     c => {
                         out.push(c);
                     }
@@ -752,9 +769,9 @@ impl ScriptHeap {
                     if !first {
                         out.push(',')
                     }
-                    self.to_json_inner(key, out);
+                    self.to_json_depth(key, out, depth + 1);
                     out.push(':');
-                    self.to_json_inner(value, out);
+                    self.to_json_depth(value, out, depth + 1);
                     first = false;
                 });
                 for kv in object.vec.iter() {
@@ -762,9 +779,9 @@ impl ScriptHeap {
                         out.push(',')
                     }
                     first = false;
-                    self.to_json_inner(kv.key, out);
+                    self.to_json_depth(kv.key, out, depth + 1);
                     out.push(':');
-                    self.to_json_inner(kv.value, out);
+                    self.to_json_depth(kv.value, out, depth + 1);
                 }
                 if let Some(next_ptr) = object.proto.as_object() {
                     ptr = next_ptr
@@ -784,7 +801,7 @@ impl ScriptHeap {
                         out.push(',')
                     }
                     first = false;
-                    self.to_json_inner(value, out);
+                    self.to_json_depth(value, out, depth + 1);
                 }
             }
             out.push(']');
@@ -823,7 +840,9 @@ impl ScriptHeap {
         } else if let Some(v) = value.as_number() {
             write!(out, "{}", v).ok();
         } else if let Some(v) = value.as_handle() {
-            write!(out, "Handle{:?}", v).ok();
+            // A handle has no JSON form; null is honest and stays parseable.
+            let _ = v;
+            out.push_str("null");
         } else {
             out.push_str("null");
         }

--- a/platform/script/src/json.rs
+++ b/platform/script/src/json.rs
@@ -20,6 +20,10 @@ pub struct JsonParser {
     pub root: ScriptValue,
     pub(crate) state: Vec<State>,
     pub errors: Vec<(u32, String)>,
+    /// A `-` seen in value position, waiting for its number. The tokenizer
+    /// emits the sign as its own Operator token, so without this every
+    /// negative value (and, in an object, its whole key) was dropped.
+    negate: bool,
 }
 
 impl JsonParser {
@@ -29,6 +33,16 @@ impl JsonParser {
         self.state.clear();
         self.state.push(State::Root);
         self.errors.clear();
+        self.negate = false;
+    }
+
+    /// Applies a pending `-` to a freshly-read number.
+    fn signed(&mut self, v: f64) -> f64 {
+        if self.negate {
+            self.negate = false;
+            return -v;
+        }
+        v
     }
 }
 
@@ -61,6 +75,13 @@ impl JsonParser {
                 }
             }
             State::Root => {
+                if let ScriptToken::Operator(op) = tok {
+                    if op == id!(-) {
+                        self.negate = true;
+                        self.state.push(State::Root);
+                        return;
+                    }
+                }
                 match tok {
                     ScriptToken::Identifier(id) => match id {
                         id!(true) => self.root = TRUE.into(),
@@ -76,11 +97,13 @@ impl JsonParser {
                         self.state.push(State::RootMaybeObject);
                     }
                     ScriptToken::U40(v) => {
-                        self.root = (v as f64).into();
+                        let n = self.signed(v as f64);
+                        self.root = n.into();
                         self.state.push(State::RootMaybeObject);
                     }
                     ScriptToken::F64(v) => {
-                        self.root = v.into();
+                        let n = self.signed(v);
+                        self.root = n.into();
                         self.state.push(State::RootMaybeObject);
                     }
                     ScriptToken::Color(v) => {
@@ -198,6 +221,15 @@ impl JsonParser {
                 }
             },
             State::ObjectValue(obj, key) => {
+                // A leading `-` is its own token; keep waiting for the number
+                // it belongs to instead of consuming the value slot.
+                if let ScriptToken::Operator(op) = tok {
+                    if op == id!(-) {
+                        self.negate = true;
+                        self.state.push(State::ObjectValue(obj, key));
+                        return;
+                    }
+                }
                 self.state.push(State::ObjectKey(obj));
                 match tok {
                     ScriptToken::Identifier(id) => match id {
@@ -210,10 +242,12 @@ impl JsonParser {
                         heap.set_value_def(obj, key, v);
                     }
                     ScriptToken::U40(v) => {
-                        heap.set_value_def(obj, key, (v as f64).into());
+                        let n = self.signed(v as f64);
+                        heap.set_value_def(obj, key, n.into());
                     }
                     ScriptToken::F64(v) => {
-                        heap.set_value_def(obj, key, v.into());
+                        let n = self.signed(v);
+                        heap.set_value_def(obj, key, n.into());
                     }
                     ScriptToken::Color(v) => {
                         heap.set_value_def(obj, key, v.into());
@@ -260,6 +294,13 @@ impl JsonParser {
                 }
             }
             State::Array(arr) => {
+                if let ScriptToken::Operator(op) = tok {
+                    if op == id!(-) {
+                        self.negate = true;
+                        self.state.push(State::Array(arr));
+                        return;
+                    }
+                }
                 self.state.push(State::Array(arr));
                 // alright we can parse a value or ]
                 match tok {
@@ -273,10 +314,12 @@ impl JsonParser {
                         heap.array_push_unchecked(arr, v);
                     }
                     ScriptToken::U40(v) => {
-                        heap.array_push_unchecked(arr, (v as f64).into());
+                        let n = self.signed(v as f64);
+                        heap.array_push_unchecked(arr, n.into());
                     }
                     ScriptToken::F64(v) => {
-                        heap.array_push_unchecked(arr, v.into());
+                        let n = self.signed(v);
+                        heap.array_push_unchecked(arr, n.into());
                     }
                     ScriptToken::Color(v) => {
                         heap.array_push_unchecked(arr, ScriptValue::from_color(v));

--- a/platform/script/src/parser.rs
+++ b/platform/script/src/parser.rs
@@ -733,6 +733,12 @@ pub struct ScriptParser {
     pub opcodes: Vec<ScriptValue>,
     pub source_map: Vec<Option<u32>>,
     pub had_error: bool,
+    /// Formatted parse errors, mirroring what `report_error` logged. Parse
+    /// errors never reach the VM's trap queue (the parser recovers and the
+    /// module still runs), so hosts capturing diagnostics (validation, AI
+    /// repair loops) read them from here — the eval paths drain this into
+    /// `ScriptVmBase::captured_errors` when a sink is installed.
+    pub errors: Vec<String>,
 
     state: Vec<State>,
     pub file: String,
@@ -766,6 +772,7 @@ impl Default for ScriptParser {
             opcodes: Default::default(),
             source_map: Default::default(),
             had_error: false,
+            errors: Default::default(),
             state: vec![State::BeginStmt {
                 last_was_sep: false,
             }],
@@ -800,6 +807,13 @@ impl ScriptParser {
         let (line, col) = tokenizer
             .token_index_to_row_col(self.index)
             .unwrap_or((0, 0));
+        self.errors.push(format!(
+            "{}:{}:{} - {}",
+            self.file,
+            line as u32 + self.line_offset as u32,
+            col as u32 + self.col_offset as u32,
+            msg
+        ));
         log_with_level(
             &self.file,
             line as u32 + self.line_offset as u32,

--- a/platform/script/src/vm.rs
+++ b/platform/script/src/vm.rs
@@ -1266,7 +1266,14 @@ impl<'a> ScriptVm<'a> {
                 );
                 body.source_len = body.effective_code.len();
             }
+            // Parse errors never enter the trap queue (the parser recovers);
+            // surface them to a captured-diagnostics sink here or a validating
+            // host reports success for a script that failed to parse.
+            let parse_errors = std::mem::take(&mut body.parser.errors);
             drop(bodies);
+            if let Some(sink) = self.bx.captured_errors.as_mut() {
+                sink.extend(parse_errors);
+            }
             // lets point our thread to it
             let result = self.run_root(body_id);
             // Mark the result object with FROM_EVAL flag
@@ -1379,7 +1386,12 @@ impl<'a> ScriptVm<'a> {
 
             body.checkpoint = Some(cp);
 
+            // Same parse-error surfacing as the non-streaming eval above.
+            let parse_errors = std::mem::take(&mut body.parser.errors);
             drop(bodies);
+            if let Some(sink) = self.bx.captured_errors.as_mut() {
+                sink.extend(parse_errors);
+            }
             // Silence runtime errors during incremental eval — incomplete code
             // will inevitably produce errors that are meaningless until the
             // source is fully received.

--- a/platform/script/tests/extra_arg_typecheck.rs
+++ b/platform/script/tests/extra_arg_typecheck.rs
@@ -1,0 +1,116 @@
+//! Regression: a callback minted inside a closure that was invoked with MORE
+//! args than it declares must still be callable with any type.
+//!
+//! Empirically (host_launcher, 2026-08-14): a mini-app's `host.request`
+//! callback created inside a `start_timeout(0.05, || { ... })` body died with
+//! "arg 0 (nil) type mismatch: expected number, got object" when the host
+//! answered. The timer invokes the zero-arg closure with one number (the
+//! time), which lands in the frame as an EXTRA arg keyed NIL; a closure
+//! created in that body inherits the frame as its prototype, so the leftover
+//! number became a "declared default" and typechecked every later call.
+//!
+//! The `(nil)` in the message is the tell: a declared parameter has a real
+//! key, so only a pushed extra arg can produce it.
+
+use std::cell::RefCell;
+
+use makepad_script::*;
+
+fn test_vm() -> ScriptVm<'static> {
+    let host = Box::leak(Box::new(0i32));
+    let std = Box::leak(Box::new(0i32));
+    ScriptVm {
+        host,
+        std,
+        bx: Box::new(ScriptVmBase::new()),
+    }
+}
+
+std::thread_local! {
+    static OUTER: RefCell<Option<ScriptFnRef>> = RefCell::new(None);
+    static INNER: RefCell<Option<ScriptFnRef>> = RefCell::new(None);
+}
+
+#[test]
+fn callback_minted_in_an_over_called_closure_survives() {
+    let mut vm = test_vm();
+    let m = vm.new_module(id!(hostx));
+    // Stands in for start_timeout: keeps the closure to fire later.
+    vm.add_method(m, id_lut!(later), script_args_def!(cb = NIL), |vm, args| {
+        let cb = script_value!(vm, args.cb);
+        let obj = cb.as_object().expect("closure object");
+        let fnref = vm.bx.heap.new_fn_ref(obj);
+        OUTER.with(|s| *s.borrow_mut() = Some(fnref));
+        NIL
+    });
+    // Stands in for host.request: keeps the result callback.
+    vm.add_method(
+        m,
+        id_lut!(request),
+        script_args_def!(service = NIL, on_result = NIL),
+        |vm, args| {
+            let on_result = script_value!(vm, args.on_result);
+            let obj = on_result.as_object().expect("callback object");
+            let fnref = vm.bx.heap.new_fn_ref(obj);
+            INNER.with(|s| *s.borrow_mut() = Some(fnref));
+            NIL
+        },
+    );
+
+    vm.bx.captured_errors = Some(Vec::new());
+    let code = "\
+let out = \"PENDING\"
+fn done(r){
+    out = \"GOT\"
+}
+let _t = mod.hostx.later(|| {
+    let _r = mod.hostx.request(\"svc\", |r| done(r))
+})";
+    vm.with_instruction_limit(500_000, |vm| {
+        vm.eval(ScriptMod {
+            cargo_manifest_path: String::new(),
+            module_path: String::new(),
+            file: "extra_arg_typecheck".to_string(),
+            line: 0,
+            column: 0,
+            code: code.to_string(),
+            values: vec![],
+        })
+    });
+
+    // The timer fires the zero-arg closure WITH a time number, exactly like
+    // handle_script_timer does. This is what poisons the frame.
+    let outer = OUTER.with(|s| s.borrow_mut().take()).expect("outer closure");
+    vm.with_instruction_limit(500_000, |vm| {
+        vm.call(outer.as_object().into(), &[1.5.into()]);
+    });
+
+    // Now the host answers with an OBJECT, as every bridge response does.
+    let inner = INNER.with(|s| s.borrow_mut().take()).expect("inner callback");
+    let obj = vm.bx.heap.new_object();
+    let trap = vm.bx.threads.cur().trap.pass();
+    vm.bx.heap.set_value(obj, id!(is_ok).into(), true.into(), trap);
+    vm.with_instruction_limit(500_000, |vm| {
+        vm.call(inner.as_object().into(), &[obj.into()]);
+    });
+
+    let errors = vm.take_errors();
+    assert!(errors.is_empty(), "callback errored: {errors:?}");
+
+    let scope = {
+        let bodies = vm.bx.code.bodies.borrow();
+        bodies
+            .iter()
+            .find_map(|body| match &body.source {
+                ScriptSource::Mod(m) if m.file == "extra_arg_typecheck" => {
+                    Some(body.scope.as_object())
+                }
+                _ => None,
+            })
+            .expect("body scope")
+    };
+    let out = vm.bx.heap.scope_value(scope, id!(out), vm.trap());
+    let mut got = String::new();
+    vm.string_with(out, |_vm, s| got = s.to_string());
+    assert_eq!(got, "GOT", "the callback never ran");
+}

--- a/platform/script/tests/fn_ref_callback.rs
+++ b/platform/script/tests/fn_ref_callback.rs
@@ -87,3 +87,73 @@ fn stored_fn_ref_calls_back_with_built_object() {
     let value = vm.bx.heap.value(got_obj, id!(value).into(), vm.trap());
     assert_eq!(value.as_bool(), Some(true), "callback did not run: {value:?}");
 }
+
+/// The isolation_probe shape: the request is made inside a closure, the
+/// callback is a `fn(r)` expression argument, and the result lands in a
+/// module scalar through a named fn.
+#[test]
+fn nested_fn_arg_callback_mutates_module_scalar() {
+    let mut vm = test_vm();
+    let m = vm.new_module(id!(hostx));
+    vm.add_method(
+        m,
+        id_lut!(request),
+        script_args_def!(service = NIL, args = NIL, on_result = NIL),
+        |vm, args| {
+            let on_result = script_value!(vm, args.on_result);
+            let obj = on_result.as_object().expect("callback object");
+            assert!(vm.bx.heap.is_fn(obj), "callback object is not fn-tagged");
+            let fnref = vm.bx.heap.new_fn_ref(obj);
+            STORED.with(|s| *s.borrow_mut() = Some(fnref));
+            1.0.into()
+        },
+    );
+    vm.bx.captured_errors = Some(Vec::new());
+    let code = "\
+let svc_text = \"PENDING\"
+fn svc_result(r){
+    if r.is_ok {
+        svc_text = \"ALLOWED\"
+        return nil
+    }
+    svc_text = \"DENIED\"
+}
+let run = || {
+    let _rid = mod.hostx.request(\"svc\", {}, fn(r) { svc_result(r) })
+}
+run()";
+    vm.with_instruction_limit(500_000, |vm| {
+        vm.eval(ScriptMod {
+            cargo_manifest_path: String::new(),
+            module_path: String::new(),
+            file: "nested_fn_cb".to_string(),
+            line: 0,
+            column: 0,
+            code: code.to_string(),
+            values: vec![],
+        })
+    });
+    let callback = STORED.with(|s| s.borrow_mut().take()).expect("stored");
+    let obj = vm.bx.heap.new_object();
+    let trap = vm.bx.threads.cur().trap.pass();
+    vm.bx.heap.set_value(obj, id!(is_ok).into(), false.into(), trap);
+    vm.with_instruction_limit(500_000, |vm| {
+        vm.call(callback.as_object().into(), &[obj.into()]);
+    });
+    let errors = vm.take_errors();
+    assert!(errors.is_empty(), "callback errored: {errors:?}");
+    let scope = {
+        let bodies = vm.bx.code.bodies.borrow();
+        bodies
+            .iter()
+            .find_map(|body| match &body.source {
+                ScriptSource::Mod(m) if m.file == "nested_fn_cb" => Some(body.scope.as_object()),
+                _ => None,
+            })
+            .expect("body scope")
+    };
+    let text = vm.bx.heap.scope_value(scope, id!(svc_text), vm.trap());
+    let mut out = String::new();
+    vm.string_with(text, |_vm, s| out = s.to_string());
+    assert_eq!(out, "DENIED", "callback chain did not update the module var");
+}

--- a/platform/script/tests/fn_ref_callback.rs
+++ b/platform/script/tests/fn_ref_callback.rs
@@ -1,0 +1,89 @@
+//! Mirrors the splash_host bridge: a native fn stores a script closure as a
+//! ScriptFnRef; the host later builds a result object and calls it.
+
+use std::cell::RefCell;
+use makepad_script::*;
+
+fn test_vm() -> ScriptVm<'static> {
+    let host = Box::leak(Box::new(0i32));
+    let std = Box::leak(Box::new(0i32));
+    ScriptVm {
+        host,
+        std,
+        bx: Box::new(ScriptVmBase::new()),
+    }
+}
+
+std::thread_local! {
+    static STORED: RefCell<Option<ScriptFnRef>> = RefCell::new(None);
+}
+
+#[test]
+fn stored_fn_ref_calls_back_with_built_object() {
+    let mut vm = test_vm();
+    let m = vm.new_module(id!(hostx));
+    vm.add_method(
+        m,
+        id_lut!(request),
+        script_args_def!(service = NIL, args = NIL, on_result = NIL),
+        |vm, args| {
+            let on_result = script_value!(vm, args.on_result);
+            let Some(obj) = on_result.as_object() else {
+                panic!("callback is not an object");
+            };
+            assert!(vm.bx.heap.is_fn(obj), "callback object is not fn-tagged");
+            let fnref = vm.bx.heap.new_fn_ref(obj);
+            STORED.with(|s| *s.borrow_mut() = Some(fnref));
+            1.0.into()
+        },
+    );
+
+    vm.bx.captured_errors = Some(Vec::new());
+    vm.with_instruction_limit(500_000, |vm| {
+        vm.eval(ScriptMod {
+            cargo_manifest_path: String::new(),
+            module_path: String::new(),
+            file: "fn_ref_callback".to_string(),
+            line: 0,
+            column: 0,
+            // `is_ok`, not `ok`: `ok` is the ok-test keyword and `r.ok` does
+            // not parse as field access — the exact bug that motivated the
+            // bridge's result-field name.
+            code: "let got = {value: -1}\nlet _rid = mod.hostx.request(\"svc\", {}, fn(r) { got.value = r.is_ok })\n(got)"
+                .to_string(),
+            values: vec![],
+        })
+    });
+
+    // The host answers later: build {ok: true, ...} and invoke the callback,
+    // exactly as splash_host_respond does.
+    let callback = STORED.with(|s| s.borrow_mut().take()).expect("stored");
+    let obj = vm.bx.heap.new_object();
+    let trap = vm.bx.threads.cur().trap.pass();
+    vm.bx.heap.set_value(obj, id!(is_ok).into(), true.into(), trap);
+    vm.bx.heap.set_value(obj, id!(data).into(), NIL, trap);
+    vm.with_instruction_limit(500_000, |vm| {
+        vm.call(callback.as_object().into(), &[obj.into()]);
+    });
+
+    let errors = vm.take_errors();
+    assert!(errors.is_empty(), "callback errored: {errors:?}");
+
+    // The closure wrote r.ok into module state.
+    let scope = {
+        let bodies = vm.bx.code.bodies.borrow();
+        bodies
+            .iter()
+            .find_map(|body| match &body.source {
+                ScriptSource::Mod(m) if m.file == "fn_ref_callback" => {
+                    Some(body.scope.as_object())
+                }
+                _ => None,
+            })
+            .expect("body scope")
+    };
+    let got = vm.bx.heap.scope_value(scope, id!(got), vm.trap());
+    let got_obj = got.as_object().expect("got object");
+    let value = vm.bx.heap.value(got_obj, id!(value).into(), vm.trap());
+    assert_eq!(value.as_bool(), Some(true), "callback did not run: {value:?}");
+}

--- a/platform/script/tests/json_negative_numbers.rs
+++ b/platform/script/tests/json_negative_numbers.rs
@@ -1,0 +1,66 @@
+//! Regression: JSON negative numbers must survive `parse_json`.
+//!
+//! Empirically (host_launcher, 2026-08-14): the tokenizer emits a leading `-`
+//! as its own Operator token, and the value positions had no case for it — so
+//! the sign was swallowed AND, inside an object, the key it belonged to was
+//! dropped entirely. `{"lat":37.7,"lon":-122.4}` parsed to `{"lat":37.7}`,
+//! silently. A mini-app asking the host for a location got coordinates with
+//! no longitude and quietly fell back to a default city; sub-zero
+//! temperatures and negative UTC offsets had the same fate.
+
+use makepad_script::*;
+
+fn test_vm() -> ScriptVm<'static> {
+    let host = Box::leak(Box::new(0i32));
+    let std = Box::leak(Box::new(0i32));
+    ScriptVm {
+        host,
+        std,
+        bx: Box::new(ScriptVmBase::new()),
+    }
+}
+
+fn eval_str(vm: &mut ScriptVm, code: &str) -> String {
+    let v = vm.with_instruction_limit(500_000, |vm| {
+        vm.eval(ScriptMod {
+            cargo_manifest_path: String::new(),
+            module_path: String::new(),
+            file: "json_negative".to_string(),
+            line: 0,
+            column: 0,
+            code: code.to_string(),
+            values: vec![],
+        })
+    });
+    let mut out = String::new();
+    vm.string_with(v, |_vm, s| out = s.to_string());
+    out
+}
+
+#[test]
+fn object_keeps_negative_values_and_their_keys() {
+    let mut vm = test_vm();
+    let out = eval_str(
+        &mut vm,
+        "let o = \"{\\\"lat\\\":37.7,\\\"lon\\\":-122.4,\\\"n\\\":-5}\".parse_json()\n(\"\" + o.to_json())",
+    );
+    assert!(out.contains("\"lon\":-122.4"), "lon lost: {out}");
+    assert!(out.contains("\"n\":-5"), "negative int lost: {out}");
+    assert!(out.contains("\"lat\":37.7"), "positive lost: {out}");
+}
+
+#[test]
+fn arrays_and_nested_values_keep_the_sign() {
+    let mut vm = test_vm();
+    let arr = eval_str(&mut vm, "let a = \"[-1, 2, -3.5]\".parse_json()\n(\"\" + a.to_json())");
+    assert_eq!(arr, "[-1,2,-3.5]");
+    // Nested, which is the shape real payloads arrive in (a forecast row, a
+    // timezone offset). A bare scalar root like `"-42"` stays unsupported —
+    // `"42"` never parsed either, so that is a separate, pre-existing gap.
+    let nested = eval_str(
+        &mut vm,
+        "let o = \"{\\\"d\\\":{\\\"lo\\\":-7},\\\"z\\\":[-14400]}\".parse_json()\n(\"\" + o.to_json())",
+    );
+    assert!(nested.contains("\"lo\":-7"), "nested object negative lost: {nested}");
+    assert!(nested.contains("[-14400]"), "nested array negative lost: {nested}");
+}

--- a/platform/script/tests/parse_error_capture.rs
+++ b/platform/script/tests/parse_error_capture.rs
@@ -1,0 +1,102 @@
+//! Regression tests: parse errors must reach a captured-diagnostics sink.
+//!
+//! Empirically (host_launcher, 2026-08-14): the parser RECOVERS from errors
+//! like a dangling `else` in expression position — it logs, sets `had_error`,
+//! and still produces a runnable module. Nothing entered the trap queue, so a
+//! validating host (`captured_errors` sink + `take_errors`) reported SUCCESS
+//! for scripts that failed to parse, and broken mini-apps sailed through
+//! validation with their errors only in the log.
+
+use makepad_script::*;
+
+fn test_vm() -> ScriptVm<'static> {
+    let host = Box::leak(Box::new(0i32));
+    let std = Box::leak(Box::new(0i32));
+    ScriptVm {
+        host,
+        std,
+        bx: Box::new(ScriptVmBase::new()),
+    }
+}
+
+fn eval_captured(vm: &mut ScriptVm, name: &str, code: &str) -> Vec<String> {
+    vm.bx.captured_errors = Some(Vec::new());
+    vm.with_instruction_limit(500_000, |vm| {
+        vm.eval(ScriptMod {
+            cargo_manifest_path: String::new(),
+            module_path: String::new(),
+            file: format!("parse_error_capture_{name}"),
+            line: 0,
+            column: 0,
+            code: code.to_string(),
+            values: vec![],
+        })
+    });
+    vm.take_errors()
+}
+
+/// The exact shape that sailed through host_launcher's validation while
+/// failing to parse (isolation_probe's svc_result, 2026-08-14): a fn whose
+/// FINAL statement is an if with call-statement branches and the `else` on
+/// its own line. The parser reports "Unexpected else" and recovers; the sink
+/// must see it.
+const DANGLING_ELSE: &str = "\
+fn svc_result(r){
+    let ok = r.ok
+    if ok {
+        ui.a.set_text(\"A\")
+        ui.b.set_text(\"A\")
+    }
+    else {
+        ui.a.set_text(\"B\")
+        ui.b.set_text(\"B\")
+    }
+}
+1 + 2";
+
+#[test]
+fn dangling_else_reaches_the_sink() {
+    let mut vm = test_vm();
+    let errors = eval_captured(&mut vm, "dangling_else", DANGLING_ELSE);
+    assert!(
+        errors.iter().any(|e| e.contains("Unexpected else")),
+        "parse error missing from captured sink: {errors:?}"
+    );
+}
+
+/// A clean script contributes nothing. (Ends on a parenthesized expression:
+/// a final `let` and a final bare ident each trip unrelated quirks.)
+#[test]
+fn clean_parse_captures_nothing() {
+    let mut vm = test_vm();
+    let errors = eval_captured(&mut vm, "clean", "let x = 1 + 2\n(x + 1)");
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+}
+
+/// The append/streaming eval path surfaces parse errors the same way.
+#[test]
+fn streaming_eval_surfaces_parse_errors() {
+    let mut vm = test_vm();
+    vm.bx.captured_errors = Some(Vec::new());
+    let code = DANGLING_ELSE;
+    vm.with_instruction_limit(500_000, |vm| {
+        vm.eval_with_append_source(
+            ScriptMod {
+                cargo_manifest_path: String::new(),
+                module_path: "stream#1".to_string(),
+                file: "parse_error_capture_stream".to_string(),
+                line: 0,
+                column: 0,
+                code: String::new(),
+                values: vec![],
+            },
+            code,
+            NIL.into(),
+        )
+    });
+    let errors = vm.take_errors();
+    assert!(
+        errors.iter().any(|e| e.contains("Unexpected else")),
+        "streaming parse error missing from captured sink: {errors:?}"
+    );
+}

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -22,6 +22,7 @@ pub mod theme_desktop_light;
 pub mod theme_desktop_skeleton;
 pub mod widget;
 pub mod widget_async;
+pub mod splash_host;
 pub mod splash_storage;
 pub mod widget_match_event;
 pub mod widget_tree;

--- a/widgets/src/splash.rs
+++ b/widgets/src/splash.rs
@@ -45,6 +45,15 @@ pub struct Splash {
     /// between eval and a later call).
     #[rust]
     body_id: Option<u16>,
+    /// Host-trusted identity carried on every `host.request` this isolate
+    /// makes (see splash_host.rs). None = requests arrive untagged, which a
+    /// policy-enforcing host treats as deniable — right for previews.
+    #[rust]
+    host_tag: Option<String>,
+    /// Granted-capability names `host.capabilities()` reports. Informational
+    /// for the script's UI; enforcement is the host's per-request decision.
+    #[rust]
+    host_caps: Vec<String>,
     /// What to call this script in error messages. Set by the host to the
     /// mini-app's id; empty for previews and one-off evals.
     ///
@@ -61,18 +70,22 @@ pub struct Splash {
 // scope as a bare name — app scripts say `fs.read("/x")`, not `mod.fs.read`.
 // A script reassigning `fs` only sabotages its own binding; the jail itself
 // lives host-side.
-/// Lines the prefixes below occupy, which is the amount every reported script
-/// line is ahead of the app's own file. Subtract it to get the line in the
-/// `.splash` source.
+/// Lines the no-net prefix occupies, which is the amount every reported
+/// script line is ahead of the app's own file. Subtract it to get the line in
+/// the `.splash` source; net-enabled apps carry one extra line
+/// ([`SPLASH_NET_PREFIX_LINES`]).
 ///
 /// It cannot be zero: the prefix would then have to share line 1 with the
 /// app's first line, and a generated app's first line is its `// name:`
 /// header — a comment, which would swallow the rest of the prefix.
-pub const SPLASH_PREFIX_LINES: u32 = 2;
+pub const SPLASH_PREFIX_LINES: u32 = 3;
+/// Line offset for net-enabled apps (their prefix adds `use mod.net`).
+pub const SPLASH_NET_PREFIX_LINES: u32 = 4;
 
-const SPLASH_PREFIX: &str = "use mod.prelude.widgets.*\nlet fs = mod.fs\nView{height:Fit, ";
+const SPLASH_PREFIX: &str =
+    "use mod.prelude.widgets.*\nlet fs = mod.fs\nlet host = mod.host\nView{height:Fit, ";
 const SPLASH_NET_PREFIX: &str =
-    "use mod.prelude.widgets.*\nuse mod.net\nlet fs = mod.fs\nView{height:Fit, ";
+    "use mod.prelude.widgets.*\nuse mod.net\nlet fs = mod.fs\nlet host = mod.host\nView{height:Fit, ";
 const SPLASH_EVAL_INSTRUCTION_LIMIT: usize = 200_000;
 
 impl Splash {
@@ -120,10 +133,12 @@ impl Splash {
         if self.vm_id == MAIN_SPLASH_VM_ID {
             self.vm_id = cx.alloc_splash_vm_with_network(self.allow_net);
         }
-        // (Re)bind this isolate's storage jail. Keyed by heap so the script
-        // can neither read nor retarget it.
+        // (Re)bind this isolate's storage jail and host-bridge identity.
+        // Keyed by heap so the script can neither read nor retarget them.
         let heap_key = cx.with_script_vm_id(self.vm_id, |vm| vm.bx.heap.heap_key());
         crate::splash_storage::set_root_for_heap(heap_key, self.sandbox_dir.clone());
+        crate::splash_host::set_tag_for_heap(heap_key, self.host_tag.clone());
+        crate::splash_host::set_caps_for_heap(heap_key, self.host_caps.clone());
 
         let body_key = self.body_key();
         // Full code string: prefix + body (no closing - parser auto-closes)
@@ -382,6 +397,30 @@ impl Splash {
         })
     }
 
+    /// Like [`Self::call_script_fn`], but with string arguments — those are
+    /// heap values, so they must be minted inside this isolate's own heap
+    /// right before the call (a cross-heap ScriptValue would resolve in the
+    /// wrong arena). Used for host->script deliveries like IPC messages.
+    pub fn call_script_fn_with_strings(&mut self, cx: &mut Cx, name: LiveId, args: &[&str]) -> bool {
+        let Some(scope) = self.body_scope(cx) else {
+            return false;
+        };
+        cx.with_script_vm_id(self.vm_id, |vm| {
+            let fnval = vm.bx.heap.scope_value(scope, name, NoTrap);
+            if fnval.is_nil() || fnval.is_err() {
+                return false;
+            }
+            let vals: Vec<ScriptValue> = args
+                .iter()
+                .map(|s| vm.new_string_with(|_vm, out| out.push_str(s)))
+                .collect();
+            vm.with_instruction_limit(WIDGET_SCRIPT_INSTRUCTION_LIMIT, |vm| {
+                vm.call(fnval, &vals);
+            });
+            true
+        })
+    }
+
     /// Sets whether this Splash's isolate gets the networking runtime. Must be
     /// called before the body is first evaluated (i.e. before `set_text`) — the
     /// VM is allocated with or without network on that first eval and isn't
@@ -399,6 +438,28 @@ impl Splash {
         if self.vm_id != MAIN_SPLASH_VM_ID {
             let heap_key = cx.with_script_vm_id(self.vm_id, |vm| vm.bx.heap.heap_key());
             crate::splash_storage::set_root_for_heap(heap_key, dir);
+        }
+    }
+
+    /// Assigns the host-trusted identity for this app's `host.request` calls.
+    /// Call BEFORE set_text so boot-time requests already carry it; takes
+    /// effect immediately when the isolate is live.
+    pub fn set_host_tag(&mut self, cx: &mut Cx, tag: Option<String>) {
+        self.host_tag = tag.clone();
+        if self.vm_id != MAIN_SPLASH_VM_ID {
+            let heap_key = cx.with_script_vm_id(self.vm_id, |vm| vm.bx.heap.heap_key());
+            crate::splash_host::set_tag_for_heap(heap_key, tag);
+        }
+    }
+
+    /// Replaces the capability list `host.capabilities()` reports to this
+    /// app. Informational (the host still decides every request); push it
+    /// again whenever grants change so the script's UI can adapt.
+    pub fn set_host_caps(&mut self, cx: &mut Cx, caps: Vec<String>) {
+        self.host_caps = caps.clone();
+        if self.vm_id != MAIN_SPLASH_VM_ID {
+            let heap_key = cx.with_script_vm_id(self.vm_id, |vm| vm.bx.heap.heap_key());
+            crate::splash_host::set_caps_for_heap(heap_key, caps);
         }
     }
 
@@ -452,10 +513,33 @@ impl SplashRef {
         }
     }
 
+    /// See [`Splash::set_host_tag`].
+    pub fn set_host_tag(&self, cx: &mut Cx, tag: Option<String>) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_host_tag(cx, tag);
+        }
+    }
+
+    /// See [`Splash::set_host_caps`].
+    pub fn set_host_caps(&self, cx: &mut Cx, caps: Vec<String>) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_host_caps(cx, caps);
+        }
+    }
+
     /// See [`Splash::call_script_fn`].
     pub fn call_script_fn(&self, cx: &mut Cx, name: LiveId, args: &[ScriptValue]) -> bool {
         if let Some(mut inner) = self.borrow_mut() {
             inner.call_script_fn(cx, name, args)
+        } else {
+            false
+        }
+    }
+
+    /// See [`Splash::call_script_fn_with_strings`].
+    pub fn call_script_fn_with_strings(&self, cx: &mut Cx, name: LiveId, args: &[&str]) -> bool {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.call_script_fn_with_strings(cx, name, args)
         } else {
             false
         }

--- a/widgets/src/splash.rs
+++ b/widgets/src/splash.rs
@@ -54,6 +54,11 @@ pub struct Splash {
     /// for the script's UI; enforcement is the host's per-request decision.
     #[rust]
     host_caps: Vec<String>,
+    /// Whether this isolate's surface may raise user prompts (true for a
+    /// foreground app host, false for background surfaces like home-screen
+    /// widget tiles). Rides on every host.request as `may_prompt`.
+    #[rust(true)]
+    host_prompts: bool,
     /// What to call this script in error messages. Set by the host to the
     /// mini-app's id; empty for previews and one-off evals.
     ///
@@ -139,6 +144,7 @@ impl Splash {
         crate::splash_storage::set_root_for_heap(heap_key, self.sandbox_dir.clone());
         crate::splash_host::set_tag_for_heap(heap_key, self.host_tag.clone());
         crate::splash_host::set_caps_for_heap(heap_key, self.host_caps.clone());
+        crate::splash_host::set_prompts_for_heap(heap_key, self.host_prompts);
 
         let body_key = self.body_key();
         // Full code string: prefix + body (no closing - parser auto-closes)
@@ -463,6 +469,27 @@ impl Splash {
         }
     }
 
+    /// Marks whether this isolate's surface may raise user prompts; see
+    /// `SplashHostRequest::may_prompt`. Defaults true.
+    pub fn set_host_prompts(&mut self, cx: &mut Cx, may_prompt: bool) {
+        self.host_prompts = may_prompt;
+        if self.vm_id != MAIN_SPLASH_VM_ID {
+            let heap_key = cx.with_script_vm_id(self.vm_id, |vm| vm.bx.heap.heap_key());
+            crate::splash_host::set_prompts_for_heap(heap_key, may_prompt);
+        }
+    }
+
+    /// This Splash's live isolate heap identity (None while stopped) — the
+    /// same key `SplashHostRequest::heap_key` carries, so hosts can relate a
+    /// request to a specific widget (e.g. to skip an IPC sender's own isolate
+    /// when fanning a message out).
+    pub fn isolate_heap_key(&mut self, cx: &mut Cx) -> Option<usize> {
+        if self.vm_id == MAIN_SPLASH_VM_ID {
+            return None;
+        }
+        Some(cx.with_script_vm_id(self.vm_id, |vm| vm.bx.heap.heap_key()))
+    }
+
     /// Sets (or replaces) a global visible to this Splash's script, like the
     /// injected `ui` handle. Useful for handing scripts host-provided context
     /// (configuration, sizes, capabilities) without re-evaluating the body.
@@ -524,6 +551,22 @@ impl SplashRef {
     pub fn set_host_caps(&self, cx: &mut Cx, caps: Vec<String>) {
         if let Some(mut inner) = self.borrow_mut() {
             inner.set_host_caps(cx, caps);
+        }
+    }
+
+    /// See [`Splash::set_host_prompts`].
+    pub fn set_host_prompts(&self, cx: &mut Cx, may_prompt: bool) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_host_prompts(cx, may_prompt);
+        }
+    }
+
+    /// See [`Splash::isolate_heap_key`].
+    pub fn isolate_heap_key(&self, cx: &mut Cx) -> Option<usize> {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.isolate_heap_key(cx)
+        } else {
+            None
         }
     }
 

--- a/widgets/src/splash.rs
+++ b/widgets/src/splash.rs
@@ -59,6 +59,10 @@ pub struct Splash {
     /// widget tiles). Rides on every host.request as `may_prompt`.
     #[rust(true)]
     host_prompts: bool,
+    /// Whole-jail byte cap when the host has granted this app extra room.
+    /// None leaves the storage default.
+    #[rust]
+    storage_quota: Option<u64>,
     /// What to call this script in error messages. Set by the host to the
     /// mini-app's id; empty for previews and one-off evals.
     ///
@@ -145,6 +149,7 @@ impl Splash {
         crate::splash_host::set_tag_for_heap(heap_key, self.host_tag.clone());
         crate::splash_host::set_caps_for_heap(heap_key, self.host_caps.clone());
         crate::splash_host::set_prompts_for_heap(heap_key, self.host_prompts);
+        crate::splash_storage::set_quota_for_heap(heap_key, self.storage_quota);
 
         let body_key = self.body_key();
         // Full code string: prefix + body (no closing - parser auto-closes)
@@ -469,6 +474,17 @@ impl Splash {
         }
     }
 
+    /// Raises this app's whole-jail storage cap (None = the default). Takes
+    /// effect immediately; a lowered cap refuses further growth rather than
+    /// deleting anything the app already wrote.
+    pub fn set_storage_quota(&mut self, cx: &mut Cx, total_bytes: Option<u64>) {
+        self.storage_quota = total_bytes;
+        if self.vm_id != MAIN_SPLASH_VM_ID {
+            let heap_key = cx.with_script_vm_id(self.vm_id, |vm| vm.bx.heap.heap_key());
+            crate::splash_storage::set_quota_for_heap(heap_key, total_bytes);
+        }
+    }
+
     /// Marks whether this isolate's surface may raise user prompts; see
     /// `SplashHostRequest::may_prompt`. Defaults true.
     pub fn set_host_prompts(&mut self, cx: &mut Cx, may_prompt: bool) {
@@ -551,6 +567,13 @@ impl SplashRef {
     pub fn set_host_caps(&self, cx: &mut Cx, caps: Vec<String>) {
         if let Some(mut inner) = self.borrow_mut() {
             inner.set_host_caps(cx, caps);
+        }
+    }
+
+    /// See [`Splash::set_storage_quota`].
+    pub fn set_storage_quota(&self, cx: &mut Cx, total_bytes: Option<u64>) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_storage_quota(cx, total_bytes);
         }
     }
 

--- a/widgets/src/splash_host.rs
+++ b/widgets/src/splash_host.rs
@@ -1,0 +1,285 @@
+//! Host-service bridge for Splash isolates.
+//!
+//! Mini-apps are sandboxed: no filesystem beyond their jail, no processes,
+//! and no network unless granted. Real apps still need the things a phone
+//! offers its apps — location, clipboard, notifications, pickers, messaging.
+//! This module is the ONE doorway for all of that: an isolate's script asks,
+//! the embedding host (the launcher) decides and answers. No policy lives
+//! here; an undrained or unrecognized request simply never resolves, and a
+//! host that says no answers `{ok: false}`.
+//!
+//! Registered in isolates as `mod.host` (bound as `host` by the Splash
+//! prefix, like `fs`):
+//!
+//! ```text
+//! let id = host.request("location.get", {}, fn(r) {
+//!     if r.ok { use_it(r.data) } else { show(r.error) }
+//! })
+//! host.capabilities()   // host-pushed grant list, for adapting UI
+//! host.has("location")  // membership test on the same list
+//! ```
+//!
+//! Mechanics mirror the storage jail (splash_storage.rs): all state lives
+//! host-side in thread-locals keyed by the isolate's heap, where script code
+//! can neither read nor forge it. A request serializes its args to JSON and
+//! queues `{app_tag, heap_key, req_id, service, args_json}`; the app_tag is
+//! host-assigned (`Splash::set_host_tag`), so the host can trust request
+//! identity. The callback is held as a rooted `ScriptFnRef` until the host
+//! answers via [`splash_host_respond`], which re-enters the owning isolate
+//! under the standard entry budget and calls it with `{ok, data, error}`.
+//! Dead isolates drop their queued requests and callbacks in the isolate GC.
+
+use std::collections::HashMap;
+
+use crate::makepad_draw::makepad_platform::makepad_script;
+use crate::makepad_draw::makepad_platform::SignalToUI;
+use crate::widget_async::{CxSplashVmExt, WIDGET_SCRIPT_INSTRUCTION_LIMIT};
+use crate::makepad_draw::makepad_platform::Cx;
+use makepad_script::*;
+
+/// One script-originated service request, as drained by the host.
+#[derive(Clone, Debug)]
+pub struct SplashHostRequest {
+    /// Host-assigned identity of the requesting isolate (empty for isolates
+    /// the host never tagged, e.g. previews and validation runs).
+    pub app_tag: String,
+    /// The requesting isolate's heap key; pass back to [`splash_host_respond`].
+    pub heap_key: usize,
+    /// Per-process unique id; pass back to [`splash_host_respond`].
+    pub req_id: u64,
+    /// Service name as the script gave it, e.g. `"location.get"`.
+    pub service: String,
+    /// The request's args value serialized to JSON (`"null"` when absent).
+    pub args_json: String,
+}
+
+#[derive(Default)]
+struct HostBridge {
+    /// heap key -> host-assigned app tag.
+    tags: HashMap<usize, String>,
+    /// heap key -> granted-capability names, for `host.capabilities()`.
+    /// Informational only; enforcement happens host-side per request.
+    caps: HashMap<usize, Vec<String>>,
+    /// Requests awaiting the host's next drain.
+    queue: Vec<SplashHostRequest>,
+    /// (heap key, req id) -> the script callback awaiting an answer.
+    callbacks: HashMap<(usize, u64), ScriptFnRef>,
+    next_req_id: u64,
+}
+
+std::thread_local! {
+    /// UI-thread-owned like the isolate registry itself.
+    static BRIDGE: std::cell::RefCell<HostBridge> = Default::default();
+}
+
+/// Assigns (or clears) the host-trusted identity tag for an isolate.
+pub(crate) fn set_tag_for_heap(heap_key: usize, tag: Option<String>) {
+    BRIDGE.with(|b| {
+        let mut b = b.borrow_mut();
+        match tag {
+            Some(tag) => {
+                b.tags.insert(heap_key, tag);
+            }
+            None => {
+                b.tags.remove(&heap_key);
+            }
+        }
+    });
+}
+
+/// Replaces the granted-capability list `host.capabilities()` reports.
+pub(crate) fn set_caps_for_heap(heap_key: usize, caps: Vec<String>) {
+    BRIDGE.with(|b| {
+        b.borrow_mut().caps.insert(heap_key, caps);
+    });
+}
+
+/// Drops all bridge state for reclaimed isolates (called from the isolate GC).
+pub(crate) fn gc_bridge(dead_heaps: &[usize]) {
+    BRIDGE.with(|b| {
+        let mut b = b.borrow_mut();
+        for heap in dead_heaps {
+            b.tags.remove(heap);
+            b.caps.remove(heap);
+        }
+        b.queue.retain(|r| !dead_heaps.contains(&r.heap_key));
+        b.callbacks.retain(|(heap, _), _| !dead_heaps.contains(heap));
+    });
+}
+
+/// Drains every request queued since the last call. The host owns answering
+/// each one (or consciously dropping it); un-drained requests just wait.
+pub fn take_splash_host_requests() -> Vec<SplashHostRequest> {
+    BRIDGE.with(|b| std::mem::take(&mut b.borrow_mut().queue))
+}
+
+/// Answers one request: `Ok(json)` becomes `{ok: true, data: <parsed>}`,
+/// `Err(msg)` becomes `{ok: false, error: msg}`. A no-op (beyond dropping the
+/// stored callback) when the isolate died or the script passed no callback.
+pub fn splash_host_respond(cx: &mut Cx, heap_key: usize, req_id: u64, result: Result<&str, &str>) {
+    let callback = BRIDGE.with(|b| b.borrow_mut().callbacks.remove(&(heap_key, req_id)));
+    let Some(callback) = callback else { return };
+    let Some(vm_id) = crate::widget_async::vm_for_heap(cx, heap_key) else {
+        return;
+    };
+    cx.with_script_vm_id(vm_id, |vm| {
+        let (ok, data, error) = match result {
+            Ok(json) => {
+                let mut parser = makepad_script::json::JsonParserThread::default();
+                let data = parser.read_json(json, &mut vm.bx.heap);
+                (true, data, NIL)
+            }
+            Err(msg) => (false, NIL, vm.new_string_with(|_vm, s| s.push_str(msg))),
+        };
+        let obj = vm.bx.heap.new_object();
+        let trap = vm.bx.threads.cur().trap.pass();
+        vm.bx.heap.set_value(obj, id!(ok).into(), ok.into(), trap);
+        vm.bx.heap.set_value(obj, id!(data).into(), data, trap);
+        vm.bx.heap.set_value(obj, id!(error).into(), error, trap);
+        vm.with_instruction_limit(WIDGET_SCRIPT_INSTRUCTION_LIMIT, |vm| {
+            vm.call(callback.as_object().into(), &[obj.into()]);
+        });
+    });
+}
+
+/// Registers the `host` bridge module into an isolate VM.
+pub fn script_mod(vm: &mut ScriptVm) {
+    let host = vm.new_module(id!(host));
+
+    vm.add_method(
+        host,
+        id_lut!(request),
+        script_args_def!(service = NIL, args = NIL, on_result = NIL),
+        |vm, args| {
+            let service_val = script_value!(vm, args.service);
+            let request_args = script_value!(vm, args.args);
+            let on_result = script_value!(vm, args.on_result);
+
+            let mut service = None;
+            vm.string_with(service_val, |_vm, s| service = Some(s.to_string()));
+            let Some(service) = service else {
+                return script_err_invalid_args!(vm.trap(), "service must be a string");
+            };
+
+            let mut args_json = String::new();
+            vm.bx.heap.to_json_inner(request_args, &mut args_json);
+
+            let callback = if let Some(obj) = on_result.as_object() {
+                Some(vm.bx.heap.new_fn_ref(obj))
+            } else if on_result.is_nil() {
+                None
+            } else {
+                return script_err_invalid_args!(vm.trap(), "on_result must be a fn or nil");
+            };
+
+            let heap_key = vm.bx.heap.heap_key();
+            let req_id = BRIDGE.with(|b| {
+                let mut b = b.borrow_mut();
+                b.next_req_id += 1;
+                let req_id = b.next_req_id;
+                if let Some(callback) = callback {
+                    b.callbacks.insert((heap_key, req_id), callback);
+                }
+                let app_tag = b.tags.get(&heap_key).cloned().unwrap_or_default();
+                b.queue.push(SplashHostRequest {
+                    app_tag,
+                    heap_key,
+                    req_id,
+                    service,
+                    args_json,
+                });
+                req_id
+            });
+            // The request was queued mid-script, after this pass's host code
+            // already ran; a UI signal gets it drained promptly instead of on
+            // the next input event.
+            SignalToUI::set_ui_signal();
+            (req_id as f64).into()
+        },
+    );
+
+    vm.add_method(host, id_lut!(capabilities), script_args_def!(), |vm, _args| {
+        let heap_key = vm.bx.heap.heap_key();
+        let caps = BRIDGE.with(|b| b.borrow().caps.get(&heap_key).cloned().unwrap_or_default());
+        let array = vm.bx.heap.new_array();
+        vm.bx.heap.array_mut_mut_self_with(array, |heap, storage| {
+            *storage = ScriptArrayStorage::ScriptValue(Default::default());
+            if let ScriptArrayStorage::ScriptValue(vec) = storage {
+                for cap in &caps {
+                    vec.push_back(heap.new_string_from_str(cap));
+                }
+            }
+        });
+        array.into()
+    });
+
+    vm.add_method(host, id_lut!(has), script_args_def!(cap = NIL), |vm, args| {
+        let cap_val = script_value!(vm, args.cap);
+        let mut cap = None;
+        vm.string_with(cap_val, |_vm, s| cap = Some(s.to_string()));
+        let Some(cap) = cap else {
+            return script_err_invalid_args!(vm.trap(), "capability must be a string");
+        };
+        let heap_key = vm.bx.heap.heap_key();
+        BRIDGE
+            .with(|b| {
+                b.borrow()
+                    .caps
+                    .get(&heap_key)
+                    .map(|caps| caps.iter().any(|c| c == &cap))
+                    .unwrap_or(false)
+            })
+            .into()
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn queue_raw(heap_key: usize, req_id: u64, service: &str) {
+        BRIDGE.with(|b| {
+            b.borrow_mut().queue.push(SplashHostRequest {
+                app_tag: String::new(),
+                heap_key,
+                req_id,
+                service: service.to_string(),
+                args_json: "null".to_string(),
+            })
+        });
+    }
+
+    #[test]
+    fn take_drains_and_gc_drops_dead_state() {
+        queue_raw(11, 1, "a");
+        queue_raw(22, 2, "b");
+        set_tag_for_heap(11, Some("app_a".into()));
+        set_caps_for_heap(11, vec!["network".into()]);
+
+        gc_bridge(&[11]);
+        let reqs = take_splash_host_requests();
+        assert_eq!(reqs.len(), 1);
+        assert_eq!(reqs[0].heap_key, 22);
+        assert!(take_splash_host_requests().is_empty());
+        BRIDGE.with(|b| {
+            let b = b.borrow();
+            assert!(!b.tags.contains_key(&11));
+            assert!(!b.caps.contains_key(&11));
+        });
+    }
+
+    #[test]
+    fn tags_and_caps_are_per_heap() {
+        set_tag_for_heap(1, Some("one".into()));
+        set_tag_for_heap(2, Some("two".into()));
+        set_caps_for_heap(1, vec!["location".into()]);
+        BRIDGE.with(|b| {
+            let b = b.borrow();
+            assert_eq!(b.tags.get(&1).unwrap(), "one");
+            assert_eq!(b.tags.get(&2).unwrap(), "two");
+            assert!(b.caps.get(&2).is_none());
+        });
+        set_tag_for_heap(1, None);
+        BRIDGE.with(|b| assert!(!b.borrow().tags.contains_key(&1)));
+    }
+}

--- a/widgets/src/splash_host.rs
+++ b/widgets/src/splash_host.rs
@@ -13,11 +13,14 @@
 //!
 //! ```text
 //! let id = host.request("location.get", {}, fn(r) {
-//!     if r.ok { use_it(r.data) } else { show(r.error) }
+//!     if r.is_ok { use_it(r.data) } else { show(r.error) }
 //! })
 //! host.capabilities()   // host-pushed grant list, for adapting UI
 //! host.has("location")  // membership test on the same list
 //! ```
+//!
+//! The success field is `is_ok`, NOT `ok`: `ok` is a script keyword (the
+//! ok-test operator), so `r.ok` doesn't parse as a field access.
 //!
 //! Mechanics mirror the storage jail (splash_storage.rs): all state lives
 //! host-side in thread-locals keyed by the isolate's heap, where script code
@@ -51,12 +54,19 @@ pub struct SplashHostRequest {
     pub service: String,
     /// The request's args value serialized to JSON (`"null"` when absent).
     pub args_json: String,
+    /// Whether this isolate's surface may raise user prompts (host-assigned,
+    /// like the tag). Background surfaces — home-screen widget tiles — set
+    /// this false so a permission-needing request FAILS instead of popping a
+    /// consent dialog nobody asked for.
+    pub may_prompt: bool,
 }
 
 #[derive(Default)]
 struct HostBridge {
     /// heap key -> host-assigned app tag.
     tags: HashMap<usize, String>,
+    /// heap keys whose surface must NOT raise prompts (absent = may prompt).
+    no_prompt: std::collections::HashSet<usize>,
     /// heap key -> granted-capability names, for `host.capabilities()`.
     /// Informational only; enforcement happens host-side per request.
     caps: HashMap<usize, Vec<String>>,
@@ -94,6 +104,18 @@ pub(crate) fn set_caps_for_heap(heap_key: usize, caps: Vec<String>) {
     });
 }
 
+/// Marks whether this isolate's surface may raise user prompts.
+pub(crate) fn set_prompts_for_heap(heap_key: usize, may_prompt: bool) {
+    BRIDGE.with(|b| {
+        let mut b = b.borrow_mut();
+        if may_prompt {
+            b.no_prompt.remove(&heap_key);
+        } else {
+            b.no_prompt.insert(heap_key);
+        }
+    });
+}
+
 /// Drops all bridge state for reclaimed isolates (called from the isolate GC).
 pub(crate) fn gc_bridge(dead_heaps: &[usize]) {
     BRIDGE.with(|b| {
@@ -101,6 +123,7 @@ pub(crate) fn gc_bridge(dead_heaps: &[usize]) {
         for heap in dead_heaps {
             b.tags.remove(heap);
             b.caps.remove(heap);
+            b.no_prompt.remove(heap);
         }
         b.queue.retain(|r| !dead_heaps.contains(&r.heap_key));
         b.callbacks.retain(|(heap, _), _| !dead_heaps.contains(heap));
@@ -114,13 +137,20 @@ pub fn take_splash_host_requests() -> Vec<SplashHostRequest> {
 }
 
 /// Answers one request: `Ok(json)` becomes `{ok: true, data: <parsed>}`,
-/// `Err(msg)` becomes `{ok: false, error: msg}`. A no-op (beyond dropping the
-/// stored callback) when the isolate died or the script passed no callback.
-pub fn splash_host_respond(cx: &mut Cx, heap_key: usize, req_id: u64, result: Result<&str, &str>) {
+/// `Err(msg)` becomes `{ok: false, error: msg}`. Returns what happened, so a
+/// host can log undeliverable answers instead of wondering why an app hangs.
+pub fn splash_host_respond(
+    cx: &mut Cx,
+    heap_key: usize,
+    req_id: u64,
+    result: Result<&str, &str>,
+) -> SplashRespondOutcome {
     let callback = BRIDGE.with(|b| b.borrow_mut().callbacks.remove(&(heap_key, req_id)));
-    let Some(callback) = callback else { return };
+    let Some(callback) = callback else {
+        return SplashRespondOutcome::NoCallback;
+    };
     let Some(vm_id) = crate::widget_async::vm_for_heap(cx, heap_key) else {
-        return;
+        return SplashRespondOutcome::IsolateGone;
     };
     cx.with_script_vm_id(vm_id, |vm| {
         let (ok, data, error) = match result {
@@ -133,13 +163,28 @@ pub fn splash_host_respond(cx: &mut Cx, heap_key: usize, req_id: u64, result: Re
         };
         let obj = vm.bx.heap.new_object();
         let trap = vm.bx.threads.cur().trap.pass();
-        vm.bx.heap.set_value(obj, id!(ok).into(), ok.into(), trap);
+        // `is_ok`, never `ok`: `ok` is a script keyword and unusable as a field.
+        vm.bx.heap.set_value(obj, id!(is_ok).into(), ok.into(), trap);
         vm.bx.heap.set_value(obj, id!(data).into(), data, trap);
         vm.bx.heap.set_value(obj, id!(error).into(), error, trap);
         vm.with_instruction_limit(WIDGET_SCRIPT_INSTRUCTION_LIMIT, |vm| {
             vm.call(callback.as_object().into(), &[obj.into()]);
         });
     });
+    SplashRespondOutcome::Delivered
+}
+
+/// What [`splash_host_respond`] managed to do with an answer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SplashRespondOutcome {
+    /// The script callback ran (or at least was invoked; script errors are
+    /// the script's own and land in the log).
+    Delivered,
+    /// The request carried no callback (fire-and-forget) — or was already
+    /// answered once.
+    NoCallback,
+    /// The isolate died between asking and answering.
+    IsolateGone,
 }
 
 /// Registers the `host` bridge module into an isolate VM.
@@ -181,12 +226,14 @@ pub fn script_mod(vm: &mut ScriptVm) {
                     b.callbacks.insert((heap_key, req_id), callback);
                 }
                 let app_tag = b.tags.get(&heap_key).cloned().unwrap_or_default();
+                let may_prompt = !b.no_prompt.contains(&heap_key);
                 b.queue.push(SplashHostRequest {
                     app_tag,
                     heap_key,
                     req_id,
                     service,
                     args_json,
+                    may_prompt,
                 });
                 req_id
             });
@@ -245,6 +292,7 @@ mod tests {
                 req_id,
                 service: service.to_string(),
                 args_json: "null".to_string(),
+                may_prompt: true,
             })
         });
     }

--- a/widgets/src/splash_storage.rs
+++ b/widgets/src/splash_storage.rs
@@ -50,6 +50,35 @@ std::thread_local! {
     /// local like the isolate registry itself (isolates are UI-thread-owned).
     static SANDBOX_ROOTS: std::cell::RefCell<HashMap<usize, PathBuf>> =
         std::cell::RefCell::new(HashMap::new());
+
+    /// heap-key → total-bytes cap, for isolates the host has granted more
+    /// room than the default. Absent means [`MAX_TOTAL_BYTES`]. Kept host-side
+    /// beside the root so script can neither read nor raise its own quota.
+    static JAIL_QUOTAS: std::cell::RefCell<HashMap<usize, u64>> =
+        std::cell::RefCell::new(HashMap::new());
+}
+
+/// Raises (or clears) an isolate's whole-jail byte cap. `None` restores the
+/// default. Existing files are never deleted by lowering it — the smaller cap
+/// simply refuses further growth.
+pub(crate) fn set_quota_for_heap(heap_key: usize, total_bytes: Option<u64>) {
+    JAIL_QUOTAS.with(|q| {
+        let mut q = q.borrow_mut();
+        match total_bytes {
+            Some(bytes) => {
+                q.insert(heap_key, bytes);
+            }
+            None => {
+                q.remove(&heap_key);
+            }
+        }
+    });
+}
+
+/// This isolate's whole-jail cap.
+fn quota_for_vm(vm: &ScriptVm) -> u64 {
+    let heap_key = vm.bx.heap.heap_key();
+    JAIL_QUOTAS.with(|q| q.borrow().get(&heap_key).copied()).unwrap_or(MAX_TOTAL_BYTES)
 }
 
 /// Assigns (or clears) the sandbox root for an isolate, keyed by its heap.
@@ -73,6 +102,12 @@ pub(crate) fn gc_roots(dead_heaps: &[usize]) {
         let mut r = r.borrow_mut();
         for heap in dead_heaps {
             r.remove(heap);
+        }
+    });
+    JAIL_QUOTAS.with(|q| {
+        let mut q = q.borrow_mut();
+        for heap in dead_heaps {
+            q.remove(heap);
         }
     });
 }
@@ -239,8 +274,9 @@ pub fn script_mod(vm: &mut ScriptVm) {
                 if new_len > MAX_FILE_BYTES {
                     return script_err_io!(vm.trap(), "file too large");
                 }
+                let cap = quota_for_vm(vm);
                 let (total, entries) = jail_usage(&root);
-                if total - existing.min(total) + new_len > MAX_TOTAL_BYTES {
+                if total - existing.min(total) + new_len > cap {
                     return script_err_io!(vm.trap(), "app storage is full");
                 }
                 // Charge the file AND any parent dirs create_dir_all would make,

--- a/widgets/src/widget_async.rs
+++ b/widgets/src/widget_async.rs
@@ -89,8 +89,9 @@ pub fn gc_dead_splash_isolates(cx: &mut Cx) {
         cx.stop_timer(timer);
         cx.script_data.timers.timers.retain(|t| t.id != id);
     }
-    // Sandbox roots die with their isolates.
+    // Sandbox roots and host-bridge state die with their isolates.
     crate::splash_storage::gc_roots(&dead_heaps);
+    crate::splash_host::gc_bridge(&dead_heaps);
     let state = cx.global::<CxWidgetAsync>();
     for vm_id in dead {
         state.isolated_vms.vms.remove(&vm_id);
@@ -355,10 +356,12 @@ impl CxSplashVmExt for Cx {
             // through the gated net runtime. Raw sockets are gated separately:
             // the stdlib's `net.socket_stream` errors when no net runtime is
             // configured, same as `net.http_request`.
+            // `cx.quit` would let any mini-app close the whole host process.
             let strip = crate::makepad_script::script! {
                 mod.fs = nil
                 mod.run = nil
                 mod.res = nil
+                mod.cx.quit = nil
             };
             vm.eval(strip);
             // Re-register `fs` as the JAILED per-app storage module: inside an
@@ -366,6 +369,10 @@ impl CxSplashVmExt for Cx {
             // (assigned by the host via Splash::set_sandbox_dir; without one,
             // every call errors). See splash_storage.rs for the containment.
             crate::splash_storage::script_mod(&mut vm);
+            // `host` is the brokered doorway to host services (location,
+            // clipboard, IPC, ...); requests queue for the embedding host to
+            // answer, and no host = nothing resolves. See splash_host.rs.
+            crate::splash_host::script_mod(&mut vm);
             vm.bx
         };
 
@@ -428,6 +435,11 @@ impl CxSplashVmExt for Cx {
             .copied()
             .unwrap_or(MAIN_SPLASH_VM_ID)
     }
+}
+
+/// The isolate (if any) that owns a heap, for host-bridge response routing.
+pub(crate) fn vm_for_heap(cx: &mut Cx, heap_key: usize) -> Option<SplashVmId> {
+    cx.global::<CxWidgetAsync>().heap_to_vm.get(&heap_key).copied()
 }
 
 /// Deliver `Event::NetworkResponses` to a Splash isolate's script (resolving its


### PR DESCRIPTION
Follow-up to #1139. That PR locked mini-app isolates down (no fs, no
processes, no net). This adds one controlled way back out, so a host can
offer them real capabilities.

### `mod.host` — one doorway, no policy

Registered in every isolate, bound as `host` like `fs`:

```
host.request("location.get", {}, |r| {
    if r.is_ok { use_it(r.data) } else { show(r.error) }
})
host.has("location")     // what the host has granted
```

The request queues for the embedding host to drain and answer; makepad just
carries it. No host draining = nothing resolves. The host stamps each
isolate's identity, so a script can't claim to be another app.

Everything else (which permissions exist, who may use them, prompting the
user) lives in the host. Mine is
[host_launcher](https://github.com/project-robius/host_launcher), where this
backs an Android/iOS-style permission system.

Also: `mod.cx.quit` is now stripped from isolates — a mini-app could quit the
whole host process with one call.

### One more knob

`Splash::set_storage_quota` lets a host raise a single isolate's storage-jail
cap (the 16MB whole-app limit was a constant). Script still can't see or
change its own. I use it for a revocable "extra storage" permission.

### Four fixes, independent of the above

Happy to split these into their own PR if you'd rather review them separately.

- **Validation passed scripts that don't parse.** The parser recovers from
  errors and returns a runnable module, so `validate_splash_body` saw nothing
  and reported success. Parse errors now reach the captured-error sink.
- **A closure's captured varargs shadowed its own parameters.** Timers call
  their callback with a time number; give `start_timeout` a zero-arg closure
  and any closure created inside it binds its *first* parameter to that
  leftover number. Callbacks made in a boot timer silently never ran.
- **`parse_json` dropped negative numbers — and their keys.** A leading `-`
  is its own token and no value position handled it, so
  `{"lat":37.7,"lon":-122.4}` parsed to `{"lat":37.7}`. Silently. Found when
  an app asked the host for a location and got coordinates with no
  longitude; sub-zero temperatures and negative UTC offsets went the same
  way.
- **`to_json`:** cyclic values overflowed the stack, and `\` / tab / control
  chars produced invalid JSON.

### Tests

New regression tests in `platform/script/tests/`. `cargo test -p
makepad-script` green (56). `-p makepad-widgets` green except two
`widget_tree` tests that fail the same way on `dev` without this branch.
