### PR TITLE
splash: per-isolate resource limits on the container model

### DIFF
--- a/platform/script/src/gc.rs
+++ b/platform/script/src/gc.rs
@@ -699,6 +699,18 @@ impl ScriptHeap {
     /// - Use minimum thresholds to avoid GC thrashing on small heaps
     /// - Objects are weighted more heavily as they're the primary allocation type
 
+    /// Live slots across every table — what an embedder hosting untrusted
+    /// script measures a heap by. Cheap: the same five subtractions
+    /// [`Self::needs_gc`] already does, and meaningful right after a sweep,
+    /// where what is left is what the script is actually holding on to.
+    pub fn live_slots(&self) -> usize {
+        (self.objects.len() - self.objects_free.len())
+            + (self.strings.len() - self.strings_free.len())
+            + (self.arrays.len() - self.arrays_free.len())
+            + (self.pods.len() - self.pods_free.len())
+            + (self.handles.len() - self.handles_free.len())
+    }
+
     pub fn needs_gc(&self) -> bool {
         // Minimum thresholds before GC can trigger (avoid thrashing on small heaps)
         const MIN_OBJECTS: usize = 1024;

--- a/platform/script/std/src/data.rs
+++ b/platform/script/std/src/data.rs
@@ -33,4 +33,9 @@ pub struct ScriptData {
     pub socket_streams: std::rc::Rc<std::cell::RefCell<Vec<ScriptSocketStream>>>,
     pub http_requests: Vec<ScriptHttp>,
     pub http_servers: Vec<ScriptHttpServer>,
+    /// How many HTTP requests this script may have in flight at once. `None`
+    /// (the default) is unlimited, which is right for an embedder's own
+    /// script; a host running untrusted script sets it, since each in-flight
+    /// request holds a connection and a callback the host will have to run.
+    pub max_inflight_http: Option<usize>,
 }

--- a/platform/script/std/src/net.rs
+++ b/platform/script/std/src/net.rs
@@ -753,6 +753,11 @@ pub fn script_mod(vm: &mut ScriptVm) {
             };
 
             let std = vm.std_mut::<ScriptStd>();
+            if let Some(cap) = std.data.max_inflight_http {
+                if std.data.http_requests.len() >= cap {
+                    return script_err_limit!(vm.trap(), "too many requests in flight");
+                }
+            }
             let Some(runtime) = std.net.as_ref() else {
                 return script_err_io!(vm.trap(), "script net runtime is not configured");
             };

--- a/platform/script/std/src/net.rs
+++ b/platform/script/std/src/net.rs
@@ -753,11 +753,6 @@ pub fn script_mod(vm: &mut ScriptVm) {
             };
 
             let std = vm.std_mut::<ScriptStd>();
-            if let Some(cap) = std.data.max_inflight_http {
-                if std.data.http_requests.len() >= cap {
-                    return script_err_limit!(vm.trap(), "too many requests in flight");
-                }
-            }
             let Some(runtime) = std.net.as_ref() else {
                 return script_err_io!(vm.trap(), "script net runtime is not configured");
             };
@@ -789,6 +784,15 @@ pub fn script_mod(vm: &mut ScriptVm) {
             let events = HttpEvents::script_from_value(vm, events);
 
             let std = vm.std_mut::<ScriptStd>();
+            // The in-flight ceiling belongs HERE, on the requests it counts —
+            // it was being applied to `http_server` instead, where the number
+            // of requests in flight says nothing about whether another
+            // listener may be opened, and so it never once refused a request.
+            if let Some(cap) = std.data.max_inflight_http {
+                if std.data.http_requests.len() >= cap {
+                    return script_err_limit!(vm.trap(), "too many requests in flight");
+                }
+            }
             let Some(runtime) = std.net.as_ref() else {
                 return script_err_io!(vm.trap(), "script net runtime is not configured");
             };

--- a/platform/src/script/res.rs
+++ b/platform/src/script/res.rs
@@ -70,6 +70,55 @@ impl CxScriptResources {
             .copied()
     }
 
+    /// Forget everything heaps in `dead` owned — call this the moment a script
+    /// heap is dropped WHOLESALE, rather than collected.
+    ///
+    /// A `heap_key` is an allocation address, so a heap that dies frees its key
+    /// for the next heap to land on. The per-handle [`CxScriptResourceGc`] only
+    /// runs when the owning heap's own GC sweeps that handle, which never
+    /// happens for a heap that is simply dropped — so its `(heap_key, path)`
+    /// entries outlive it, and the NEXT heap allocated at that address is
+    /// handed a dead heap's handle index for a path it asks about. That index
+    /// means nothing in the new heap's own (usually smaller) handle table, and
+    /// nothing notices at the time: the value sits in a font object until that
+    /// heap's next GC walks it and indexes out of bounds, in code that did
+    /// nothing wrong.
+    pub fn gc_heaps(&self, dead: &[usize]) {
+        if dead.is_empty() {
+            return;
+        }
+        let mut orphaned: Vec<(String, ScriptHandle)> = Vec::new();
+        self.handles_by_abs_path.borrow_mut().retain(|(heap_key, path), handle| {
+            if dead.contains(heap_key) {
+                orphaned.push((path.clone(), *handle));
+                return false;
+            }
+            true
+        });
+        if orphaned.is_empty() {
+            return;
+        }
+        // Handle VALUES are heap-local, so a dead heap's handle can be equal to
+        // a live heap's. Only detach one that no surviving heap still maps to.
+        let live: Vec<ScriptHandle> = self
+            .handles_by_abs_path
+            .borrow()
+            .values()
+            .copied()
+            .collect();
+        let mut resources = self.resources.borrow_mut();
+        for (abs_path, handle) in orphaned {
+            if live.contains(&handle) {
+                continue;
+            }
+            if let Some(res) = resources.iter_mut().find(|v| v.abs_path == abs_path) {
+                res.handles.retain(|h| *h != handle);
+            }
+        }
+        // An entry nobody references anymore goes with them.
+        resources.retain(|v| !v.handles.is_empty());
+    }
+
     pub fn insert_resource(&self, heap_key: usize, resource: CxScriptResource) {
         self.handles_by_abs_path.borrow_mut().insert(
             (heap_key, resource.abs_path.clone()),

--- a/platform/src/script/timer.rs
+++ b/platform/src/script/timer.rs
@@ -17,13 +17,70 @@ pub struct CxScriptTimer {
 /// handled the timer; false falls through to the default main-VM dispatch.
 pub type CxScriptTimerDispatchHook = fn(cx: &mut Cx, timer: &CxScriptTimer, time: ScriptValue) -> bool;
 
+/// A hook consulted BEFORE a script timer is created, so an embedder that runs
+/// untrusted script (see the widgets crate's Splash isolates) can cap how many
+/// timers one heap holds and how fast they may tick.
+///
+/// `heap_key` identifies the script heap asking. Return the interval to use —
+/// possibly clamped — or `None` to refuse the timer outright. The default,
+/// with no hook registered, is the requested interval unchanged.
+pub type CxScriptTimerAdmitHook = fn(cx: &mut Cx, heap_key: usize, requested_s: f64) -> Option<f64>;
+
+/// The matching release hook: called when a timer this embedder admitted is
+/// stopped, or fires for the last time, so its slot can be given back.
+pub type CxScriptTimerReleaseHook = fn(cx: &mut Cx, heap_key: usize);
+
 #[derive(Clone, Default)]
 pub struct CxScriptTimers {
     pub timers: Vec<CxScriptTimer>,
     pub dispatch_hooks: Vec<CxScriptTimerDispatchHook>,
+    pub admit_hooks: Vec<CxScriptTimerAdmitHook>,
+    pub release_hooks: Vec<CxScriptTimerReleaseHook>,
 }
 
 impl Cx {
+    /// Registers the admission/release pair that caps script timers per heap.
+    pub fn set_script_timer_quota_hooks(
+        &mut self,
+        admit: CxScriptTimerAdmitHook,
+        release: CxScriptTimerReleaseHook,
+    ) {
+        let timers = &mut self.script_data.timers;
+        if !timers.admit_hooks.iter().any(|v| (*v as usize) == (admit as usize)) {
+            timers.admit_hooks.push(admit);
+        }
+        if !timers.release_hooks.iter().any(|v| (*v as usize) == (release as usize)) {
+            timers.release_hooks.push(release);
+        }
+    }
+
+    /// The interval a new script timer for `heap_key` may actually use, after
+    /// every registered quota hook has had its say. `None` = refused.
+    ///
+    /// The clamp is not only a policy matter: several platform backends hand
+    /// the interval to `Duration::from_secs_f64`, which PANICS on a negative,
+    /// NaN or infinite value, so an unfiltered `start_interval(-1.0)` from
+    /// script takes the process down. The floor below is the last line of
+    /// defence for embedders with no hook registered at all.
+    fn admit_script_timer(&mut self, heap_key: usize, requested_s: f64) -> Option<f64> {
+        let hooks = self.script_data.timers.admit_hooks.clone();
+        let mut interval = requested_s;
+        for hook in hooks {
+            interval = hook(self, heap_key, interval)?;
+        }
+        if !interval.is_finite() || interval < 0.0 {
+            return Some(0.0);
+        }
+        Some(interval)
+    }
+
+    fn release_script_timer(&mut self, heap_key: usize) {
+        let hooks = self.script_data.timers.release_hooks.clone();
+        for hook in hooks {
+            hook(self, heap_key);
+        }
+    }
+
     pub fn add_script_timer_dispatch_hook(&mut self, hook: CxScriptTimerDispatchHook) {
         if !self
             .script_data
@@ -47,6 +104,9 @@ impl Cx {
             let timer = self.script_data.timers.timers[i].clone();
             if !timer.repeat {
                 self.script_data.timers.timers.remove(i);
+                // A one-shot that has fired is gone; give its slot back or an
+                // app that uses timeouts normally would run itself out of them.
+                self.release_script_timer(timer.callback.heap_key());
             }
             let time = if let Some(time) = event.time {
                 time.into()
@@ -219,8 +279,18 @@ pub fn script_mod(vm: &mut ScriptVm) {
             }
             let callback = ScriptFnRef::script_from_value(vm, callback);
 
+            let heap_key = vm.bx.heap.heap_key();
             let cx = vm.cx_mut();
-            let timer = cx.start_timeout(delay.as_number().unwrap_or(1.0));
+            // A refused timer answers NIL rather than trapping. The embedder
+            // that set the cap already knows it was hit (it is what refused
+            // it), and a script that asks for one timer too many should be
+            // able to cope — `if t.is_nil()` — instead of dying mid-function.
+            let Some(delay) = cx.admit_script_timer(heap_key, delay.as_number().unwrap_or(1.0))
+            else {
+                return NIL;
+            };
+            let cx = vm.cx_mut();
+            let timer = cx.start_timeout(delay);
 
             let id = LiveId::unique();
             cx.script_data.timers.timers.push(CxScriptTimer {
@@ -246,9 +316,16 @@ pub fn script_mod(vm: &mut ScriptVm) {
             }
             let callback = ScriptFnRef::script_from_value(vm, callback);
 
+            let heap_key = vm.bx.heap.heap_key();
+            let cx = vm.cx_mut();
+            // See start_timeout: over the cap, NIL rather than a trap.
+            let Some(delay) = cx.admit_script_timer(heap_key, delay.as_number().unwrap_or(1.0))
+            else {
+                return NIL;
+            };
             let cx = vm.cx_mut();
 
-            let timer = cx.start_interval(delay.as_number().unwrap_or(1.0));
+            let timer = cx.start_interval(delay);
 
             let id = LiveId::unique();
             cx.script_data.timers.timers.push(CxScriptTimer {
@@ -271,8 +348,24 @@ pub fn script_mod(vm: &mut ScriptVm) {
                 return script_err_type_mismatch!(vm.trap(), "invalid timer arg type");
             }
             let timer = timer.as_id().unwrap_or(id!());
+            // Read the heap BEFORE borrowing cx out of vm.
+            let heap_key = vm.bx.heap.heap_key();
             let cx = vm.cx_mut();
-            cx.script_data.timers.timers.retain(|v| v.id != timer);
+            // Only your own timers, and actually STOP them: dropping the
+            // bookkeeping entry alone left the OS timer firing for the life of
+            // the process, invisible to every teardown path (they all filter
+            // this same Vec), and still costing a full event pass per fire.
+            let found = cx
+                .script_data
+                .timers
+                .timers
+                .iter()
+                .position(|v| v.id == timer && v.callback.heap_key() == heap_key);
+            if let Some(i) = found {
+                let entry = cx.script_data.timers.timers.remove(i);
+                cx.stop_timer(entry.timer);
+                cx.release_script_timer(heap_key);
+            }
             NIL
         },
     );

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -23,6 +23,7 @@ pub mod theme_desktop_skeleton;
 pub mod widget;
 pub mod widget_async;
 pub mod splash_host;
+pub mod splash_limits;
 pub mod splash_storage;
 pub mod widget_match_event;
 pub mod widget_tree;

--- a/widgets/src/splash.rs
+++ b/widgets/src/splash.rs
@@ -190,8 +190,12 @@ impl Splash {
 
         let vm_id = self.vm_id;
         let new_view = cx.with_script_vm_id(vm_id, |vm| {
-            let value = vm.with_instruction_limit(SPLASH_EVAL_INSTRUCTION_LIMIT, |vm| {
-                vm.eval_with_append_source(script_mod, &code, NIL.into())
+            // Setup, not ongoing work: a body that cannot finish evaluating is
+            // an app that does not exist, and trimming it gives nobody a frame.
+            let value = crate::splash_limits::with_setup_slice(|| {
+                vm.with_instruction_limit(SPLASH_EVAL_INSTRUCTION_LIMIT, |vm| {
+                    vm.eval_with_append_source(script_mod, &code, NIL.into())
+                })
             });
             if !value.is_err() && !value.is_nil() {
                 Some(View::script_from_value(vm, value))
@@ -299,8 +303,12 @@ pub fn validate_splash_body(cx: &mut Cx, body: &str, allow_net: bool) -> Vec<Str
         // Capture instead of logging: mid-eval errors otherwise go straight to
         // the error log (see `ScriptVm::take_errors`) and can't be returned.
         vm.bx.captured_errors = Some(Vec::new());
-        let value = vm.with_instruction_limit(SPLASH_EVAL_INSTRUCTION_LIMIT, |vm| {
-            vm.eval_with_append_source(script_mod, &code, NIL.into())
+        // Same exemption as eval_body: validation is setup, and a validator
+        // that fails only because the machine was busy validates nothing.
+        let value = crate::splash_limits::with_setup_slice(|| {
+            vm.with_instruction_limit(SPLASH_EVAL_INSTRUCTION_LIMIT, |vm| {
+                vm.eval_with_append_source(script_mod, &code, NIL.into())
+            })
         });
         let mut errors = vm.take_errors();
         if errors.is_empty() {

--- a/widgets/src/splash.rs
+++ b/widgets/src/splash.rs
@@ -63,6 +63,13 @@ pub struct Splash {
     /// None leaves the storage default.
     #[rust]
     storage_quota: Option<u64>,
+    /// How much CPU, memory, timers and concurrency this isolate may use
+    /// (see splash_limits.rs). None = the built-in defaults.
+    ///
+    /// `#[rust]`, like every other host-assigned field here: a script that
+    /// could raise its own limits from its own DSL would not have limits.
+    #[rust]
+    limits: Option<crate::splash_limits::SplashLimits>,
     /// What to call this script in error messages. Set by the host to the
     /// mini-app's id; empty for previews and one-off evals.
     ///
@@ -140,7 +147,13 @@ impl Splash {
         }
 
         if self.vm_id == MAIN_SPLASH_VM_ID {
-            self.vm_id = cx.alloc_splash_vm_with_network(self.allow_net);
+            // Privilege only ever narrows when Splashes nest. `allow_net` is a
+            // `#[live]` field, so a script CAN write `Splash{allow_net: true}`
+            // in its own body — harmless while nothing evaluates such a widget,
+            // and a network grant it was never given the moment something does.
+            // A nested isolate gets at most what the isolate creating it has.
+            let allow_net = self.allow_net && cx.current_vm_allows_net();
+            self.vm_id = cx.alloc_splash_vm_with_network(allow_net);
         }
         // (Re)bind this isolate's storage jail and host-bridge identity.
         // Keyed by heap so the script can neither read nor retarget them.
@@ -150,6 +163,8 @@ impl Splash {
         crate::splash_host::set_caps_for_heap(heap_key, self.host_caps.clone());
         crate::splash_host::set_prompts_for_heap(heap_key, self.host_prompts);
         crate::splash_storage::set_quota_for_heap(heap_key, self.storage_quota);
+        crate::splash_limits::set_limits_for_heap(heap_key, self.limits);
+        cx.sync_splash_http_cap(self.vm_id);
 
         let body_key = self.body_key();
         // Full code string: prefix + body (no closing - parser auto-closes)
@@ -485,6 +500,19 @@ impl Splash {
         }
     }
 
+    /// Sets this isolate's resource limits (CPU share, timers, heap ceiling,
+    /// concurrent requests). `None` restores the defaults. Like the other
+    /// host-assigned state, call BEFORE `set_text` so the isolate is created
+    /// with them; setting them later applies from that moment.
+    pub fn set_limits(&mut self, cx: &mut Cx, limits: Option<crate::splash_limits::SplashLimits>) {
+        self.limits = limits;
+        if self.vm_id != MAIN_SPLASH_VM_ID {
+            let heap_key = cx.with_script_vm_id(self.vm_id, |vm| vm.bx.heap.heap_key());
+            crate::splash_limits::set_limits_for_heap(heap_key, limits);
+            cx.sync_splash_http_cap(self.vm_id);
+        }
+    }
+
     /// Marks whether this isolate's surface may raise user prompts; see
     /// `SplashHostRequest::may_prompt`. Defaults true.
     pub fn set_host_prompts(&mut self, cx: &mut Cx, may_prompt: bool) {
@@ -574,6 +602,13 @@ impl SplashRef {
     pub fn set_storage_quota(&self, cx: &mut Cx, total_bytes: Option<u64>) {
         if let Some(mut inner) = self.borrow_mut() {
             inner.set_storage_quota(cx, total_bytes);
+        }
+    }
+
+    /// See [`Splash::set_limits`].
+    pub fn set_limits(&self, cx: &mut Cx, limits: Option<crate::splash_limits::SplashLimits>) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_limits(cx, limits);
         }
     }
 

--- a/widgets/src/splash_host.rs
+++ b/widgets/src/splash_host.rs
@@ -36,7 +36,7 @@ use std::collections::HashMap;
 
 use crate::makepad_draw::makepad_platform::makepad_script;
 use crate::makepad_draw::makepad_platform::SignalToUI;
-use crate::widget_async::{CxSplashVmExt, WIDGET_SCRIPT_INSTRUCTION_LIMIT};
+use crate::widget_async::CxSplashVmExt;
 use crate::makepad_draw::makepad_platform::Cx;
 use makepad_script::*;
 
@@ -178,7 +178,8 @@ pub fn splash_host_respond(
         vm.bx.heap.set_value(obj, id!(is_ok).into(), ok.into(), trap);
         vm.bx.heap.set_value(obj, id!(data).into(), data, trap);
         vm.bx.heap.set_value(obj, id!(error).into(), error, trap);
-        vm.with_instruction_limit(WIDGET_SCRIPT_INSTRUCTION_LIMIT, |vm| {
+        let limit = crate::splash_limits::entry_instructions(heap_key);
+        vm.with_instruction_limit(limit, |vm| {
             vm.call(callback.as_object().into(), &[obj.into()]);
         });
     });

--- a/widgets/src/splash_limits.rs
+++ b/widgets/src/splash_limits.rs
@@ -439,6 +439,30 @@ fn record(heap_key: usize, kind: SplashLimitKind, wanted: u64, allowed: u64) {
     });
 }
 
+thread_local! {
+    /// Nesting depth of "this entry is SETUP, not ongoing work".
+    static SETUP_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+/// Runs `f` with this isolate exempt from contention trimming.
+///
+/// Evaluating a script — booting an app, validating one — is not the kind of
+/// work fairness is about. It happens once, it has to finish or the app simply
+/// does not exist, and trimming it does not give anybody else a frame back: it
+/// just breaks the app, and breaks it exactly when the machine is busy, which
+/// is the worst possible time to lose one. The per-entry ceilings still apply,
+/// so a genuinely runaway body is still cut off.
+pub fn with_setup_slice<R>(f: impl FnOnce() -> R) -> R {
+    SETUP_DEPTH.with(|d| d.set(d.get() + 1));
+    let out = f();
+    SETUP_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
+    out
+}
+
+fn in_setup() -> bool {
+    SETUP_DEPTH.with(|d| d.get() > 0)
+}
+
 /// Takes every limit crossing since the last call. The host drains this the
 /// same way it drains the service bridge, and decides what to do about it.
 pub fn take_limit_events() -> Vec<SplashLimitEvent> {
@@ -472,7 +496,8 @@ pub(crate) fn cpu_allowance(heap_key: usize) -> Option<Duration> {
             // Frames are fine: nobody is waiting on anything, so trimming an
             // app would slow it down for no one's benefit. This is the case
             // for one app alone on an idle machine, and it is the common one.
-            if !w.contended() {
+            // Setup is exempt for a different reason — see `with_setup_slice`.
+            if in_setup() || !w.contended() {
                 return Some(entry);
             }
             // The launcher is losing its frame. Two things decide the slice:

--- a/widgets/src/splash_limits.rs
+++ b/widgets/src/splash_limits.rs
@@ -1,4 +1,4 @@
-//! Per-isolate resource limits for Splash mini-apps.
+//! Per-isolate resource limits for Splash mini-apps, on the container model.
 //!
 //! A Splash isolate already cannot reach the filesystem, the network, or
 //! another isolate's heap without the host handing it those things. What it
@@ -8,90 +8,151 @@
 //! 200k instructions every time, forever. Nothing capped an isolate's heap,
 //! its timer count, or its share of the frame.
 //!
-//! This module holds the numbers that answer "how much", per isolate, and the
-//! accounting to enforce them. It follows the same shape as the storage jail
-//! (`splash_storage`) and the host bridge (`splash_host`): host-assigned state
-//! in a thread-local keyed by the isolate's heap, which script cannot read or
-//! retarget, cleaned up when the isolate is reclaimed.
+//! # The rule
 //!
-//! Defaults are chosen to be invisible to an app doing its job — they sit
-//! roughly an order of magnitude above what the mini-apps in this repo's own
-//! sample set use — while a runaway one hits them in well under a second. A
-//! host that wants different numbers sets them per isolate; a host that says
-//! nothing gets [`SplashLimits::default`].
+//! **Nothing is limited while limiting it would buy nothing.** This is cgroup
+//! v2's split, and it is the whole design:
+//!
+//! - a **weight** ([`SplashLimits::weight`], cgroup `cpu.weight`/`io.weight`)
+//!   decides who yields to whom when isolates actually compete. It has no
+//!   effect at all when they do not.
+//! - a **max** (`cpu_max_ms`, `mem_max_slots`, …, cgroup `cpu.max`/
+//!   `memory.max`) is an absolute ceiling that applies whatever else is
+//!   happening. Every one of them is OFF or set to a runaway backstop by
+//!   default, because an absolute cap on an idle system is a tax with no
+//!   beneficiary.
+//!
+//! So one mini-app alone gets the machine. Five split it by weight. A quiet
+//! app costs nothing and holds nothing back for anyone else. An app is only
+//! ever trimmed while the pool it is drawing from is genuinely full AND it is
+//! the one over its share of it.
+//!
+//! # Every contended resource works the same way
+//!
+//! CPU is time-multiplexed and memory, timers and requests are
+//! space-multiplexed, but the rationing rule is identical
+//! ([`over_share`]): compare the pool's total against its budget, and only
+//! then compare this isolate against its weighted slice.
+//!
+//! - **CPU** — a wall-clock window. Over-share means shorter entry slices.
+//! - **Memory** — live heap slots after a collection. Over-share is reported
+//!   as pressure; the host collects that isolate harder and stops it only if
+//!   it stays over (cgroup `memory.high` then `memory.max`).
+//! - **Timers** and **in-flight requests** — slot pools. Over-share means the
+//!   next one is refused.
+//!
+//! Storage is deliberately NOT on this model: disk is not reclaimed when
+//! pressure passes, so a share of it would be a share of something nobody
+//! gives back. It stays an absolute quota, enforced by the jail.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
+/// The window every CPU decision is made over.
+const WINDOW: Duration = Duration::from_secs(1);
+
+/// What all mini-apps together may spend of a window before ANYONE is
+/// trimmed. Below this there is headroom, so limiting an isolate would slow
+/// it down without speeding anything else up.
+///
+/// Not 100%: the rest is the launcher's own — drawing, input, the frame it
+/// owes the user. An app going flat out should not be able to stop the
+/// window it is drawn in from being painted.
+const COLLECTIVE_BUDGET: Duration = Duration::from_millis(800);
+
+/// Live heap slots ALL isolates together may hold before anyone is asked to
+/// give some back. A lone app may use the lot.
+const GLOBAL_HEAP_SLOTS: usize = 24_000_000;
+
+/// Live script timers across every isolate before the pool starts rationing.
+const GLOBAL_TIMERS: u32 = 512;
+
+/// In-flight HTTP requests across every isolate before the pool rations.
+const GLOBAL_INFLIGHT_HTTP: u32 = 64;
+
+/// The container rule, in one function, for every contended resource.
+///
+/// `true` means "this isolate must yield": the pool is genuinely full AND
+/// this isolate is holding more than its weighted slice of it. Either half
+/// alone is not enough — a full pool where everyone is within their share is
+/// simply a busy system working correctly, and an isolate over its share of a
+/// pool with room to spare is costing nobody anything.
+fn over_share(total: f64, budget: f64, mine: f64, fraction: f64) -> bool {
+    total > budget && mine > budget * fraction
+}
+
 /// How much one Splash isolate may consume.
 ///
-/// Every field is a hard number rather than a level ("strict"/"relaxed"),
-/// because the right value depends on what the surface is for: a foreground
-/// app the user is looking at deserves more of the frame than a home-screen
-/// tile that has to share it with eleven others.
+/// One `weight` governs every contended resource — an app is "important" or
+/// it is not, and asking a user to rank it separately for processor, memory
+/// and downloads is asking them to invent numbers. The `*_max` fields are the
+/// absolute ceilings, off or set to runaway backstops by default.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SplashLimits {
-    /// Wall-clock an isolate may spend in ONE entry into script.
+    /// This isolate's pull on every contended pool (cgroup `cpu.weight`).
+    /// Relative, not absolute: two isolates at 4 and 1 split a contended
+    /// resource 80/20, and either one alone is not limited at all.
+    pub weight: u32,
+    /// Wall-clock an isolate may spend in ONE entry into script. A latency
+    /// bound rather than a share: it stops a single entry eating a frame.
     pub entry_time_ms: u64,
     /// Instructions an isolate may execute in ONE entry.
     pub entry_instructions: usize,
-    /// The window over which cumulative CPU is measured.
-    pub cpu_window: Duration,
-    /// Wall-clock the isolate may spend in script per `cpu_window`, summed
-    /// across every entry. This is the limit that per-entry budgets cannot
-    /// express: ten cheap entries a frame are ten times the cost of one.
-    pub cpu_per_window_ms: u64,
-    /// Live script timers the isolate may hold at once.
-    pub max_timers: u32,
+    /// Absolute wall-clock cap per window, whatever else is running
+    /// (`cpu.max`). `None` — the default — means "share only".
+    pub cpu_max_ms: Option<u64>,
+    /// Live heap slots this isolate alone may hold, however quiet the system
+    /// is (`memory.max`). A runaway backstop, not a working limit: memory is
+    /// shared out by weight long before this. Defaults to the whole pool, so
+    /// a lone app is never stopped for using memory nobody else wants — a
+    /// backstop BELOW the pool would quietly make the sharing unreachable.
+    pub mem_max_slots: usize,
+    /// Live script timers it may hold (a sanity backstop; what those timers
+    /// COST is already charged as CPU when their callbacks run).
+    pub timers_max: u32,
     /// Shortest interval/timeout it may ask for, in seconds. Also the floor a
     /// nonsense value (negative, NaN, infinite) is clamped to.
     pub min_timer_interval_s: f64,
-    /// Live heap slots (objects + arrays + strings + pods + handles) the
-    /// isolate may hold after a collection. Slots rather than bytes because
-    /// that is what the GC already counts; a script that keeps allocating
-    /// without releasing crosses it, one that reuses its memory never does.
-    pub live_heap_slots: usize,
-    /// Concurrent in-flight HTTP requests. Only meaningful for an isolate the
-    /// host gave network to at all.
-    pub max_inflight_http: u32,
+    /// Concurrent in-flight HTTP requests it may hold.
+    pub http_max: u32,
 }
 
 impl Default for SplashLimits {
     fn default() -> Self {
         Self {
+            // Only ratios matter, so the number is arbitrary; it sits above 1
+            // so a host can say "less than normal" without fractions.
+            weight: 4,
             // The values the widgets crate has always applied, now nameable.
             entry_time_ms: 64,
             entry_instructions: 200_000,
-            // A quarter of one core, averaged over a second. An app that
-            // redraws on a timer sits far below this; a busy loop that bails
-            // and immediately re-enters sits far above it.
-            cpu_window: Duration::from_secs(1),
-            cpu_per_window_ms: 250,
-            // The busiest sample app holds three timers; the fastest asks for
-            // 100ms. Both defaults are an order of magnitude clear of that.
-            max_timers: 32,
+            cpu_max_ms: None,
+            mem_max_slots: GLOBAL_HEAP_SLOTS,
+            timers_max: 256,
             min_timer_interval_s: 0.016,
-            // ~10x the largest heap any sample app settles at.
-            live_heap_slots: 2_000_000,
-            max_inflight_http: 8,
+            http_max: 16,
         }
     }
 }
 
 impl SplashLimits {
     /// Limits for a surface that runs while the user is looking at something
-    /// else — a home-screen tile, a preview. Same rules, smaller share: such a
-    /// surface competes with every other tile for one frame, and is by
-    /// definition not what the user is waiting on.
+    /// else — a home-screen tile, a preview.
+    ///
+    /// The difference is WEIGHT: a tile competes with eleven others and is not
+    /// what the user is waiting on, so under contention it yields. With
+    /// nothing to compete against it runs exactly as fast as anything else,
+    /// which is the entire point of a share.
     pub fn background() -> Self {
         Self {
+            weight: 1,
             entry_time_ms: 16,
-            cpu_per_window_ms: 60,
-            max_timers: 8,
+            timers_max: 64,
             min_timer_interval_s: 0.1,
-            live_heap_slots: 500_000,
-            max_inflight_http: 2,
+            // A tile has no business ballooning even on an idle system.
+            mem_max_slots: GLOBAL_HEAP_SLOTS / 3,
+            http_max: 4,
             ..Self::default()
         }
     }
@@ -101,14 +162,16 @@ impl SplashLimits {
 /// repeat offender deserves — this module only measures and refuses.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SplashLimitKind {
-    /// Burned its whole CPU allowance for the current window.
+    /// Held over its share while the thread was contended, or crossed its own
+    /// hard ceiling.
     Cpu,
     /// Asked for more timers than it may hold.
     Timers,
     /// Asked for a timer faster than the floor (the request was clamped, not
     /// refused — a clamped timer is still a working app).
     TimerInterval,
-    /// Still holding more heap than allowed after a collection.
+    /// Holding more heap than its share of a system that has run out, or more
+    /// than its own backstop.
     Memory,
     /// Too many HTTP requests in flight at once.
     Network,
@@ -133,29 +196,102 @@ pub struct SplashLimitEvent {
     pub heap_key: usize,
     pub kind: SplashLimitKind,
     /// What was asked for and what was allowed, for a message the user can
-    /// understand ("wanted 4000 timers, allowed 32").
+    /// understand ("wanted 4000 timers, allowed 256").
     pub wanted: u64,
     pub allowed: u64,
 }
 
-/// Per-isolate limits and the running counts they are checked against.
+/// Per-isolate settings and the counts that are not about time.
 #[derive(Default)]
-struct LimitState {
+struct IsolateState {
     limits: SplashLimits,
-    /// Start of the current CPU window and what has been spent in it.
-    window_start: Option<Instant>,
-    cpu_spent: Duration,
-    /// Live timers this isolate holds.
+    /// Live timers this isolate holds, and in-flight requests — both slot
+    /// pools, rationed by the same rule as CPU and memory.
     timers: u32,
-    /// Crossings not yet collected by the host.
-    events: Vec<SplashLimitEvent>,
+    /// Live heap slots as of this isolate's last collection.
+    heap_slots: usize,
+    /// In-flight HTTP requests, as last reported by the stdlib.
+    inflight_http: usize,
+    /// Consecutive collections this isolate has finished over its share.
+    /// Pressure first, a stop only if it will not come back down — cgroup
+    /// `memory.high` before `memory.max`.
+    heap_pressure: u32,
+}
+
+/// The shared CPU window. One window for every isolate, or shares would not
+/// be comparable.
+struct CpuWindow {
+    started: Instant,
+    /// Wall-clock spent in script this window, per heap.
+    spent: HashMap<usize, Duration>,
+    total: Duration,
+}
+
+impl Default for CpuWindow {
+    fn default() -> Self {
+        Self { started: Instant::now(), spent: HashMap::new(), total: Duration::ZERO }
+    }
+}
+
+impl CpuWindow {
+    fn roll(&mut self, now: Instant) {
+        if now.duration_since(self.started) >= WINDOW {
+            self.started = now;
+            self.spent.clear();
+            self.total = Duration::ZERO;
+        }
+    }
+
+    fn spent_by(&self, heap_key: usize) -> Duration {
+        self.spent.get(&heap_key).copied().unwrap_or(Duration::ZERO)
+    }
+
+    /// This heap's fraction of the contended thread, by weight, counting only
+    /// isolates that have actually run this window.
+    ///
+    /// Demand-based on purpose: eleven idle tiles must not shrink the share of
+    /// the one app doing something. An isolate that has spent nothing is not
+    /// competing, so it holds nothing back.
+    fn share_fraction(&self, heap_key: usize, states: &HashMap<usize, IsolateState>) -> (f64, usize) {
+        let weight_of = |k: &usize| {
+            states
+                .get(k)
+                .map(|s| s.limits.weight)
+                .unwrap_or(SplashLimits::default().weight)
+                .max(1)
+        };
+        let mut weights: u64 = 0;
+        let mut count = 0usize;
+        for (k, spent) in &self.spent {
+            if !spent.is_zero() {
+                weights += weight_of(k) as u64;
+                count += 1;
+            }
+        }
+        let mine = weight_of(&heap_key) as u64;
+        // Count ourselves even on our first entry of the window, or a fresh
+        // isolate would compute a share of zero and be trimmed instantly.
+        if self.spent_by(heap_key).is_zero() {
+            weights += mine;
+            count += 1;
+        }
+        if weights == 0 {
+            return (1.0, 1);
+        }
+        (mine as f64 / weights as f64, count)
+    }
+
+    /// This heap's slice of the collective budget, by weight.
+    fn share_of(&self, heap_key: usize, states: &HashMap<usize, IsolateState>) -> Duration {
+        COLLECTIVE_BUDGET.mul_f64(self.share_fraction(heap_key, states).0)
+    }
 }
 
 thread_local! {
-    /// heap key -> that isolate's limits and counters. Keyed by heap for the
-    /// same reason the storage jail is: a script has no way to name, read or
-    /// retarget it.
-    static LIMITS: RefCell<HashMap<usize, LimitState>> = RefCell::new(HashMap::new());
+    /// heap key -> that isolate's limits and non-time counters.
+    static STATES: RefCell<HashMap<usize, IsolateState>> = RefCell::new(HashMap::new());
+    /// The one CPU window every isolate is measured against.
+    static WINDOW_STATE: RefCell<CpuWindow> = RefCell::new(CpuWindow::default());
     /// Crossings from every isolate, in order, awaiting [`take_limit_events`].
     static EVENTS: RefCell<Vec<SplashLimitEvent>> = const { RefCell::new(Vec::new()) };
 }
@@ -163,14 +299,14 @@ thread_local! {
 /// Installs (or clears) an isolate's limits. Host-only: called from
 /// `Splash::set_limits`, never reachable from script.
 pub(crate) fn set_limits_for_heap(heap_key: usize, limits: Option<SplashLimits>) {
-    LIMITS.with(|l| {
-        let mut l = l.borrow_mut();
+    STATES.with(|s| {
+        let mut s = s.borrow_mut();
         match limits {
-            Some(limits) => l.entry(heap_key).or_default().limits = limits,
+            Some(limits) => s.entry(heap_key).or_default().limits = limits,
             // Back to the defaults, and forget the counters with them: a host
             // clearing limits is not trying to keep a grudge.
             None => {
-                l.remove(&heap_key);
+                s.remove(&heap_key);
             }
         }
     });
@@ -178,21 +314,24 @@ pub(crate) fn set_limits_for_heap(heap_key: usize, limits: Option<SplashLimits>)
 
 /// The limits in force for a heap — the defaults when the host set none.
 pub fn limits_for_heap(heap_key: usize) -> SplashLimits {
-    LIMITS.with(|l| {
-        l.borrow()
-            .get(&heap_key)
-            .map(|s| s.limits)
-            .unwrap_or_default()
-    })
+    STATES.with(|s| s.borrow().get(&heap_key).map(|st| st.limits).unwrap_or_default())
 }
 
 /// Drops the limits and counters of reclaimed isolates. Called from
 /// `gc_dead_splash_isolates` alongside the storage roots and bridge state.
 pub(crate) fn gc_limits(dead_heaps: &[usize]) {
-    LIMITS.with(|l| {
-        let mut l = l.borrow_mut();
+    STATES.with(|s| {
+        let mut s = s.borrow_mut();
         for heap in dead_heaps {
-            l.remove(heap);
+            s.remove(heap);
+        }
+    });
+    WINDOW_STATE.with(|w| {
+        let mut w = w.borrow_mut();
+        for heap in dead_heaps {
+            if let Some(spent) = w.spent.remove(heap) {
+                w.total = w.total.saturating_sub(spent);
+            }
         }
     });
     EVENTS.with(|e| e.borrow_mut().retain(|ev| !dead_heaps.contains(&ev.heap_key)));
@@ -216,53 +355,88 @@ pub fn take_limit_events() -> Vec<SplashLimitEvent> {
     EVENTS.with(|e| std::mem::take(&mut *e.borrow_mut()))
 }
 
-/// How much wall-clock this isolate's next entry may use, given what it has
-/// already spent in the current window.
+/// How much wall-clock this isolate's next entry may use.
 ///
-/// Always some time: see the floor below for why an over-budget isolate is
-/// throttled rather than starved.
+/// Full speed unless BOTH of these are true: the mini-apps have collectively
+/// saturated the window, and this isolate is the one over its share of it.
+/// Everything else — an app alone, an app under its share, an app on an idle
+/// system — runs unthrottled.
 pub(crate) fn cpu_allowance(heap_key: usize) -> Option<Duration> {
-    LIMITS.with(|l| {
-        let mut l = l.borrow_mut();
-        let state = l.entry(heap_key).or_default();
-        let limits = state.limits;
-        let now = Instant::now();
-        let started = *state.window_start.get_or_insert(now);
-        if now.duration_since(started) >= limits.cpu_window {
-            state.window_start = Some(now);
-            state.cpu_spent = Duration::ZERO;
-        }
-        let budget = Duration::from_millis(limits.cpu_per_window_ms);
+    let now = Instant::now();
+    STATES.with(|states| {
+        let states = states.borrow();
+        let limits = states.get(&heap_key).map(|s| s.limits).unwrap_or_default();
         let entry = Duration::from_millis(limits.entry_time_ms);
-        // An over-budget isolate is THROTTLED, not starved. Handing out a
-        // sliver would leave every entry bailing part-way through its own
-        // work, which is a broken app rather than a slow one — and a script
-        // cut in half mid-loop leaves worse state behind than one that never
-        // ran. The floor is small enough to be a real penalty (a tight loop
-        // gets a fraction of what it wants) and large enough that ordinary
-        // callbacks still finish.
-        let floor = (entry / 8).max(Duration::from_millis(8));
-        let left = budget.saturating_sub(state.cpu_spent);
-        Some(entry.min(left).max(floor))
+
+        WINDOW_STATE.with(|w| {
+            let mut w = w.borrow_mut();
+            w.roll(now);
+            let mine = w.spent_by(heap_key);
+            let (fraction, active) = w.share_fraction(heap_key, &states);
+
+            // The trimmed slice. Two jobs at once: leave the launcher enough
+            // of the window to draw the frame this app is being drawn in, and
+            // keep the weights meaningful while doing it — a heavyweight over
+            // budget should still run faster than a lightweight over budget,
+            // or the weight stops mattering exactly when it matters most.
+            // `fraction * active` is 1.0 for an even split, so an even split
+            // gives everyone the same trim.
+            let scale = fraction * active.max(1) as f64;
+            let trimmed = (entry / 8)
+                .mul_f64(scale)
+                .max(Duration::from_millis(4))
+                .min(entry);
+
+            // An absolute ceiling does not care who else is running, which is
+            // exactly why it is off by default.
+            if let Some(cap) = limits.cpu_max_ms {
+                if mine >= Duration::from_millis(cap) {
+                    return Some(trimmed);
+                }
+            }
+            if over_share(
+                w.total.as_secs_f64(),
+                COLLECTIVE_BUDGET.as_secs_f64(),
+                mine.as_secs_f64(),
+                fraction,
+            ) {
+                return Some(trimmed);
+            }
+            // Either there is headroom or this isolate is inside its share:
+            // both mean trimming it would slow it down for nobody's benefit.
+            Some(entry)
+        })
     })
 }
 
-/// Charges what an entry actually took against the isolate's window.
+/// Charges what an entry actually took against the shared window.
 pub(crate) fn charge_cpu(heap_key: usize, spent: Duration) {
-    LIMITS.with(|l| {
-        let mut l = l.borrow_mut();
-        let Some(state) = l.get_mut(&heap_key) else {
-            return;
-        };
-        state.cpu_spent += spent;
-        let budget = Duration::from_millis(state.limits.cpu_per_window_ms);
-        if state.cpu_spent >= budget {
-            let spent_ms = state.cpu_spent.as_millis() as u64;
-            let allowed = state.limits.cpu_per_window_ms;
-            drop(l);
-            record(heap_key, SplashLimitKind::Cpu, spent_ms, allowed);
-        }
+    let now = Instant::now();
+    let (yielded, mine, share) = WINDOW_STATE.with(|w| {
+        let mut w = w.borrow_mut();
+        w.roll(now);
+        *w.spent.entry(heap_key).or_default() += spent;
+        w.total += spent;
+        let mine = w.spent_by(heap_key);
+        let (fraction, _) = STATES.with(|s| w.share_fraction(heap_key, &s.borrow()));
+        let yielded = over_share(
+            w.total.as_secs_f64(),
+            COLLECTIVE_BUDGET.as_secs_f64(),
+            mine.as_secs_f64(),
+            fraction,
+        );
+        (yielded, mine, COLLECTIVE_BUDGET.mul_f64(fraction))
     });
+    // Only worth telling the host about when it means something: the thread
+    // was full AND this isolate was the one over its share of it.
+    if yielded {
+        record(
+            heap_key,
+            SplashLimitKind::Cpu,
+            mine.as_millis() as u64,
+            share.as_millis() as u64,
+        );
+    }
 }
 
 /// Instructions this isolate may execute in one entry.
@@ -280,75 +454,177 @@ pub(crate) fn entry_instructions(heap_key: usize) -> usize {
 /// reaches `Duration::from_secs_f64` on several platform backends, which
 /// panics — so it is clamped by the same path.
 pub(crate) fn admit_timer(heap_key: usize, requested_s: f64) -> Option<f64> {
-    LIMITS.with(|l| {
-        let mut l = l.borrow_mut();
-        let state = l.entry(heap_key).or_default();
-        let limits = state.limits;
-        if state.timers >= limits.max_timers {
-            let wanted = state.timers as u64 + 1;
-            drop(l);
-            record(heap_key, SplashLimitKind::Timers, wanted, limits.max_timers as u64);
-            return None;
-        }
-        state.timers += 1;
-        let floor = limits.min_timer_interval_s;
-        let clamped = if requested_s.is_finite() && requested_s > floor {
-            requested_s
-        } else {
-            floor
-        };
-        if clamped != requested_s {
-            drop(l);
-            record(
-                heap_key,
-                SplashLimitKind::TimerInterval,
-                (requested_s.max(0.0) * 1000.0) as u64,
-                (floor * 1000.0) as u64,
+    let (refused, limits, held, allowed) = STATES.with(|s| {
+        let mut st = s.borrow_mut();
+        st.entry(heap_key).or_default();
+        let limits = st[&heap_key].limits;
+        let held = st[&heap_key].timers;
+        // Timer slots are a pool like any other: while the system as a whole
+        // is nowhere near using them up, one app holding a lot of them costs
+        // nobody anything.
+        let pool: u32 = st.values().map(|v| v.timers).sum();
+        let weights: u64 = st
+            .values()
+            .filter(|v| v.timers > 0)
+            .map(|v| v.limits.weight.max(1) as u64)
+            .sum::<u64>()
+            .max(limits.weight.max(1) as u64);
+        let fraction = limits.weight.max(1) as f64 / weights as f64;
+        let refused = held >= limits.timers_max
+            || over_share(
+                pool as f64 + 1.0,
+                GLOBAL_TIMERS as f64,
+                held as f64 + 1.0,
+                fraction,
             );
+        let allowed = if held >= limits.timers_max {
+            limits.timers_max as u64
+        } else {
+            (GLOBAL_TIMERS as f64 * fraction) as u64
+        };
+        if !refused {
+            st.get_mut(&heap_key).unwrap().timers += 1;
         }
-        Some(clamped)
-    })
+        (refused, limits, held, allowed)
+    });
+    if refused {
+        record(heap_key, SplashLimitKind::Timers, held as u64 + 1, allowed);
+        return None;
+    }
+    let floor = limits.min_timer_interval_s;
+    let clamped = if requested_s.is_finite() && requested_s > floor {
+        requested_s
+    } else {
+        floor
+    };
+    if clamped != requested_s {
+        record(
+            heap_key,
+            SplashLimitKind::TimerInterval,
+            (requested_s.max(0.0) * 1000.0) as u64,
+            (floor * 1000.0) as u64,
+        );
+    }
+    Some(clamped)
 }
 
 /// Gives back a timer slot when one is stopped or fires for the last time.
 pub(crate) fn release_timer(heap_key: usize) {
-    LIMITS.with(|l| {
-        if let Some(state) = l.borrow_mut().get_mut(&heap_key) {
+    STATES.with(|s| {
+        if let Some(state) = s.borrow_mut().get_mut(&heap_key) {
             state.timers = state.timers.saturating_sub(1);
         }
     });
 }
 
-/// Checks a post-collection heap size against the isolate's ceiling.
-/// `live_slots` is what the GC just counted. Reports a crossing; the caller
-/// decides whether to stop the isolate.
+/// Records a post-collection heap size and says whether the isolate may carry
+/// on holding it.
+///
+/// Memory is shared the way CPU is: while every isolate together fits under
+/// [`GLOBAL_HEAP_SLOTS`], nobody is capped — a lone app on a quiet system may
+/// use all of it. Past that watermark the isolate holding more than its
+/// weighted share is the one reported, and its own backstop applies whatever
+/// else is happening.
 pub(crate) fn check_heap(heap_key: usize, live_slots: usize) -> bool {
-    let limits = limits_for_heap(heap_key);
-    if live_slots <= limits.live_heap_slots {
+    /// Collections an isolate may finish over its share before the launcher
+    /// is told to stop it. Pressure first (cgroup `memory.high`), a stop only
+    /// for something that will not come back down (`memory.max`).
+    const PRESSURE_BEFORE_STOP: u32 = 3;
+
+    let (verdict, live, allowed) = STATES.with(|s| {
+        let mut st = s.borrow_mut();
+        let state = st.entry(heap_key).or_default();
+        state.heap_slots = live_slots;
+        let limits = state.limits;
+
+        // Its own backstop is absolute: a single isolate this large is a
+        // runaway whatever the rest of the system is doing.
+        if live_slots > limits.mem_max_slots {
+            return (Some(limits.mem_max_slots), live_slots, limits.mem_max_slots);
+        }
+
+        let total: usize = st.values().map(|v| v.heap_slots).sum();
+        let weights: u64 = st
+            .values()
+            .filter(|v| v.heap_slots > 0)
+            .map(|v| v.limits.weight.max(1) as u64)
+            .sum::<u64>()
+            .max(limits.weight.max(1) as u64);
+        let fraction = limits.weight.max(1) as f64 / weights as f64;
+        let share = (GLOBAL_HEAP_SLOTS as f64 * fraction) as usize;
+        let over = over_share(
+            total as f64,
+            GLOBAL_HEAP_SLOTS as f64,
+            live_slots as f64,
+            fraction,
+        );
+
+        let state = st.get_mut(&heap_key).unwrap();
+        if !over {
+            // Back inside its share: the pressure it was under is over.
+            state.heap_pressure = 0;
+            return (None, live_slots, share);
+        }
+        state.heap_pressure += 1;
+        // Under pressure but not yet condemned: the host collects this
+        // isolate harder, and an app that frees what it grabbed never
+        // reaches the next step.
+        if state.heap_pressure < PRESSURE_BEFORE_STOP {
+            return (None, live_slots, share);
+        }
+        (Some(share), live_slots, share)
+    });
+    let Some(_) = verdict else {
         return true;
-    }
-    record(
-        heap_key,
-        SplashLimitKind::Memory,
-        live_slots as u64,
-        limits.live_heap_slots as u64,
-    );
+    };
+    record(heap_key, SplashLimitKind::Memory, live as u64, allowed as u64);
     false
+}
+
+/// Whether this isolate is currently over its share of a full system, and so
+/// should be collected harder than the round-robin would otherwise reach it.
+/// The cgroup `memory.high` half: pressure, not a verdict.
+pub(crate) fn under_memory_pressure(heap_key: usize) -> bool {
+    STATES.with(|s| s.borrow().get(&heap_key).map(|st| st.heap_pressure > 0).unwrap_or(false))
 }
 
 /// Whether one more HTTP request may go out, given how many are already in
 /// flight for this isolate.
 pub(crate) fn admit_http(heap_key: usize, in_flight: usize) -> bool {
     let limits = limits_for_heap(heap_key);
-    if (in_flight as u64) < limits.max_inflight_http as u64 {
+    // The launcher tells us this isolate's own count; the pool is every
+    // isolate's. Same rule again: a lone app downloading twenty things is
+    // using capacity nobody else wants.
+    let (pool, fraction) = STATES.with(|s| {
+        let st = s.borrow();
+        let pool: usize = st.values().map(|v| v.inflight_http).sum();
+        let weights: u64 = st
+            .values()
+            .filter(|v| v.inflight_http > 0)
+            .map(|v| v.limits.weight.max(1) as u64)
+            .sum::<u64>()
+            .max(limits.weight.max(1) as u64);
+        (pool, limits.weight.max(1) as f64 / weights as f64)
+    });
+    STATES.with(|s| {
+        s.borrow_mut().entry(heap_key).or_default().inflight_http = in_flight;
+    });
+    let refused = in_flight as u64 >= limits.http_max as u64
+        || over_share(
+            pool as f64 + 1.0,
+            GLOBAL_INFLIGHT_HTTP as f64,
+            in_flight as f64 + 1.0,
+            fraction,
+        );
+    if !refused {
         return true;
     }
-    record(
-        heap_key,
-        SplashLimitKind::Network,
-        in_flight as u64 + 1,
-        limits.max_inflight_http as u64,
-    );
+    let allowed = if in_flight as u64 >= limits.http_max as u64 {
+        limits.http_max as u64
+    } else {
+        (GLOBAL_INFLIGHT_HTTP as f64 * fraction) as u64
+    };
+    record(heap_key, SplashLimitKind::Network, in_flight as u64 + 1, allowed);
     false
 }
 
@@ -356,125 +632,271 @@ pub(crate) fn admit_http(heap_key: usize, in_flight: usize) -> bool {
 mod tests {
     use super::*;
 
-    const H: usize = 0xBEEF;
+    const A: usize = 0xA;
+    const B: usize = 0xB;
 
     fn reset() {
-        LIMITS.with(|l| l.borrow_mut().clear());
+        STATES.with(|s| s.borrow_mut().clear());
+        WINDOW_STATE.with(|w| *w.borrow_mut() = CpuWindow::default());
         EVENTS.with(|e| e.borrow_mut().clear());
     }
 
-    /// An isolate with no host-set limits still has limits.
-    #[test]
-    fn defaults_apply_without_a_host() {
-        reset();
-        let l = limits_for_heap(H);
-        assert_eq!(l, SplashLimits::default());
-        assert!(l.max_timers > 0 && l.cpu_per_window_ms > 0);
+    fn full() -> Duration {
+        Duration::from_millis(SplashLimits::default().entry_time_ms)
     }
 
-    /// The cumulative window is the thing per-entry budgets cannot express:
-    /// spend it and later entries are cut down to a throttled slice.
+    // ---- the rule itself -------------------------------------------------
+
+    /// Both halves are required. A full pool where everyone is inside their
+    /// share is a busy system working; an isolate over its share of a pool
+    /// with room to spare is costing nobody anything.
     #[test]
-    fn cpu_runs_out_across_many_entries() {
+    fn nothing_yields_unless_the_pool_is_full_and_it_is_over() {
+        assert!(!over_share(50.0, 100.0, 50.0, 0.1), "room to spare, no matter who holds it");
+        assert!(!over_share(150.0, 100.0, 5.0, 0.5), "full, but this one is well inside its share");
+        assert!(over_share(150.0, 100.0, 80.0, 0.5), "full AND over: yield");
+    }
+
+    // ---- CPU -------------------------------------------------------------
+
+    /// The headline property: one mini-app on its own is never trimmed for
+    /// being the only one running.
+    #[test]
+    fn one_app_alone_gets_the_machine() {
         reset();
-        set_limits_for_heap(H, Some(SplashLimits::default()));
-        let entry = Duration::from_millis(64);
-        // Three full entries fit in the 250ms window; the fourth is trimmed to
-        // what is left of it (58ms), which is the budget doing its job.
-        for _ in 0..3 {
-            assert_eq!(cpu_allowance(H), Some(entry), "an unspent window pays in full");
-            charge_cpu(H, entry);
+        set_limits_for_heap(A, Some(SplashLimits::default()));
+        // Far more than any static per-app quota would ever have allowed.
+        for _ in 0..10 {
+            assert_eq!(cpu_allowance(A), Some(full()), "nothing to share with");
+            charge_cpu(A, full());
         }
-        assert_eq!(cpu_allowance(H), Some(Duration::from_millis(58)), "trimmed to the remainder");
-        charge_cpu(H, entry);
-        // Now the window is spent, and what is left is the throttle floor.
-        let throttled = cpu_allowance(H).expect("throttled, never starved");
-        assert!(throttled < entry, "an over-budget isolate is cut down");
-        assert_eq!(throttled, Duration::from_millis(8));
-        assert!(take_limit_events().iter().any(|e| e.kind == SplashLimitKind::Cpu));
+        assert!(take_limit_events().is_empty(), "it has crossed nothing by running");
     }
 
-    /// Throttled is not starved: an ordinary callback still has room to run,
-    /// or the app is broken rather than slowed.
+    /// ...but the launcher still gets to draw: past the collective budget
+    /// even a lone app yields some of the window back.
     #[test]
-    fn an_over_budget_isolate_is_throttled_not_starved() {
+    fn the_launcher_keeps_its_own_air() {
         reset();
-        set_limits_for_heap(H, Some(SplashLimits { cpu_per_window_ms: 10, ..Default::default() }));
-        charge_cpu(H, Duration::from_millis(500));
-        let slice = cpu_allowance(H).expect("always some time");
-        assert!(slice >= Duration::from_millis(8));
+        set_limits_for_heap(A, Some(SplashLimits::default()));
+        let mut spent = Duration::ZERO;
+        while spent < COLLECTIVE_BUDGET {
+            charge_cpu(A, full());
+            spent += full();
+        }
+        assert!(cpu_allowance(A).unwrap() < full(), "a runaway is trimmed even alone");
     }
 
-    /// One entry never gets more than its own share, even with a full window.
+    /// Five equally-weighted apps, all busy, end up level with each other.
     #[test]
-    fn one_entry_cannot_take_the_whole_window() {
+    fn five_apps_balance_out() {
         reset();
-        let allowance = cpu_allowance(H).expect("fresh window");
-        assert_eq!(allowance, Duration::from_millis(64));
+        let heaps = [1usize, 2, 3, 4, 5];
+        for h in heaps {
+            set_limits_for_heap(h, Some(SplashLimits::default()));
+        }
+        let mut spent = [Duration::ZERO; 5];
+        for _ in 0..100 {
+            for (i, h) in heaps.iter().enumerate() {
+                let slice = cpu_allowance(*h).unwrap();
+                charge_cpu(*h, slice);
+                spent[i] += slice;
+            }
+        }
+        let (min, max) = (spent.iter().min().unwrap(), spent.iter().max().unwrap());
+        assert!(
+            *max - *min < full(),
+            "five equals should stay level; got {min:?}..{max:?}"
+        );
+        // And they are actually being rationed rather than running free.
+        assert!(cpu_allowance(1).unwrap() < full());
     }
 
-    /// Timers are capped, and a nonsense interval is clamped rather than
-    /// passed to a platform backend that would panic on it.
+    /// Weight is what decides who yields, and only while they compete.
     #[test]
-    fn timers_are_capped_and_intervals_floored() {
+    fn weight_decides_who_yields() {
         reset();
-        let limits = SplashLimits { max_timers: 3, min_timer_interval_s: 0.05, ..Default::default() };
-        set_limits_for_heap(H, Some(limits));
-
-        assert_eq!(admit_timer(H, 1.0), Some(1.0), "a sane interval is untouched");
-        assert_eq!(admit_timer(H, 0.001), Some(0.05), "too fast is floored");
-        assert_eq!(admit_timer(H, -1.0), Some(0.05), "negative is floored, not passed on");
-        assert_eq!(admit_timer(H, 1.0), None, "the fourth timer is refused");
-
-        release_timer(H);
-        assert_eq!(admit_timer(H, 2.0), Some(2.0), "stopping one frees a slot");
-
-        let kinds: Vec<_> = take_limit_events().into_iter().map(|e| e.kind).collect();
-        assert!(kinds.contains(&SplashLimitKind::Timers));
-        assert!(kinds.contains(&SplashLimitKind::TimerInterval));
+        set_limits_for_heap(A, Some(SplashLimits::default())); // weight 4
+        set_limits_for_heap(B, Some(SplashLimits::background())); // weight 1
+        // Both busy, window full, split evenly so far.
+        charge_cpu(A, COLLECTIVE_BUDGET.mul_f64(0.5));
+        charge_cpu(B, COLLECTIVE_BUDGET.mul_f64(0.5));
+        assert_eq!(cpu_allowance(A), Some(full()), "4/5 share: still inside it");
+        assert!(cpu_allowance(B).unwrap() < full(), "1/5 share: over it, yields");
     }
 
-    /// NaN and infinity are the other two shapes of nonsense.
+    /// A trimmed heavyweight still outruns a trimmed lightweight, or the
+    /// weight stops meaning anything exactly when it matters most.
     #[test]
-    fn non_finite_intervals_are_floored() {
+    fn trimming_stays_proportional() {
         reset();
-        assert_eq!(admit_timer(H, f64::NAN), Some(0.016));
-        assert_eq!(admit_timer(H, f64::INFINITY), Some(0.016));
-        assert_eq!(admit_timer(H, f64::NEG_INFINITY), Some(0.016));
+        set_limits_for_heap(A, Some(SplashLimits { weight: 16, ..Default::default() }));
+        set_limits_for_heap(B, Some(SplashLimits { weight: 1, ..Default::default() }));
+        charge_cpu(A, COLLECTIVE_BUDGET);
+        charge_cpu(B, COLLECTIVE_BUDGET);
+        let (a, b) = (cpu_allowance(A).unwrap(), cpu_allowance(B).unwrap());
+        assert!(a > b, "over budget, the heavyweight still gets the bigger slice: {a:?} vs {b:?}");
     }
 
-    /// The heap ceiling is checked against what a collection actually left.
+    /// An idle isolate holds nothing back for anyone else.
     #[test]
-    fn heap_ceiling_reports_when_crossed() {
+    fn quiet_apps_do_not_shrink_anyone_elses_share() {
         reset();
-        set_limits_for_heap(H, Some(SplashLimits { live_heap_slots: 1000, ..Default::default() }));
-        assert!(check_heap(H, 999));
-        assert!(take_limit_events().is_empty());
-        assert!(!check_heap(H, 1001));
+        for h in [1usize, 2, 3, 4, 5] {
+            set_limits_for_heap(h, Some(SplashLimits::default()));
+        }
+        charge_cpu(1, COLLECTIVE_BUDGET.mul_f64(0.9));
+        assert_eq!(
+            cpu_allowance(1),
+            Some(full()),
+            "four registered-but-quiet apps must not cost the busy one its share"
+        );
+    }
+
+    /// `cpu.max`: absolute, and off unless a host asks for it.
+    #[test]
+    fn an_explicit_max_applies_even_on_an_idle_system() {
+        reset();
+        assert!(SplashLimits::default().cpu_max_ms.is_none(), "off by default");
+        set_limits_for_heap(A, Some(SplashLimits { cpu_max_ms: Some(100), ..Default::default() }));
+        charge_cpu(A, Duration::from_millis(120));
+        assert!(cpu_allowance(A).unwrap() < full(), "a max does not care that the system is idle");
+    }
+
+    /// The window forgets: an app trimmed a second ago starts even.
+    #[test]
+    fn the_window_rolls() {
+        reset();
+        set_limits_for_heap(A, Some(SplashLimits::default()));
+        charge_cpu(A, COLLECTIVE_BUDGET);
+        WINDOW_STATE.with(|w| w.borrow_mut().started = Instant::now() - WINDOW);
+        assert_eq!(cpu_allowance(A), Some(full()), "a new window is a clean start");
+    }
+
+    // ---- memory ----------------------------------------------------------
+
+    /// Same rule, space-multiplexed: a lone app may hold memory nobody else
+    /// wants, far past any per-app number.
+    #[test]
+    fn one_app_may_hold_the_memory_nobody_is_using() {
+        reset();
+        set_limits_for_heap(A, Some(SplashLimits::default()));
+        assert!(check_heap(A, GLOBAL_HEAP_SLOTS / 2));
+        assert!(take_limit_events().is_empty(), "plenty spare, so nothing to report");
+    }
+
+    /// Over its share of a FULL system it gets pressure first, and is only
+    /// given up on if it will not come back down.
+    #[test]
+    fn memory_pressure_comes_before_a_stop() {
+        reset();
+        set_limits_for_heap(A, Some(SplashLimits::default()));
+        set_limits_for_heap(B, Some(SplashLimits::default()));
+        // Between them they have filled the pool; A holds far more.
+        check_heap(B, GLOBAL_HEAP_SLOTS / 4);
+        let hog = GLOBAL_HEAP_SLOTS;
+        assert!(check_heap(A, hog), "first collection over share: pressure, not a stop");
+        assert!(check_heap(A, hog), "second: still just pressure");
+        assert!(!check_heap(A, hog), "third: it is not coming down");
+        assert!(take_limit_events().iter().any(|e| e.kind == SplashLimitKind::Memory));
+    }
+
+    /// An app that frees what it grabbed never reaches the stop.
+    #[test]
+    fn giving_memory_back_clears_the_pressure() {
+        reset();
+        set_limits_for_heap(A, Some(SplashLimits::default()));
+        set_limits_for_heap(B, Some(SplashLimits::default()));
+        check_heap(B, GLOBAL_HEAP_SLOTS / 4);
+        assert!(check_heap(A, GLOBAL_HEAP_SLOTS));
+        assert!(check_heap(A, 1000), "back inside its share");
+        assert!(check_heap(A, GLOBAL_HEAP_SLOTS), "pressure starts over, not where it left off");
+        assert!(check_heap(A, GLOBAL_HEAP_SLOTS));
+    }
+
+    /// `memory.max`: its own backstop is absolute and immediate.
+    #[test]
+    fn the_per_app_backstop_catches_a_runaway_at_once() {
+        reset();
+        set_limits_for_heap(A, Some(SplashLimits { mem_max_slots: 1000, ..Default::default() }));
+        assert!(!check_heap(A, 1001), "no pressure ladder for a single runaway isolate");
         assert_eq!(take_limit_events().len(), 1);
     }
 
-    /// A dead isolate's limits, counters and pending events go with it.
+    // ---- timers and requests --------------------------------------------
+
+    /// A lone app may hold many timers; the cap is a backstop, not a budget.
+    #[test]
+    fn timers_are_pooled_not_rationed_per_app() {
+        reset();
+        set_limits_for_heap(A, Some(SplashLimits::default()));
+        for _ in 0..64 {
+            assert!(admit_timer(A, 1.0).is_some(), "nobody else wants the slots");
+        }
+        assert!(take_limit_events().is_empty());
+    }
+
+    /// Nonsense intervals are clamped rather than passed to a platform
+    /// backend that would panic on them.
+    #[test]
+    fn intervals_are_floored() {
+        reset();
+        set_limits_for_heap(A, Some(SplashLimits { min_timer_interval_s: 0.05, ..Default::default() }));
+        assert_eq!(admit_timer(A, 1.0), Some(1.0), "a sane interval is untouched");
+        assert_eq!(admit_timer(A, 0.001), Some(0.05), "too fast is floored");
+        assert_eq!(admit_timer(A, -1.0), Some(0.05), "negative is floored, not passed on");
+        assert_eq!(admit_timer(A, f64::NAN), Some(0.05));
+        assert_eq!(admit_timer(A, f64::INFINITY), Some(0.05));
+        assert!(take_limit_events().iter().any(|e| e.kind == SplashLimitKind::TimerInterval));
+    }
+
+    /// The per-app backstop still stops a hoarder.
+    #[test]
+    fn a_timer_hoarder_is_refused() {
+        reset();
+        set_limits_for_heap(A, Some(SplashLimits { timers_max: 3, ..Default::default() }));
+        for _ in 0..3 {
+            assert!(admit_timer(A, 1.0).is_some());
+        }
+        assert_eq!(admit_timer(A, 1.0), None, "the fourth is refused");
+        release_timer(A);
+        assert!(admit_timer(A, 1.0).is_some(), "stopping one frees a slot");
+    }
+
+    /// Downloads are a pool too: alone, an app may have plenty in flight.
+    #[test]
+    fn requests_are_pooled() {
+        reset();
+        set_limits_for_heap(A, Some(SplashLimits::default()));
+        assert!(admit_http(A, 8), "eight at once is fine when nobody else is asking");
+        assert!(!admit_http(A, SplashLimits::default().http_max as usize), "its own max still binds");
+    }
+
+    // ---- housekeeping ----------------------------------------------------
+
+    /// A dead isolate's limits, counters and pending events go with it — and
+    /// its spend stops counting against everyone else's share.
     #[test]
     fn reclaiming_an_isolate_forgets_it() {
         reset();
-        set_limits_for_heap(H, Some(SplashLimits { max_timers: 1, ..Default::default() }));
-        admit_timer(H, 1.0);
-        admit_timer(H, 1.0); // refused, records an event
-        gc_limits(&[H]);
+        set_limits_for_heap(A, Some(SplashLimits { timers_max: 1, ..Default::default() }));
+        admit_timer(A, 1.0);
+        admit_timer(A, 1.0); // refused, records an event
+        charge_cpu(A, COLLECTIVE_BUDGET);
+        gc_limits(&[A]);
         assert!(take_limit_events().is_empty(), "a dead isolate's events die with it");
-        assert_eq!(limits_for_heap(H), SplashLimits::default());
+        assert_eq!(limits_for_heap(A), SplashLimits::default());
+        WINDOW_STATE.with(|w| assert!(w.borrow().total.is_zero(), "its spend leaves with it"));
     }
 
-    /// A background surface gets a smaller share than a foreground one, which
-    /// is the whole reason these are numbers and not a flag.
+    /// A background surface yields under contention and is not otherwise
+    /// second-class — no arbitrary ceiling for being a tile.
     #[test]
-    fn background_is_stricter_than_foreground() {
+    fn background_yields_but_is_not_crippled() {
         let fg = SplashLimits::default();
         let bg = SplashLimits::background();
-        assert!(bg.cpu_per_window_ms < fg.cpu_per_window_ms);
-        assert!(bg.max_timers < fg.max_timers);
-        assert!(bg.min_timer_interval_s > fg.min_timer_interval_s);
-        assert!(bg.live_heap_slots < fg.live_heap_slots);
+        assert!(bg.weight < fg.weight, "it yields when they compete");
+        assert_eq!(bg.entry_instructions, fg.entry_instructions, "same work per entry");
+        assert!(bg.cpu_max_ms.is_none(), "no absolute cap on an idle system");
     }
 }

--- a/widgets/src/splash_limits.rs
+++ b/widgets/src/splash_limits.rs
@@ -52,18 +52,48 @@ use std::time::{Duration, Instant};
 /// The window every CPU decision is made over.
 const WINDOW: Duration = Duration::from_secs(1);
 
-/// What all mini-apps together may spend of a window before ANYONE is
-/// trimmed. Below this there is headroom, so limiting an isolate would slow
-/// it down without speeding anything else up.
+/// The frame interval the host is trying to hold, in seconds. Set by the
+/// embedder ([`set_frame_target`]); 60Hz until it says otherwise.
+const DEFAULT_FRAME_TARGET: f64 = 1.0 / 60.0;
+
+/// How far past the target the smoothed frame interval must drift before the
+/// system counts as contended. Frames are noisy, and trimming apps over a
+/// single late frame would be a controller chasing its own tail.
+const CONTENTION_FACTOR: f64 = 1.5;
+
+/// What one timer FIRE costs its isolate, beyond the script it then runs.
 ///
-/// Not 100%: the rest is the launcher's own — drawing, input, the frame it
-/// owes the user. An app going flat out should not be able to stop the
-/// window it is drawn in from being painted.
-const COLLECTIVE_BUDGET: Duration = Duration::from_millis(800);
+/// A wakeup is not free even when the callback is empty: the event reaches
+/// the app through a full dispatch pass before any script executes, and that
+/// pass is host cost the script-time accounting cannot see. Charging it is
+/// what makes a 1ms timer expensive to the app that asked for it — which is
+/// the honest version of the arbitrary "fastest timer" floor this replaced.
+/// An estimate, deliberately: measuring the pre-hook dispatch per timer costs
+/// more than the number is worth.
+const WAKEUP_COST: Duration = Duration::from_micros(250);
 
 /// Live heap slots ALL isolates together may hold before anyone is asked to
-/// give some back. A lone app may use the lot.
-const GLOBAL_HEAP_SLOTS: usize = 24_000_000;
+/// give some back, unless the host says otherwise ([`set_memory_pool`]). A
+/// lone app may use the lot.
+///
+/// A default rather than a truth: how much memory there is to share is
+/// something the embedder knows and this crate does not.
+const DEFAULT_HEAP_POOL: usize = 24_000_000;
+
+thread_local! {
+    static HEAP_POOL: std::cell::Cell<usize> = const { std::cell::Cell::new(DEFAULT_HEAP_POOL) };
+}
+
+/// How many live heap slots all isolates together may hold. The host sets
+/// this from what the machine actually has; the default is a guess and says
+/// so.
+pub fn set_memory_pool(slots: usize) {
+    HEAP_POOL.with(|p| p.set(slots.max(1)));
+}
+
+fn heap_pool() -> usize {
+    HEAP_POOL.with(|p| p.get())
+}
 
 /// Live script timers across every isolate before the pool starts rationing.
 const GLOBAL_TIMERS: u32 = 512;
@@ -111,9 +141,6 @@ pub struct SplashLimits {
     /// Live script timers it may hold (a sanity backstop; what those timers
     /// COST is already charged as CPU when their callbacks run).
     pub timers_max: u32,
-    /// Shortest interval/timeout it may ask for, in seconds. Also the floor a
-    /// nonsense value (negative, NaN, infinite) is clamped to.
-    pub min_timer_interval_s: f64,
     /// Concurrent in-flight HTTP requests it may hold.
     pub http_max: u32,
 }
@@ -128,9 +155,8 @@ impl Default for SplashLimits {
             entry_time_ms: 64,
             entry_instructions: 200_000,
             cpu_max_ms: None,
-            mem_max_slots: GLOBAL_HEAP_SLOTS,
+            mem_max_slots: DEFAULT_HEAP_POOL,
             timers_max: 256,
-            min_timer_interval_s: 0.016,
             http_max: 16,
         }
     }
@@ -149,9 +175,8 @@ impl SplashLimits {
             weight: 1,
             entry_time_ms: 16,
             timers_max: 64,
-            min_timer_interval_s: 0.1,
             // A tile has no business ballooning even on an idle system.
-            mem_max_slots: GLOBAL_HEAP_SLOTS / 3,
+            mem_max_slots: DEFAULT_HEAP_POOL / 3,
             http_max: 4,
             ..Self::default()
         }
@@ -167,9 +192,6 @@ pub enum SplashLimitKind {
     Cpu,
     /// Asked for more timers than it may hold.
     Timers,
-    /// Asked for a timer faster than the floor (the request was clamped, not
-    /// refused — a clamped timer is still a working app).
-    TimerInterval,
     /// Holding more heap than its share of a system that has run out, or more
     /// than its own backstop.
     Memory,
@@ -182,7 +204,6 @@ impl SplashLimitKind {
         match self {
             SplashLimitKind::Cpu => "cpu",
             SplashLimitKind::Timers => "timers",
-            SplashLimitKind::TimerInterval => "timer-interval",
             SplashLimitKind::Memory => "memory",
             SplashLimitKind::Network => "network",
         }
@@ -218,18 +239,77 @@ struct IsolateState {
     heap_pressure: u32,
 }
 
-/// The shared CPU window. One window for every isolate, or shares would not
-/// be comparable.
+/// The shared CPU window, plus how the frame is actually doing. One window
+/// for every isolate, or shares would not be comparable.
 struct CpuWindow {
     started: Instant,
     /// Wall-clock spent in script this window, per heap.
     spent: HashMap<usize, Duration>,
     total: Duration,
+    /// The interval the host wants to hold between frames.
+    frame_target: f64,
+    /// Smoothed frame interval, or `None` while nothing is drawing — which
+    /// is not contention, it is quiet.
+    frame_ema: Option<f64>,
+    /// How much of their slice apps are currently allowed, 0..1. Falls while
+    /// the frame is being missed and climbs back when it recovers, so apps
+    /// give up exactly as much as the launcher needs and no more. There is no
+    /// number here that anybody chose.
+    pressure: f64,
 }
 
 impl Default for CpuWindow {
     fn default() -> Self {
-        Self { started: Instant::now(), spent: HashMap::new(), total: Duration::ZERO }
+        Self {
+            started: Instant::now(),
+            spent: HashMap::new(),
+            total: Duration::ZERO,
+            frame_target: DEFAULT_FRAME_TARGET,
+            frame_ema: None,
+            pressure: 1.0,
+        }
+    }
+}
+
+impl CpuWindow {
+    /// Whether the thing that owns the frame is losing it.
+    ///
+    /// This is the whole contention signal, and it deliberately measures the
+    /// LAUNCHER rather than the apps. The launcher draws every app's pixels,
+    /// so if it cannot make its deadline nothing else on screen matters —
+    /// which is why it does not sit in the same weighted pool as the apps.
+    /// It is not given a reserved slice either: a reservation would be an
+    /// arbitrary tax whenever it has nothing to draw. It simply gets first
+    /// call, and apps are trimmed exactly when, and only while, it is short.
+    fn contended(&self) -> bool {
+        match self.frame_ema {
+            // Nothing is drawing. Nobody is being kept waiting.
+            None => false,
+            Some(ema) => ema > self.frame_target * CONTENTION_FACTOR,
+        }
+    }
+
+    fn note_frame(&mut self, interval_s: f64) {
+        if !interval_s.is_finite() || interval_s <= 0.0 {
+            return;
+        }
+        // A long gap means nothing was being drawn, not that a frame was
+        // late; and one slow frame should not be a verdict, so a sample's
+        // influence is capped as well as smoothed.
+        let sample = interval_s.min(self.frame_target * 3.0);
+        self.frame_ema = Some(match self.frame_ema {
+            None => sample,
+            Some(ema) => ema * 0.8 + sample * 0.2,
+        });
+        // Squeeze while the frame is being missed, release when it is not.
+        // The floor is there so a squeezed app still makes progress, and the
+        // ceiling is "not squeezed at all", which is where it sits whenever
+        // the launcher is keeping up.
+        self.pressure = if self.contended() {
+            (self.pressure * 0.9).max(0.15)
+        } else {
+            (self.pressure * 1.05).min(1.0)
+        };
     }
 }
 
@@ -281,10 +361,6 @@ impl CpuWindow {
         (mine as f64 / weights as f64, count)
     }
 
-    /// This heap's slice of the collective budget, by weight.
-    fn share_of(&self, heap_key: usize, states: &HashMap<usize, IsolateState>) -> Duration {
-        COLLECTIVE_BUDGET.mul_f64(self.share_fraction(heap_key, states).0)
-    }
 }
 
 thread_local! {
@@ -371,40 +447,33 @@ pub(crate) fn cpu_allowance(heap_key: usize) -> Option<Duration> {
         WINDOW_STATE.with(|w| {
             let mut w = w.borrow_mut();
             w.roll(now);
-            let mine = w.spent_by(heap_key);
-            let (fraction, active) = w.share_fraction(heap_key, &states);
-
-            // The trimmed slice. Two jobs at once: leave the launcher enough
-            // of the window to draw the frame this app is being drawn in, and
-            // keep the weights meaningful while doing it — a heavyweight over
-            // budget should still run faster than a lightweight over budget,
-            // or the weight stops mattering exactly when it matters most.
-            // `fraction * active` is 1.0 for an even split, so an even split
-            // gives everyone the same trim.
-            let scale = fraction * active.max(1) as f64;
-            let trimmed = (entry / 8)
-                .mul_f64(scale)
-                .max(Duration::from_millis(4))
-                .min(entry);
 
             // An absolute ceiling does not care who else is running, which is
             // exactly why it is off by default.
             if let Some(cap) = limits.cpu_max_ms {
-                if mine >= Duration::from_millis(cap) {
-                    return Some(trimmed);
+                if w.spent_by(heap_key) >= Duration::from_millis(cap) {
+                    return Some(Duration::from_millis(4).max(entry / 8));
                 }
             }
-            if over_share(
-                w.total.as_secs_f64(),
-                COLLECTIVE_BUDGET.as_secs_f64(),
-                mine.as_secs_f64(),
-                fraction,
-            ) {
-                return Some(trimmed);
+            // Frames are fine: nobody is waiting on anything, so trimming an
+            // app would slow it down for no one's benefit. This is the case
+            // for one app alone on an idle machine, and it is the common one.
+            if !w.contended() {
+                return Some(entry);
             }
-            // Either there is headroom or this isolate is inside its share:
-            // both mean trimming it would slow it down for nobody's benefit.
-            Some(entry)
+            // The launcher is losing its frame. Two things decide the slice:
+            // WEIGHT splits what the apps get between them, and PRESSURE says
+            // how much that is in total — it falls while frames are missed and
+            // climbs back when they recover, so apps give up as much as the
+            // launcher needs and no more. Note the two multiply, which is why
+            // one app alone is squeezed just as hard as five together: the
+            // fractions across competing apps sum to one either way.
+            let (fraction, _) = w.share_fraction(heap_key, &states);
+            Some(
+                entry
+                    .mul_f64(fraction * w.pressure)
+                    .max(Duration::from_millis(4)),
+            )
         })
     })
 }
@@ -412,31 +481,58 @@ pub(crate) fn cpu_allowance(heap_key: usize) -> Option<Duration> {
 /// Charges what an entry actually took against the shared window.
 pub(crate) fn charge_cpu(heap_key: usize, spent: Duration) {
     let now = Instant::now();
-    let (yielded, mine, share) = WINDOW_STATE.with(|w| {
+    let (report, mine, fraction) = WINDOW_STATE.with(|w| {
         let mut w = w.borrow_mut();
         w.roll(now);
         *w.spent.entry(heap_key).or_default() += spent;
         w.total += spent;
         let mine = w.spent_by(heap_key);
         let (fraction, _) = STATES.with(|s| w.share_fraction(heap_key, &s.borrow()));
-        let yielded = over_share(
-            w.total.as_secs_f64(),
-            COLLECTIVE_BUDGET.as_secs_f64(),
-            mine.as_secs_f64(),
-            fraction,
-        );
-        (yielded, mine, COLLECTIVE_BUDGET.mul_f64(fraction))
+        // Worth telling the host about only when it means something: frames
+        // are being missed AND this isolate is the one using more than its
+        // weight of what the apps are collectively taking.
+        let report = w.contended() && mine.as_secs_f64() > w.total.as_secs_f64() * fraction;
+        (report, mine, fraction)
     });
-    // Only worth telling the host about when it means something: the thread
-    // was full AND this isolate was the one over its share of it.
-    if yielded {
+    if report {
         record(
             heap_key,
             SplashLimitKind::Cpu,
             mine.as_millis() as u64,
-            share.as_millis() as u64,
+            (mine.as_millis() as f64 * fraction) as u64,
         );
     }
+}
+
+/// Charges one timer FIRE to its isolate.
+///
+/// A wakeup costs the host a dispatch pass whether or not the callback does
+/// anything, and that cost is invisible to script-time accounting. Charging
+/// it here is what makes a fast timer expensive to the app that asked for
+/// one — replacing an arbitrary floor on how fast a timer may tick with the
+/// actual price of ticking that fast.
+pub(crate) fn charge_wakeup(heap_key: usize) {
+    charge_cpu(heap_key, WAKEUP_COST);
+}
+
+/// Tells the accounting how the frame is doing. The host calls this once per
+/// rendered frame with the interval since the last one; without it, nothing
+/// is ever considered contended and no app is ever trimmed.
+pub fn note_frame(interval_s: f64) {
+    WINDOW_STATE.with(|w| w.borrow_mut().note_frame(interval_s));
+}
+
+/// Sets the frame interval the host is trying to hold (default 60Hz).
+pub fn set_frame_target(interval_s: f64) {
+    if interval_s.is_finite() && interval_s > 0.0 {
+        WINDOW_STATE.with(|w| w.borrow_mut().frame_target = interval_s);
+    }
+}
+
+/// Whether the frame is currently being missed — exposed so a host can show
+/// or log why apps are being trimmed.
+pub fn is_contended() -> bool {
+    WINDOW_STATE.with(|w| w.borrow().contended())
 }
 
 /// Instructions this isolate may execute in one entry.
@@ -454,14 +550,17 @@ pub(crate) fn entry_instructions(heap_key: usize) -> usize {
 /// reaches `Duration::from_secs_f64` on several platform backends, which
 /// panics — so it is clamped by the same path.
 pub(crate) fn admit_timer(heap_key: usize, requested_s: f64) -> Option<f64> {
-    let (refused, limits, held, allowed) = STATES.with(|s| {
+    let (refused, held, allowed) = STATES.with(|s| {
         let mut st = s.borrow_mut();
         st.entry(heap_key).or_default();
         let limits = st[&heap_key].limits;
         let held = st[&heap_key].timers;
-        // Timer slots are a pool like any other: while the system as a whole
-        // is nowhere near using them up, one app holding a lot of them costs
-        // nobody anything.
+        // Timer slots are a pool like any other: while the system is nowhere
+        // near using them up, one app holding a lot of them costs nobody
+        // anything. How FAST they tick is not rationed here at all — a wakeup
+        // is charged to the app's processor share when it fires, which is the
+        // price of ticking fast, rather than an arbitrary floor on how fast an
+        // app is allowed to want to.
         let pool: u32 = st.values().map(|v| v.timers).sum();
         let weights: u64 = st
             .values()
@@ -485,27 +584,16 @@ pub(crate) fn admit_timer(heap_key: usize, requested_s: f64) -> Option<f64> {
         if !refused {
             st.get_mut(&heap_key).unwrap().timers += 1;
         }
-        (refused, limits, held, allowed)
+        (refused, held, allowed)
     });
     if refused {
         record(heap_key, SplashLimitKind::Timers, held as u64 + 1, allowed);
         return None;
     }
-    let floor = limits.min_timer_interval_s;
-    let clamped = if requested_s.is_finite() && requested_s > floor {
-        requested_s
-    } else {
-        floor
-    };
-    if clamped != requested_s {
-        record(
-            heap_key,
-            SplashLimitKind::TimerInterval,
-            (requested_s.max(0.0) * 1000.0) as u64,
-            (floor * 1000.0) as u64,
-        );
-    }
-    Some(clamped)
+    // The interval itself passes through untouched. Platform still refuses a
+    // value that would panic a backend (negative, NaN, infinite) — that is a
+    // validity check, not a policy about how often an app may work.
+    Some(requested_s)
 }
 
 /// Gives back a timer slot when one is stopped or fires for the last time.
@@ -521,7 +609,7 @@ pub(crate) fn release_timer(heap_key: usize) {
 /// on holding it.
 ///
 /// Memory is shared the way CPU is: while every isolate together fits under
-/// [`GLOBAL_HEAP_SLOTS`], nobody is capped — a lone app on a quiet system may
+/// [`heap_pool()`], nobody is capped — a lone app on a quiet system may
 /// use all of it. Past that watermark the isolate holding more than its
 /// weighted share is the one reported, and its own backstop applies whatever
 /// else is happening.
@@ -551,10 +639,10 @@ pub(crate) fn check_heap(heap_key: usize, live_slots: usize) -> bool {
             .sum::<u64>()
             .max(limits.weight.max(1) as u64);
         let fraction = limits.weight.max(1) as f64 / weights as f64;
-        let share = (GLOBAL_HEAP_SLOTS as f64 * fraction) as usize;
+        let share = (heap_pool() as f64 * fraction) as usize;
         let over = over_share(
             total as f64,
-            GLOBAL_HEAP_SLOTS as f64,
+            heap_pool() as f64,
             live_slots as f64,
             fraction,
         );
@@ -639,117 +727,129 @@ mod tests {
         STATES.with(|s| s.borrow_mut().clear());
         WINDOW_STATE.with(|w| *w.borrow_mut() = CpuWindow::default());
         EVENTS.with(|e| e.borrow_mut().clear());
+        set_memory_pool(DEFAULT_HEAP_POOL);
     }
 
     fn full() -> Duration {
         Duration::from_millis(SplashLimits::default().entry_time_ms)
     }
 
-    // ---- the rule itself -------------------------------------------------
+    /// Frames arriving late enough, often enough, to count as contention.
+    fn frames_are_slipping() {
+        for _ in 0..20 {
+            note_frame(DEFAULT_FRAME_TARGET * 4.0);
+        }
+    }
 
-    /// Both halves are required. A full pool where everyone is inside their
-    /// share is a busy system working; an isolate over its share of a pool
-    /// with room to spare is costing nobody anything.
+    fn frames_are_fine() {
+        for _ in 0..20 {
+            note_frame(DEFAULT_FRAME_TARGET);
+        }
+    }
+
+    // ---- what contention even is ----------------------------------------
+
+    /// Nothing drawing is not contention. It is quiet.
     #[test]
-    fn nothing_yields_unless_the_pool_is_full_and_it_is_over() {
-        assert!(!over_share(50.0, 100.0, 50.0, 0.1), "room to spare, no matter who holds it");
-        assert!(!over_share(150.0, 100.0, 5.0, 0.5), "full, but this one is well inside its share");
-        assert!(over_share(150.0, 100.0, 80.0, 0.5), "full AND over: yield");
+    fn silence_is_not_contention() {
+        reset();
+        assert!(!is_contended(), "no frames, no complaint");
+        frames_are_fine();
+        assert!(!is_contended(), "frames on time, nobody is waiting");
+        frames_are_slipping();
+        assert!(is_contended(), "the launcher is losing its frame");
+    }
+
+    /// One late frame is not a verdict.
+    #[test]
+    fn a_single_slow_frame_does_not_trip_it() {
+        reset();
+        frames_are_fine();
+        note_frame(DEFAULT_FRAME_TARGET * 8.0);
+        assert!(!is_contended(), "frames are noisy; the signal is smoothed");
     }
 
     // ---- CPU -------------------------------------------------------------
 
-    /// The headline property: one mini-app on its own is never trimmed for
-    /// being the only one running.
+    /// The headline property: an app is limited by nothing while the machine
+    /// is keeping up, however much it uses.
     #[test]
-    fn one_app_alone_gets_the_machine() {
+    fn an_app_is_not_trimmed_while_the_frame_is_fine() {
         reset();
         set_limits_for_heap(A, Some(SplashLimits::default()));
-        // Far more than any static per-app quota would ever have allowed.
-        for _ in 0..10 {
-            assert_eq!(cpu_allowance(A), Some(full()), "nothing to share with");
+        frames_are_fine();
+        for _ in 0..50 {
+            assert_eq!(cpu_allowance(A), Some(full()), "nobody is waiting on anything");
             charge_cpu(A, full());
         }
         assert!(take_limit_events().is_empty(), "it has crossed nothing by running");
     }
 
-    /// ...but the launcher still gets to draw: past the collective budget
-    /// even a lone app yields some of the window back.
+    /// And it is trimmed exactly when the launcher starts losing frames.
     #[test]
-    fn the_launcher_keeps_its_own_air() {
+    fn trimming_starts_when_frames_start_slipping() {
         reset();
         set_limits_for_heap(A, Some(SplashLimits::default()));
-        let mut spent = Duration::ZERO;
-        while spent < COLLECTIVE_BUDGET {
-            charge_cpu(A, full());
-            spent += full();
-        }
-        assert!(cpu_allowance(A).unwrap() < full(), "a runaway is trimmed even alone");
+        frames_are_fine();
+        assert_eq!(cpu_allowance(A), Some(full()));
+        frames_are_slipping();
+        assert!(cpu_allowance(A).unwrap() < full(), "the launcher gets its frame back");
     }
 
-    /// Five equally-weighted apps, all busy, end up level with each other.
+    /// Five equally-weighted apps under contention get equal slices.
     #[test]
     fn five_apps_balance_out() {
         reset();
         let heaps = [1usize, 2, 3, 4, 5];
         for h in heaps {
             set_limits_for_heap(h, Some(SplashLimits::default()));
+            charge_cpu(h, Duration::from_millis(1));
         }
-        let mut spent = [Duration::ZERO; 5];
-        for _ in 0..100 {
-            for (i, h) in heaps.iter().enumerate() {
-                let slice = cpu_allowance(*h).unwrap();
-                charge_cpu(*h, slice);
-                spent[i] += slice;
-            }
-        }
-        let (min, max) = (spent.iter().min().unwrap(), spent.iter().max().unwrap());
-        assert!(
-            *max - *min < full(),
-            "five equals should stay level; got {min:?}..{max:?}"
-        );
-        // And they are actually being rationed rather than running free.
-        assert!(cpu_allowance(1).unwrap() < full());
+        frames_are_slipping();
+        let slices: Vec<_> = heaps.iter().map(|h| cpu_allowance(*h).unwrap()).collect();
+        let (min, max) = (slices.iter().min().unwrap(), slices.iter().max().unwrap());
+        assert_eq!(min, max, "five equals, five equal slices");
+        assert!(*max < full(), "and all of them trimmed");
     }
 
-    /// Weight is what decides who yields, and only while they compete.
+    /// Weight decides who yields, and by how much.
     #[test]
-    fn weight_decides_who_yields() {
-        reset();
-        set_limits_for_heap(A, Some(SplashLimits::default())); // weight 4
-        set_limits_for_heap(B, Some(SplashLimits::background())); // weight 1
-        // Both busy, window full, split evenly so far.
-        charge_cpu(A, COLLECTIVE_BUDGET.mul_f64(0.5));
-        charge_cpu(B, COLLECTIVE_BUDGET.mul_f64(0.5));
-        assert_eq!(cpu_allowance(A), Some(full()), "4/5 share: still inside it");
-        assert!(cpu_allowance(B).unwrap() < full(), "1/5 share: over it, yields");
-    }
-
-    /// A trimmed heavyweight still outruns a trimmed lightweight, or the
-    /// weight stops meaning anything exactly when it matters most.
-    #[test]
-    fn trimming_stays_proportional() {
+    fn weight_decides_the_split() {
         reset();
         set_limits_for_heap(A, Some(SplashLimits { weight: 16, ..Default::default() }));
         set_limits_for_heap(B, Some(SplashLimits { weight: 1, ..Default::default() }));
-        charge_cpu(A, COLLECTIVE_BUDGET);
-        charge_cpu(B, COLLECTIVE_BUDGET);
+        charge_cpu(A, Duration::from_millis(1));
+        charge_cpu(B, Duration::from_millis(1));
+        frames_are_slipping();
         let (a, b) = (cpu_allowance(A).unwrap(), cpu_allowance(B).unwrap());
-        assert!(a > b, "over budget, the heavyweight still gets the bigger slice: {a:?} vs {b:?}");
+        assert!(a > b, "the heavyweight keeps the bigger slice: {a:?} vs {b:?}");
     }
 
-    /// An idle isolate holds nothing back for anyone else.
+    /// A quiet app holds nothing back for anyone else.
     #[test]
     fn quiet_apps_do_not_shrink_anyone_elses_share() {
         reset();
         for h in [1usize, 2, 3, 4, 5] {
             set_limits_for_heap(h, Some(SplashLimits::default()));
         }
-        charge_cpu(1, COLLECTIVE_BUDGET.mul_f64(0.9));
-        assert_eq!(
-            cpu_allowance(1),
-            Some(full()),
-            "four registered-but-quiet apps must not cost the busy one its share"
+        charge_cpu(1, Duration::from_millis(50));
+        // Only just slipping: deep pressure would floor both slices and the
+        // comparison below would be measuring the floor, not the share.
+        frames_are_fine();
+        for _ in 0..4 {
+            note_frame(DEFAULT_FRAME_TARGET * 3.0);
+        }
+        // Same pressure either way, so this compares the SHARE and nothing
+        // else: with four idle neighbours the busy app has the thread to
+        // itself, and it only drops to a fifth once they are busy too.
+        let alone_among_idlers = cpu_allowance(1).unwrap();
+        for h in [2usize, 3, 4, 5] {
+            charge_cpu(h, Duration::from_millis(50));
+        }
+        let sharing = cpu_allowance(1).unwrap();
+        assert!(
+            sharing < alone_among_idlers / 4,
+            "idle neighbours must not count as competitors ({alone_among_idlers:?} -> {sharing:?})"
         );
     }
 
@@ -759,8 +859,21 @@ mod tests {
         reset();
         assert!(SplashLimits::default().cpu_max_ms.is_none(), "off by default");
         set_limits_for_heap(A, Some(SplashLimits { cpu_max_ms: Some(100), ..Default::default() }));
+        frames_are_fine();
         charge_cpu(A, Duration::from_millis(120));
-        assert!(cpu_allowance(A).unwrap() < full(), "a max does not care that the system is idle");
+        assert!(cpu_allowance(A).unwrap() < full(), "a max does not care that frames are fine");
+    }
+
+    /// A wakeup costs its isolate, which is what replaced the arbitrary floor
+    /// on how fast a timer may tick.
+    #[test]
+    fn a_wakeup_is_charged_to_whoever_asked_for_it() {
+        reset();
+        set_limits_for_heap(A, Some(SplashLimits::default()));
+        let before = WINDOW_STATE.with(|w| w.borrow().spent_by(A));
+        charge_wakeup(A);
+        let after = WINDOW_STATE.with(|w| w.borrow().spent_by(A));
+        assert!(after > before, "waking the machine is not free");
     }
 
     /// The window forgets: an app trimmed a second ago starts even.
@@ -768,9 +881,11 @@ mod tests {
     fn the_window_rolls() {
         reset();
         set_limits_for_heap(A, Some(SplashLimits::default()));
-        charge_cpu(A, COLLECTIVE_BUDGET);
+        charge_cpu(A, Duration::from_millis(500));
         WINDOW_STATE.with(|w| w.borrow_mut().started = Instant::now() - WINDOW);
-        assert_eq!(cpu_allowance(A), Some(full()), "a new window is a clean start");
+        WINDOW_STATE.with(|w| assert!(w.borrow().spent_by(A) > Duration::ZERO));
+        cpu_allowance(A);
+        WINDOW_STATE.with(|w| assert!(w.borrow().spent_by(A).is_zero(), "clean start"));
     }
 
     // ---- memory ----------------------------------------------------------
@@ -781,8 +896,23 @@ mod tests {
     fn one_app_may_hold_the_memory_nobody_is_using() {
         reset();
         set_limits_for_heap(A, Some(SplashLimits::default()));
-        assert!(check_heap(A, GLOBAL_HEAP_SLOTS / 2));
-        assert!(take_limit_events().is_empty(), "plenty spare, so nothing to report");
+        assert!(check_heap(A, heap_pool() / 2));
+        assert!(take_limit_events().is_empty(), "plenty spare, nothing to report");
+    }
+
+    /// The pool is the host's to size — this crate does not know how much
+    /// memory the machine has.
+    #[test]
+    fn the_host_sizes_the_memory_pool() {
+        reset();
+        set_memory_pool(1000);
+        set_limits_for_heap(A, Some(SplashLimits::default()));
+        set_limits_for_heap(B, Some(SplashLimits::default()));
+        check_heap(B, 400);
+        // A is over half of a 1000-slot pool that is now full.
+        assert!(check_heap(A, 900));
+        assert!(check_heap(A, 900));
+        assert!(!check_heap(A, 900), "pressure, then a verdict");
     }
 
     /// Over its share of a FULL system it gets pressure first, and is only
@@ -792,10 +922,9 @@ mod tests {
         reset();
         set_limits_for_heap(A, Some(SplashLimits::default()));
         set_limits_for_heap(B, Some(SplashLimits::default()));
-        // Between them they have filled the pool; A holds far more.
-        check_heap(B, GLOBAL_HEAP_SLOTS / 4);
-        let hog = GLOBAL_HEAP_SLOTS;
-        assert!(check_heap(A, hog), "first collection over share: pressure, not a stop");
+        check_heap(B, heap_pool() / 4);
+        let hog = heap_pool();
+        assert!(check_heap(A, hog), "first collection over share: pressure");
         assert!(check_heap(A, hog), "second: still just pressure");
         assert!(!check_heap(A, hog), "third: it is not coming down");
         assert!(take_limit_events().iter().any(|e| e.kind == SplashLimitKind::Memory));
@@ -807,11 +936,11 @@ mod tests {
         reset();
         set_limits_for_heap(A, Some(SplashLimits::default()));
         set_limits_for_heap(B, Some(SplashLimits::default()));
-        check_heap(B, GLOBAL_HEAP_SLOTS / 4);
-        assert!(check_heap(A, GLOBAL_HEAP_SLOTS));
+        check_heap(B, heap_pool() / 4);
+        assert!(check_heap(A, heap_pool()));
         assert!(check_heap(A, 1000), "back inside its share");
-        assert!(check_heap(A, GLOBAL_HEAP_SLOTS), "pressure starts over, not where it left off");
-        assert!(check_heap(A, GLOBAL_HEAP_SLOTS));
+        assert!(check_heap(A, heap_pool()), "pressure starts over, not where it left off");
+        assert!(check_heap(A, heap_pool()));
     }
 
     /// `memory.max`: its own backstop is absolute and immediate.
@@ -825,29 +954,25 @@ mod tests {
 
     // ---- timers and requests --------------------------------------------
 
+    /// An app may ask for any interval it likes; what it pays is the wakeups.
+    #[test]
+    fn intervals_are_not_second_guessed() {
+        reset();
+        set_limits_for_heap(A, Some(SplashLimits::default()));
+        assert_eq!(admit_timer(A, 0.001), Some(0.001), "1ms is the app's business");
+        assert_eq!(admit_timer(A, 30.0), Some(30.0));
+        assert!(take_limit_events().is_empty(), "wanting a fast timer is not a crossing");
+    }
+
     /// A lone app may hold many timers; the cap is a backstop, not a budget.
     #[test]
     fn timers_are_pooled_not_rationed_per_app() {
         reset();
         set_limits_for_heap(A, Some(SplashLimits::default()));
-        for _ in 0..64 {
+        for _ in 0..200 {
             assert!(admit_timer(A, 1.0).is_some(), "nobody else wants the slots");
         }
         assert!(take_limit_events().is_empty());
-    }
-
-    /// Nonsense intervals are clamped rather than passed to a platform
-    /// backend that would panic on them.
-    #[test]
-    fn intervals_are_floored() {
-        reset();
-        set_limits_for_heap(A, Some(SplashLimits { min_timer_interval_s: 0.05, ..Default::default() }));
-        assert_eq!(admit_timer(A, 1.0), Some(1.0), "a sane interval is untouched");
-        assert_eq!(admit_timer(A, 0.001), Some(0.05), "too fast is floored");
-        assert_eq!(admit_timer(A, -1.0), Some(0.05), "negative is floored, not passed on");
-        assert_eq!(admit_timer(A, f64::NAN), Some(0.05));
-        assert_eq!(admit_timer(A, f64::INFINITY), Some(0.05));
-        assert!(take_limit_events().iter().any(|e| e.kind == SplashLimitKind::TimerInterval));
     }
 
     /// The per-app backstop still stops a hoarder.
@@ -869,7 +994,7 @@ mod tests {
         reset();
         set_limits_for_heap(A, Some(SplashLimits::default()));
         assert!(admit_http(A, 8), "eight at once is fine when nobody else is asking");
-        assert!(!admit_http(A, SplashLimits::default().http_max as usize), "its own max still binds");
+        assert!(!admit_http(A, SplashLimits::default().http_max as usize), "its own max binds");
     }
 
     // ---- housekeeping ----------------------------------------------------
@@ -882,7 +1007,7 @@ mod tests {
         set_limits_for_heap(A, Some(SplashLimits { timers_max: 1, ..Default::default() }));
         admit_timer(A, 1.0);
         admit_timer(A, 1.0); // refused, records an event
-        charge_cpu(A, COLLECTIVE_BUDGET);
+        charge_cpu(A, Duration::from_millis(500));
         gc_limits(&[A]);
         assert!(take_limit_events().is_empty(), "a dead isolate's events die with it");
         assert_eq!(limits_for_heap(A), SplashLimits::default());
@@ -897,6 +1022,6 @@ mod tests {
         let bg = SplashLimits::background();
         assert!(bg.weight < fg.weight, "it yields when they compete");
         assert_eq!(bg.entry_instructions, fg.entry_instructions, "same work per entry");
-        assert!(bg.cpu_max_ms.is_none(), "no absolute cap on an idle system");
+        assert!(bg.cpu_max_ms.is_none(), "no absolute cap on a healthy system");
     }
 }

--- a/widgets/src/splash_limits.rs
+++ b/widgets/src/splash_limits.rs
@@ -216,12 +216,11 @@ pub fn take_limit_events() -> Vec<SplashLimitEvent> {
     EVENTS.with(|e| std::mem::take(&mut *e.borrow_mut()))
 }
 
-/// Whether this isolate has any CPU allowance left in the current window, and
-/// how much of one entry's wall-clock it may use.
+/// How much wall-clock this isolate's next entry may use, given what it has
+/// already spent in the current window.
 ///
-/// Returns `None` when the isolate is out of allowance — the caller skips the
-/// entry entirely. That is the point of a cumulative budget: a script that
-/// spends its second can be refused the frame, not merely trimmed.
+/// Always some time: see the floor below for why an over-budget isolate is
+/// throttled rather than starved.
 pub(crate) fn cpu_allowance(heap_key: usize) -> Option<Duration> {
     LIMITS.with(|l| {
         let mut l = l.borrow_mut();
@@ -234,13 +233,17 @@ pub(crate) fn cpu_allowance(heap_key: usize) -> Option<Duration> {
             state.cpu_spent = Duration::ZERO;
         }
         let budget = Duration::from_millis(limits.cpu_per_window_ms);
-        if state.cpu_spent >= budget {
-            return None;
-        }
-        // Never hand out more than one entry's worth, nor more than what is
-        // left of the window.
         let entry = Duration::from_millis(limits.entry_time_ms);
-        Some(entry.min(budget - state.cpu_spent))
+        // An over-budget isolate is THROTTLED, not starved. Handing out a
+        // sliver would leave every entry bailing part-way through its own
+        // work, which is a broken app rather than a slow one — and a script
+        // cut in half mid-loop leaves worse state behind than one that never
+        // ran. The floor is small enough to be a real penalty (a tight loop
+        // gets a fraction of what it wants) and large enough that ordinary
+        // callbacks still finish.
+        let floor = (entry / 8).max(Duration::from_millis(8));
+        let left = budget.saturating_sub(state.cpu_spent);
+        Some(entry.min(left).max(floor))
     })
 }
 
@@ -370,22 +373,36 @@ mod tests {
     }
 
     /// The cumulative window is the thing per-entry budgets cannot express:
-    /// enough entries and the isolate is refused the next one outright.
+    /// spend it and later entries are cut down to a throttled slice.
     #[test]
     fn cpu_runs_out_across_many_entries() {
         reset();
         set_limits_for_heap(H, Some(SplashLimits::default()));
         let entry = Duration::from_millis(64);
-        let mut entries = 0;
-        while cpu_allowance(H).is_some() {
+        // Three full entries fit in the 250ms window; the fourth is trimmed to
+        // what is left of it (58ms), which is the budget doing its job.
+        for _ in 0..3 {
+            assert_eq!(cpu_allowance(H), Some(entry), "an unspent window pays in full");
             charge_cpu(H, entry);
-            entries += 1;
-            assert!(entries < 100, "the window must close");
         }
-        // 250ms of allowance at 64ms an entry.
-        assert_eq!(entries, 4);
-        let events = take_limit_events();
-        assert!(events.iter().any(|e| e.kind == SplashLimitKind::Cpu));
+        assert_eq!(cpu_allowance(H), Some(Duration::from_millis(58)), "trimmed to the remainder");
+        charge_cpu(H, entry);
+        // Now the window is spent, and what is left is the throttle floor.
+        let throttled = cpu_allowance(H).expect("throttled, never starved");
+        assert!(throttled < entry, "an over-budget isolate is cut down");
+        assert_eq!(throttled, Duration::from_millis(8));
+        assert!(take_limit_events().iter().any(|e| e.kind == SplashLimitKind::Cpu));
+    }
+
+    /// Throttled is not starved: an ordinary callback still has room to run,
+    /// or the app is broken rather than slowed.
+    #[test]
+    fn an_over_budget_isolate_is_throttled_not_starved() {
+        reset();
+        set_limits_for_heap(H, Some(SplashLimits { cpu_per_window_ms: 10, ..Default::default() }));
+        charge_cpu(H, Duration::from_millis(500));
+        let slice = cpu_allowance(H).expect("always some time");
+        assert!(slice >= Duration::from_millis(8));
     }
 
     /// One entry never gets more than its own share, even with a full window.

--- a/widgets/src/splash_limits.rs
+++ b/widgets/src/splash_limits.rs
@@ -105,9 +105,6 @@ fn heap_pool() -> usize {
 /// Live script timers across every isolate before the pool starts rationing.
 const GLOBAL_TIMERS: u32 = 512;
 
-/// In-flight HTTP requests across every isolate before the pool rations.
-const GLOBAL_INFLIGHT_HTTP: u32 = 64;
-
 /// The container rule, in one function, for every contended resource.
 ///
 /// `true` means "this isolate must yield": the pool is genuinely full AND
@@ -233,13 +230,11 @@ pub struct SplashLimitEvent {
 #[derive(Default)]
 struct IsolateState {
     limits: SplashLimits,
-    /// Live timers this isolate holds, and in-flight requests — both slot
-    /// pools, rationed by the same rule as CPU and memory.
+    /// Live timers this isolate holds — a slot pool, rationed by the same
+    /// rule as CPU and memory.
     timers: u32,
     /// Live heap slots as of this isolate's last collection.
     heap_slots: usize,
-    /// In-flight HTTP requests, as last reported by the stdlib.
-    inflight_http: usize,
     /// Consecutive collections this isolate has finished over its share.
     /// Pressure first, a stop only if it will not come back down — cgroup
     /// `memory.high` before `memory.max`.
@@ -715,46 +710,16 @@ pub(crate) fn under_memory_pressure(heap_key: usize) -> bool {
     STATES.with(|s| s.borrow().get(&heap_key).map(|st| st.heap_pressure > 0).unwrap_or(false))
 }
 
-/// Whether one more HTTP request may go out, given how many are already in
-/// flight for this isolate.
-pub(crate) fn admit_http(heap_key: usize, in_flight: usize) -> bool {
-    let limits = limits_for_heap(heap_key);
-    // The launcher tells us this isolate's own count; the pool is every
-    // isolate's. Same rule again: a lone app downloading twenty things is
-    // using capacity nobody else wants.
-    let (pool, fraction) = STATES.with(|s| {
-        let st = s.borrow();
-        let pool: usize = st.values().map(|v| v.inflight_http).sum();
-        let weights: u64 = st
-            .values()
-            .filter(|v| v.inflight_http > 0)
-            .map(|v| v.limits.weight.max(1) as u64)
-            .sum::<u64>()
-            .max(limits.weight.max(1) as u64);
-        (pool, limits.weight.max(1) as f64 / weights as f64)
-    });
-    STATES.with(|s| {
-        s.borrow_mut().entry(heap_key).or_default().inflight_http = in_flight;
-    });
-    let refused = in_flight as u64 >= limits.http_max as u64
-        || over_share(
-            pool as f64 + 1.0,
-            GLOBAL_INFLIGHT_HTTP as f64,
-            in_flight as f64 + 1.0,
-            fraction,
-        );
-    if !refused {
-        return true;
-    }
-    let allowed = if in_flight as u64 >= limits.http_max as u64 {
-        limits.http_max as u64
-    } else {
-        (GLOBAL_INFLIGHT_HTTP as f64 * fraction) as u64
-    };
-    record(heap_key, SplashLimitKind::Network, in_flight as u64 + 1, allowed);
-    false
-}
-
+/// Network is the one resource here that is a CEILING rather than a share.
+///
+/// The others are rationed against a measured pool because the machine has one
+/// processor and one heap to go round. In-flight requests are not that: what
+/// is actually scarce is bandwidth, which this cannot see, and the count says
+/// nothing about how much of it any one request uses. The ceiling exists as a
+/// backstop against a runaway loop, and the launcher can set it per app
+/// ([`SplashLimits::http_max`]); it is pushed into the isolate's own net
+/// runtime, which is where a request is admitted, rather than being consulted
+/// here — that path has no `Cx` and so no view of anyone else's traffic.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1056,15 +1021,6 @@ mod tests {
         assert_eq!(admit_timer(A, 1.0), None, "the fourth is refused");
         release_timer(A);
         assert!(admit_timer(A, 1.0).is_some(), "stopping one frees a slot");
-    }
-
-    /// Downloads are a pool too: alone, an app may have plenty in flight.
-    #[test]
-    fn requests_are_pooled() {
-        reset();
-        set_limits_for_heap(A, Some(SplashLimits::default()));
-        assert!(admit_http(A, 8), "eight at once is fine when nobody else is asking");
-        assert!(!admit_http(A, SplashLimits::default().http_max as usize), "its own max binds");
     }
 
     // ---- housekeeping ----------------------------------------------------

--- a/widgets/src/splash_limits.rs
+++ b/widgets/src/splash_limits.rs
@@ -1,0 +1,463 @@
+//! Per-isolate resource limits for Splash mini-apps.
+//!
+//! A Splash isolate already cannot reach the filesystem, the network, or
+//! another isolate's heap without the host handing it those things. What it
+//! could still do was *cost* whatever it liked: the VM's budgets are per
+//! ENTRY, so a script that arranges to be entered often — a fast interval, a
+//! network callback, a chain of widget events — got a fresh 64ms and a fresh
+//! 200k instructions every time, forever. Nothing capped an isolate's heap,
+//! its timer count, or its share of the frame.
+//!
+//! This module holds the numbers that answer "how much", per isolate, and the
+//! accounting to enforce them. It follows the same shape as the storage jail
+//! (`splash_storage`) and the host bridge (`splash_host`): host-assigned state
+//! in a thread-local keyed by the isolate's heap, which script cannot read or
+//! retarget, cleaned up when the isolate is reclaimed.
+//!
+//! Defaults are chosen to be invisible to an app doing its job — they sit
+//! roughly an order of magnitude above what the mini-apps in this repo's own
+//! sample set use — while a runaway one hits them in well under a second. A
+//! host that wants different numbers sets them per isolate; a host that says
+//! nothing gets [`SplashLimits::default`].
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// How much one Splash isolate may consume.
+///
+/// Every field is a hard number rather than a level ("strict"/"relaxed"),
+/// because the right value depends on what the surface is for: a foreground
+/// app the user is looking at deserves more of the frame than a home-screen
+/// tile that has to share it with eleven others.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SplashLimits {
+    /// Wall-clock an isolate may spend in ONE entry into script.
+    pub entry_time_ms: u64,
+    /// Instructions an isolate may execute in ONE entry.
+    pub entry_instructions: usize,
+    /// The window over which cumulative CPU is measured.
+    pub cpu_window: Duration,
+    /// Wall-clock the isolate may spend in script per `cpu_window`, summed
+    /// across every entry. This is the limit that per-entry budgets cannot
+    /// express: ten cheap entries a frame are ten times the cost of one.
+    pub cpu_per_window_ms: u64,
+    /// Live script timers the isolate may hold at once.
+    pub max_timers: u32,
+    /// Shortest interval/timeout it may ask for, in seconds. Also the floor a
+    /// nonsense value (negative, NaN, infinite) is clamped to.
+    pub min_timer_interval_s: f64,
+    /// Live heap slots (objects + arrays + strings + pods + handles) the
+    /// isolate may hold after a collection. Slots rather than bytes because
+    /// that is what the GC already counts; a script that keeps allocating
+    /// without releasing crosses it, one that reuses its memory never does.
+    pub live_heap_slots: usize,
+    /// Concurrent in-flight HTTP requests. Only meaningful for an isolate the
+    /// host gave network to at all.
+    pub max_inflight_http: u32,
+}
+
+impl Default for SplashLimits {
+    fn default() -> Self {
+        Self {
+            // The values the widgets crate has always applied, now nameable.
+            entry_time_ms: 64,
+            entry_instructions: 200_000,
+            // A quarter of one core, averaged over a second. An app that
+            // redraws on a timer sits far below this; a busy loop that bails
+            // and immediately re-enters sits far above it.
+            cpu_window: Duration::from_secs(1),
+            cpu_per_window_ms: 250,
+            // The busiest sample app holds three timers; the fastest asks for
+            // 100ms. Both defaults are an order of magnitude clear of that.
+            max_timers: 32,
+            min_timer_interval_s: 0.016,
+            // ~10x the largest heap any sample app settles at.
+            live_heap_slots: 2_000_000,
+            max_inflight_http: 8,
+        }
+    }
+}
+
+impl SplashLimits {
+    /// Limits for a surface that runs while the user is looking at something
+    /// else — a home-screen tile, a preview. Same rules, smaller share: such a
+    /// surface competes with every other tile for one frame, and is by
+    /// definition not what the user is waiting on.
+    pub fn background() -> Self {
+        Self {
+            entry_time_ms: 16,
+            cpu_per_window_ms: 60,
+            max_timers: 8,
+            min_timer_interval_s: 0.1,
+            live_heap_slots: 500_000,
+            max_inflight_http: 2,
+            ..Self::default()
+        }
+    }
+}
+
+/// Which limit an isolate crossed. Reported to the host, which decides what a
+/// repeat offender deserves — this module only measures and refuses.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SplashLimitKind {
+    /// Burned its whole CPU allowance for the current window.
+    Cpu,
+    /// Asked for more timers than it may hold.
+    Timers,
+    /// Asked for a timer faster than the floor (the request was clamped, not
+    /// refused — a clamped timer is still a working app).
+    TimerInterval,
+    /// Still holding more heap than allowed after a collection.
+    Memory,
+    /// Too many HTTP requests in flight at once.
+    Network,
+}
+
+impl SplashLimitKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SplashLimitKind::Cpu => "cpu",
+            SplashLimitKind::Timers => "timers",
+            SplashLimitKind::TimerInterval => "timer-interval",
+            SplashLimitKind::Memory => "memory",
+            SplashLimitKind::Network => "network",
+        }
+    }
+}
+
+/// One limit crossing, for the host to act on.
+#[derive(Clone, Debug)]
+pub struct SplashLimitEvent {
+    /// The isolate's heap key, which the host maps back to its own identity.
+    pub heap_key: usize,
+    pub kind: SplashLimitKind,
+    /// What was asked for and what was allowed, for a message the user can
+    /// understand ("wanted 4000 timers, allowed 32").
+    pub wanted: u64,
+    pub allowed: u64,
+}
+
+/// Per-isolate limits and the running counts they are checked against.
+#[derive(Default)]
+struct LimitState {
+    limits: SplashLimits,
+    /// Start of the current CPU window and what has been spent in it.
+    window_start: Option<Instant>,
+    cpu_spent: Duration,
+    /// Live timers this isolate holds.
+    timers: u32,
+    /// Crossings not yet collected by the host.
+    events: Vec<SplashLimitEvent>,
+}
+
+thread_local! {
+    /// heap key -> that isolate's limits and counters. Keyed by heap for the
+    /// same reason the storage jail is: a script has no way to name, read or
+    /// retarget it.
+    static LIMITS: RefCell<HashMap<usize, LimitState>> = RefCell::new(HashMap::new());
+    /// Crossings from every isolate, in order, awaiting [`take_limit_events`].
+    static EVENTS: RefCell<Vec<SplashLimitEvent>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Installs (or clears) an isolate's limits. Host-only: called from
+/// `Splash::set_limits`, never reachable from script.
+pub(crate) fn set_limits_for_heap(heap_key: usize, limits: Option<SplashLimits>) {
+    LIMITS.with(|l| {
+        let mut l = l.borrow_mut();
+        match limits {
+            Some(limits) => l.entry(heap_key).or_default().limits = limits,
+            // Back to the defaults, and forget the counters with them: a host
+            // clearing limits is not trying to keep a grudge.
+            None => {
+                l.remove(&heap_key);
+            }
+        }
+    });
+}
+
+/// The limits in force for a heap — the defaults when the host set none.
+pub fn limits_for_heap(heap_key: usize) -> SplashLimits {
+    LIMITS.with(|l| {
+        l.borrow()
+            .get(&heap_key)
+            .map(|s| s.limits)
+            .unwrap_or_default()
+    })
+}
+
+/// Drops the limits and counters of reclaimed isolates. Called from
+/// `gc_dead_splash_isolates` alongside the storage roots and bridge state.
+pub(crate) fn gc_limits(dead_heaps: &[usize]) {
+    LIMITS.with(|l| {
+        let mut l = l.borrow_mut();
+        for heap in dead_heaps {
+            l.remove(heap);
+        }
+    });
+    EVENTS.with(|e| e.borrow_mut().retain(|ev| !dead_heaps.contains(&ev.heap_key)));
+}
+
+fn record(heap_key: usize, kind: SplashLimitKind, wanted: u64, allowed: u64) {
+    let event = SplashLimitEvent { heap_key, kind, wanted, allowed };
+    EVENTS.with(|e| {
+        let mut e = e.borrow_mut();
+        // A misbehaving isolate can cross a limit every frame; the host only
+        // needs to know THAT it did, not four thousand times over.
+        if e.len() < 64 {
+            e.push(event);
+        }
+    });
+}
+
+/// Takes every limit crossing since the last call. The host drains this the
+/// same way it drains the service bridge, and decides what to do about it.
+pub fn take_limit_events() -> Vec<SplashLimitEvent> {
+    EVENTS.with(|e| std::mem::take(&mut *e.borrow_mut()))
+}
+
+/// Whether this isolate has any CPU allowance left in the current window, and
+/// how much of one entry's wall-clock it may use.
+///
+/// Returns `None` when the isolate is out of allowance — the caller skips the
+/// entry entirely. That is the point of a cumulative budget: a script that
+/// spends its second can be refused the frame, not merely trimmed.
+pub(crate) fn cpu_allowance(heap_key: usize) -> Option<Duration> {
+    LIMITS.with(|l| {
+        let mut l = l.borrow_mut();
+        let state = l.entry(heap_key).or_default();
+        let limits = state.limits;
+        let now = Instant::now();
+        let started = *state.window_start.get_or_insert(now);
+        if now.duration_since(started) >= limits.cpu_window {
+            state.window_start = Some(now);
+            state.cpu_spent = Duration::ZERO;
+        }
+        let budget = Duration::from_millis(limits.cpu_per_window_ms);
+        if state.cpu_spent >= budget {
+            return None;
+        }
+        // Never hand out more than one entry's worth, nor more than what is
+        // left of the window.
+        let entry = Duration::from_millis(limits.entry_time_ms);
+        Some(entry.min(budget - state.cpu_spent))
+    })
+}
+
+/// Charges what an entry actually took against the isolate's window.
+pub(crate) fn charge_cpu(heap_key: usize, spent: Duration) {
+    LIMITS.with(|l| {
+        let mut l = l.borrow_mut();
+        let Some(state) = l.get_mut(&heap_key) else {
+            return;
+        };
+        state.cpu_spent += spent;
+        let budget = Duration::from_millis(state.limits.cpu_per_window_ms);
+        if state.cpu_spent >= budget {
+            let spent_ms = state.cpu_spent.as_millis() as u64;
+            let allowed = state.limits.cpu_per_window_ms;
+            drop(l);
+            record(heap_key, SplashLimitKind::Cpu, spent_ms, allowed);
+        }
+    });
+}
+
+/// Instructions this isolate may execute in one entry.
+pub(crate) fn entry_instructions(heap_key: usize) -> usize {
+    limits_for_heap(heap_key).entry_instructions
+}
+
+/// Asks permission to create one more timer, and clamps its interval to the
+/// isolate's floor.
+///
+/// Returns the interval to actually use, or `None` if the isolate already
+/// holds as many timers as it may. The clamp is deliberately not a refusal: an
+/// app asking for 1ms is usually just being greedy, and a 16ms timer still
+/// works. A NEGATIVE or non-finite interval is not greed but nonsense — it
+/// reaches `Duration::from_secs_f64` on several platform backends, which
+/// panics — so it is clamped by the same path.
+pub(crate) fn admit_timer(heap_key: usize, requested_s: f64) -> Option<f64> {
+    LIMITS.with(|l| {
+        let mut l = l.borrow_mut();
+        let state = l.entry(heap_key).or_default();
+        let limits = state.limits;
+        if state.timers >= limits.max_timers {
+            let wanted = state.timers as u64 + 1;
+            drop(l);
+            record(heap_key, SplashLimitKind::Timers, wanted, limits.max_timers as u64);
+            return None;
+        }
+        state.timers += 1;
+        let floor = limits.min_timer_interval_s;
+        let clamped = if requested_s.is_finite() && requested_s > floor {
+            requested_s
+        } else {
+            floor
+        };
+        if clamped != requested_s {
+            drop(l);
+            record(
+                heap_key,
+                SplashLimitKind::TimerInterval,
+                (requested_s.max(0.0) * 1000.0) as u64,
+                (floor * 1000.0) as u64,
+            );
+        }
+        Some(clamped)
+    })
+}
+
+/// Gives back a timer slot when one is stopped or fires for the last time.
+pub(crate) fn release_timer(heap_key: usize) {
+    LIMITS.with(|l| {
+        if let Some(state) = l.borrow_mut().get_mut(&heap_key) {
+            state.timers = state.timers.saturating_sub(1);
+        }
+    });
+}
+
+/// Checks a post-collection heap size against the isolate's ceiling.
+/// `live_slots` is what the GC just counted. Reports a crossing; the caller
+/// decides whether to stop the isolate.
+pub(crate) fn check_heap(heap_key: usize, live_slots: usize) -> bool {
+    let limits = limits_for_heap(heap_key);
+    if live_slots <= limits.live_heap_slots {
+        return true;
+    }
+    record(
+        heap_key,
+        SplashLimitKind::Memory,
+        live_slots as u64,
+        limits.live_heap_slots as u64,
+    );
+    false
+}
+
+/// Whether one more HTTP request may go out, given how many are already in
+/// flight for this isolate.
+pub(crate) fn admit_http(heap_key: usize, in_flight: usize) -> bool {
+    let limits = limits_for_heap(heap_key);
+    if (in_flight as u64) < limits.max_inflight_http as u64 {
+        return true;
+    }
+    record(
+        heap_key,
+        SplashLimitKind::Network,
+        in_flight as u64 + 1,
+        limits.max_inflight_http as u64,
+    );
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const H: usize = 0xBEEF;
+
+    fn reset() {
+        LIMITS.with(|l| l.borrow_mut().clear());
+        EVENTS.with(|e| e.borrow_mut().clear());
+    }
+
+    /// An isolate with no host-set limits still has limits.
+    #[test]
+    fn defaults_apply_without_a_host() {
+        reset();
+        let l = limits_for_heap(H);
+        assert_eq!(l, SplashLimits::default());
+        assert!(l.max_timers > 0 && l.cpu_per_window_ms > 0);
+    }
+
+    /// The cumulative window is the thing per-entry budgets cannot express:
+    /// enough entries and the isolate is refused the next one outright.
+    #[test]
+    fn cpu_runs_out_across_many_entries() {
+        reset();
+        set_limits_for_heap(H, Some(SplashLimits::default()));
+        let entry = Duration::from_millis(64);
+        let mut entries = 0;
+        while cpu_allowance(H).is_some() {
+            charge_cpu(H, entry);
+            entries += 1;
+            assert!(entries < 100, "the window must close");
+        }
+        // 250ms of allowance at 64ms an entry.
+        assert_eq!(entries, 4);
+        let events = take_limit_events();
+        assert!(events.iter().any(|e| e.kind == SplashLimitKind::Cpu));
+    }
+
+    /// One entry never gets more than its own share, even with a full window.
+    #[test]
+    fn one_entry_cannot_take_the_whole_window() {
+        reset();
+        let allowance = cpu_allowance(H).expect("fresh window");
+        assert_eq!(allowance, Duration::from_millis(64));
+    }
+
+    /// Timers are capped, and a nonsense interval is clamped rather than
+    /// passed to a platform backend that would panic on it.
+    #[test]
+    fn timers_are_capped_and_intervals_floored() {
+        reset();
+        let limits = SplashLimits { max_timers: 3, min_timer_interval_s: 0.05, ..Default::default() };
+        set_limits_for_heap(H, Some(limits));
+
+        assert_eq!(admit_timer(H, 1.0), Some(1.0), "a sane interval is untouched");
+        assert_eq!(admit_timer(H, 0.001), Some(0.05), "too fast is floored");
+        assert_eq!(admit_timer(H, -1.0), Some(0.05), "negative is floored, not passed on");
+        assert_eq!(admit_timer(H, 1.0), None, "the fourth timer is refused");
+
+        release_timer(H);
+        assert_eq!(admit_timer(H, 2.0), Some(2.0), "stopping one frees a slot");
+
+        let kinds: Vec<_> = take_limit_events().into_iter().map(|e| e.kind).collect();
+        assert!(kinds.contains(&SplashLimitKind::Timers));
+        assert!(kinds.contains(&SplashLimitKind::TimerInterval));
+    }
+
+    /// NaN and infinity are the other two shapes of nonsense.
+    #[test]
+    fn non_finite_intervals_are_floored() {
+        reset();
+        assert_eq!(admit_timer(H, f64::NAN), Some(0.016));
+        assert_eq!(admit_timer(H, f64::INFINITY), Some(0.016));
+        assert_eq!(admit_timer(H, f64::NEG_INFINITY), Some(0.016));
+    }
+
+    /// The heap ceiling is checked against what a collection actually left.
+    #[test]
+    fn heap_ceiling_reports_when_crossed() {
+        reset();
+        set_limits_for_heap(H, Some(SplashLimits { live_heap_slots: 1000, ..Default::default() }));
+        assert!(check_heap(H, 999));
+        assert!(take_limit_events().is_empty());
+        assert!(!check_heap(H, 1001));
+        assert_eq!(take_limit_events().len(), 1);
+    }
+
+    /// A dead isolate's limits, counters and pending events go with it.
+    #[test]
+    fn reclaiming_an_isolate_forgets_it() {
+        reset();
+        set_limits_for_heap(H, Some(SplashLimits { max_timers: 1, ..Default::default() }));
+        admit_timer(H, 1.0);
+        admit_timer(H, 1.0); // refused, records an event
+        gc_limits(&[H]);
+        assert!(take_limit_events().is_empty(), "a dead isolate's events die with it");
+        assert_eq!(limits_for_heap(H), SplashLimits::default());
+    }
+
+    /// A background surface gets a smaller share than a foreground one, which
+    /// is the whole reason these are numbers and not a flag.
+    #[test]
+    fn background_is_stricter_than_foreground() {
+        let fg = SplashLimits::default();
+        let bg = SplashLimits::background();
+        assert!(bg.cpu_per_window_ms < fg.cpu_per_window_ms);
+        assert!(bg.max_timers < fg.max_timers);
+        assert!(bg.min_timer_interval_s > fg.min_timer_interval_s);
+        assert!(bg.live_heap_slots < fg.live_heap_slots);
+    }
+}

--- a/widgets/src/splash_limits.rs
+++ b/widgets/src/splash_limits.rs
@@ -56,6 +56,13 @@ const WINDOW: Duration = Duration::from_secs(1);
 /// embedder ([`set_frame_target`]); 60Hz until it says otherwise.
 const DEFAULT_FRAME_TARGET: f64 = 1.0 / 60.0;
 
+/// How much of a window mini-apps must collectively be using before a missed
+/// frame is treated as THEIR contention. Below this the machine is slow for
+/// reasons trimming an app cannot fix — a software rasteriser, another
+/// process, a cold cache — and squeezing apps would be punishing them for
+/// someone else's problem.
+const APP_BLAME_FRACTION: f64 = 0.2;
+
 /// How far past the target the smoothed frame interval must drift before the
 /// system counts as contended. Frames are noisy, and trimming apps over a
 /// single late frame would be a controller chasing its own tail.
@@ -272,21 +279,28 @@ impl Default for CpuWindow {
 }
 
 impl CpuWindow {
-    /// Whether the thing that owns the frame is losing it.
+    /// Whether the thing that owns the frame is losing it, AND the apps are
+    /// why.
     ///
-    /// This is the whole contention signal, and it deliberately measures the
-    /// LAUNCHER rather than the apps. The launcher draws every app's pixels,
-    /// so if it cannot make its deadline nothing else on screen matters —
-    /// which is why it does not sit in the same weighted pool as the apps.
-    /// It is not given a reserved slice either: a reservation would be an
-    /// arbitrary tax whenever it has nothing to draw. It simply gets first
-    /// call, and apps are trimmed exactly when, and only while, it is short.
+    /// Both halves are load-bearing. The first measures the LAUNCHER rather
+    /// than the apps: it draws every app's pixels, so if it cannot make its
+    /// deadline nothing else on screen matters — which is why it does not sit
+    /// in the same weighted pool, and is not given a reserved slice either. It
+    /// gets first call on the time it actually needs.
+    ///
+    /// The second stops that becoming a tax on apps for someone else's
+    /// slowness. A machine can miss frames because the renderer is slow, the
+    /// display is software-rasterised, or another process is thrashing — none
+    /// of which an app can fix by being trimmed, and all of which would
+    /// otherwise leave every app permanently squeezed. So apps are only
+    /// blamed when they are actually using a meaningful part of the window.
     fn contended(&self) -> bool {
-        match self.frame_ema {
+        let frames_late = match self.frame_ema {
             // Nothing is drawing. Nobody is being kept waiting.
             None => false,
             Some(ema) => ema > self.frame_target * CONTENTION_FACTOR,
-        }
+        };
+        frames_late && self.total.as_secs_f64() >= WINDOW.as_secs_f64() * APP_BLAME_FRACTION
     }
 
     fn note_frame(&mut self, interval_s: f64) {
@@ -734,8 +748,16 @@ mod tests {
         Duration::from_millis(SplashLimits::default().entry_time_ms)
     }
 
-    /// Frames arriving late enough, often enough, to count as contention.
+    /// Frames arriving late enough, often enough, to count as contention —
+    /// AND apps using enough of the window to be the reason.
     fn frames_are_slipping() {
+        WINDOW_STATE.with(|w| {
+            let mut w = w.borrow_mut();
+            let blame = WINDOW.mul_f64(APP_BLAME_FRACTION * 1.5);
+            if w.total < blame {
+                w.total = blame;
+            }
+        });
         for _ in 0..20 {
             note_frame(DEFAULT_FRAME_TARGET * 4.0);
         }
@@ -757,7 +779,23 @@ mod tests {
         frames_are_fine();
         assert!(!is_contended(), "frames on time, nobody is waiting");
         frames_are_slipping();
-        assert!(is_contended(), "the launcher is losing its frame");
+        assert!(is_contended(), "the launcher is losing its frame to the apps");
+    }
+
+    /// A slow machine is not the apps' fault. Frames can be late because the
+    /// renderer is slow or another process is thrashing, and trimming an app
+    /// fixes none of that — it just punishes it for someone else's problem.
+    #[test]
+    fn missed_frames_alone_do_not_blame_the_apps() {
+        reset();
+        set_limits_for_heap(A, Some(SplashLimits::default()));
+        // Frames are dreadful, but the apps have barely run.
+        charge_cpu(A, Duration::from_millis(5));
+        for _ in 0..20 {
+            note_frame(DEFAULT_FRAME_TARGET * 6.0);
+        }
+        assert!(!is_contended(), "the apps are not what is slow");
+        assert_eq!(cpu_allowance(A), Some(full()), "so nothing is taken from them");
     }
 
     /// One late frame is not a verdict.
@@ -835,6 +873,13 @@ mod tests {
         charge_cpu(1, Duration::from_millis(50));
         // Only just slipping: deep pressure would floor both slices and the
         // comparison below would be measuring the floor, not the share.
+        WINDOW_STATE.with(|w| {
+            let mut w = w.borrow_mut();
+            let blame = WINDOW.mul_f64(APP_BLAME_FRACTION * 1.5);
+            if w.total < blame {
+                w.total = blame;
+            }
+        });
         frames_are_fine();
         for _ in 0..4 {
             note_frame(DEFAULT_FRAME_TARGET * 3.0);

--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -4,7 +4,7 @@ use {
         animator::*,
         makepad_derive_widget::*,
         makepad_draw::*,
-        makepad_script::{script_err_wrong_value, ScriptFnRef},
+        makepad_script::ScriptFnRef,
         scroll_bars::ScrollBars,
         widget::*,
         widget_async::{
@@ -749,36 +749,6 @@ impl Widget for View {
                     id!(render),
                 )
             });
-        }
-        if method == live_id!(set_visible) {
-            if let Some(args_obj) = args.as_object() {
-                let trap = vm.bx.threads.cur().trap.pass();
-                let value = vm.bx.heap.vec_value(args_obj, 0, trap);
-                let visible = value
-                    .as_bool()
-                    .or_else(|| value.as_number().map(|n| n != 0.0));
-                match visible {
-                    Some(visible) => {
-                        vm.with_cx_mut(|cx| {
-                            if self.visible != visible {
-                                self.visible = visible;
-                                self.redraw(cx);
-                            }
-                        });
-                    }
-                    // Never guess on a bad argument: a silent default (especially
-                    // `true`) turns script bugs into invisible misbehavior. Keep
-                    // the current visibility and surface an error instead.
-                    None => {
-                        return ScriptAsyncResult::Return(script_err_wrong_value!(
-                            vm.trap(),
-                            "set_visible expects a bool (or number), got {:?}",
-                            value.value_type()
-                        ));
-                    }
-                }
-            }
-            return ScriptAsyncResult::Return(NIL);
         }
         ScriptAsyncResult::MethodNotFound
     }

--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -737,6 +737,18 @@ impl Widget for View {
         args: ScriptValue,
     ) -> ScriptAsyncResult {
         if method == live_id!(render) {
+            // `me` protos off `self.source`, and the caller's `args` object
+            // travels into the VM that owns `on_render` — both are heap values,
+            // and a heap value means nothing outside the heap that minted it.
+            // Refuse when this view was minted somewhere else: rendering it
+            // would build `me` here holding another heap's object index (or
+            // plant these args over there), and nothing would notice until that
+            // heap's next GC walked the value and indexed out of bounds, in
+            // code that did nothing wrong. Includes the case that actually
+            // bites — a view whose isolate has since been torn down.
+            if !self.source.is_zero() && self.source.heap_key() != vm.bx.heap.heap_key() {
+                return ScriptAsyncResult::MethodNotFound;
+            }
             let me = self.make_render_me(vm);
             return vm.with_cx_mut(|cx| {
                 cx.widget_to_script_async_call_fwd(

--- a/widgets/src/widget.rs
+++ b/widgets/src/widget.rs
@@ -1,6 +1,7 @@
 pub use crate::register_widget;
 use {
     crate::makepad_draw::*,
+    crate::makepad_script::script_err_wrong_value,
     crate::widget_async::{ScriptAsyncId, ScriptAsyncResult},
     crate::widget_tree::{set_ui_root, CxWidgetExt},
     std::any::{Any, TypeId},
@@ -719,8 +720,46 @@ impl WidgetRef {
         method: LiveId,
         args: ScriptValue,
     ) -> ScriptAsyncResult {
-        if let Some(inner) = self.0.borrow_mut().as_mut() {
-            return inner.widget.script_call(vm, method, args);
+        {
+            let mut borrow = self.0.borrow_mut();
+            let Some(inner) = borrow.as_mut() else {
+                return ScriptAsyncResult::MethodNotFound;
+            };
+            match inner.widget.script_call(vm, method, args) {
+                ScriptAsyncResult::MethodNotFound => {}
+                handled => return handled,
+            }
+        }
+        // Visibility is a property of EVERY widget (the `Widget` trait carries
+        // it, and `#[visible]` derives it), so a script gets it on every widget
+        // too. It used to live in `View::script_call` alone, which meant
+        // `ui.some_label.set_visible(false)` raised "method not found" — the
+        // one call a responsive layout leans on hardest, silently refused on
+        // every leaf widget.
+        if method == live_id!(set_visible) {
+            let Some(args_obj) = args.as_object() else {
+                return ScriptAsyncResult::Return(NIL);
+            };
+            let trap = vm.bx.threads.cur().trap.pass();
+            let value = vm.bx.heap.vec_value(args_obj, 0, trap);
+            let visible = value
+                .as_bool()
+                .or_else(|| value.as_number().map(|n| n != 0.0));
+            // Never guess on a bad argument: a silent default (especially
+            // `true`) turns script bugs into invisible misbehavior. Keep the
+            // current visibility and surface an error instead.
+            let Some(visible) = visible else {
+                return ScriptAsyncResult::Return(script_err_wrong_value!(
+                    vm.trap(),
+                    "set_visible expects a bool (or number), got {:?}",
+                    value.value_type()
+                ));
+            };
+            vm.with_cx_mut(|cx| self.set_visible(cx, visible));
+            return ScriptAsyncResult::Return(NIL);
+        }
+        if method == live_id!(visible) {
+            return ScriptAsyncResult::Return(self.visible().into());
         }
         ScriptAsyncResult::MethodNotFound
     }

--- a/widgets/src/widget_async.rs
+++ b/widgets/src/widget_async.rs
@@ -378,7 +378,7 @@ impl CxSplashVmExt for Cx {
             .find(|(_, v)| **v == vm_id)
             .map(|(k, _)| *k);
         let Some(heap_key) = heap_key else { return };
-        let cap = crate::splash_limits::limits_for_heap(heap_key).max_inflight_http as usize;
+        let cap = crate::splash_limits::limits_for_heap(heap_key).http_max as usize;
         if let Some(iso) = self.global::<CxWidgetAsync>().isolated_vms.vms.get_mut(&vm_id) {
             iso.std.data.max_inflight_http = Some(cap);
         }
@@ -1348,8 +1348,17 @@ fn pump_widget_async(cx: &mut Cx) -> bool {
                     // catches an app growing a retained structure forever,
                     // where every individual step is well inside every
                     // per-entry budget.
+                    // `check_heap` applies the pressure ladder itself: an
+                    // isolate over its share of a FULL system is collected
+                    // again here, and only a third failure to come back down
+                    // (or its own absolute backstop) condemns it.
                     if !crate::splash_limits::check_heap(bx.heap.heap_key(), bx.heap.live_slots()) {
                         over_ceiling = Some(SplashVmId(next));
+                    } else if crate::splash_limits::under_memory_pressure(bx.heap.heap_key()) {
+                        // Reclaim harder while it is over: collecting the same
+                        // isolate again next pump is the pressure.
+                        bx.heap.mark(&bx.threads, &bx.code);
+                        bx.heap.sweep(false);
                     }
                 }
             }

--- a/widgets/src/widget_async.rs
+++ b/widgets/src/widget_async.rs
@@ -92,6 +92,7 @@ pub fn gc_dead_splash_isolates(cx: &mut Cx) {
     // Sandbox roots and host-bridge state die with their isolates.
     crate::splash_storage::gc_roots(&dead_heaps);
     crate::splash_host::gc_bridge(&dead_heaps);
+    crate::splash_limits::gc_limits(&dead_heaps);
     let state = cx.global::<CxWidgetAsync>();
     state.dead_heaps.extend(dead_heaps.iter().copied());
     for vm_id in dead {
@@ -297,20 +298,37 @@ fn with_isolate_installed<R>(cx: &mut Cx, vm_id: SplashVmId, f: impl FnOnce(&mut
 }
 
 /// A Splash isolate runs untrusted-ish user script on the UI thread; cap how long any
-/// single entry into it may run.
+/// single entry into it may run, and how much it may spend across ALL entries
+/// in a window (`splash_limits`).
+///
+/// The second half is what a per-entry budget cannot say. Ten cheap entries in
+/// a frame cost ten times one, and a script that arranges to be entered often
+/// — a fast interval, a chain of widget events — used to get a fresh full
+/// allowance every time. When the window is spent the entry still RUNS, but on
+/// what is left of the window rather than a fresh 64ms; at zero it gets the
+/// minimum slice, which is enough to make progress and not enough to matter.
 fn with_splash_budget<R>(vm: &mut ScriptVm, f: impl FnOnce(&mut ScriptVm) -> R) -> R {
-    let old_budget = vm.bx.run_budget.replace(ScriptRunBudget::from_durations(
-        std::time::Duration::from_millis(64),
-        std::time::Duration::from_millis(64),
-        512,
-    ));
+    let heap_key = vm.bx.heap.heap_key();
+    let slice = crate::splash_limits::cpu_allowance(heap_key)
+        .unwrap_or(std::time::Duration::from_millis(1));
+    let old_budget = vm.bx.run_budget.replace(ScriptRunBudget::from_durations(slice, slice, 512));
+    let started = std::time::Instant::now();
     let out = f(vm);
+    crate::splash_limits::charge_cpu(heap_key, started.elapsed());
     vm.bx.run_budget = old_budget;
     out
 }
 
 pub trait CxSplashVmExt {
     fn alloc_splash_vm(&mut self) -> SplashVmId;
+    /// Whether the VM currently installed on `Cx` has the net runtime. The app
+    /// VM (the embedder's own script) counts as yes; an isolate answers with
+    /// what it was actually allocated. Used to stop a nested Splash granting
+    /// itself more than its parent has.
+    fn current_vm_allows_net(&mut self) -> bool;
+    /// Pushes an isolate's in-flight HTTP cap from its limits into the stdlib
+    /// state that enforces it. Called whenever those limits change.
+    fn sync_splash_http_cap(&mut self, vm_id: SplashVmId);
     fn alloc_splash_vm_with_network(&mut self, network_enabled: bool) -> SplashVmId;
     fn with_script_vm_id<R>(&mut self, vm_id: SplashVmId, f: impl FnOnce(&mut ScriptVm) -> R) -> R;
     fn with_script_vm_id_thread<R>(
@@ -333,6 +351,37 @@ pub trait CxSplashVmExt {
 impl CxSplashVmExt for Cx {
     fn alloc_splash_vm(&mut self) -> SplashVmId {
         self.alloc_splash_vm_with_network(false)
+    }
+
+    fn current_vm_allows_net(&mut self) -> bool {
+        let state = self.global::<CxWidgetAsync>();
+        let current = state.current_vm_id;
+        if current == MAIN_SPLASH_VM_ID {
+            return true;
+        }
+        state
+            .isolated_vms
+            .vms
+            .get(&current)
+            .map(|iso| iso.network_enabled)
+            .unwrap_or(false)
+    }
+
+    fn sync_splash_http_cap(&mut self, vm_id: SplashVmId) {
+        if vm_id == MAIN_SPLASH_VM_ID {
+            return;
+        }
+        let heap_key = self
+            .global::<CxWidgetAsync>()
+            .heap_to_vm
+            .iter()
+            .find(|(_, v)| **v == vm_id)
+            .map(|(k, _)| *k);
+        let Some(heap_key) = heap_key else { return };
+        let cap = crate::splash_limits::limits_for_heap(heap_key).max_inflight_http as usize;
+        if let Some(iso) = self.global::<CxWidgetAsync>().isolated_vms.vms.get_mut(&vm_id) {
+            iso.std.data.max_inflight_http = Some(cap);
+        }
     }
 
     fn alloc_splash_vm_with_network(&mut self, network_enabled: bool) -> SplashVmId {
@@ -373,11 +422,17 @@ impl CxSplashVmExt for Cx {
             // the stdlib's `net.socket_stream` errors when no net runtime is
             // configured, same as `net.http_request`.
             // `cx.quit` would let any mini-app close the whole host process.
+            // `gc.set_static` marks a value (and everything it reaches)
+            // permanently unreclaimable — no collection, the host's or the
+            // script's own, can ever free it again. In an isolate that is not
+            // an optimisation, it is an unbounded memory leak with a friendly
+            // name, and it defeats the heap ceiling below it.
             let strip = crate::makepad_script::script! {
                 mod.fs = nil
                 mod.run = nil
                 mod.res = nil
                 mod.cx.quit = nil
+                mod.gc.set_static = nil
             };
             vm.eval(strip);
             // Re-register `fs` as the JAILED per-app storage module: inside an
@@ -514,8 +569,26 @@ pub(crate) fn handle_splash_network_responses(
 
     // The isolate has to be installed on `Cx` while its handlers run — see
     // `with_isolate_installed`.
+    //
+    // Budget it like every other entry. This path used to be the one way into
+    // an isolate with NO deadline at all: `with_isolate_installed` does not
+    // apply one (unlike `with_script_vm_id`), and the handlers are invoked bare
+    // several frames down in the net module. So for any app granted network,
+    // `http_request(url, {on_response: || loop {}})` hung the UI thread
+    // permanently — the only unrecoverable CPU hole in the isolate story.
     with_isolate_installed(cx, vm_id, |cx| {
-        cx.handle_script_network_events_for_current_vm(responses)
+        let heap_key = cx.with_vm(|vm| vm.bx.heap.heap_key());
+        let slice = crate::splash_limits::cpu_allowance(heap_key)
+            .unwrap_or(std::time::Duration::from_millis(1));
+        let old_budget = cx.with_vm(|vm| {
+            vm.bx
+                .run_budget
+                .replace(ScriptRunBudget::from_durations(slice, slice, 512))
+        });
+        let started = std::time::Instant::now();
+        cx.handle_script_network_events_for_current_vm(responses);
+        crate::splash_limits::charge_cpu(heap_key, started.elapsed());
+        cx.with_vm(|vm| vm.bx.run_budget = old_budget);
     });
 }
 
@@ -715,7 +788,8 @@ impl<'a> WidgetToScriptCallExt for ScriptVm<'a> {
         let ui_handle = self.build_ui_handle_for_uid(target_uid);
         let call_args =
             self.make_call_args_object_with_context(source.as_object(), ui_handle, args);
-        let result = self.with_instruction_limit(WIDGET_SCRIPT_INSTRUCTION_LIMIT, |vm| {
+        let limit = crate::splash_limits::entry_instructions(self.bx.heap.heap_key());
+        let result = self.with_instruction_limit(limit, |vm| {
             vm.call_with_args_object_with_me(script_fn.clone().into(), call_args, me)
         });
 
@@ -1179,7 +1253,8 @@ fn pump_widget_async(cx: &mut Cx) -> bool {
                         ui_handle,
                         req.args,
                     );
-                    let _ = vm.with_instruction_limit(WIDGET_SCRIPT_INSTRUCTION_LIMIT, |vm| {
+                    let limit = crate::splash_limits::entry_instructions(vm.bx.heap.heap_key());
+                    let _ = vm.with_instruction_limit(limit, |vm| {
                         vm.call_with_args_object_with_me(
                             req.script_fn.clone().into(),
                             call_args,
@@ -1261,13 +1336,26 @@ fn pump_widget_async(cx: &mut Cx) -> bool {
         let last = state.gc_rr_last;
         let next = ids.iter().copied().find(|id| *id > last).unwrap_or(ids[0]);
         state.gc_rr_last = next;
+        let mut over_ceiling = None;
         if let Some(iso) = state.isolated_vms.vms.get_mut(&SplashVmId(next)) {
             if let Some(bx) = iso.vm.as_mut() {
                 if bx.heap.needs_gc() {
                     bx.heap.mark(&bx.threads, &bx.code);
                     bx.heap.sweep(false);
+                    // What a collection LEAVES is what the script is holding.
+                    // An isolate over its ceiling here is not going to come
+                    // back under it on its own — this is the only signal that
+                    // catches an app growing a retained structure forever,
+                    // where every individual step is well inside every
+                    // per-entry budget.
+                    if !crate::splash_limits::check_heap(bx.heap.heap_key(), bx.heap.live_slots()) {
+                        over_ceiling = Some(SplashVmId(next));
+                    }
                 }
             }
+        }
+        if let Some(vm_id) = over_ceiling {
+            mark_splash_isolate_dead(vm_id);
         }
     }
 
@@ -1278,6 +1366,23 @@ fn register_task_hooks(cx: &mut Cx) {
     cx.add_script_task_on_thread_completed_hook(on_widget_script_thread_completed_hook);
     cx.add_script_task_pump_hook(pump_widget_async_hook);
     cx.add_script_timer_dispatch_hook(script_timer_dispatch_hook);
+    cx.set_script_timer_quota_hooks(splash_timer_admit_hook, splash_timer_release_hook);
+}
+
+/// Caps how many timers an isolate holds and how fast they may tick
+/// (`splash_limits`). The main app VM is not an isolate and is left alone:
+/// its script is the embedder's own.
+fn splash_timer_admit_hook(cx: &mut Cx, heap_key: usize, requested_s: f64) -> Option<f64> {
+    if !cx.global::<CxWidgetAsync>().heap_to_vm.contains_key(&heap_key) {
+        return Some(requested_s);
+    }
+    crate::splash_limits::admit_timer(heap_key, requested_s)
+}
+
+fn splash_timer_release_hook(cx: &mut Cx, heap_key: usize) {
+    if cx.global::<CxWidgetAsync>().heap_to_vm.contains_key(&heap_key) {
+        crate::splash_limits::release_timer(heap_key);
+    }
 }
 
 /// Routes a firing script timer to the isolate VM that owns its callback. Without this,
@@ -1298,7 +1403,8 @@ fn script_timer_dispatch_hook(cx: &mut Cx, timer: &CxScriptTimer, time: ScriptVa
             // Same budget/limit as any other isolate entry, so a runaway timer callback
             // can't hang the host.
             cx.with_script_vm_id(vm_id, |vm| {
-                vm.with_instruction_limit(WIDGET_SCRIPT_INSTRUCTION_LIMIT, |vm| {
+                let limit = crate::splash_limits::entry_instructions(vm.bx.heap.heap_key());
+                vm.with_instruction_limit(limit, |vm| {
                     vm.call(timer.callback.as_object().into(), &[time]);
                 });
             });

--- a/widgets/src/widget_async.rs
+++ b/widgets/src/widget_async.rs
@@ -1381,6 +1381,14 @@ fn register_task_hooks(cx: &mut Cx) {
 /// Caps how many timers an isolate holds and how fast they may tick
 /// (`splash_limits`). The main app VM is not an isolate and is left alone:
 /// its script is the embedder's own.
+/// Charges a timer FIRE to the isolate that owns it, on top of whatever its
+/// callback then costs. A wakeup is not free even when the callback is empty.
+fn splash_charge_wakeup(cx: &mut Cx, heap_key: usize) {
+    if cx.global::<CxWidgetAsync>().heap_to_vm.contains_key(&heap_key) {
+        crate::splash_limits::charge_wakeup(heap_key);
+    }
+}
+
 fn splash_timer_admit_hook(cx: &mut Cx, heap_key: usize, requested_s: f64) -> Option<f64> {
     if !cx.global::<CxWidgetAsync>().heap_to_vm.contains_key(&heap_key) {
         return Some(requested_s);
@@ -1409,6 +1417,11 @@ fn script_timer_dispatch_hook(cx: &mut Cx, timer: &CxScriptTimer, time: ScriptVa
         .copied();
     match vm_id {
         Some(vm_id) => {
+            // The wakeup itself is charged before the callback runs: the
+            // dispatch that got us here cost the host whether or not the
+            // script does anything, and an app that asks to be woken a
+            // thousand times a second should pay for it out of its own share.
+            splash_charge_wakeup(cx, heap_key);
             // Same budget/limit as any other isolate entry, so a runaway timer callback
             // can't hang the host.
             cx.with_script_vm_id(vm_id, |vm| {

--- a/widgets/src/widget_async.rs
+++ b/widgets/src/widget_async.rs
@@ -93,6 +93,10 @@ pub fn gc_dead_splash_isolates(cx: &mut Cx) {
     crate::splash_storage::gc_roots(&dead_heaps);
     crate::splash_host::gc_bridge(&dead_heaps);
     crate::splash_limits::gc_limits(&dead_heaps);
+    // And the resource cache, which is keyed by heap ADDRESS: dropping a heap
+    // frees that address for the next isolate, and a leftover entry would hand
+    // the newcomer a dead heap's handle. See `CxScriptResources::gc_heaps`.
+    cx.script_data.resources.gc_heaps(&dead_heaps);
     let state = cx.global::<CxWidgetAsync>();
     state.dead_heaps.extend(dead_heaps.iter().copied());
     for vm_id in dead {


### PR DESCRIPTION
Stacks on #1186 (shares context in `widget_async.rs`; happy to rebase once that lands).

The VM bounds **one entry** into script — 64ms and 200k instructions — and that is all it bounds. A script that arranges to be entered often gets a fresh full allowance every time, and nothing capped how often it could arrange that. Hosting untrusted mini-apps (project-robius/host_launcher) turned that into concrete holes, and into a design question worth getting right.

### The model

**Nothing is limited while limiting it would buy nothing.** cgroup v2's split, in its vocabulary:

- a **weight** (`cpu.weight`) decides who yields when isolates actually compete, and does nothing at all when they don't. One weight covers every contended resource: an isolate is important or it isn't, and ranking it separately for processor, memory and downloads is inventing numbers.
- a **max** (`cpu.max`, `memory.max`) is an absolute ceiling for a host that wants one. Every one ships off or as a runaway backstop.

**Contention is measured, and it takes two signals.** The host reports frame intervals (`note_frame`); isolates are trimmed only when the host is missing its deadline AND the isolates are collectively using enough of the window to plausibly be why. The first half is because the host draws every isolate's pixels — if it cannot paint, nothing else on screen matters, which is why it is prioritised rather than pooled and why it holds no reserved slice (a reservation would be a tax whenever it has nothing to draw). The second half is because a machine can miss frames for reasons trimming an isolate cannot fix: a software rasteriser, another process thrashing. Without it, the headless test renderer — which misses every frame by construction — squeezed every isolate permanently.

When both hold, isolates run on their weighted fraction of an entry, scaled by a pressure term that deepens while frames keep slipping and relaxes when they recover. They give up as much as the host needs and no more.

Memory, timers and in-flight requests are space-multiplexed rather than time-multiplexed, but the rationing rule is one function — *is the pool full, AND is this isolate over its weighted slice*. Memory additionally gets cgroup's ladder: over its share it is collected harder (`memory.high`) and only condemned after three collections that fail to bring it down (`memory.max`). The pool size is the host's to set (`set_memory_pool`), because how much memory there is to share is something the embedder knows and this crate does not.

There is deliberately **no rule about how fast a timer may tick**. What an isolate pays is the WAKEUP: every fire is charged to its processor share, because a fire costs a dispatch pass whether or not the callback does anything. Fast timers are therefore expensive when the machine is busy and free when it is not. Entry time and instructions stay absolute — stopping one entry from eating a frame is a latency job, not a fairness one.

### Bugs fixed on the way

- **`start_interval(-1.0)` panics the process.** `timer.rs`'s check is `delay.is_number()`, a bit-range test that negatives, NaN and infinity all pass. The value reaches `Duration::from_secs_f64` on the headless, stdin, android and open_harmony backends, which panics. One statement from a mini-app takes the whole app down. (Clamped now as a validity check, not a policy.)
- **`stop_timer` leaks the OS timer forever.** It removed the bookkeeping entry but never called `cx.stop_timer`, so the timer kept firing for the life of the process — and with its entry gone it was invisible to *both* teardown paths, which filter that same `Vec`. It also matched by id alone with no ownership check.
- **Network callbacks had no deadline at all.** `handle_splash_network_responses` installs the isolate with `with_isolate_installed`, which unlike `with_script_vm_id` applies no budget, and the handlers are invoked bare inside `net.rs`. For any isolate granted network, `http_request(url, {on_response: || loop {}})` hung the UI thread permanently.
- **A nested `Splash` could widen privilege.** `allow_net` is `#[live]` (its six host-assigned siblings are `#[rust]`), so a script can write `Splash{allow_net: true}` in its own body. Nothing evaluates such a widget today — `eval_body`'s only caller is `set_text` — so it is inert, but one future script binding makes it a network grant nobody gave. A nested isolate now gets at most what its creator has.

### Also

`ScriptHeap::live_slots()` (the five subtractions `needs_gc` already does), `gc.set_static` stripped from isolates since it makes memory permanently unreclaimable, and `gc_dead_splash_isolates` now purges the queues holding a dying isolate's values *before* dropping the heap those values live in — matching what `gc_bridge` above it already did.

### Verification

22 unit tests in `splash_limits`, written against the properties rather than the numbers: an isolate is not trimmed while frames are fine however much it uses; five equally-weighted ones get equal slices; a quiet isolate holds nothing back; a heavyweight keeps the bigger slice when squeezed; missed frames alone do not blame the isolates; memory pressure precedes a stop and clears if the app frees what it grabbed. Plus end-to-end from real mini-apps in the launcher. `makepad-widgets` and `makepad-script` suites pass (two pre-existing `widget_tree` failures on `dev` fail without this branch too).