### PR TITLE
Fingers: mark a second touch on an already-captured area as handled

### DIFF
--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -1077,6 +1077,16 @@ impl Event {
                             // someone did a second call on our area
                             if cx.fingers.find_digit_for_captured_area(area).is_some() {
                                 let rect = area.clipped_rect(&cx);
+                                // A second touch landing on an area that already captured one
+                                // belongs to that area (e.g. the second finger of a pinch), so
+                                // mark it handled to keep widgets behind us from capturing it.
+                                // The emptiness check preserves the claim of a widget (e.g. a
+                                // child) that already handled this touch earlier in dispatch.
+                                if t.handled.get().is_empty()
+                                    && hit_test(t.abs, &rect, &options.margin_for(&device))
+                                {
+                                    t.handled.set(area);
+                                }
                                 return Hit::FingerDown(FingerDownEvent {
                                     window_id: e.window_id,
                                     abs: t.abs,


### PR DESCRIPTION
When an area that has already captured a touch sees another touch start, `hits()` returns a `FingerDown` for it so the owner can drive multi-touch gestures like pinch-to-zoom, but it never marked that touch as `handled`. Any widget later in event dispatch (i.e. behind the owner) could then capture the second touch itself.

In practice: with a fullscreen image viewer open atop a timeline, the second finger of a pinch-to-zoom gesture would start a drag-scroll on the `PortalList` behind the viewer, or press widgets back there on release.

The fix marks the touch as handled in that early-return branch, with two guards:
* only when the touch actually hit-tests within the area (mirroring the normal capture path just below it), so a small widget holding a capture doesn't consume unrelated touches elsewhere on screen;
* only when nothing has handled the touch yet, so a child widget that already claimed it earlier in the same dispatch keeps its claim (children are dispatched before their parents' own hit processing).