### PR TITLE
Don’t panic on a stale `Area::Rect` (follow-up)

### DIFF
--- a/draw/src/turtle.rs
+++ b/draw/src/turtle.rs
@@ -2692,11 +2692,14 @@ impl<'a, 'b> Cx2d<'a, 'b> {
                 }
                 AlignEntry::Area(Area::Rect(ra)) => {
                     let draw_list = &mut self.cx.draw_lists[ra.draw_list_id];
-                    let rect_area = &mut draw_list.rect_areas[ra.rect_id];
-                    rect_area.rect.pos += d;
-                    if shift_clip {
-                        rect_area.draw_clip.0 += d;
-                        rect_area.draw_clip.1 += d;
+                    if draw_list.redraw_id == ra.redraw_id {
+                        if let Some(rect_area) = draw_list.rect_areas.get_mut(ra.rect_id) {
+                            rect_area.rect.pos += d;
+                            if shift_clip {
+                                rect_area.draw_clip.0 += d;
+                                rect_area.draw_clip.1 += d;
+                            }
+                        }
                     }
                 }
                 AlignEntry::BeginClip(clip0, clip1) => {
@@ -2779,9 +2782,12 @@ impl<'a, 'b> Cx2d<'a, 'b> {
                 AlignEntry::Area(Area::Rect(ra)) => {
                     if let Some((clip0, clip1)) = self.turtle_clips.last() {
                         let draw_list = &mut self.cx.draw_lists[ra.draw_list_id];
-                        let rect_area = &mut draw_list.rect_areas[ra.rect_id];
-                        rect_area.draw_clip.0 = *clip0;
-                        rect_area.draw_clip.1 = *clip1;
+                        if draw_list.redraw_id == ra.redraw_id {
+                            if let Some(rect_area) = draw_list.rect_areas.get_mut(ra.rect_id) {
+                                rect_area.draw_clip.0 = *clip0;
+                                rect_area.draw_clip.1 = *clip1;
+                            }
+                        }
                     }
                 }
                 AlignEntry::Unset => {}

--- a/platform/src/area.rs
+++ b/platform/src/area.rs
@@ -62,6 +62,20 @@ impl Into<Area> for InstanceArea {
     }
 }
 
+/// Live `Area::Rect` slot, or `None` when the draw list was rebuilt (stale
+/// `redraw_id`) or `rect_id` is past `rect_areas` (partial/sibling redraw).
+fn live_rect_area<'a>(
+    ra: &RectArea,
+    cx: &'a Cx,
+) -> Option<(&'a crate::draw_list::CxDrawList, &'a crate::draw_list::CxRectArea)> {
+    let draw_list = cx.draw_lists.checked_index(ra.draw_list_id)?;
+    if draw_list.redraw_id != ra.redraw_id {
+        return None;
+    }
+    let rect_area = draw_list.rect_areas.get(ra.rect_id)?;
+    Some((draw_list, rect_area))
+}
+
 impl Area {
     pub fn area(&self) -> Self {
         self.clone()
@@ -158,15 +172,7 @@ impl Area {
                 }
                 return false;
             }
-            Area::Rect(list) => {
-                if let Some(draw_list) = cx.draw_lists.checked_index(list.draw_list_id) {
-                    if draw_list.redraw_id != list.redraw_id {
-                        return false;
-                    }
-                    return true;
-                }
-                return false;
-            }
+            Area::Rect(list) => live_rect_area(list, cx).is_some(),
             _ => false,
         };
     }
@@ -239,14 +245,10 @@ impl Area {
                 Rect::default()
             }
             Area::Rect(ra) => {
-                // we need to clip this drawlist too
-                let draw_list = &cx.draw_lists[ra.draw_list_id];
-                // A stale area outlives the draw that made it, and its rect_id
-                // can then be past the end of a shorter list.
-                if draw_list.redraw_id != ra.redraw_id {
-                    return Rect::default();
-                }
-                let Some(rect_area) = draw_list.rect_areas.get(ra.rect_id) else {
+                // Clip this draw list too. Stale rect areas are common after a
+                // hide/rebuild; Instance already bails on redraw_id, Rect must
+                // too, and must bounds-check — Win32 WndProc cannot unwind.
+                let Some((draw_list, rect_area)) = live_rect_area(ra, cx) else {
                     return Rect::default();
                 };
                 if draw_list.draw_list_has_clip {
@@ -311,15 +313,9 @@ impl Area {
                 }
                 Rect::default()
             }
-            Area::Rect(ra) => {
-                let draw_list = &cx.draw_lists[ra.draw_list_id];
-                if draw_list.redraw_id == ra.redraw_id {
-                    if let Some(rect_area) = draw_list.rect_areas.get(ra.rect_id) {
-                        return rect_area.rect;
-                    }
-                }
-                Rect::default()
-            }
+            Area::Rect(ra) => live_rect_area(ra, cx)
+                .map(|(_, rect_area)| rect_area.rect)
+                .unwrap_or_default(),
             _ => Rect::default(),
         };
     }
@@ -350,19 +346,13 @@ impl Area {
                 }
                 abs
             }
-            Area::Rect(ra) => {
-                let draw_list = &cx.draw_lists[ra.draw_list_id];
-                if draw_list.redraw_id != ra.redraw_id {
-                    return abs;
-                }
-                let Some(rect_area) = draw_list.rect_areas.get(ra.rect_id) else {
-                    return abs;
-                };
-                Vec2d {
+            Area::Rect(ra) => match live_rect_area(ra, cx) {
+                Some((_, rect_area)) => Vec2d {
                     x: abs.x - rect_area.rect.pos.x,
                     y: abs.y - rect_area.rect.pos.y,
-                }
-            }
+                },
+                None => abs,
+            },
             _ => abs,
         };
     }
@@ -421,7 +411,7 @@ impl Area {
                     return;
                 }
                 if let Some(rect_area) = draw_list.rect_areas.get_mut(ra.rect_id) {
-                    rect_area.rect = *rect
+                    rect_area.rect = *rect;
                 }
             }
             _ => (),

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -2356,7 +2356,7 @@ impl Widget for PortalList {
         // One rect test here guards the entire item subtree from high-rate
         // mouse-move fan-out.
         if let Event::MouseMove(e) = event {
-            let inside = self.area.clipped_rect(cx).contains(e.abs);
+            let inside = self.area.is_valid(cx) && self.area.clipped_rect(cx).contains(e.abs);
             if !inside && !self.pointer_was_inside {
                 pass_through_to_children = false;
             }


### PR DESCRIPTION
Follow-up to [#1171](https://github.com/makepad/makepad/pull/1171) (`Area: don't panic on a stale Area::Rect`). That change made `Area::clipped_rect` / `rect` / `abs_to_rel` / `set_rect` check `redraw_id` and `rect_areas.get`. Crashes remained on other paths that still indexed `rect_areas[rect_id]` or treated a dead list area as live during mouse hit-testing.

## Summary

- Centralize “is this `Area::Rect` still live?” in `live_rect_area` (`checked_index` + `redraw_id` + `rect_areas.get`).
- Skip turtle align-list mutate when the rect slot is gone (layout shift/clip after a hide/rebuild).
- PortalList: ignore high-rate `MouseMove` fan-out unless the list’s area is still valid.

## Motivation

`Area::Rect` is a `(draw_list_id, rect_id, redraw_id)` handle into that draw list’s `rect_areas`. It outlives the draw that created it.

Typical sequence (e.g. chrome **back → library**, or hiding a panel):

1. Widget A draws, stores `Area::Rect { rect_id: 173, redraw_id: N }` on itself / in the turtle align list.
2. A later draw rebuilds the same draw list with **fewer** rects (or a sibling partial redraw truncates `rect_areas`). Generation becomes `N+1`, length might be 105.
3. Hit-testing, hover, or layout alignment still holds the old handle.

`rect_areas[173]` then panics. On **Windows**, that panic often runs inside `WndProc`. Rust cannot unwind through the FFI boundary, so the process aborts instead of a recoverable UI error.

#1171 stopped the panic inside `Area` query methods, but:

| Path | After #1171 |
|------|-------------|
| `Area::clipped_rect` / `rect` / `abs_to_rel` | `redraw_id` + `get` — safe for a **valid** draw-list index |
| `cx.draw_lists[ra.draw_list_id]` | still panics if the draw-list id itself is dead |
| `Area::is_valid` for `Rect` | only compared `redraw_id`; an OOB `rect_id` still counted as valid |
| Turtle `move_align_list` / `clip_and_shift_align_list` | still `rect_areas[ra.rect_id]` |
| PortalList `MouseMove` | called `clipped_rect` on a possibly stale list area and still walked every item |

## Changes

### `platform/src/area.rs`

```rust
fn live_rect_area<'a>(ra: &RectArea, cx: &'a Cx)
    -> Option<(&'a CxDrawList, &'a CxRectArea)>
```

Returns `None` when:

- `draw_list_id` is not in the pool (`checked_index` — no panic),
- `redraw_id` does not match the current draw (rebuild),
- `rect_id` is past `rect_areas` (partial / sibling redraw).

Used by `is_valid`, `clipped_rect`, `rect`, and `abs_to_rel`. Same fallbacks as before (`Rect::default()`, identity for `abs_to_rel`).

`is_valid(Area::Rect)` is now **stricter**: matching generation is not enough; the slot must exist. Callers that used `is_valid` as “safe to index” were previously wrong for the OOB case.

### `draw/src/turtle.rs`

End-of-turtle alignment walks `align_list` and **mutates** stored `Area::Rect` slots (shift position, apply clip). Those entries can be stale when a nested/sibling redraw shortened `rect_areas` before the parent turtle closed.

`move_align_list` and `clip_and_shift_align_list` now:

- require `draw_list.redraw_id == ra.redraw_id`,
- use `rect_areas.get_mut(ra.rect_id)`,
- skip the entry if either check fails.

Skipping is correct: the rect belongs to a previous draw and must not be written. Instance entries in the align list are unchanged (they already keyed off `redraw_id` in `Area` query APIs; this PR is the rect-slot hole).

### `widgets/src/portal_list.rs`

`MouseMove` is high-rate. The list already uses one rect test to avoid fanning the event into every visible item when the pointer is outside.

```rust
let inside = self.area.is_valid(cx) && self.area.clipped_rect(cx).contains(e.abs);
```

If the list was hidden or rebuilt, `clipped_rect` is `Rect::default()` (origin, zero size). That is the wrong question: we need “is the list live?”, not “does the pointer hit a degenerate rect?”. `is_valid` (now slot-accurate) fails closed. Hover-out still runs when `pointer_was_inside` was true last frame.

## Behavior after this PR

| Situation | Before | After |
|-----------|--------|--------|
| Stale `rect_id` in `Area::{clipped_rect,rect,…}` | #1171: no panic | Same, plus dead `draw_list_id` is also `None` |
| Stale `rect_id` in turtle align shift/clip | **panic** (Windows abort in `WndProc`) | Skip that align entry |
| `is_valid(Rect)` with matching `redraw_id` but OOB `rect_id` | `true` | `false` |
| PortalList `MouseMove` after hide/rebuild | Could still hit-test / fan out | No child fan-out unless the pointer just left |

## Out of scope

- Turtle still indexes `draw_lists[ra.draw_list_id]` without `checked_index`. A recycled **draw-list id** (not just a short `rect_areas`) could still panic there. The crashes we care about are OOB `rect_id` after a rebuild of an existing list.
- `Area::Instance` paths in turtle (draw-item / instance buffer index).