### PR TITLE
Change the platform_ops queue from LIFO to FIFO

### DIFF
--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -38,7 +38,7 @@ use {
     std::{
         any::{Any, TypeId},
         cell::RefCell,
-        collections::{HashMap, HashSet},
+        collections::{HashMap, HashSet, VecDeque},
         rc::Rc,
         sync::Arc,
     },
@@ -104,7 +104,7 @@ pub struct Cx {
     pub keyboard_shift: f64,
     pub(crate) drag_drop: CxDragDrop,
 
-    pub(crate) platform_ops: Vec<CxOsOp>,
+    pub(crate) platform_ops: VecDeque<CxOsOp>,
     pub(crate) pending_camera_playbacks: Vec<PendingCameraPlayback>,
 
     pub(crate) new_next_frames: HashSet<NextFrame>,

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -30,6 +30,7 @@ use {
     },
     std::{
         any::{Any, TypeId},
+        collections::VecDeque,
         ops::Range,
         rc::Rc,
     },
@@ -104,14 +105,14 @@ impl<'a> CxSystemBrowser<'a> {
     }
 
     pub fn spawn(&mut self, url: &str) {
-        self.cx.platform_ops.push(CxOsOp::SpawnSystemBrowser {
+        self.cx.platform_ops.push_back(CxOsOp::SpawnSystemBrowser {
             browser_id: self.id.0,
             url: url.to_string(),
         });
     }
 
     pub fn update(&mut self, area: Area, visible: bool) {
-        self.cx.platform_ops.push(CxOsOp::UpdateSystemBrowser {
+        self.cx.platform_ops.push_back(CxOsOp::UpdateSystemBrowser {
             browser_id: self.id.0,
             area,
             visible,
@@ -119,13 +120,13 @@ impl<'a> CxSystemBrowser<'a> {
     }
 
     pub fn detach(&mut self) {
-        self.cx.platform_ops.push(CxOsOp::DetachSystemBrowser {
+        self.cx.platform_ops.push_back(CxOsOp::DetachSystemBrowser {
             browser_id: self.id.0,
         });
     }
 
     pub fn set_url(&mut self, url: &str, replace: bool) {
-        self.cx.platform_ops.push(CxOsOp::SetSystemBrowserUrl {
+        self.cx.platform_ops.push_back(CxOsOp::SetSystemBrowserUrl {
             browser_id: self.id.0,
             url: url.to_string(),
             replace,
@@ -133,14 +134,14 @@ impl<'a> CxSystemBrowser<'a> {
     }
 
     pub fn history_go(&mut self, delta: i32) {
-        self.cx.platform_ops.push(CxOsOp::SystemBrowserHistoryGo {
+        self.cx.platform_ops.push_back(CxOsOp::SystemBrowserHistoryGo {
             browser_id: self.id.0,
             delta,
         });
     }
 
     pub fn close(&mut self) {
-        self.cx.platform_ops.push(CxOsOp::CloseSystemBrowser {
+        self.cx.platform_ops.push_back(CxOsOp::CloseSystemBrowser {
             browser_id: self.id.0,
         });
     }
@@ -501,6 +502,15 @@ impl std::fmt::Debug for CxOsOp {
         }
     }
 }
+
+/// Requeue an OS op that cannot run yet. FIFO: append so remaining already-queued
+/// ops still run first. Returns `true` if the drain should continue (`len() > 1`);
+/// `false` if this is the only op left — break and retry on the next event.
+pub(crate) fn defer_platform_op(platform_ops: &mut VecDeque<CxOsOp>, op: CxOsOp) -> bool {
+    platform_ops.push_back(op);
+    platform_ops.len() > 1
+}
+
 impl Cx {
     pub fn in_draw_event(&self) -> bool {
         self.in_draw_event
@@ -816,35 +826,35 @@ impl Cx {
     }
 
     pub fn update_macos_menu(&mut self, menu: MacosMenu) {
-        self.platform_ops.push(CxOsOp::UpdateMacosMenu(menu));
+        self.platform_ops.push_back(CxOsOp::UpdateMacosMenu(menu));
     }
 
     pub fn xr_start_presenting(&mut self) {
-        self.platform_ops.push(CxOsOp::XrStartPresenting);
+        self.platform_ops.push_back(CxOsOp::XrStartPresenting);
     }
 
     pub fn xr_set_render_scale(&mut self, scale: f32) {
-        self.platform_ops.push(CxOsOp::XrSetRenderScale(scale));
+        self.platform_ops.push_back(CxOsOp::XrSetRenderScale(scale));
     }
 
     pub fn xr_advertise_anchor(&mut self, anchor: XrAnchor) {
-        self.platform_ops.push(CxOsOp::XrAdvertiseAnchor(anchor));
+        self.platform_ops.push_back(CxOsOp::XrAdvertiseAnchor(anchor));
     }
 
     pub fn xr_set_local_anchor(&mut self, anchor: XrAnchor) {
-        self.platform_ops.push(CxOsOp::XrSetLocalAnchor(anchor));
+        self.platform_ops.push_back(CxOsOp::XrSetLocalAnchor(anchor));
     }
 
     pub fn xr_set_local_floor(&mut self, floor_y: f32) {
-        self.platform_ops.push(CxOsOp::XrSetLocalFloor(floor_y));
+        self.platform_ops.push_back(CxOsOp::XrSetLocalFloor(floor_y));
     }
 
     pub fn xr_discover_anchor(&mut self, id: u8) {
-        self.platform_ops.push(CxOsOp::XrDiscoverAnchor(id));
+        self.platform_ops.push_back(CxOsOp::XrDiscoverAnchor(id));
     }
 
     pub fn quit(&mut self) {
-        self.platform_ops.push(CxOsOp::Quit);
+        self.platform_ops.push_back(CxOsOp::Quit);
     }
 
     pub fn request_quit(&mut self, reason: QuitReason) -> bool {
@@ -886,7 +896,7 @@ impl Cx {
     // Determines whether to show your application in the dock when it runs. The default value is true.
     // You can remove the dock icon by setting this value to false.
     pub fn show_in_dock(&mut self, show: bool) {
-        self.platform_ops.push(CxOsOp::ShowInDock(show));
+        self.platform_ops.push_back(CxOsOp::ShowInDock(show));
     }
 
     /// Controls how the system bars (status bar and navigation bar) icons and
@@ -905,8 +915,17 @@ impl Cx {
     }
     pub fn push_unique_platform_op(&mut self, op: CxOsOp) {
         if self.platform_ops.iter().find(|o| **o == op).is_none() {
-            self.platform_ops.push(op);
+            self.platform_ops.push_back(op);
         }
+    }
+
+    /// Requeue an OS op that cannot run yet (typical case: `SetTopmost` before
+    /// any native window exists). FIFO: append so remaining already-queued ops
+    /// still run first in this drain. Returns `true` if the drain should
+    /// continue (`len() > 1`); `false` if this is the only op left — break and
+    /// retry on the next event instead of spinning.
+    pub(crate) fn defer_platform_op(&mut self, op: CxOsOp) -> bool {
+        defer_platform_op(&mut self.platform_ops, op)
     }
 
     pub fn show_text_ime(&mut self, area: Area, pos: Vec2d) {
@@ -931,7 +950,7 @@ impl Cx {
         if !self.keyboard.text_ime_dismissed {
             self.ime_area = area;
             self.platform_ops
-                .push(CxOsOp::ShowTextIME(area, cursor_rect, config));
+                .push_back(CxOsOp::ShowTextIME(area, cursor_rect, config));
         }
     }
 
@@ -941,7 +960,7 @@ impl Cx {
         selection: Range<CharOffset>,
         composition: Option<Range<CharOffset>>,
     ) {
-        self.platform_ops.push(CxOsOp::SyncImeState {
+        self.platform_ops.push_back(CxOsOp::SyncImeState {
             text,
             selection,
             composition,
@@ -950,12 +969,12 @@ impl Cx {
 
     pub fn hide_text_ime(&mut self) {
         self.keyboard.reset_text_ime_dismissed();
-        self.platform_ops.push(CxOsOp::HideTextIME);
+        self.platform_ops.push_back(CxOsOp::HideTextIME);
     }
 
     pub fn text_ime_was_dismissed(&mut self) {
         self.keyboard.set_text_ime_dismissed();
-        self.platform_ops.push(CxOsOp::HideTextIME);
+        self.platform_ops.push_back(CxOsOp::HideTextIME);
     }
 
     /// Set or clear a window's `dpi_override` at runtime.
@@ -1024,7 +1043,7 @@ impl Cx {
     /// the text selection from Rust directly. The `has_selection` parameter is only
     /// used to determine which menu items to show, not for the operations themselves.
     pub fn show_clipboard_actions(&mut self, has_selection: bool, rect: Rect, keyboard_shift: f64) {
-        self.platform_ops.push(CxOsOp::ShowClipboardActions {
+        self.platform_ops.push_back(CxOsOp::ShowClipboardActions {
             has_selection,
             rect,
             keyboard_shift,
@@ -1033,7 +1052,7 @@ impl Cx {
 
     /// Hides the clipboard actions menu
     pub fn hide_clipboard_actions(&mut self) {
-        self.platform_ops.push(CxOsOp::HideClipboardActions);
+        self.platform_ops.push_back(CxOsOp::HideClipboardActions);
     }
 
     /// Copies the given string to the clipboard.
@@ -1041,14 +1060,14 @@ impl Cx {
     /// Due to lack of platform clipboard support, it does not work on Web or tvOS.
     pub fn copy_to_clipboard(&mut self, content: &str) {
         self.platform_ops
-            .push(CxOsOp::CopyToClipboard(content.to_owned()));
+            .push_back(CxOsOp::CopyToClipboard(content.to_owned()));
     }
 
     /// Sets the primary selection (Linux middle-click paste).
     /// No-op on non-Linux platforms.
     pub fn set_primary_selection(&mut self, content: &str) {
         self.platform_ops
-            .push(CxOsOp::SetPrimarySelection(content.to_owned()));
+            .push_back(CxOsOp::SetPrimarySelection(content.to_owned()));
     }
 
     /// Forward an accessibility tree update to the platform adapter.
@@ -1057,7 +1076,7 @@ impl Cx {
     /// downcast it when an accessibility adapter is active.
     pub fn update_accessibility_tree(&mut self, update: Box<dyn std::any::Any + Send>) {
         self.platform_ops
-            .push(CxOsOp::AccessibilityUpdate(AccessibilityUpdatePayload(
+            .push_back(CxOsOp::AccessibilityUpdate(AccessibilityUpdatePayload(
                 update,
             )));
     }
@@ -1065,18 +1084,18 @@ impl Cx {
     /// Show native selection handles at the given start and end positions (mobile).
     pub fn show_selection_handles(&mut self, start: Vec2d, end: Vec2d) {
         self.platform_ops
-            .push(CxOsOp::ShowSelectionHandles { start, end });
+            .push_back(CxOsOp::ShowSelectionHandles { start, end });
     }
 
     /// Update positions of visible selection handles (mobile).
     pub fn update_selection_handles(&mut self, start: Vec2d, end: Vec2d) {
         self.platform_ops
-            .push(CxOsOp::UpdateSelectionHandles { start, end });
+            .push_back(CxOsOp::UpdateSelectionHandles { start, end });
     }
 
     /// Hide selection handles (mobile).
     pub fn hide_selection_handles(&mut self) {
-        self.platform_ops.push(CxOsOp::HideSelectionHandles);
+        self.platform_ops.push_back(CxOsOp::HideSelectionHandles);
     }
 
     pub fn start_dragging(&mut self, items: Vec<DragItem>) {
@@ -1085,7 +1104,7 @@ impl Cx {
                 panic!("start drag twice");
             }
         });
-        self.platform_ops.push(CxOsOp::StartDragging(items));
+        self.platform_ops.push_back(CxOsOp::StartDragging(items));
     }
 
     pub fn set_cursor(&mut self, cursor: MouseCursor) {
@@ -1096,7 +1115,7 @@ impl Cx {
         }) {
             *p = CxOsOp::SetCursor(cursor)
         } else {
-            self.platform_ops.push(CxOsOp::SetCursor(cursor))
+            self.platform_ops.push_back(CxOsOp::SetCursor(cursor))
         }
     }
 
@@ -1153,7 +1172,7 @@ impl Cx {
 
     pub fn start_timeout(&mut self, delay: f64) -> Timer {
         self.timer_id += 1;
-        self.platform_ops.push(CxOsOp::StartTimer {
+        self.platform_ops.push_back(CxOsOp::StartTimer {
             timer_id: self.timer_id,
             interval: delay,
             repeats: false,
@@ -1163,7 +1182,7 @@ impl Cx {
 
     pub fn start_interval(&mut self, interval: f64) -> Timer {
         self.timer_id += 1;
-        self.platform_ops.push(CxOsOp::StartTimer {
+        self.platform_ops.push_back(CxOsOp::StartTimer {
             timer_id: self.timer_id,
             interval,
             repeats: true,
@@ -1173,13 +1192,13 @@ impl Cx {
 
     pub fn stop_timer(&mut self, timer: Timer) {
         if timer.0 != 0 {
-            self.platform_ops.push(CxOsOp::StopTimer(timer.0));
+            self.platform_ops.push_back(CxOsOp::StopTimer(timer.0));
         }
     }
 
     pub fn request_permission(&mut self, permission: crate::permission::Permission) -> i32 {
         self.permissions_request_id += 1;
-        self.platform_ops.push(CxOsOp::RequestPermission {
+        self.platform_ops.push_back(CxOsOp::RequestPermission {
             request_id: self.permissions_request_id,
             permission,
         });
@@ -1188,7 +1207,7 @@ impl Cx {
 
     pub fn check_permission(&mut self, permission: crate::permission::Permission) -> i32 {
         self.permissions_request_id += 1;
-        self.platform_ops.push(CxOsOp::CheckPermission {
+        self.platform_ops.push_back(CxOsOp::CheckPermission {
             request_id: self.permissions_request_id,
             permission,
         });
@@ -1202,12 +1221,12 @@ impl Cx {
     /// platform, failures arrive as [`Event::LocationError`]. Platforms
     /// without a location service log an error and stay silent.
     pub fn start_location_updates(&mut self) {
-        self.platform_ops.push(CxOsOp::StartLocationUpdates);
+        self.platform_ops.push_back(CxOsOp::StartLocationUpdates);
     }
 
     /// Stop streaming position fixes.
     pub fn stop_location_updates(&mut self) {
-        self.platform_ops.push(CxOsOp::StopLocationUpdates);
+        self.platform_ops.push_back(CxOsOp::StopLocationUpdates);
     }
 
     pub fn get_dpi_factor_of(&mut self, area: &Area) -> f64 {
@@ -1504,14 +1523,14 @@ impl Cx {
     }
     /*
         pub fn web_socket_open(&mut self, request_id: LiveId, request: HttpRequest) {
-            self.platform_ops.push(CxOsOp::WebSocketOpen{
+            self.platform_ops.push_back(CxOsOp::WebSocketOpen{
                 request,
                 request_id,
             });
         }
 
         pub fn web_socket_send_binary(&mut self, request_id: LiveId, data: Vec<u8>) {
-            self.platform_ops.push(CxOsOp::WebSocketSendBinary{
+            self.platform_ops.push_back(CxOsOp::WebSocketSendBinary{
                 request_id,
                 data,
             });
@@ -1587,7 +1606,7 @@ impl Cx {
             let _request_id = self.request_permission(permission);
             return;
         }
-        self.platform_ops.push(CxOsOp::PrepareVideoPlayback(
+        self.platform_ops.push_back(CxOsOp::PrepareVideoPlayback(
             video_id,
             source,
             camera_preview_mode,
@@ -1616,7 +1635,7 @@ impl Cx {
             }
             match result.status {
                 crate::permission::PermissionStatus::Granted => {
-                    self.platform_ops.push(CxOsOp::PrepareVideoPlayback(
+                    self.platform_ops.push_back(CxOsOp::PrepareVideoPlayback(
                         p.video_id,
                         p.source,
                         p.camera_preview_mode,
@@ -1645,11 +1664,11 @@ impl Cx {
 
     pub fn attach_camera_native_preview(&mut self, video_id: LiveId, area: Area) {
         self.platform_ops
-            .push(CxOsOp::AttachCameraNativePreview { video_id, area });
+            .push_back(CxOsOp::AttachCameraNativePreview { video_id, area });
     }
 
     pub fn update_camera_native_preview(&mut self, video_id: LiveId, area: Area, visible: bool) {
-        self.platform_ops.push(CxOsOp::UpdateCameraNativePreview {
+        self.platform_ops.push_back(CxOsOp::UpdateCameraNativePreview {
             video_id,
             area,
             visible,
@@ -1658,36 +1677,36 @@ impl Cx {
 
     pub fn detach_camera_native_preview(&mut self, video_id: LiveId) {
         self.platform_ops
-            .push(CxOsOp::DetachCameraNativePreview { video_id });
+            .push_back(CxOsOp::DetachCameraNativePreview { video_id });
     }
 
     pub fn begin_video_playback(&mut self, video_id: LiveId) {
         self.drop_pending_video_transport(video_id);
-        self.platform_ops.push(CxOsOp::BeginVideoPlayback(video_id));
+        self.platform_ops.push_back(CxOsOp::BeginVideoPlayback(video_id));
     }
 
     pub fn pause_video_playback(&mut self, video_id: LiveId) {
-        // platform_ops are drained LIFO (`pop`). Without coalescing, a same-frame
-        // pause→resume becomes resume then pause and leaves playback stuck paused.
+        // Last-wins coalescing: one frame should apply a single play/pause
+        // intent even though the queue is FIFO.
         self.drop_pending_video_transport(video_id);
-        self.platform_ops.push(CxOsOp::PauseVideoPlayback(video_id));
+        self.platform_ops.push_back(CxOsOp::PauseVideoPlayback(video_id));
     }
 
     pub fn resume_video_playback(&mut self, video_id: LiveId) {
         self.drop_pending_video_transport(video_id);
         self.platform_ops
-            .push(CxOsOp::ResumeVideoPlayback(video_id));
+            .push_back(CxOsOp::ResumeVideoPlayback(video_id));
     }
 
     pub fn mute_video_playback(&mut self, video_id: LiveId) {
         self.drop_pending_video_mute(video_id);
-        self.platform_ops.push(CxOsOp::MuteVideoPlayback(video_id));
+        self.platform_ops.push_back(CxOsOp::MuteVideoPlayback(video_id));
     }
 
     pub fn unmute_video_playback(&mut self, video_id: LiveId) {
         self.drop_pending_video_mute(video_id);
         self.platform_ops
-            .push(CxOsOp::UnmuteVideoPlayback(video_id));
+            .push_back(CxOsOp::UnmuteVideoPlayback(video_id));
     }
 
     /// Keep only the latest play/pause/begin intent for `video_id`.
@@ -1709,7 +1728,7 @@ impl Cx {
 
     pub fn cleanup_video_playback_resources(&mut self, video_id: LiveId) {
         self.platform_ops
-            .push(CxOsOp::CleanupVideoPlaybackResources(video_id));
+            .push_back(CxOsOp::CleanupVideoPlaybackResources(video_id));
     }
 
     pub fn cancel_pending_camera_playback(&mut self, video_id: LiveId) {
@@ -1719,27 +1738,27 @@ impl Cx {
 
     pub fn seek_video_playback(&mut self, video_id: LiveId, position_ms: u64) {
         self.platform_ops
-            .push(CxOsOp::SeekVideoPlayback(video_id, position_ms));
+            .push_back(CxOsOp::SeekVideoPlayback(video_id, position_ms));
     }
 
     pub fn set_video_volume(&mut self, video_id: LiveId, volume: f64) {
         self.platform_ops
-            .push(CxOsOp::SetVideoVolume(video_id, volume));
+            .push_back(CxOsOp::SetVideoVolume(video_id, volume));
     }
 
     pub fn set_video_playback_rate(&mut self, video_id: LiveId, rate: f64) {
         self.platform_ops
-            .push(CxOsOp::SetVideoPlaybackRate(video_id, rate));
+            .push_back(CxOsOp::SetVideoPlaybackRate(video_id, rate));
     }
 
     pub fn select_video_track(&mut self, video_id: LiveId, index: usize) {
         self.platform_ops
-            .push(CxOsOp::SelectVideoTrack(video_id, index));
+            .push_back(CxOsOp::SelectVideoTrack(video_id, index));
     }
 
     pub fn select_audio_track(&mut self, video_id: LiveId, index: usize) {
         self.platform_ops
-            .push(CxOsOp::SelectAudioTrack(video_id, index));
+            .push_back(CxOsOp::SelectAudioTrack(video_id, index));
     }
 
     pub fn prepare_audio_playback(
@@ -1749,7 +1768,7 @@ impl Cx {
         autoplay: bool,
         should_loop: bool,
     ) {
-        self.platform_ops.push(CxOsOp::PrepareAudioPlayback(
+        self.platform_ops.push_back(CxOsOp::PrepareAudioPlayback(
             video_id,
             source,
             autoplay,
@@ -1763,22 +1782,22 @@ impl Cx {
 
     pub fn open_system_savefile_dialog(&mut self) {
         self.platform_ops
-            .push(CxOsOp::SaveFileDialog(FileDialog::new()));
+            .push_back(CxOsOp::SaveFileDialog(FileDialog::new()));
     }
 
     pub fn open_system_openfile_dialog(&mut self) {
         self.platform_ops
-            .push(CxOsOp::SelectFileDialog(FileDialog::new()));
+            .push_back(CxOsOp::SelectFileDialog(FileDialog::new()));
     }
 
     pub fn open_system_savefolder_dialog(&mut self) {
         self.platform_ops
-            .push(CxOsOp::SaveFolderDialog(FileDialog::new()));
+            .push_back(CxOsOp::SaveFolderDialog(FileDialog::new()));
     }
 
     pub fn open_system_openfolder_dialog(&mut self) {
         self.platform_ops
-            .push(CxOsOp::SelectFolderDialog(FileDialog::new()));
+            .push_back(CxOsOp::SelectFolderDialog(FileDialog::new()));
     }
 
     pub fn event_id(&self) -> u64 {
@@ -1872,3 +1891,54 @@ macro_rules! register_component_factory {
             );
     };
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+
+    #[test]
+    fn defer_platform_op_breaks_when_requeued_op_is_alone() {
+        let window_id = WindowId(0, 0);
+        let mut platform_ops = VecDeque::new();
+
+        assert!(!defer_platform_op(
+            &mut platform_ops,
+            CxOsOp::SetTopmost(window_id, true),
+        ));
+        assert_eq!(platform_ops, vec![CxOsOp::SetTopmost(window_id, true)]);
+    }
+
+    #[test]
+    fn defer_platform_op_appends_so_pending_ops_still_run_first() {
+        let window_id = WindowId(0, 0);
+        let mut platform_ops = VecDeque::from(vec![CxOsOp::CreateWindow(window_id)]);
+
+        assert!(defer_platform_op(
+            &mut platform_ops,
+            CxOsOp::SetTopmost(window_id, true),
+        ));
+        assert_eq!(
+            platform_ops,
+            vec![
+                CxOsOp::CreateWindow(window_id),
+                CxOsOp::SetTopmost(window_id, true),
+            ]
+        );
+    }
+
+    #[test]
+    fn platform_ops_drain_fifo_create_window_then_set_topmost() {
+        let window_id = WindowId(0, 0);
+        let mut platform_ops = VecDeque::new();
+        platform_ops.push_back(CxOsOp::CreateWindow(window_id));
+        platform_ops.push_back(CxOsOp::SetTopmost(window_id, true));
+
+        let first = platform_ops.pop_front().unwrap();
+        let second = platform_ops.pop_front().unwrap();
+        assert!(matches!(first, CxOsOp::CreateWindow(_)));
+        assert!(matches!(second, CxOsOp::SetTopmost(_, true)));
+        assert!(platform_ops.is_empty());
+    }
+}
+

--- a/platform/src/os/apple/ios/ios.rs
+++ b/platform/src/os/apple/ios/ios.rs
@@ -1081,7 +1081,7 @@ impl Cx {
     }
 
     fn handle_platform_ops(&mut self, metal_cx: &MetalCx) {
-        while let Some(op) = self.platform_ops.pop() {
+        while let Some(op) = self.platform_ops.pop_front() {
             match op {
                 CxOsOp::CreateWindow(window_id) => {
                     let window = &mut self.windows[window_id];

--- a/platform/src/os/apple/macos/macos.rs
+++ b/platform/src/os/apple/macos/macos.rs
@@ -243,11 +243,6 @@ impl MetalWindow {
     }
 }
 
-fn defer_platform_op(platform_ops: &mut Vec<CxOsOp>, op: CxOsOp) -> bool {
-    platform_ops.insert(0, op);
-    platform_ops.len() > 1
-}
-
 pub(crate) struct MacosNativeCameraPreview {
     input_id: crate::video::VideoInputId,
     format_id: crate::video::VideoFormatId,
@@ -1157,7 +1152,7 @@ impl Cx {
         metal_windows: &mut Vec<MetalWindow>,
         metal_cx: &MetalCx,
     ) -> EventFlow {
-        while let Some(op) = self.platform_ops.pop() {
+        while let Some(op) = self.platform_ops.pop_front() {
             match op {
                 CxOsOp::CreateWindow(window_id) => {
                     let window = &mut self.windows[window_id];
@@ -1292,10 +1287,7 @@ impl Cx {
                 }
                 CxOsOp::SetTopmost(window_id, is_topmost) => {
                     if metal_windows.is_empty() {
-                        if defer_platform_op(
-                            &mut self.platform_ops,
-                            CxOsOp::SetTopmost(window_id, is_topmost),
-                        ) {
+                        if self.defer_platform_op(CxOsOp::SetTopmost(window_id, is_topmost)) {
                             continue;
                         }
                         break;
@@ -1861,41 +1853,6 @@ impl Cx {
                 msg_send![class!(NSBlockOperation), blockOperationWithBlock: &main_thread_block];
             let () = msg_send![main_queue, addOperation: block_operation];
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn defer_platform_op_breaks_when_requeued_op_is_alone() {
-        let window_id = WindowId(0, 0);
-        let mut platform_ops = Vec::new();
-
-        assert!(!defer_platform_op(
-            &mut platform_ops,
-            CxOsOp::SetTopmost(window_id, true),
-        ));
-        assert_eq!(platform_ops, vec![CxOsOp::SetTopmost(window_id, true)]);
-    }
-
-    #[test]
-    fn defer_platform_op_continues_when_other_ops_are_pending() {
-        let window_id = WindowId(0, 0);
-        let mut platform_ops = vec![CxOsOp::CreateWindow(window_id)];
-
-        assert!(defer_platform_op(
-            &mut platform_ops,
-            CxOsOp::SetTopmost(window_id, true),
-        ));
-        assert_eq!(
-            platform_ops,
-            vec![
-                CxOsOp::SetTopmost(window_id, true),
-                CxOsOp::CreateWindow(window_id)
-            ]
-        );
     }
 }
 

--- a/platform/src/os/apple/macos/macos_stdin.rs
+++ b/platform/src/os/apple/macos/macos_stdin.rs
@@ -371,7 +371,7 @@ impl Cx {
         _metal_cx: &MetalCx,
         stdin_windows: &mut Vec<StdinWindow>,
     ) {
-        while let Some(op) = self.platform_ops.pop() {
+        while let Some(op) = self.platform_ops.pop_front() {
             match op {
                 CxOsOp::CreateWindow(window_id) => {
                     while window_id.id() >= stdin_windows.len() {

--- a/platform/src/os/apple/tvos/tvos.rs
+++ b/platform/src/os/apple/tvos/tvos.rs
@@ -195,7 +195,7 @@ impl Cx {
     }
 
     fn handle_platform_ops(&mut self, _metal_cx: &MetalCx) {
-        while let Some(op) = self.platform_ops.pop() {
+        while let Some(op) = self.platform_ops.pop_front() {
             match op {
                 CxOsOp::CreateWindow(window_id) => {
                     let window = &mut self.windows[window_id];

--- a/platform/src/os/headless/event_loop.rs
+++ b/platform/src/os/headless/event_loop.rs
@@ -581,7 +581,7 @@ impl Cx {
         windows: &mut Vec<HeadlessWindowState>,
         send_protocol: bool,
     ) -> bool {
-        while let Some(op) = self.platform_ops.pop() {
+        while let Some(op) = self.platform_ops.pop_front() {
             match op {
                 CxOsOp::CreateWindow(window_id) => {
                     while window_id.id() >= windows.len() {

--- a/platform/src/os/linux/android/android.rs
+++ b/platform/src/os/linux/android/android.rs
@@ -2396,7 +2396,7 @@ impl Cx {
     }
 
     fn handle_platform_ops(&mut self) -> EventFlow {
-        while let Some(op) = self.platform_ops.pop() {
+        while let Some(op) = self.platform_ops.pop_front() {
             match op {
                 CxOsOp::CreateWindow(window_id) => {
                     let window = &mut self.windows[window_id];

--- a/platform/src/os/linux/direct/linux_direct.rs
+++ b/platform/src/os/linux/direct/linux_direct.rs
@@ -284,7 +284,7 @@ impl Cx {
     }
 
     fn handle_platform_ops(&mut self, direct_app: &mut DirectApp) -> EventFlow {
-        while let Some(op) = self.platform_ops.pop() {
+        while let Some(op) = self.platform_ops.pop_front() {
             match op {
                 CxOsOp::CreateWindow(window_id) => {
                     let window = &mut self.windows[window_id];

--- a/platform/src/os/linux/open_harmony/open_harmony.rs
+++ b/platform/src/os/linux/open_harmony/open_harmony.rs
@@ -517,7 +517,7 @@ impl Cx {
     }
 
     fn handle_platform_ops(&mut self) -> EventFlow {
-        while let Some(op) = self.platform_ops.pop() {
+        while let Some(op) = self.platform_ops.pop_front() {
             //crate::log!("============ handle_platform_ops");
             match op {
                 CxOsOp::CreateWindow(window_id) => {

--- a/platform/src/os/linux/wayland/linux_wayland.rs
+++ b/platform/src/os/linux/wayland/linux_wayland.rs
@@ -621,7 +621,7 @@ impl WaylandCx {
         if cx.platform_ops.is_empty() {
             return EventFlow::Poll;
         }
-        while let Some(op) = cx.platform_ops.pop() {
+        while let Some(op) = cx.platform_ops.pop_front() {
             match op {
                 CxOsOp::SetCursor(_) | CxOsOp::StartTimer { .. } | CxOsOp::StopTimer(_) => {}
                 _ => {

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -545,7 +545,7 @@ impl X11Cx {
     ) -> EventFlow {
         let mut ret = EventFlow::Poll;
         let mut cx = self.cx.borrow_mut();
-        while let Some(op) = cx.platform_ops.pop() {
+        while let Some(op) = cx.platform_ops.pop_front() {
             match op {
                 CxOsOp::CreateWindow(window_id) => {
                     let gl_cx = cx.os.opengl_cx.as_ref().unwrap();

--- a/platform/src/os/linux/x11/linux_x11_stdin.rs
+++ b/platform/src/os/linux/x11/linux_x11_stdin.rs
@@ -543,7 +543,7 @@ impl Cx {
     }
 
     fn stdin_handle_platform_ops(&mut self, stdin_windows: &mut Vec<StdinWindow>) {
-        while let Some(op) = self.platform_ops.pop() {
+        while let Some(op) = self.platform_ops.pop_front() {
             match op {
                 CxOsOp::CreateWindow(window_id) => {
                     while window_id.id() >= stdin_windows.len() {

--- a/platform/src/os/web/web.rs
+++ b/platform/src/os/web/web.rs
@@ -602,7 +602,7 @@ impl Cx {
     }
 
     fn handle_platform_ops(&mut self) {
-        while let Some(op) = self.platform_ops.pop() {
+        while let Some(op) = self.platform_ops.pop_front() {
             match op {
                 CxOsOp::CreateWindow(window_id) => {
                     let title = {

--- a/platform/src/os/windows/windows.rs
+++ b/platform/src/os/windows/windows.rs
@@ -559,7 +559,7 @@ impl Cx {
     ) -> EventFlow {
         let mut ret = EventFlow::Poll;
         let mut geom_changes = Vec::new();
-        while let Some(op) = self.platform_ops.pop() {
+        while let Some(op) = self.platform_ops.pop_front() {
             match op {
                 CxOsOp::CreateWindow(window_id) => {
                     let window = &mut self.windows[window_id];
@@ -694,9 +694,10 @@ impl Cx {
                 CxOsOp::Quit => ret = EventFlow::Exit,
                 CxOsOp::SetTopmost(window_id, is_topmost) => {
                     if d3d11_windows.len() == 0 {
-                        self.platform_ops
-                            .insert(0, CxOsOp::SetTopmost(window_id, is_topmost));
-                        continue;
+                        if self.defer_platform_op(CxOsOp::SetTopmost(window_id, is_topmost)) {
+                            continue;
+                        }
+                        break;
                     }
                     if let Some(window) =
                         d3d11_windows.iter_mut().find(|w| w.window_id == window_id)

--- a/platform/src/os/windows/windows_stdin.rs
+++ b/platform/src/os/windows/windows_stdin.rs
@@ -367,7 +367,7 @@ impl Cx {
     }
 
     fn stdin_handle_platform_ops(&mut self, stdin_windows: &mut Vec<StdinWindow>) {
-        while let Some(op) = self.platform_ops.pop() {
+        while let Some(op) = self.platform_ops.pop_front() {
             match op {
                 CxOsOp::CreateWindow(window_id) => {
                     while window_id.id() >= stdin_windows.len() {

--- a/platform/src/window.rs
+++ b/platform/src/window.rs
@@ -343,7 +343,7 @@ impl WindowHandle {
         cxwindow.popup_size = None;
         cxwindow.popup_grab_keyboard = true;
         cx.platform_ops
-            .push(CxOsOp::CreateWindow(window.window_id()));
+            .push_back(CxOsOp::CreateWindow(window.window_id()));
         window
     }
 
@@ -370,7 +370,7 @@ impl WindowHandle {
             cxwindow.popup_grab_keyboard = true;
             cxwindow.popup_grab_keyboard
         };
-        cx.platform_ops.push(CxOsOp::CreatePopupWindow {
+        cx.platform_ops.push_back(CxOsOp::CreatePopupWindow {
             window_id,
             parent_window_id: parent,
             position,
@@ -1219,5 +1219,18 @@ mod tests {
 
         assert_eq!(cx.platform_ops.len(), 1);
         assert!(matches!(cx.platform_ops[0], CxOsOp::SetTopmost(_, true)));
+    }
+
+    #[test]
+    fn create_window_then_set_topmost_queues_fifo() {
+        let mut cx = test_cx();
+        let mut window = WindowHandle::new(&mut cx);
+        window.set_topmost(&mut cx, true);
+
+        let first = cx.platform_ops.pop_front().unwrap();
+        let second = cx.platform_ops.pop_front().unwrap();
+        assert!(matches!(first, CxOsOp::CreateWindow(_)));
+        assert!(matches!(second, CxOsOp::SetTopmost(_, true)));
+        assert!(cx.platform_ops.is_empty());
     }
 }

--- a/widgets/src/video.rs
+++ b/widgets/src/video.rs
@@ -2124,11 +2124,11 @@ impl Video {
                 }
             }
             PlaybackState::Completed => {
-                // platform_ops is LIFO (`pop`). Transport ops are coalesced, but
-                // seek is separate — push resume *before* seek so drain order is
-                // seek → resume (not resume-from-EOS then seek).
-                cx.resume_video_playback(self.id);
+                // Seek is not coalesced with transport ops. Queue seek then
+                // resume so FIFO drain is seek → resume (not resume-from-EOS
+                // then seek).
                 cx.seek_video_playback(self.id, 0);
+                cx.resume_video_playback(self.id);
                 self.current_position_ms = 0;
                 self.seek_cooldown = 5;
                 self.playback_state = PlaybackState::Playing;


### PR DESCRIPTION
Background on why LIFO was wrong, with worked examples: #1180 

## Summary

- Store `Cx::platform_ops` as `VecDeque<CxOsOp>` and drain **FIFO** (`push_back` / `pop_front`) on every OS backend.
- Requeue blocked ops with `Cx::defer_platform_op` (`push_back` + break if the queue is otherwise empty). Fixes the Windows `SetTopmost` empty-queue livelock.
- Keep last-wins coalescing for video transport/mute and in-place `SetCursor`.
- Flip the one in-tree caller that pushed in reverse to compensate for LIFO (`Video` replay-from-completed: seek then resume).

## Motivation

`CxOsOp` is a command list. Callers enqueue in causal order (`CreateWindow` then `SetTopmost`, `PrepareVideoPlayback` then `BeginVideoPlayback`, `ShowTextIME` then `SyncImeState`). The old `Vec::pop` drain ran that list backwards.

LIFO then forced a second convention: requeue ops that ran too early at index 0 so they executed after the remaining tail. Windows `insert(0)` + `continue` could spin forever if `SetTopmost` was the only op left.

FIFO matches the API contract. Coalescing stays for **state** (one frame, one mute/play/cursor intent), not as a substitute for drain order.

## Changes

### Queue and enqueue

| File | Change |
|------|--------|
| `platform/src/cx.rs` | `platform_ops: VecDeque<CxOsOp>` |
| `platform/src/cx_api.rs` | Every enqueue is `push_back`. Add `defer_platform_op`. Comment on video transport coalescing no longer claims LIFO. |
| `platform/src/window.rs` | `CreateWindow` / `CreatePopupWindow` use `push_back`. FIFO unit test: create then topmost. |

`push_unique_platform_op` is unchanged: skip an **equal** op already in the deque, otherwise `push_back`. Opposite values (`SetTopmost(true)` then `SetTopmost(false)`) both stay; FIFO applies the later one last.

### Drain sites (`pop` → `pop_front`)

Every `handle_platform_ops` / stdin / headless drain:

- `platform/src/os/windows/windows.rs`
- `platform/src/os/windows/windows_stdin.rs`
- `platform/src/os/apple/macos/macos.rs`
- `platform/src/os/apple/macos/macos_stdin.rs`
- `platform/src/os/apple/ios/ios.rs`
- `platform/src/os/apple/tvos/tvos.rs`
- `platform/src/os/linux/android/android.rs`
- `platform/src/os/linux/x11/linux_x11.rs`
- `platform/src/os/linux/x11/linux_x11_stdin.rs`
- `platform/src/os/linux/wayland/linux_wayland.rs`
- `platform/src/os/linux/direct/linux_direct.rs`
- `platform/src/os/linux/open_harmony/open_harmony.rs`
- `platform/src/os/web/web.rs`
- `platform/src/os/headless/event_loop.rs`

No remaining `platform_ops.pop()` / `platform_ops.push(` in `platform/src`. `old/platform` is untouched.

### Deferral (cannot-run-yet)

Shared helper in `cx_api.rs`:

```rust
pub(crate) fn defer_platform_op(platform_ops: &mut VecDeque<CxOsOp>, op: CxOsOp) -> bool {
    platform_ops.push_back(op);
    platform_ops.len() > 1
}
```

- `true` → `continue` the drain (other ops still queued; they run first).
- `false` → `break` (this is the only op; retry next event). Do **not** `continue` on an empty queue.

Call sites:

- macOS `SetTopmost` when `metal_windows` is empty (was `insert(0)`; continue/break already correct).
- Windows `SetTopmost` when `d3d11_windows` is empty (was `insert(0)` + always `continue` — livelock).

Stdin backends ignore `SetTopmost`; no defer there. Other backends apply `SetTopmost` only if the native window already exists. Under FIFO, `CreateWindow` in the same event runs first, so the common path needs no defer.

### Coalescing left as-is

Independent of drain order. One frame should still apply a single intent:

- `drop_pending_video_transport` / `drop_pending_video_mute` — last begin/pause/resume or mute/unmute for a `video_id`.
- `Cx::set_cursor` — in-place replace of the existing `SetCursor` in the deque (value last-wins, position of the first `SetCursor` kept).
- Window visuals / chrome ops still use `push_unique_platform_op`.

**Not coalesced (callers must push in apply order):**

- `SeekVideoPlayback` vs begin/pause/resume.
- `ShowTextIME` / `HideTextIME` / `SyncImeState`.
- `StartTimer` / `StopTimer`.
- `SetSystemBarDarkIcons(true)` vs `(false)` (not equal, so `push_unique` keeps both; FIFO last-wins).

`SetScreenOrientation` is not in the current `platform/src` tree; nothing to migrate there.

### LIFO-compensating caller

`widgets/src/video.rs` replay from `PlaybackState::Completed` used to push **resume then seek** so LIFO applied seek first. Under FIFO that would resume from EOS then seek.

Now: `seek_video_playback(id, 0)` then `resume_video_playback(id)`. Restart-button path already sought then resumed; left unchanged.

Repo search found no other comments or call sites that reverse-queued for `pop()`.

## Behavior after this PR

| Same-event push order | LIFO applied | FIFO applies |
|-----------------------|--------------|--------------|
| `CreateWindow`, `SetTopmost` | topmost, create | create, topmost |
| `PrepareVideoPlayback`, `BeginVideoPlayback` | begin, prepare | prepare, begin |
| `ShowTextIME`, `SyncImeState` | sync, show | show, sync |
| `WebSocketOpen`, `WebSocketSendBinary` | send, open | open, send |
| `ResizeWindow`, `CloseWindow` | close, resize | resize, close |
| `FullscreenWindow`, `NormalizeWindow` | normalize, fullscreen | fullscreen, normalize |
| `SetTopmost(true)`, `SetTopmost(false)` | true last (`push_unique` keeps both) | false last |
| `SetCursor(Hand)`, `SetCursor(Arrow)` | in-place replace (already last-wins) | same |
| `pause` then `resume` (same `video_id`) | coalesced to one op | same |
| Video `Completed` replay (after this PR) | seek, resume | seek, resume |

Windows empty-queue `SetTopmost`: no longer busy-loops the drain.

## Out of scope

- `old/platform` (archived 1.x).
- New coalescing for IME, timers, seek+transport, or system-bar icon tint.
- Changing when backends drain (still after the event / after IME-related messages on Android).

## Residual risk

- **Out-of-tree apps** that pushed ops backwards because they knew about `pop()` will now apply in call order. In-tree, only the Video completed-replay path did this.
- **Seek vs transport** is still two ops. New replay/loop helpers must enqueue seek then play, not the reverse.
- Unit tests cover enqueue order, defer continue/break, and `CreateWindow` then `SetTopmost`. They do not drive a native window or decoder.
