### PR TITLE
Shader: keep the value of an `if` body's last statement

### DIFF
--- a/platform/script/src/shader_control.rs
+++ b/platform/script/src/shader_control.rs
@@ -226,8 +226,12 @@ impl ShaderFnCompiler {
                         if let Some(outer_phi) = outer_phi {
                             // Assign to the outer phi (flag is already set by find_and_mark_outer_phi)
                             self.out.push_str(&format!("{} = {};\n", outer_phi, val));
+                        } else if !val.is_empty() {
+                            // Nothing consumes the value, but the expression can still
+                            // have side effects, so keep it as a statement in the branch.
+                            self.out.push_str(&val);
+                            self.out.push_str(";\n");
                         }
-                        // If no outer phi, the value is discarded (this shouldn't happen in well-formed code)
                     }
                     self.stack.free_string(val);
                 } else if let Some(ref phi) = phi {

--- a/platform/script/test/src/main.rs
+++ b/platform/script/test/src/main.rs
@@ -3857,6 +3857,33 @@ pub fn main() {
         shader.test_compile_draw(gpu_stage_4l)
         assert(shader.test_compile_draw_rust_contains(gpu_stage_4l, "c.x, c.y, c.z"))
 
+        let gpu_stage_4m = #(GpuShaderStageTest::script_shader(vm)){
+            vertex_pos: shader.vertex_position(vec4f)
+            pixel: shader.fragment_output(0, vec4f)
+            v_uv: shader.varying(vec2f)
+            cutoff: shader.uniform(0.5)
+
+            side_effect: fn(v) {
+                return v * 2.0
+            }
+
+            vertex: fn() {
+                self.v_uv = vec2(0.5, 0.5)
+                self.vertex_pos = vec4(0.0, 0.0, 0.0, 1.0)
+            }
+
+            fragment: fn() {
+                // A bare `if` statement whose last body statement is a non-void
+                // call: nothing consumes the value, but it must still be emitted.
+                if self.cutoff > 0.0 {
+                    self.side_effect(7.0)
+                }
+                self.pixel = vec4(self.v_uv, 0.0, 1.0)
+            }
+        }
+        shader.test_compile_draw(gpu_stage_4m)
+        assert(shader.test_compile_draw_contains(gpu_stage_4m, "side_effect(_io, _iof, 7.0)"))
+
         println("Runtime vector methods + lerp + TAU (value-level, not shader)")
         assert(vec3(3.0, 4.0, 0.0).length() == 5.0)
         let n = vec3(0.0, 2.0, 0.0).normalized()


### PR DESCRIPTION
A bare `if cond { ... }` statement whose final body statement is a non-void expression compiles to an empty `if(cond){ }`. The expression never reaches the generated shader, so its side effects are lost.

This removes essentially every border in an app that draws them the idiomatic way:

```
pixel: fn() {
    let sdf = Sdf2d.viewport(self.pos * self.rect_size)
    sdf.box(...)
    sdf.fill_keep(self.get_color())
    if self.border_size > 0.0 {
        sdf.stroke(self.border_color, self.border_size)   // never emitted
    }
    return sdf.result;
}
```

Generated Metal before / after:

```
if((_io.u->border_size > 0)){          if((_io.u->border_size > 0)){
}                                      Sdf2d_stroke_N(...);
                                       }
```

### Why

A call is not written to the output when compiled — it is pushed on the stack as a string (`shader_calls.rs`), and only reaches `self.out` through `pop_to_me` / `maybe_pop_to_me` (`shader.rs:1565-1584`, `:1701-1709`).

Since e0a5a23f2, `parser.rs:3159` sets `last_jump_target` at the if's patch point and the rewritten `set_pop_to_me` (`parser.rs:853-872`) refuses to fuse the flag when `code_len() == last_jump_target`. The enclosing statement's POP_TO_ME is therefore emitted as a standalone opcode **at** the if's jump target rather than fused onto the body's last call. The shader compiler closes an `IfBody` as soon as `ip >= target_ip` (`shader.rs:496-500` → `shader_control.rs:138-142`), so the opcode sitting exactly at the target is never processed while the body is open.

The body's value is then dropped by the `no outer phi` arm of `handle_if_else`, whose comment assumed that could not happen:

```rust
// If no outer phi, the value is discarded (this shouldn't happen in well-formed code)
```

A constant-true condition fails identically, which is what rules out the condition itself.

Only the **last** statement of an if body is affected, and only when its value is non-void — a void trailing expression already survives via the branch just above, and non-final statements fuse normally because `code_len != last_jump_target` at their statement end.

### The fix

Emit the leftover value as a statement inside the branch when nothing consumes it, mirroring the void path a few lines above. The parser side is deliberately untouched: `last_jump_target` is load bearing for the widget-loss fix that `platform/script/tests/on_render_emission.rs` guards.

I rejected two alternatives: gating on `need_nil` is not a discriminator (the no-else path sets it unconditionally, in expression and statement position), and setting `skip_next_pop_to_me` is unnecessary — the standalone POP_TO_ME at the target is already a no-op because the stack is back at the parent's depth.

### Testing

- New `gpu_stage_4m` in `platform/script/test/src/main.rs` asserts the call survives into the generated shader. **Verified it fails without the fix** and passes with it.
- `cargo test -p makepad-script`: 50 passed, 0 failed — including `on_render_emission`, `newline_call`, `short_circuit_args` and `auto_close_eof`, so the elif-chain and newline-divert behaviour added by e0a5a23f2 is intact.
- `makepad-script-test` binary: 0 assertion failures.
- End-to-end: a minimal app drawing a guarded green border renders 0 green pixels before the fix and ~9367 after, on an otherwise identical tree. Confirmed in a real app (robrix) that reaction pill borders and input-bar borders come back.

Found by `git bisect run` over 219 commits with a rendering oracle; first bad commit e0a5a23f2.