### PR TITLE
splash: a dead isolate's widgets must not call into the app VM

### DIFF
--- a/widgets/src/animator.rs
+++ b/widgets/src/animator.rs
@@ -319,7 +319,12 @@ impl ScriptHook for Animator {
             return false;
         };
         let obj_ref = vm.bx.heap.new_object_ref(obj);
-        self.vm_id = vm.cx_mut().script_ref_vm_id(&obj_ref);
+        // Minted from the VM we are running in, so this always resolves; the
+        // fallback only exists because the lookup is fallible in general.
+        self.vm_id = vm
+            .cx_mut()
+            .script_ref_vm_id(&obj_ref)
+            .unwrap_or(crate::widget_async::MAIN_SPLASH_VM_ID);
 
         let mut process_map = |vm: &mut ScriptVm, map: &mut ScriptObjectMap| {
             for (key, map_value) in map.iter() {

--- a/widgets/src/portal_list.rs
+++ b/widgets/src/portal_list.rs
@@ -1358,7 +1358,13 @@ impl PortalList {
             // the template ref itself is exact; for a non-isolated (main-app) list it
             // yields MAIN_SPLASH_VM_ID, i.e. exactly `cx.with_vm`, so normal usage is
             // unchanged.
-            let vm_id = cx.script_ref_vm_id(template_ref);
+            let Some(vm_id) = cx.script_ref_vm_id(template_ref) else {
+                // The isolate that minted this template has been reclaimed, so
+                // the list is on its way out too. An empty item is the only
+                // honest answer: instantiating from a dead heap is what the
+                // comment above warns about.
+                return (WidgetRef::empty(), false);
+            };
             match self.items.entry(entry_id) {
                 Entry::Occupied(mut occ) => {
                     if occ.get().template == template {

--- a/widgets/src/splash_host.rs
+++ b/widgets/src/splash_host.rs
@@ -152,7 +152,18 @@ pub fn splash_host_respond(
     let Some(vm_id) = crate::widget_async::vm_for_heap(cx, heap_key) else {
         return SplashRespondOutcome::IsolateGone;
     };
+    let mut delivered = true;
     cx.with_script_vm_id(vm_id, |vm| {
+        // Prove we landed in the heap this request came from before minting
+        // anything in it. `vm_id` is looked up through a map; if that map is
+        // ever wrong, building the answer object here would plant one heap's
+        // values in another and the fault would surface later, in the GC, with
+        // nothing left to point at the cause. One compare turns that into an
+        // undeliverable answer, which callers already handle.
+        if vm.bx.heap.heap_key() != heap_key {
+            delivered = false;
+            return;
+        }
         let (ok, data, error) = match result {
             Ok(json) => {
                 let mut parser = makepad_script::json::JsonParserThread::default();
@@ -171,6 +182,9 @@ pub fn splash_host_respond(
             vm.call(callback.as_object().into(), &[obj.into()]);
         });
     });
+    if !delivered {
+        return SplashRespondOutcome::IsolateGone;
+    }
     SplashRespondOutcome::Delivered
 }
 

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -644,7 +644,11 @@ impl TextInput {
         cx.widget_action(uid, TextInputAction::Changed(self.text.clone()));
         if let Some(handler) = self.on_change.as_object() {
             let text = self.text.clone();
-            let vm_id = cx.script_ref_vm_id(&self.source);
+            // Nothing to call into if the isolate that minted this input is
+            // already gone.
+            let Some(vm_id) = cx.script_ref_vm_id(&self.source) else {
+                return;
+            };
             cx.with_script_vm_id(vm_id, |vm| {
                 let str_val = vm.bx.heap.new_string_from_str(&text);
                 vm.with_instruction_limit(
@@ -661,7 +665,11 @@ impl TextInput {
         cx.widget_action(uid, TextInputAction::Returned(self.text.clone(), mods));
         if let Some(handler) = self.on_return.as_object() {
             let text = self.text.clone();
-            let vm_id = cx.script_ref_vm_id(&self.source);
+            // Nothing to call into if the isolate that minted this input is
+            // already gone.
+            let Some(vm_id) = cx.script_ref_vm_id(&self.source) else {
+                return;
+            };
             cx.with_script_vm_id(vm_id, |vm| {
                 let str_val = vm.bx.heap.new_string_from_str(&text);
                 vm.with_instruction_limit(

--- a/widgets/src/widget_async.rs
+++ b/widgets/src/widget_async.rs
@@ -93,8 +93,12 @@ pub fn gc_dead_splash_isolates(cx: &mut Cx) {
     crate::splash_storage::gc_roots(&dead_heaps);
     crate::splash_host::gc_bridge(&dead_heaps);
     let state = cx.global::<CxWidgetAsync>();
+    state.dead_heaps.extend(dead_heaps.iter().copied());
     for vm_id in dead {
-        state.isolated_vms.vms.remove(&vm_id);
+        // Purge everything that HOLDS the isolate's values before dropping the
+        // heap those values live in: `script_to_widget_calls` carries a
+        // `ScriptObjectRef` into it, and `pending_script_to_widget_returns` a
+        // bare `ScriptValue`. Same reason `gc_bridge` above runs first.
         state.heap_to_vm.retain(|_, v| *v != vm_id);
         state.ui_handle_types.remove(&vm_id);
         state.vm_root_uids.remove(&vm_id);
@@ -105,6 +109,7 @@ pub fn gc_dead_splash_isolates(cx: &mut Cx) {
             .pending_script_to_widget_returns
             .retain(|(v, _), _| *v != vm_id);
         state.thread_map.retain(|(v, _), _| *v != vm_id);
+        state.isolated_vms.vms.remove(&vm_id);
     }
 }
 
@@ -209,11 +214,12 @@ struct CxWidgetAsync {
     ui_handle_types: HashMap<SplashVmId, ScriptHandleType>,
     global_ui_root_uid: WidgetUid,
     /// Maps a heap identity (see [`ScriptObjectRef::heap_key`]) to the isolate VM
-    /// that owns it. Only isolate heaps are inserted; a ref whose heap isn't here
-    /// (the main app heap, or an empty ref) resolves to `MAIN_SPLASH_VM_ID`. This
-    /// replaces per-widget uid registration: a widget's owning VM is derived
-    /// directly from its own `source` ref, so there are no coverage gaps for
-    /// lazily-created widgets and no wrong-heap fallbacks.
+    /// that owns it. Only isolate heaps are inserted, and an entry is removed the
+    /// moment its isolate dies — so a ref that misses here is either the main app
+    /// heap's (checked against the app VM's own key) or a dead isolate's, whose
+    /// calls are dropped rather than routed anywhere. This replaces per-widget uid
+    /// registration: a widget's owning VM is derived directly from its own
+    /// `source` ref, so there are no coverage gaps for lazily-created widgets.
     heap_to_vm: HashMap<usize, SplashVmId>,
     /// Each isolate's own view-root uid (set by [`inject_splash_ui_handle`]). Isolate `ui`
     /// handles are confined to this subtree so a mini-app can't reach host/sibling widgets.
@@ -222,6 +228,12 @@ struct CxWidgetAsync {
     current_vm_id: SplashVmId,
     /// Round-robin cursor for the per-pump isolate GC pass (last vm id serviced).
     gc_rr_last: u64,
+    /// Heaps of isolates that have been reclaimed. A widget can outlive the
+    /// isolate that minted it by a frame or two and still try to call back into
+    /// it; this is what tells such a ref apart from an app-VM one, so it can be
+    /// dropped instead of misrouted. Keys are only added once their isolate is
+    /// gone and removed again if a later heap is allocated at the same address.
+    dead_heaps: std::collections::HashSet<usize>,
 }
 
 #[derive(Default)]
@@ -311,7 +323,11 @@ pub trait CxSplashVmExt {
     /// minted by that widget (its `source`, a template, an `on_click` fn). This
     /// is exact — the heap identity comes from the ref itself — so it never
     /// mis-routes lazily-created widgets the way a uid registry could.
-    fn script_ref_vm_id(&mut self, script_ref: &ScriptObjectRef) -> SplashVmId;
+    ///
+    /// `None` means the ref belongs to a heap that is gone: an isolate was torn
+    /// down while widgets it minted were still in the tree. Such a call must be
+    /// dropped, never redirected — see the note on the impl.
+    fn script_ref_vm_id(&mut self, script_ref: &ScriptObjectRef) -> Option<SplashVmId>;
 }
 
 impl CxSplashVmExt for Cx {
@@ -380,6 +396,10 @@ impl CxSplashVmExt for Cx {
         // sources, templates, on_click fns) routes back to this VM.
         let heap_key = bx.heap.heap_key();
         let state = self.global::<CxWidgetAsync>();
+        // A heap key is an allocation address, so a fresh heap can land on one
+        // a dead isolate used to own. Live registration wins over the memory of
+        // the dead one.
+        state.dead_heaps.remove(&heap_key);
         state.heap_to_vm.insert(heap_key, id);
         state.isolated_vms.vms.insert(
             id,
@@ -394,11 +414,20 @@ impl CxSplashVmExt for Cx {
     }
 
     fn with_script_vm_id<R>(&mut self, vm_id: SplashVmId, f: impl FnOnce(&mut ScriptVm) -> R) -> R {
-        if vm_id == MAIN_SPLASH_VM_ID {
+        // "Already installed?" comes first, and the main-VM case has to prove
+        // it too: `with_vm` runs against whatever VM is currently parked on
+        // `Cx`, which during an isolate's own execution is that ISOLATE's. So
+        // an unguarded main-VM branch here silently runs app-VM work in an
+        // isolate's heap.
+        let current = self.global::<CxWidgetAsync>().current_vm_id;
+        if current == vm_id {
             return self.with_vm(f);
         }
-
-        if self.global::<CxWidgetAsync>().current_vm_id == vm_id {
+        if vm_id == MAIN_SPLASH_VM_ID {
+            debug_assert_eq!(
+                current, MAIN_SPLASH_VM_ID,
+                "main-VM script call while isolate {current:?} is installed on Cx"
+            );
             return self.with_vm(f);
         }
 
@@ -411,11 +440,15 @@ impl CxSplashVmExt for Cx {
         thread_id: ScriptThreadId,
         f: impl FnOnce(&mut ScriptVm) -> R,
     ) -> R {
-        if vm_id == MAIN_SPLASH_VM_ID {
+        let current = self.global::<CxWidgetAsync>().current_vm_id;
+        if current == vm_id {
             return self.with_vm_thread(thread_id, f);
         }
-
-        if self.global::<CxWidgetAsync>().current_vm_id == vm_id {
+        if vm_id == MAIN_SPLASH_VM_ID {
+            debug_assert_eq!(
+                current, MAIN_SPLASH_VM_ID,
+                "main-VM script call while isolate {current:?} is installed on Cx"
+            );
             return self.with_vm_thread(thread_id, f);
         }
 
@@ -424,16 +457,36 @@ impl CxSplashVmExt for Cx {
         })
     }
 
-    fn script_ref_vm_id(&mut self, script_ref: &ScriptObjectRef) -> SplashVmId {
+    fn script_ref_vm_id(&mut self, script_ref: &ScriptObjectRef) -> Option<SplashVmId> {
         let heap_key = script_ref.heap_key();
         if heap_key == 0 {
-            return MAIN_SPLASH_VM_ID;
+            return Some(MAIN_SPLASH_VM_ID);
         }
-        self.global::<CxWidgetAsync>()
-            .heap_to_vm
-            .get(&heap_key)
-            .copied()
-            .unwrap_or(MAIN_SPLASH_VM_ID)
+        let state = self.global::<CxWidgetAsync>();
+        if let Some(vm_id) = state.heap_to_vm.get(&heap_key).copied() {
+            return Some(vm_id);
+        }
+        // Not a live isolate's heap. Either the app VM's own — the common case,
+        // since the app VM is never in `heap_to_vm` — or one that has been
+        // reclaimed, and those two must not be confused.
+        //
+        // An isolate's widgets can outlive it by a frame: a tile dropped
+        // mid-gesture, an app force-stopped while its buttons are still in the
+        // tree. Each of those holds refs minted by the dead heap. Treating them
+        // as "not an isolate, therefore the app VM" routes a dead heap's
+        // objects INTO the app VM, which stores them in an args object of its
+        // own. Nothing complains at the time — the checked stores skip indices
+        // they cannot resolve — and then the next GC walks that object,
+        // indexes the app heap with a foreign heap's index, and panics
+        // somewhere else entirely, in code that did nothing wrong.
+        //
+        // So a heap we have reclaimed is remembered, and its calls are dropped
+        // rather than redirected — the same treatment
+        // `script_timer_dispatch_hook` already gives a dead isolate's timers.
+        if state.dead_heaps.contains(&heap_key) {
+            return None;
+        }
+        Some(MAIN_SPLASH_VM_ID)
     }
 }
 
@@ -863,7 +916,9 @@ impl CxWidgetToScriptCallExt for Cx {
         args: ScriptValue,
         from_method: LiveId,
     ) -> ScriptAsyncResult {
-        let vm_id = self.script_ref_vm_id(&source);
+        let Some(vm_id) = self.script_ref_vm_id(&source) else {
+            return ScriptAsyncResult::MethodNotFound;
+        };
         self.with_script_vm_id(vm_id, |vm| {
             vm.widget_to_script_async_call_fwd(
                 target_uid,
@@ -887,7 +942,9 @@ impl CxWidgetToScriptCallExt for Cx {
         args: &[ScriptValue],
         from_method: LiveId,
     ) -> ScriptAsyncResult {
-        let vm_id = self.script_ref_vm_id(&source);
+        let Some(vm_id) = self.script_ref_vm_id(&source) else {
+            return ScriptAsyncResult::MethodNotFound;
+        };
         self.with_script_vm_id(vm_id, |vm| {
             vm.widget_to_script_async_call(
                 target_uid,
@@ -909,7 +966,9 @@ impl CxWidgetToScriptCallExt for Cx {
         script_fn: ScriptFnRef,
         args: ScriptValue,
     ) {
-        let vm_id = self.script_ref_vm_id(&source);
+        let Some(vm_id) = self.script_ref_vm_id(&source) else {
+            return;
+        };
         self.with_script_vm_id(vm_id, |vm| {
             vm.widget_to_script_call_fwd(target_uid, me, source, script_fn, args);
         });
@@ -923,7 +982,9 @@ impl CxWidgetToScriptCallExt for Cx {
         script_fn: ScriptFnRef,
         args: &[ScriptValue],
     ) {
-        let vm_id = self.script_ref_vm_id(&source);
+        let Some(vm_id) = self.script_ref_vm_id(&source) else {
+            return;
+        };
         self.with_script_vm_id(vm_id, |vm| {
             vm.widget_to_script_call(target_uid, me, source, script_fn, args);
         });


### PR DESCRIPTION
Killing a Splash isolate while widgets it minted are still in the tree could take down the whole process from inside the GC, with a panic that points nowhere near the cause:

```
platform/script/src/gc.rs:300
index out of bounds: the len is 12 but the index is 19
```

### What was happening

`script_ref_vm_id` resolves a widget's owning VM from a ref the widget holds. Isolate heaps are in `heap_to_vm`; anything else was assumed to be the app VM.

But an isolate's widgets outlive it by a frame or two — a tile dropped mid-gesture, an app force-stopped while its buttons are still on screen — and their refs were minted by a heap that no longer exists. Those calls were routed **into the app VM**, which then stored the dead heap's object ids in an args object of its own (`make_call_args_object_with_context`). Nothing complained at the time: the checked stores silently skip an index they can't resolve. The next GC walked that object, indexed the app heap with the other heap's index, and panicked — somewhere else entirely, in code that did nothing wrong.

It is not heap-key reuse: a parked ref holds the heap's `root_objects` `Rc`, so the key cannot be recycled while the ref exists.

### The fix

Reclaimed heaps are remembered, so a ref from one is told apart from an app-VM ref and its call is **dropped rather than redirected** — the same thing `script_timer_dispatch_hook` already does with a dead isolate's timers.

Three related tightenings, each of which would have turned this into something local and loud:

- `with_script_vm_id` checks "is this VM already installed?" **before** the main-VM shortcut, and `debug_assert`s in the main branch. `with_vm` runs against whatever VM is parked on `Cx`, which during an isolate's own execution is that isolate's — so the old order could silently run app-VM work in an isolate's heap.
- `gc_dead_splash_isolates` purges the queues holding a dying isolate's values (`script_to_widget_calls`, `pending_script_to_widget_returns`) **before** dropping the heap those values live in, matching what `gc_bridge` above it already did.
- `splash_host_respond` checks it landed in the heap the request came from before minting the answer object there. One `usize` compare turns a future routing mistake into an undeliverable answer instead of a corrupted heap.

### How it was found and verified

A launcher that force-stops a mini-app for hammering the host bridge: ~40 requests in flight, isolate torn down in the same event pass, app reopened moments later. That reproduced the panic every run. With this branch the same test passes, with the launcher's own workaround switched off so the fix is what's being tested.

`script_ref_vm_id` now returns `Option`; the four `CxWidgetToScriptCallExt` entry points drop the call on `None`, `PortalList` hands back an empty item rather than instantiating from a dead template, and `TextInput` skips a handler whose isolate is gone.