### PR TITLE
PortalList: expose the total distance the user has scrolled

### DIFF
--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -569,6 +569,10 @@ pub struct PortalList {
     /// Whether the PortalList was actively scrolling during the most recent finger down hit.
     #[rust]
     was_scrolling: bool,
+    /// The running total of all user-driven scrolling of this list.
+    /// See [`PortalListRef::user_scroll_travel()`].
+    #[rust]
+    user_scroll_travel: f64,
 
     // Cross-boundary text selection support
     /// Enable text selection across items (for TextFlow content)
@@ -1543,8 +1547,12 @@ impl PortalList {
         transition_to_pulldown: bool,
         bounce_velocity: f64,
         touch: bool,
+        user_driven: bool,
     ) {
         let mut delta = delta;
+        if user_driven {
+            self.user_scroll_travel += delta;
+        }
         let fingers_down = !clip_top && !transition_to_pulldown;
         let extent = self.area.rect(cx).size.index(self.vec_index);
 
@@ -2201,6 +2209,7 @@ impl Widget for PortalList {
         }
 
         let mut scroll_to = None;
+        let bar_pos_before = self.scroll_bar.get_scroll_pos();
         self.scroll_bar
             .handle_event_with(cx, event, &mut |_cx, action| {
                 if let ScrollBarAction::Scroll {
@@ -2245,6 +2254,10 @@ impl Widget for PortalList {
                         * self.view_window as f64) as usize;
                     self.first_scroll = 0.0;
                 }
+
+                // Bar-driven movement doesn't pass through `delta_top_scroll`,
+                // so account for it here.
+                self.user_scroll_travel -= scroll_to - bar_pos_before;
 
                 // A scroll-bar drag stops every other kind of motion, so a leftover
                 // fling, bounce, or OS momentum stream can't resume from wherever
@@ -2398,7 +2411,7 @@ impl Widget for PortalList {
                     if self.first_id > self.range_start || self.first_scroll < 0.0 {
                         let distance = (top_edge + scroll_margin - mouse_pos).max(1.0);
                         let scroll_speed = (5.0 + distance * 0.5).clamp(5.0, 50.0);
-                        self.delta_top_scroll(cx, scroll_speed, true, false, 0.0, false);
+                        self.delta_top_scroll(cx, scroll_speed, true, false, 0.0, false, true);
                         self.area.redraw(cx);
                     }
                 } else if mouse_pos > bottom_edge - scroll_margin {
@@ -2406,7 +2419,7 @@ impl Widget for PortalList {
                     if !self.at_end {
                         let distance = (mouse_pos - (bottom_edge - scroll_margin)).max(1.0);
                         let scroll_speed = -(5.0 + distance * 0.5).clamp(5.0, 50.0);
-                        self.delta_top_scroll(cx, scroll_speed, true, false, 0.0, false);
+                        self.delta_top_scroll(cx, scroll_speed, true, false, 0.0, false, true);
                         self.area.redraw(cx);
                     }
                 }
@@ -2478,7 +2491,7 @@ impl Widget for PortalList {
                         {
                             *next_frame = cx.new_next_frame();
                         }
-                        self.delta_top_scroll(cx, delta_val, true, false, 0.0, false);
+                        self.delta_top_scroll(cx, delta_val, true, false, 0.0, false, false);
                         self.area.redraw(cx);
                     } else {
                         self.was_scrolling = false;
@@ -2512,7 +2525,7 @@ impl Widget for PortalList {
                                 let ov = fling.allows_overscroll();
                                 let fling_velocity = fling.velocity;
                                 let before = (self.first_id, self.first_scroll);
-                                self.delta_top_scroll(cx, displacement, !ov, ov, fling_velocity, true);
+                                self.delta_top_scroll(cx, displacement, !ov, ov, fling_velocity, true, false);
                                 let moved = (self.first_id, self.first_scroll) != before;
                                 if let ScrollState::Flick { parked, .. } =
                                     &mut self.scroll_state
@@ -2678,7 +2691,7 @@ impl Widget for PortalList {
                                     .map_or(1.0 / 240.0, |prev| (e.time - prev).max(1.0 / 240.0));
                                 let max_v = self.flick_scroll_maximum * PER_FRAME_TO_PER_SECOND;
                                 let velocity = (delta / dt).clamp(-max_v, max_v);
-                                self.delta_top_scroll(cx, delta, false, true, velocity, false);
+                                self.delta_top_scroll(cx, delta, false, true, velocity, false, false);
                                 if matches!(self.scroll_state, ScrollState::Pulldown { .. }) {
                                     // The bounce owns the motion now; drop the rest of the
                                     // stream so it can't fight the spring.
@@ -2779,7 +2792,7 @@ impl Widget for PortalList {
                             if delta != 0.0 {
                                 self.tail_range = false;
                                 self.detect_tail_in_draw = true;
-                                self.delta_top_scroll(cx, delta, true, false, 0.0, false);
+                                self.delta_top_scroll(cx, delta, true, false, 0.0, false, true);
                                 self.area.redraw(cx);
                             }
                         }
@@ -2796,7 +2809,7 @@ impl Widget for PortalList {
                                 self.last_finger_scroll_time = Some(e.time);
                             }
                             self.scroll_state = ScrollState::Stopped;
-                            self.delta_top_scroll(cx, delta, false, false, 0.0, false);
+                            self.delta_top_scroll(cx, delta, false, false, 0.0, false, true);
                             self.area.redraw(cx);
                         }
                         // `None` (wheels) applies the delta directly and clips at the edges.
@@ -2809,7 +2822,7 @@ impl Widget for PortalList {
                             self.scroll_state = ScrollState::Stopped;
                             // Clip to the top and don't transition to pulldown; overscroll bounce
                             // is only for touch drag/flick.
-                            self.delta_top_scroll(cx, delta, true, false, 0.0, false);
+                            self.delta_top_scroll(cx, delta, true, false, 0.0, false, true);
                             // Note: we intentionally do NOT reset `at_end` here.
                             // `at_end` is authoritatively recalculated each draw cycle
                             // in `end()`, and the redraw is already triggered below.
@@ -3030,7 +3043,7 @@ impl Widget for PortalList {
 
                             let old_sample = *samples.last().unwrap();
                             push_sample(samples, new_abs, e.time);
-                            self.delta_top_scroll(cx, new_abs - old_sample.abs, false, false, 0.0, true);
+                            self.delta_top_scroll(cx, new_abs - old_sample.abs, false, false, 0.0, true, true);
                             self.area.redraw(cx);
                         }
                     }
@@ -3281,6 +3294,28 @@ impl PortalListRef {
             return 0.0;
         };
         inner.first_scroll
+    }
+
+    /// Returns the running total of all user-driven scrolling of this list, in pixels.
+    ///
+    /// This sums every scroll delta the *user* requested: wheel and trackpad
+    /// deltas (including OS momentum), touch drags, scroll-bar drags, and
+    /// selection auto-scroll. A positive delta moves the view towards the start
+    /// of the range (revealing lower-index items), a negative one towards the
+    /// end. A delta absorbed at a clamped edge still counts. Movement the list
+    /// performs on its own (smooth scrolling, fling coasting, bounce-back,
+    /// tail-following) is excluded.
+    ///
+    /// Sample it at two points in time and subtract to learn whether the user
+    /// scrolled the list in between, and in which direction, even while the
+    /// list is also moving programmatically. Unlike comparing [`Self::first_id()`],
+    /// this is unaffected by items being inserted or removed, since it measures
+    /// movement rather than position.
+    pub fn user_scroll_travel(&self) -> f64 {
+        let Some(inner) = self.borrow() else {
+            return 0.0;
+        };
+        inner.user_scroll_travel
     }
 
     /// Returns a compact debug line with the current animated scroll state.


### PR DESCRIPTION
Adds `PortalListRef::user_scroll_travel()`, a running sum of every user-driven scroll delta: wheel/trackpad (including OS momentum), touch drags, scroll-bar drags, and selection auto-scroll. Deltas absorbed at a clamped edge still count, while the list's own movement (smooth scrolls, fling coasting, bounce-back, tail-following) does not.

Sampling it at two points and subtracting tells a caller whether the user scrolled in between and in which direction, which comparing `first_id()` cannot do once items are inserted or removed. A positive difference means the user scrolled toward earlier items.

All user-driven paths already funnel through `delta_top_scroll()`, so this just adds a `user_driven` flag there and accumulates the delta when it's set. The one exception is scroll-bar drags, which move the list via the `ScrollBar`'s own event handling, so those are measured from the bar position delta around that call.

Robrix uses this to tell whether the user actually scrolled the timeline (and which way) when deciding to send Matrix read receipts.