### PR TITLE
Wayland: mark windows as created, fixing dpi override and pass dpi factor

### DIFF
--- a/platform/src/os/linux/wayland/linux_wayland.rs
+++ b/platform/src/os/linux/wayland/linux_wayland.rs
@@ -659,6 +659,9 @@ impl WaylandCx {
                     if cx.windows[window_id].backdrop != crate::window::WindowBackdrop::None {
                         log_linux_backdrop_unsupported_once();
                     }
+                    let cx_window = &mut cx.windows[window_id];
+                    cx_window.window_geom = window.window_geom.clone();
+                    cx_window.is_created = true;
                     state.windows.push(window);
                 }
                 CxOsOp::CreatePopupWindow {
@@ -695,6 +698,9 @@ impl WaylandCx {
                         cx.windows[window_id].popup_position = Some(position);
                         cx.windows[window_id].popup_size = Some(size);
                         cx.windows[window_id].popup_grab_keyboard = grab_keyboard;
+                        let cx_window = &mut cx.windows[window_id];
+                        cx_window.window_geom = popup.window_geom.clone();
+                        cx_window.is_created = true;
                         state.popups.push(popup);
                     }
                 }

--- a/platform/src/os/linux/wayland/linux_wayland.rs
+++ b/platform/src/os/linux/wayland/linux_wayland.rs
@@ -659,10 +659,20 @@ impl WaylandCx {
                     if cx.windows[window_id].backdrop != crate::window::WindowBackdrop::None {
                         log_linux_backdrop_unsupported_once();
                     }
-                    let cx_window = &mut cx.windows[window_id];
-                    cx_window.window_geom = window.window_geom.clone();
-                    cx_window.is_created = true;
+                    // Same as every other backend (x11/windows/macos/...): the Cx window
+                    // only becomes usable once its OS window exists. Without `is_created`,
+                    // `Cx::dpi_override_scale()` and `get_delegated_dpi_factor()` silently
+                    // no-op, so pointer `abs` keeps arriving in native surface points while
+                    // widget rects live in (zoomed) layout points and every click misses.
+                    // Seed the geom too: the default `dpi_factor` is 0.0, which would make
+                    // `get_pass_rect()` produce NaN once the flag is on.
+                    let native_geom = window.window_geom.clone();
                     state.windows.push(window);
+                    let cx_window = &mut cx.windows[window_id];
+                    cx_window.os_dpi_factor = Some(native_geom.dpi_factor);
+                    let layout_geom = cx_window.native_window_geom_to_layout(native_geom);
+                    cx_window.window_geom = layout_geom;
+                    cx_window.is_created = true;
                 }
                 CxOsOp::CreatePopupWindow {
                     window_id,
@@ -698,10 +708,14 @@ impl WaylandCx {
                         cx.windows[window_id].popup_position = Some(position);
                         cx.windows[window_id].popup_size = Some(size);
                         cx.windows[window_id].popup_grab_keyboard = grab_keyboard;
-                        let cx_window = &mut cx.windows[window_id];
-                        cx_window.window_geom = popup.window_geom.clone();
-                        cx_window.is_created = true;
+                        // See CreateWindow above.
+                        let native_geom = popup.window_geom.clone();
                         state.popups.push(popup);
+                        let cx_window = &mut cx.windows[window_id];
+                        cx_window.os_dpi_factor = Some(native_geom.dpi_factor);
+                        let layout_geom = cx_window.native_window_geom_to_layout(native_geom);
+                        cx_window.window_geom = layout_geom;
+                        cx_window.is_created = true;
                     }
                 }
                 CxOsOp::CloseWindow(window_id) => {


### PR DESCRIPTION
Wayland is the only backend that never sets `is_created = true` on the `Cx` window. Every other one does it in `CxOsOp::CreateWindow` — x11, windows, macos, direct, android, open_harmony, web, ios, tvos, headless, and the stdin variants. The only two mentions of `is_created` in the wayland module are both `= false`.

That one flag gates three things:

**1. Pointer coordinates ignore the dpi override.** `Cx::dpi_override_scale()` early-returns on `!is_created`, so all seven calls on the wayland pointer path (`MouseMove`/`Down`/`Up`/`Scroll`/`WindowDragQuery`/`Drag`/`Drop`) are no-ops. `abs` reaches widgets as the raw `wl_pointer` surface coordinate while hit rects live in layout space, so with a UI zoom active every click misses its widget by the zoom factor, with the error growing linearly from the window origin.

Measured on a 1.0-dpi wayland session at ~91% zoom: a button painted at layout `x 1001..1095, y 787..833` delivered `MouseDown abs = (952.4, 746.1)` — exactly `centre × 0.909`. Nothing in the app was clickable where it appeared.

**2. Every draw pass gets a hardcoded dpi factor of 1.0.** `get_delegated_dpi_factor()` returns `1.0` when `!is_created`, so `CxDrawPass::dpi_factor` is wrong on wayland for any non-1.0 scale. That feeds pixel snapping in `get_pass_rect` and `pass.set_dpi_factor()` (shader pixel size / SDF AA fringe), so antialiasing is computed against the wrong device scale on HiDPI wayland.

**3. `SetWindowVisuals` ops are silently dropped**, since `window.rs` gates them on `is_created`. (`set_topmost` turns out to be unaffected — it was never gated on the flag, and remains unimplemented on wayland either way.)

The fix sets the flag in both `CreateWindow` and `CreatePopupWindow`, the same place x11 does. It also seeds the `Cx` window's geom at creation — without it the `Cx` window sits at `dpi_factor 0.0` until the first configure arrives, which makes an early `set_window_dpi_override()` compute its baseline from `0.0` and would make `get_pass_rect()` produce NaN once the flag is on. Unlike x11, the seeded geom is converted to layout points and `os_dpi_factor` is recorded, matching what the `WindowGeomChange` path already does — seeding the raw native geom would leave `window_geom` in native units during exactly the pre-configure window this fix exists for.

Confirmed on a live GNOME/Wayland session (NVIDIA, native dpi 1.0) at ~91% UI zoom: before the fix nothing in the app was clickable where it appeared; after it, clicks land on their widgets again. The `abs` vs rect numbers quoted above are real logged values from that session.

