### PR TITLE
vj: DJ-tab scroll knobs, title-click reset, crossfade fix, stem headroom — plus the pre-Ampere CUDA fix

### DIFF
--- a/apps/vj/src/decks.rs
+++ b/apps/vj/src/decks.rs
@@ -734,12 +734,17 @@ impl DeckEngine {
     }
 
     /// Timed move to one side (the "fade to A/B" performance buttons).
+    ///
+    /// `crossfader` is NOT jumped to the target here: the fade takes the
+    /// operator's chosen seconds, and this field is what the on-screen fader
+    /// mirrors. Landing it now made the fader teleport while the audio was
+    /// still crossing — the move looked instant and untrusted even though it
+    /// was running. The host walks it across (`track_crossfade`) instead.
     pub fn fade_to(&mut self, deck: DeckId, secs: f32) -> Vec<DeckCmd> {
         let position = match deck {
             DeckId::A => 0.0,
             DeckId::B => 1.0,
         };
-        self.crossfader = position;
         vec![DeckCmd::FadeCrossfader { position, secs: secs.max(0.0) }]
     }
 

--- a/apps/vj/src/main.rs
+++ b/apps/vj/src/main.rs
@@ -5289,6 +5289,11 @@ pub struct App {
     deck_target: DeckTarget,
     #[rust(4.0f32)]
     xfade_secs: f32,
+    /// Where a timed crossfade is heading, while one is running. The fade
+    /// itself lives on the mixer (it has the device clock); this only says
+    /// "keep mirroring it onto the surface until it lands".
+    #[rust]
+    xfade_target: Option<f32>,
 
     // Music mode: whole-track analysis off-thread, and the deck surface it
     // feeds (waveform tiles, beat grids, explorer rows, queue).
@@ -16352,21 +16357,48 @@ p2 {}
         self.handle_wave_input(cx);
     }
 
+    /// Arm the surface to follow a timed crossfade to `target`.
+    fn start_crossfade_tracking(&mut self, cx: &mut Cx, target: f32) {
+        self.xfade_target = Some(target);
+        // A fade with both decks paused still has to animate, and the music
+        // pump only runs for a moving deck — so ask for the first frame here.
+        self.music_pump = cx.new_next_frame();
+    }
+
+    /// Mirror the mixer's real fader onto the deck surface while a timed
+    /// fade runs, and let go once it lands.
+    ///
+    /// The mixer owns the ramp because it rides the audio device clock; the
+    /// surface only reports it. That is what makes the on-screen fader agree
+    /// with what is actually audible, second for second.
+    fn track_crossfade(&mut self, cx: &mut Cx) {
+        let Some(target) = self.xfade_target else { return };
+        let position = self.mixer.crossfader_position();
+        self.decks.crossfader = position;
+        self.ui.slider(cx, ids!(xfader)).set_value(cx, position as f64);
+        if (position - target).abs() <= 1e-4 {
+            self.decks.crossfader = target;
+            self.xfade_target = None;
+        }
+    }
+
     /// One display frame of the deck surface: fresh playheads into the
     /// lanes and nothing else. Scheduled while a deck is playing or a hand
     /// is on a record, so a scratch tracks at the display's rate rather
     /// than the console's poll rate.
     fn pump_music_frame(&mut self, cx: &mut Cx) {
         self.push_wave_positions(cx);
+        self.track_crossfade(cx);
         self.schedule_music_frame(cx);
     }
 
     /// Ask for another frame while anything on the surface is moving.
     fn schedule_music_frame(&mut self, cx: &mut Cx) {
-        let moving = [DeckId::A, DeckId::B].iter().any(|deck| {
-            let (_, _, playing, scratching) = self.mixer.deck_snapshot(*deck);
-            playing || scratching
-        });
+        let moving = self.xfade_target.is_some()
+            || [DeckId::A, DeckId::B].iter().any(|deck| {
+                let (_, _, playing, scratching) = self.mixer.deck_snapshot(*deck);
+                playing || scratching
+            });
         if moving {
             self.music_pump = cx.new_next_frame();
             // Karaoke lives on the PROGRAM, which normally only redraws when
@@ -17410,6 +17442,9 @@ impl MatchEvent for App {
         }
         self.handle_deck_controls(cx, actions);
         if let Some(v) = self.ui.slider(cx, ids!(xfader)).slided(actions) {
+            // A hand on the fader outranks a running fade, exactly as it
+            // does for the visual AUTOFADE.
+            self.xfade_target = None;
             let cmds = self.decks.set_crossfader(v as f32);
             self.run_deck_cmds(cx, cmds);
         }
@@ -17696,13 +17731,13 @@ impl MatchEvent for App {
             let secs = self.xfade_secs;
             let cmds = self.decks.fade_to(DeckId::A, secs);
             self.run_deck_cmds(cx, cmds);
-            self.ui.slider(cx, ids!(xfader)).set_value(cx, 0.0);
+            self.start_crossfade_tracking(cx, 0.0);
         }
         if self.ui.button(cx, ids!(fade_to_b)).clicked(actions) {
             let secs = self.xfade_secs;
             let cmds = self.decks.fade_to(DeckId::B, secs);
             self.run_deck_cmds(cx, cmds);
-            self.ui.slider(cx, ids!(xfader)).set_value(cx, 1.0);
+            self.start_crossfade_tracking(cx, 1.0);
         }
         if let Some(index) = self.ui.drop_down(cx, ids!(xcurve)).selected(actions) {
             let curve = if index == 1 { FadeCurve::Linear } else { FadeCurve::EqualPower };

--- a/apps/vj/src/main.rs
+++ b/apps/vj/src/main.rs
@@ -2525,9 +2525,11 @@ struct DeckRefs {
     vu: ViewRef,
     eq_knobs: Vec<SliderRef>,
     eq_kills: Vec<ButtonRef>,
+    eq_labels: Vec<ButtonRef>,
+    filter_label: ButtonRef,
     stem_knobs: Vec<SliderRef>,
     stem_kills: Vec<ButtonRef>,
-    stem_labels: Vec<LabelRef>,
+    stem_labels: Vec<ButtonRef>,
     /// The transcript panel filling the bottom of the deck column.
     lyrics: WidgetRef,
 }
@@ -2560,9 +2562,11 @@ impl DeckRefs {
             vu: ui.view(cx, ids.vu),
             eq_knobs: ids.eq_knobs.iter().map(|p| ui.slider(cx, p)).collect(),
             eq_kills: ids.eq_kills.iter().map(|p| ui.button(cx, p)).collect(),
+            eq_labels: ids.eq_labels.iter().map(|p| ui.button(cx, p)).collect(),
+            filter_label: ui.button(cx, ids.filter_label),
             stem_knobs: ids.stem_knobs.iter().map(|p| ui.slider(cx, p)).collect(),
             stem_kills: ids.stem_kills.iter().map(|p| ui.button(cx, p)).collect(),
-            stem_labels: ids.stem_labels.iter().map(|p| ui.label(cx, p)).collect(),
+            stem_labels: ids.stem_labels.iter().map(|p| ui.button(cx, p)).collect(),
             lyrics: ui.widget(cx, ids.lyrics),
         }
     }
@@ -2648,6 +2652,9 @@ struct MusicDeckIds {
     lyrics: &'static [LiveId],
     /// The legends over those knobs, tinted to match the waveform.
     stem_labels: [&'static [LiveId]; 4],
+    /// Low, mid, high — matches `eq_knobs`.
+    eq_labels: [&'static [LiveId]; 3],
+    filter_label: &'static [LiveId],
 }
 
 impl MusicDeckIds {
@@ -2704,6 +2711,12 @@ impl MusicDeckIds {
                     ids!(deck_a_label_bass),
                     ids!(deck_a_label_other),
                 ],
+                eq_labels: [
+                    ids!(deck_a_label_eq_low),
+                    ids!(deck_a_label_eq_mid),
+                    ids!(deck_a_label_eq_high),
+                ],
+                filter_label: ids!(deck_a_label_filter),
                 lyrics: ids!(deck_a_lyrics),
             },
             DeckId::B => MusicDeckIds {
@@ -2757,6 +2770,12 @@ impl MusicDeckIds {
                     ids!(deck_b_label_bass),
                     ids!(deck_b_label_other),
                 ],
+                eq_labels: [
+                    ids!(deck_b_label_eq_low),
+                    ids!(deck_b_label_eq_mid),
+                    ids!(deck_b_label_eq_high),
+                ],
+                filter_label: ids!(deck_b_label_filter),
                 lyrics: ids!(deck_b_lyrics),
             },
         }

--- a/apps/vj/src/main.rs
+++ b/apps/vj/src/main.rs
@@ -14536,7 +14536,12 @@ p2 {}
                     let mono = (frame[0] as f64 + frame[1] as f64) * 0.5 / 32768.0;
                     sum += mono * mono;
                 }
-                rms[lane] = (sum / (end - offset) as f64).sqrt();
+                // The headroom is undone once per lane rather than per
+                // sample. `stem_column_shares` only reads these relative to
+                // each other, so it cannot change the picture — but a level
+                // that claims to be an amplitude should be one.
+                rms[lane] = (sum / (end - offset) as f64).sqrt()
+                    * crate::mixer::STEM_CHUNK_HEADROOM as f64;
             }
             if any {
                 tiles[column] = crate::music_view::stem_column_shares(rms);

--- a/apps/vj/src/main.rs
+++ b/apps/vj/src/main.rs
@@ -16320,6 +16320,28 @@ p2 {}
                     self.run_deck_cmds(cx, cmds);
                 }
             }
+            if refs.filter_label.clicked(actions) {
+                if let Some(value) = refs.filter.reset_to_default(cx) {
+                    let cmds = self.decks.set_filter(deck, value as f32);
+                    self.run_deck_cmds(cx, cmds);
+                }
+            }
+            for (band, label) in refs.eq_labels.iter().enumerate() {
+                if label.clicked(actions) {
+                    if let Some(value) = refs.eq_knobs[band].reset_to_default(cx) {
+                        let cmds = self.decks.set_eq(deck, band, value as f32);
+                        self.run_deck_cmds(cx, cmds);
+                    }
+                }
+            }
+            for (stem, label) in refs.stem_labels.iter().enumerate() {
+                if label.clicked(actions) {
+                    if let Some(value) = refs.stem_knobs[stem].reset_to_default(cx) {
+                        let cmds = self.decks.set_stem(deck, stem, value as f32);
+                        self.run_deck_cmds(cx, cmds);
+                    }
+                }
+            }
             self.music_refs.decks[deck.index()] = refs;
         }
         if self.music_refs.auto_sync.clicked(actions) {

--- a/apps/vj/src/mixer.rs
+++ b/apps/vj/src/mixer.rs
@@ -191,8 +191,35 @@ impl TrackPcm {
     }
 }
 
+/// Headroom the stem lanes are stored with.
+///
+/// BS-RoFormer's masks are complex ratios, not a partition of unity, so a
+/// stem legitimately peaks ABOVE full scale: the reference vocals stem hits
+/// 1.12 and a measured drums stem 1.47. Encoding those straight to i16 hard-
+/// clipped every peak past 1.0 — about 0.05% of drum samples on a real
+/// track, which is exactly the transients, and it hardens them audibly.
+///
+/// So every lane is divided by this on the way in and multiplied back on the
+/// way out, spending one bit of resolution to keep the peaks intact. The
+/// on-disk span cache solves the same problem differently (a per-span peak
+/// stored beside the samples); this is the in-memory playback format, where
+/// a chunk has to be indexable arithmetically and cannot carry side data.
+///
+/// Every producer of a [`TrackStems`] lane must encode through
+/// [`encode_stem_sample`], and the only consumer that reads absolute levels
+/// out of one is [`DeckSource::frame`].
+pub const STEM_CHUNK_HEADROOM: f32 = 2.0;
+
+/// One stem sample (nominally -1.0..1.0, legitimately beyond) into the lane
+/// format. See [`STEM_CHUNK_HEADROOM`].
+pub fn encode_stem_sample(value: f32) -> i16 {
+    ((value / STEM_CHUNK_HEADROOM).clamp(-1.0, 1.0) * 32767.0) as i16
+}
+
 /// A separated track: four stem lanes on the SAME timeline as the mixed
 /// file, delivered in fixed chunks as the separator streams them.
+///
+/// Lanes are stored with [`STEM_CHUNK_HEADROOM`], not at full scale.
 ///
 /// A chunk that has not arrived is not silence — the deck falls back to the
 /// mixed file there, so playback is never interrupted by separation and the
@@ -268,8 +295,11 @@ impl FrameSource for DeckSource<'_> {
                 continue;
             }
             let Some(frame) = block.get(offset) else { continue };
-            out[0] += frame[0] as f32 / 32768.0 * gain;
-            out[1] += frame[1] as f32 / 32768.0 * gain;
+            // Lanes carry STEM_CHUNK_HEADROOM; undo it here so a stem that
+            // peaks past full scale plays at the level it was separated at.
+            let scale = STEM_CHUNK_HEADROOM / 32768.0 * gain;
+            out[0] += frame[0] as f32 * scale;
+            out[1] += frame[1] as f32 * scale;
         }
         // Nothing separated here yet: the mixed file plays, as it did
         // before separation existed.
@@ -1468,6 +1498,30 @@ mod tests {
         20.0 * ratio.max(1e-12).log10()
     }
 
+    /// A separated stem peaks above full scale — the lane format has to
+    /// carry that, because clipping it is what hardened the transients.
+    #[test]
+    fn stem_lanes_carry_peaks_above_full_scale() {
+        // The decode side of `DeckSource::frame`, at unity gain.
+        let played = |value: f32| {
+            encode_stem_sample(value) as f32 / 32768.0 * STEM_CHUNK_HEADROOM
+        };
+        // The two peaks this bug was found on: the reference vocals stem
+        // and a measured drums stem.
+        for peak in [1.12f32, 1.47] {
+            let out = played(peak);
+            assert!(
+                (out - peak).abs() < 0.001,
+                "a stem peaking at {peak} must survive the lane format: {out}"
+            );
+        }
+        // Ordinary audio is unharmed, and the format still clamps — just at
+        // the headroom instead of at full scale.
+        assert!((played(0.5) - 0.5).abs() < 0.001);
+        assert!((played(-0.5) + 0.5).abs() < 0.001);
+        assert!((played(9.0) - STEM_CHUNK_HEADROOM).abs() < 0.001);
+    }
+
     /// The "fade to A/B" buttons hand the mixer a duration; the fader must
     /// take that long to cross, not jump and land.
     #[test]
@@ -1634,6 +1688,22 @@ mod tests {
         );
     }
 
+    /// Full-scale PCM re-encoded into the lane format, the way every real
+    /// producer does it — so a fixture measures what playback measures.
+    fn stem_block(frames: &[[i16; 2]]) -> Arc<Vec<[i16; 2]>> {
+        Arc::new(
+            frames
+                .iter()
+                .map(|f| {
+                    [
+                        encode_stem_sample(f[0] as f32 / 32768.0),
+                        encode_stem_sample(f[1] as f32 / 32768.0),
+                    ]
+                })
+                .collect(),
+        )
+    }
+
     /// Four chunked stem lanes over a four-second track.
     fn chunked_stems(tones: [f64; 4], rate: u32, seconds: f64) -> Arc<TrackStems> {
         let chunk = rate as usize;
@@ -1648,8 +1718,7 @@ mod tests {
             for index in 0..count {
                 let start = index * chunk;
                 let end = (start + chunk).min(frames);
-                stems.lanes[lane][index] =
-                    Some(Arc::new(pcm.frames[start..end].to_vec()));
+                stems.lanes[lane][index] = Some(stem_block(&pcm.frames[start..end]));
             }
         }
         Arc::new(stems)
@@ -1688,9 +1757,8 @@ mod tests {
         for index in 2..4 {
             let start = index * 48_000;
             for lane in 0..STEM_COUNT {
-                stems.lanes[lane][index] = Some(Arc::new(
-                    separated.frames[start..start + 48_000].to_vec(),
-                ));
+                stems.lanes[lane][index] =
+                    Some(stem_block(&separated.frames[start..start + 48_000]));
             }
         }
         assert!(!stems.covers(0) && stems.covers(2 * 48_000));

--- a/apps/vj/src/mixer.rs
+++ b/apps/vj/src/mixer.rs
@@ -959,6 +959,13 @@ impl Mixer {
         self.state.lock().unwrap().fader.slew(position.clamp(0.0, 1.0), secs.max(SLEW_SECS));
     }
 
+    /// Where the crossfader actually is right now, mid-ramp included. The
+    /// deck surface mirrors this while a timed fade runs, so the on-screen
+    /// fader travels with the audio instead of teleporting to the target.
+    pub fn crossfader_position(&self) -> f32 {
+        self.state.lock().unwrap().fader.current
+    }
+
     pub fn set_curve(&self, curve: FadeCurve) {
         self.state.lock().unwrap().curve = curve;
     }
@@ -1459,6 +1466,35 @@ mod tests {
 
     fn decibels(ratio: f64) -> f64 {
         20.0 * ratio.max(1e-12).log10()
+    }
+
+    /// The "fade to A/B" buttons hand the mixer a duration; the fader must
+    /// take that long to cross, not jump and land.
+    #[test]
+    fn a_timed_crossfade_takes_its_duration() {
+        let mixer = Mixer::new();
+        mixer.set_master(1.0);
+        mixer.set_crossfader(0.0);
+        mixer.install_deck(DeckId::A, tone_pcm(440.0, 48_000, 10.0));
+        mixer.install_deck(DeckId::B, tone_pcm(440.0, 48_000, 10.0));
+        mixer.set_deck_playing(DeckId::A, true);
+        mixer.set_deck_playing(DeckId::B, true);
+        // Let the initial jump to 0.0 settle before the timed move starts.
+        render(&mixer, 48_000.0, 4_096);
+        assert!(mixer.state.lock().unwrap().fader.current < 1e-6);
+
+        mixer.fade_crossfader(1.0, 4.0);
+        // A quarter of the way through a four-second fade.
+        render(&mixer, 48_000.0, 48_000);
+        let quarter = mixer.state.lock().unwrap().fader.current;
+        assert!(
+            quarter > 0.2 && quarter < 0.3,
+            "one second into a 4s fade the fader should be near 0.25: {quarter}"
+        );
+        // And it must actually arrive by the end.
+        render(&mixer, 48_000.0, 48_000 * 4);
+        let done = mixer.state.lock().unwrap().fader.current;
+        assert!((done - 1.0).abs() < 1e-6, "the fade must land on B: {done}");
     }
 
     // A deck's tone chain has to be in the audible path, not just in the

--- a/apps/vj/src/music_view.rs
+++ b/apps/vj/src/music_view.rs
@@ -505,11 +505,28 @@ script_mod! {
     }
 
     // A knob's legend: fills its stack, never widens it, never wraps.
-    let KnobLabel = MusicLabel{
+    // A flat Button rather than a Label so a click on it resets its knob.
+    let KnobLabel = Button{
         width: Fill
-        flow: Flow.Right{wrap: false}
-        max_lines: 1
-        draw_text.text_style: theme.font_bold{font_size: 7}
+        height: Fit
+        padding: 0
+        margin: 0
+        align: Align{x: 0.5, y: 0.0}
+        draw_bg +: {
+            color: #x00000000
+            color_focus: #x00000000
+            color_hover: #x00000000
+            color_down: #x00000000
+            border_size: 0.0
+            border_radius: 0.0
+        }
+        draw_text +: {
+            color: #xa6b1bd
+            color_focus: #xa6b1bd
+            color_hover: #xd6dee6
+            color_down: #x8e9aa7
+            text_style: theme.font_bold{font_size: 7}
+        }
     }
 
     let KnobStack = View{
@@ -828,22 +845,22 @@ script_mod! {
                             flow: Right
                             spacing: 3
                             KnobStack{
-                                KnobLabel{text: "HIGH"}
+                                deck_a_label_eq_high := KnobLabel{text: "HIGH"}
                                 deck_a_eq_high := MusicKnob{}
                                 deck_a_kill_high := KillButton{}
                             }
                             KnobStack{
-                                KnobLabel{text: "MID"}
+                                deck_a_label_eq_mid := KnobLabel{text: "MID"}
                                 deck_a_eq_mid := MusicKnob{}
                                 deck_a_kill_mid := KillButton{}
                             }
                             KnobStack{
-                                KnobLabel{text: "LOW"}
+                                deck_a_label_eq_low := KnobLabel{text: "LOW"}
                                 deck_a_eq_low := MusicKnob{}
                                 deck_a_kill_low := KillButton{}
                             }
                             KnobStack{
-                                KnobLabel{text: "FILTER"}
+                                deck_a_label_filter := KnobLabel{text: "FILTER"}
                                 deck_a_filter := MusicKnob{min: 0.0 max: 1.0 default: 0.5}
                             }
                         }
@@ -929,21 +946,21 @@ script_mod! {
                             flow: Right
                             spacing: 3
                             KnobStack{
-                                KnobLabel{text: "FILTER"}
+                                deck_b_label_filter := KnobLabel{text: "FILTER"}
                                 deck_b_filter := MusicKnob{min: 0.0 max: 1.0 default: 0.5}
                             }
                             KnobStack{
-                                KnobLabel{text: "LOW"}
+                                deck_b_label_eq_low := KnobLabel{text: "LOW"}
                                 deck_b_eq_low := MusicKnob{}
                                 deck_b_kill_low := KillButton{}
                             }
                             KnobStack{
-                                KnobLabel{text: "MID"}
+                                deck_b_label_eq_mid := KnobLabel{text: "MID"}
                                 deck_b_eq_mid := MusicKnob{}
                                 deck_b_kill_mid := KillButton{}
                             }
                             KnobStack{
-                                KnobLabel{text: "HIGH"}
+                                deck_b_label_eq_high := KnobLabel{text: "HIGH"}
                                 deck_b_eq_high := MusicKnob{}
                                 deck_b_kill_high := KillButton{}
                             }

--- a/apps/vj/src/music_view.rs
+++ b/apps/vj/src/music_view.rs
@@ -467,6 +467,7 @@ script_mod! {
         min: 0.0
         max: 2.0
         default: 1.0
+        scroll_step: 0.025
         text: ""
         flow: Down
         text_input: TextInput{width: 0 height: 0}
@@ -525,6 +526,7 @@ script_mod! {
 
     let MusicFader = Slider{
         axis: DragAxis.Vertical
+        scroll_step: 0.025
         width: 40
         height: Fill
         text: ""
@@ -565,6 +567,7 @@ script_mod! {
         height: 40
         min: 0.0
         max: 1.0
+        scroll_step: 0.025
         text: ""
         text_input: TextInput{width: 0 height: 0}
         draw_bg +: {

--- a/apps/vj/src/side_channels.rs
+++ b/apps/vj/src/side_channels.rs
@@ -29,7 +29,7 @@
 //! what THIS machine separated.
 
 use crate::decks::DeckId;
-use crate::mixer::TrackPcm;
+use crate::mixer::{encode_stem_sample, TrackPcm};
 use crate::stems::{
     chunk_count, chunk_frames, model_frames, resample, track_digest, StemChunk, StemsMsg,
 };
@@ -150,12 +150,7 @@ fn decode_stem(path: &Path, track_rate: u32) -> Result<Vec<[i16; 2]>, String> {
     Ok(left
         .iter()
         .zip(right.iter())
-        .map(|(l, r)| {
-            [
-                (l.clamp(-1.0, 1.0) * 32767.0) as i16,
-                (r.clamp(-1.0, 1.0) * 32767.0) as i16,
-            ]
-        })
+        .map(|(l, r)| [encode_stem_sample(*l), encode_stem_sample(*r)])
         .collect())
 }
 

--- a/apps/vj/src/stems.rs
+++ b/apps/vj/src/stems.rs
@@ -34,7 +34,7 @@
 //! arrived simply falls back to the mixed file.
 
 use crate::decks::DeckId;
-use crate::mixer::TrackPcm;
+use crate::mixer::{encode_stem_sample, TrackPcm};
 use makepad_ai_stems::{
     CacheHeader, Demixer, StemCache, StemSet, StemsModel, StereoBuf, CHUNK_STEP,
     SAMPLE_RATE as STEMS_RATE,
@@ -447,12 +447,7 @@ fn i16_frames(
     };
     left.iter()
         .zip(right.iter())
-        .map(|(l, r)| {
-            [
-                (l.clamp(-1.0, 1.0) * 32767.0) as i16,
-                (r.clamp(-1.0, 1.0) * 32767.0) as i16,
-            ]
-        })
+        .map(|(l, r)| [encode_stem_sample(*l), encode_stem_sample(*r)])
         .collect()
 }
 
@@ -475,8 +470,17 @@ fn run_sidecar(job: &StemsJob, lanes: [TrackPcm; 4], out: &Sender<StemsMsg>) {
         }
         let mut blocks: Vec<Arc<Vec<[i16; 2]>>> = Vec::with_capacity(4);
         for lane in lanes.iter() {
+            // Sidecar WAVs are ordinary full-scale audio, so they are
+            // re-encoded into the lane format rather than copied: every
+            // producer of a lane owes it the same headroom.
             let slice: Vec<[i16; 2]> = (start..end)
-                .map(|frame| lane.frames.get(frame).copied().unwrap_or([0, 0]))
+                .map(|frame| {
+                    let f = lane.frames.get(frame).copied().unwrap_or([0, 0]);
+                    [
+                        encode_stem_sample(f[0] as f32 / 32768.0),
+                        encode_stem_sample(f[1] as f32 / 32768.0),
+                    ]
+                })
                 .collect();
             blocks.push(Arc::new(slice));
         }
@@ -1068,7 +1072,9 @@ mod tests {
         // reads back rotated — which is the mapping the mixer depends on.
         let first = &chunks[0].lanes;
         for (lane, stem) in [(0usize, 3usize), (1, 0), (2, 1), (3, 2)] {
-            let want = ((stem as f32 + 1.0) * 0.1 * 32767.0) as i16;
+            // Published lanes carry STEM_CHUNK_HEADROOM, so the expectation
+            // goes through the same encoder the publisher used.
+            let want = encode_stem_sample((stem as f32 + 1.0) * 0.1);
             assert!(
                 (first[lane][0][0] - want).abs() <= 2,
                 "lane {lane} came back as {} not {want}",

--- a/docs/superpowers/plans/2026-08-25-dj-knob-scroll-title-reset.md
+++ b/docs/superpowers/plans/2026-08-25-dj-knob-scroll-title-reset.md
@@ -1,0 +1,410 @@
+# DJ Knob Scroll + Title-Click Reset Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In the vj app's DJ tab, the scroll wheel adjusts any hovered knob/fader (Shift fine, Ctrl coarse, Ctrl+Shift super coarse), and clicking the title above a knob resets it to its default.
+
+**Architecture:** Scroll lives in the shared `Slider` widget as an opt-in `scroll_step` field (0 = off) that the DJ-tab DSL styles enable; the pure notch/ladder math is a unit-tested helper. Title-click reset is app-side: the `KnobLabel` DSL style is rebased from `Label` onto a flat `Button`, EQ/FILTER labels get instance names, and `main.rs` wires clicks to `SliderRef::reset_to_default` plus the same `decks.set_*` calls the knobs already use.
+
+**Tech Stack:** Rust, Makepad widgets (`script_mod!` DSL — see AGENTS.md for syntax; `Name: value`, `+:` merges), vj app.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-dj-knob-scroll-title-reset-design.md`
+
+## Global Constraints
+
+- Modifier ladder per wheel notch, fraction of range: Shift 0.5%, none 2.5%, Ctrl 10%, Ctrl+Shift 25%. Base `scroll_step: 0.025`; multipliers ×0.2 / ×1 / ×4 / ×10 are widget constants.
+- Scroll up = value up. Windows sends wheel-up as `scroll.y = -120` (one notch = 120 units).
+- `scroll_step: 0.0` (the default) must leave every existing Slider untouched.
+- Defaults come from each slider's DSL `default:` field (EQ/stems 1.0, FILTER 0.5) — never hardcode them in `main.rs`.
+- Rustfmt is disabled repo-wide — match surrounding indentation by hand, never run `cargo fmt`.
+- The repo builds with `cargo check -p <pkg>` / `cargo build --release -p <pkg>`. The vj package is `makepad-vj`; the widgets package is `makepad-widgets`.
+
+---
+
+### Task 1: Scroll handling in the Slider widget
+
+**Files:**
+- Modify: `widgets/src/slider.rs` (struct ~line 1390, `impl Slider` ~line 1489, `handle_event` ~line 1579, `impl SliderRef` ~line 1677)
+
+**Interfaces:**
+- Produces: `Slider.scroll_step: f64` live field (DSL-settable); `pub(crate) fn wheel_value_delta(scroll: Vec2d, modifiers: &KeyModifiers, scroll_step: f64) -> f64`; `Slider::reset_to_default(&mut self, cx)`; `SliderRef::reset_to_default(&self, cx) -> Option<f64>` (returns the new external value); scroll emits `SliderAction::Slide(v)` then `SliderAction::EndSlide(v)` exactly like a drag ending.
+
+- [ ] **Step 1: Write the failing unit tests** — at the bottom of `widgets/src/slider.rs`:
+
+```rust
+#[cfg(test)]
+mod wheel_tests {
+    use super::*;
+
+    fn mods(control: bool, shift: bool) -> KeyModifiers {
+        KeyModifiers { control, shift, alt: false, logo: false }
+    }
+
+    #[test]
+    fn wheel_ladder() {
+        // One Windows notch is scroll.y = -120 (wheel up) -> value moves UP.
+        let up = Vec2d { x: 0.0, y: -120.0 };
+        assert!((wheel_value_delta(up, &mods(false, false), 0.025) - 0.025).abs() < 1e-12);
+        assert!((wheel_value_delta(up, &mods(false, true), 0.025) - 0.005).abs() < 1e-12);
+        assert!((wheel_value_delta(up, &mods(true, false), 0.025) - 0.10).abs() < 1e-12);
+        assert!((wheel_value_delta(up, &mods(true, true), 0.025) - 0.25).abs() < 1e-12);
+    }
+
+    #[test]
+    fn wheel_down_decreases() {
+        let down = Vec2d { x: 0.0, y: 120.0 };
+        assert!((wheel_value_delta(down, &mods(false, false), 0.025) + 0.025).abs() < 1e-12);
+    }
+
+    #[test]
+    fn horizontal_axis_fallback() {
+        // Tilt wheels / horizontal trackpad gestures land on x when y is 0.
+        let tilt = Vec2d { x: -120.0, y: 0.0 };
+        assert!((wheel_value_delta(tilt, &mods(false, false), 0.025) - 0.025).abs() < 1e-12);
+    }
+
+    #[test]
+    fn zero_step_disables() {
+        let up = Vec2d { x: 0.0, y: -120.0 };
+        assert_eq!(wheel_value_delta(up, &mods(true, true), 0.0), 0.0);
+    }
+}
+```
+
+If `KeyModifiers` has more fields than `{shift, control, alt, logo}`, extend `mods()` with `..Default::default()` instead of listing them.
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `cargo test -p makepad-widgets wheel_` — expected: compile error, `wheel_value_delta` not found.
+
+- [ ] **Step 3: Implement the helper, the field, and the event handling**
+
+Add to the `Slider` live struct (next to `default: f64`, ~line 1390):
+
+```rust
+    /// Fraction of the value range one scroll-wheel notch moves while the
+    /// pointer hovers this slider. 0.0 (the default) disables wheel input.
+    #[live]
+    scroll_step: f64,
+```
+
+Add near the top of the file (module level, after the imports):
+
+```rust
+/// Value delta for one scroll event: notch count (Windows wheels send 120
+/// units per notch; trackpads send smaller deltas that accumulate over the
+/// gesture) times the step fraction, scaled by the modifier ladder —
+/// Shift fine (x0.2), plain (x1), Ctrl coarse (x4), Ctrl+Shift (x10).
+/// Scroll up (negative y) raises the value; a zero step disables wheel input.
+pub(crate) fn wheel_value_delta(
+    scroll: Vec2d,
+    modifiers: &KeyModifiers,
+    scroll_step: f64,
+) -> f64 {
+    if scroll_step == 0.0 {
+        return 0.0;
+    }
+    let axis = if scroll.y != 0.0 { -scroll.y } else { -scroll.x };
+    let ladder = match (modifiers.control, modifiers.shift) {
+        (true, true) => 10.0,
+        (true, false) => 4.0,
+        (false, true) => 0.2,
+        (false, false) => 1.0,
+    };
+    (axis / 120.0) * scroll_step * ladder
+}
+```
+
+Add to `impl Slider` (next to `set_value`, ~line 1493):
+
+```rust
+    /// Snap back to the DSL `default:` value, as a title-click reset does.
+    pub fn reset_to_default(&mut self, cx: &mut Cx) {
+        self.set_internal(self.default);
+        self.update_text_input(cx);
+        self.draw_bg.redraw(cx);
+    }
+```
+
+Add to `impl SliderRef` (next to its `set_value`, ~line 1686):
+
+```rust
+    /// Reset to the DSL default and return the value now in effect, so the
+    /// caller can push it into whatever the slider is bound to.
+    pub fn reset_to_default(&self, cx: &mut Cx) -> Option<f64> {
+        let mut inner = self.borrow_mut()?;
+        inner.reset_to_default(cx);
+        Some(inner.to_external())
+    }
+```
+
+(`borrow_mut` returns `Option`; if the `?` form doesn't compile in this codebase's Ref idiom, use `if let Some(mut inner) = self.borrow_mut() { ... }` returning the value.)
+
+In `handle_event`, inside `match event.hits(cx, self.draw_bg.area())` (~line 1579), add an arm after `Hit::FingerHoverOver`:
+
+```rust
+            Hit::FingerScroll(e) => {
+                if self.scroll_step > 0.0 && !self.animator_in_state(cx, ids!(disabled.on)) {
+                    let delta = wheel_value_delta(e.scroll, &e.modifiers, self.scroll_step);
+                    if delta != 0.0 && self.dragging.is_none() {
+                        self.relative_value = (self.relative_value + delta).max(0.0).min(1.0);
+                        self.set_internal(self.to_external());
+                        self.draw_bg.redraw(cx);
+                        self.update_text_input(cx);
+                        cx.widget_action(uid, SliderAction::Slide(self.to_external()));
+                        cx.widget_action(uid, SliderAction::EndSlide(self.to_external()));
+                    }
+                }
+            }
+```
+
+The `set_internal(self.to_external())` round-trip is the same quantization dragging uses (`step:` respected). Guarding on `dragging.is_none()` keeps a wheel event during an active drag from fighting the finger.
+
+- [ ] **Step 4: Run the tests, verify they pass**
+
+Run: `cargo test -p makepad-widgets wheel_` — expected: 4 passed.
+Then: `cargo check -p makepad-widgets` — expected: clean (warnings at parity with before).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add widgets/src/slider.rs
+git commit -m "widgets: Slider takes the scroll wheel — opt-in scroll_step, modifier ladder, DSL-default reset helper"
+```
+
+---
+
+### Task 2: Enable scroll on every DJ-tab control
+
+**Files:**
+- Modify: `apps/vj/src/music_view.rs` — the `MusicKnob` (~line 464), `MusicFader` (~line 526), `CrossFader` (~line 563) style blocks
+
+**Interfaces:**
+- Consumes: `scroll_step` live field from Task 1.
+- Produces: every DJ-tab knob (EQ ×3, FILTER, stems ×4 per deck), the pitch and gain faders, and the crossfader respond to the wheel; nothing else in the app does.
+
+- [ ] **Step 1: Add `scroll_step: 0.025` to the three styles**
+
+In `MusicKnob` (covers EQ, FILTER, and `StemKnob` which inherits it), directly under `default: 1.0`:
+
+```text
+        scroll_step: 0.025
+```
+
+In `MusicFader` (covers `deck_x_pitch`, `deck_x_gain`), directly under `axis: DragAxis.Vertical`:
+
+```text
+        scroll_step: 0.025
+```
+
+In `CrossFader`, directly under `max: 1.0`:
+
+```text
+        scroll_step: 0.025
+```
+
+- [ ] **Step 2: Build**
+
+Run: `cargo build --release -p makepad-vj` — expected: clean build.
+
+- [ ] **Step 3: Smoke-test scroll via the remote protocol**
+
+```bash
+./target/release/makepad-vj --remote > /tmp/vj.log 2>&1 &
+sleep 8 && PORT=$(grep -o 'listening on 127.0.0.1:[0-9]*' /tmp/vj.log | grep -o '[0-9]*$')
+```
+
+Open the DJ tab in the app window (or locate it via `curl http://127.0.0.1:$PORT/snap`), find a stem knob's rect in the snap JSON (widget id `deck_a_stem_drums`), then scroll one notch up over its center and read the value back:
+
+```bash
+curl -s "http://127.0.0.1:$PORT/snap" | jq '..|objects|select(.id?=="deck_a_stem_drums")'
+curl -s -X POST "http://127.0.0.1:$PORT/m" -d '{"action":"scroll","x":CX,"y":CY,"dy":-120}'
+curl -s "http://127.0.0.1:$PORT/snap" | jq '..|objects|select(.id?=="deck_a_stem_drums")'
+```
+
+Expected: the knob's value rises by 0.05 (2.5% of the 0–2 range). Repeat with `"mods":"shift"` / `"ctrl"` / `"ctrl shift"` (check `platform/src/remote.rs` `Params::mods` for the exact accepted spelling) and confirm 0.01 / 0.20 / 0.50 moves. Finish with `curl http://127.0.0.1:$PORT/gq`.
+
+If the snap JSON does not expose a slider value, verify by eye in the window instead and note it in the commit message.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/vj/src/music_view.rs
+git commit -m "vj: DJ-tab knobs and faders ride the scroll wheel"
+```
+
+---
+
+### Task 3: Clickable knob titles
+
+**Files:**
+- Modify: `apps/vj/src/music_view.rs` — `KnobLabel` (~line 507), the EQ/FILTER label instances (~lines 827–844 deck A, ~928–944 deck B)
+- Modify: `apps/vj/src/main.rs` — `MusicDeckRefs` (~line 2530), its constructor (~line 2565), `MusicDeckIds` (~line 2650) and both deck id tables (~lines 2701, 2754)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `KnobLabel` is a flat `Button` (emits `clicked`, hand cursor); new ids `deck_a_label_eq_low/mid/high`, `deck_a_label_filter` (same for deck B); `MusicDeckIds` gains `eq_labels: [&'static [LiveId]; 3]` (ordered low, mid, high — matching `eq_knobs`) and `filter_label: &'static [LiveId]`; `MusicDeckRefs` gains `eq_labels: Vec<ButtonRef>`, `filter_label: ButtonRef`, and `stem_labels` becomes `Vec<ButtonRef>`.
+
+- [ ] **Step 1: Rebase `KnobLabel` onto a flat Button**
+
+Replace the `KnobLabel` definition (keep the comment above it):
+
+```text
+    // A knob's legend: fills its stack, never widens it, never wraps.
+    // A flat Button rather than a Label so a click on it resets its knob.
+    let KnobLabel = Button{
+        width: Fill
+        height: Fit
+        padding: Padding{left: 0 right: 0 top: 0 bottom: 0}
+        margin: Margin{left: 0 right: 0 top: 0 bottom: 0}
+        align: Align{x: 0.5, y: 0.0}
+        draw_bg +: {
+            color: #x00000000
+            color_focus: #x00000000
+            color_hover: #x00000000
+            color_down: #x00000000
+            border_size: 0.0
+            border_radius: 0.0
+        }
+        draw_text +: {
+            color: #xa6b1bd
+            color_focus: #xa6b1bd
+            color_hover: #xd6dee6
+            color_down: #x8e9aa7
+            text_style: theme.font_bold{font_size: 7}
+        }
+    }
+```
+
+Match the stock `Button`'s actual draw_bg/draw_text uniform names — check `widgets/src/button.rs`'s script block and the `MusicButton` style above (~line 415) for the exact set; drop any that don't exist. The visual target: identical to today's label at rest, slightly lighter on hover, hand cursor.
+
+- [ ] **Step 2: Name the EQ and FILTER labels**
+
+Deck A (~lines 827–844): `KnobLabel{text: "HIGH"}` → `deck_a_label_eq_high := KnobLabel{text: "HIGH"}`, same for `MID` → `deck_a_label_eq_mid`, `LOW` → `deck_a_label_eq_low`, `FILTER` → `deck_a_label_filter`. Deck B likewise with the `deck_b_` prefix (~lines 928–944; note deck B lists FILTER first, then LOW/MID/HIGH — names follow the text, not the position).
+
+- [ ] **Step 3: Extend the id tables and refs in `main.rs`**
+
+In `MusicDeckIds` (~line 2650) add, next to `stem_labels`:
+
+```rust
+    eq_labels: [&'static [LiveId]; 3],
+    filter_label: &'static [LiveId],
+```
+
+In both deck tables (deck A ~line 2701, deck B ~line 2754), ordered like `eq_knobs` (low, mid, high):
+
+```rust
+                eq_labels: [
+                    ids!(deck_a_label_eq_low),
+                    ids!(deck_a_label_eq_mid),
+                    ids!(deck_a_label_eq_high),
+                ],
+                filter_label: ids!(deck_a_label_filter),
+```
+
+(and the `deck_b_` versions). In `MusicDeckRefs` (~line 2530) change `stem_labels: Vec<LabelRef>` to `Vec<ButtonRef>` and add `eq_labels: Vec<ButtonRef>`, `filter_label: ButtonRef`; in the constructor (~line 2565) build them with `ui.button(cx, p)` instead of `ui.label(cx, p)`:
+
+```rust
+            stem_labels: ids.stem_labels.iter().map(|p| ui.button(cx, p)).collect(),
+            eq_labels: ids.eq_labels.iter().map(|p| ui.button(cx, p)).collect(),
+            filter_label: ui.button(cx, ids.filter_label),
+```
+
+`paint_stem_knob` (~line 14798) needs no change — it colors the legend through a generic `self.ui.widget(...)` + `draw_text` apply, which works on a Button.
+
+- [ ] **Step 4: Build and check the tab still renders**
+
+Run: `cargo build --release -p makepad-vj`, launch, confirm the DJ tab looks unchanged (labels same size/color, stem labels still take their stem colors) and label hover shows the hand cursor. If a label's layout shifted (Button padding), adjust the `padding`/`margin` zeros until the stack matches the old spacing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/vj/src/music_view.rs apps/vj/src/main.rs
+git commit -m "vj: knob titles are flat buttons with names — clickable, still painted like labels"
+```
+
+---
+
+### Task 4: Title click resets the knob
+
+**Files:**
+- Modify: `apps/vj/src/main.rs` — the deck action handler (~line 16276, next to the existing `filter`/`eq_knobs`/`stem_knobs` blocks)
+
+**Interfaces:**
+- Consumes: `SliderRef::reset_to_default` (Task 1), `eq_labels`/`filter_label`/`stem_labels` refs (Task 3), existing `self.decks.set_eq / set_filter / set_stem` + `run_deck_cmds`.
+
+- [ ] **Step 1: Wire the clicks**
+
+In the handler that already contains `if let Some(value) = refs.filter.slided(actions)` (~line 16276), add alongside the matching blocks:
+
+```rust
+            if refs.filter_label.clicked(actions) {
+                if let Some(value) = refs.filter.reset_to_default(cx) {
+                    let cmds = self.decks.set_filter(deck, value as f32);
+                    self.run_deck_cmds(cx, cmds);
+                }
+            }
+            for (band, label) in refs.eq_labels.iter().enumerate() {
+                if label.clicked(actions) {
+                    if let Some(value) = refs.eq_knobs[band].reset_to_default(cx) {
+                        let cmds = self.decks.set_eq(deck, band, value as f32);
+                        self.run_deck_cmds(cx, cmds);
+                    }
+                }
+            }
+            for (stem, label) in refs.stem_labels.iter().enumerate() {
+                if label.clicked(actions) {
+                    if let Some(value) = refs.stem_knobs[stem].reset_to_default(cx) {
+                        let cmds = self.decks.set_stem(deck, stem, value as f32);
+                        self.run_deck_cmds(cx, cmds);
+                    }
+                }
+            }
+```
+
+Ordering caveat: `eq_labels` was defined low/mid/high to match `eq_knobs` (Task 3) and `stem_labels` already matches `stem_knobs` (vocals, drums, bass, other) — both arrays index-pair label→knob 1:1; do not reorder either side.
+
+- [ ] **Step 2: Build**
+
+Run: `cargo build --release -p makepad-vj` — expected: clean.
+
+- [ ] **Step 3: Verify end to end via the remote protocol**
+
+Launch with `--remote` as in Task 2. Scroll `deck_a_stem_drums` a few notches away from 1.0, then click the center of `deck_a_label_drums` (rect from `/snap`):
+
+```bash
+curl -s -X POST "http://127.0.0.1:$PORT/m" -d '{"action":"click","x":LX,"y":LY}'
+```
+
+Expected: the knob snaps back to 1.0 (value in `/snap`, pointer at 12 o'clock-ish in a screenshot via `/g`). Repeat for `deck_a_label_filter` (default 0.5) after dragging it aside. Confirm audio follows if a track is playing (stem gain audibly returns). Finish with `/gq`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/vj/src/main.rs
+git commit -m "vj: click a knob title to snap the knob home"
+```
+
+---
+
+### Task 5: Align the spec with the implemented scroll-consumption behavior
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-08-25-dj-knob-scroll-title-reset-design.md`
+
+The spec says the widget "consumes the event (the containing view must not also scroll)". The codebase's established `Hit::FingerScroll` consumers (chart, browser, portal_list) handle without a consume flag, and the DJ tab has no enclosing scroll view — so Task 1 matched that pattern instead.
+
+- [ ] **Step 1: Replace that bullet** with:
+
+```text
+  - Handles `Hit::FingerScroll` the same way the existing chart/browser
+    widgets do (no consume flag exists in the Hit API); the DJ tab has no
+    enclosing scroll view, so no scroll conflict arises.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-08-25-dj-knob-scroll-title-reset-design.md
+git commit -m "vj: spec follows the widget's real scroll-consumption pattern"
+```

--- a/docs/superpowers/specs/2026-08-25-dj-knob-scroll-title-reset-design.md
+++ b/docs/superpowers/specs/2026-08-25-dj-knob-scroll-title-reset-design.md
@@ -1,0 +1,95 @@
+# DJ tab: scroll-wheel knob control + title-click reset
+
+Date: 2026-08-25
+Scope: the vj app's DJ tab (music view) knobs and faders; one opt-in addition to the shared `Slider` widget.
+
+## Goal
+
+Two ergonomic behaviors for the DJ tab:
+
+1. Hovering any knob or fader lets the scroll wheel adjust it.
+2. Clicking the title above a knob resets that knob to its default value.
+
+## Background
+
+Every DJ-tab control is the one Rust `Slider` widget under different DSL styles in
+`apps/vj/src/music_view.rs`: `MusicKnob` (Rotary; EQ low/mid/high and the four
+stem knobs, `default: 1.0`), the FILTER knob (`default: 0.5`), `MusicFader`
+(vertical), and `CrossFader`. Titles are separate `KnobLabel` (`MusicLabel`)
+widgets stacked above each knob; stem labels already have instance names
+(used for paint colors), EQ/FILTER labels do not yet. The platform delivers
+`Hit::FingerScroll` to the hovered widget with `scroll: Vec2d` and
+`modifiers: KeyModifiers`.
+
+## Design
+
+### 1. Scroll-on-hover (widget: `widgets/src/slider.rs`)
+
+- New `#[live] scroll_step: f64` on `Slider`: the fraction of the value range
+  one wheel notch moves. `0.0` (the default) disables the feature entirely, so
+  no slider outside the DJ tab changes behavior.
+- In `handle_event`, on `Hit::FingerScroll` when `scroll_step > 0.0`:
+  - Direction: scroll up increases the value (vertical wheel axis; fall back
+    to the horizontal axis when the vertical component is zero, for tilt
+    wheels / trackpads over the crossfader).
+  - Wheel deltas are normalized to notches (sign plus magnitude scaled by the
+    platform's per-notch unit; trackpad `phase`d scrolls accumulate so smooth
+    gestures still work).
+  - Modifier ladder, per notch, as a fraction of range:
+    - Shift: 0.5% (fine)
+    - none: 2.5% (standard)
+    - Ctrl: 10% (coarse)
+    - Ctrl+Shift: 25% (super coarse)
+  - `relative_value` moves by `notches * step_fraction`, clamped to [0, 1],
+    respecting the existing `step` quantization via the same
+    `to_external`/`set_internal` round-trip dragging uses.
+  - Emits the same `Slide(value)` then `EndSlide(value)` actions as a drag, so
+    app handlers, `bind`, and the text display update through existing paths.
+  - Redraws and consumes the event (the containing view must not also scroll).
+
+### 2. Title-click reset (app: `apps/vj/src/music_view.rs` + `main.rs`)
+
+- The eight knob titles per deck become clickable: HIGH, MID, LOW, FILTER,
+  DRUMS, BASS, VOCALS, OTHER. EQ and FILTER labels gain instance names
+  (`deck_a_label_eq_high`, …, `deck_a_label_filter`, same for deck B); stem
+  labels keep their existing names.
+- `KnobLabel` is rebased from `MusicLabel` onto a flat `Button` styled to
+  render exactly like today's label (same font, colors, no background or
+  border — the same approach the stock `LinkLabel` takes), so it emits
+  `clicked` actions and shows the hand cursor on hover.
+- On click, `main.rs` resets the paired knob to its DSL default (EQ/stems
+  1.0, FILTER 0.5) and applies the value through the same per-knob handler
+  that runs when the knob is turned, so the mixer state follows.
+- Stem-title click resets the gain only; it does not change kill-button state.
+- Controls without titles (crossfader, pitch, gain, volume faders) get no
+  click-reset; pitch keeps its existing reset button. Scroll still works on
+  all of them.
+
+### 3. DSL changes (DJ tab styles)
+
+- `MusicKnob`, `StemKnob`, `MusicFader`, `CrossFader`: `scroll_step: 0.025`.
+- The modifier multipliers (×0.2, ×4, ×10) live in the widget as constants;
+  only the base step is styled.
+
+## Error handling
+
+- Scroll with `scroll_step: 0.0` falls through untouched (feature off).
+- Clamping keeps scrolled values inside [min, max]; a zero-width range
+  (min == max) ignores scroll.
+- A title click for a knob id that fails lookup is a no-op (defensive; the
+  ids are static).
+
+## Testing
+
+- vj UI test via the remote protocol: hover a stem knob, inject scroll,
+  assert the value moved by one standard notch; inject Shift/Ctrl/Ctrl+Shift
+  scrolls and assert the ladder; turn a knob then click its title and assert
+  the value snapped to default and the mixer saw it.
+- Unit test in `slider.rs` for the notch math (ladder fractions, clamping,
+  step quantization) if the existing test layout allows.
+
+## Out of scope
+
+- Sliders outside the DJ tab (they keep today's behavior).
+- Double-click-on-knob reset, per-knob custom scroll speeds, wheel
+  acceleration.

--- a/docs/superpowers/specs/2026-08-25-dj-knob-scroll-title-reset-design.md
+++ b/docs/superpowers/specs/2026-08-25-dj-knob-scroll-title-reset-design.md
@@ -45,7 +45,9 @@ widgets stacked above each knob; stem labels already have instance names
     `to_external`/`set_internal` round-trip dragging uses.
   - Emits the same `Slide(value)` then `EndSlide(value)` actions as a drag, so
     app handlers, `bind`, and the text display update through existing paths.
-  - Redraws and consumes the event (the containing view must not also scroll).
+  - Handles `Hit::FingerScroll` the same way the existing chart/browser
+    widgets do (no consume flag exists in the Hit API); the DJ tab has no
+    enclosing scroll view, so no scroll conflict arises.
 
 ### 2. Title-click reset (app: `apps/vj/src/music_view.rs` + `main.rs`)
 

--- a/libs/ai/cuda/kernels/diffusion_ops.cu
+++ b/libs/ai/cuda/kernels/diffusion_ops.cu
@@ -1804,11 +1804,27 @@ static __device__ __forceinline__ void makepad_cuda_fa_cp_async16(
         void * dst_shared,
         const void * src_global,
         int src_bytes) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
     const unsigned dst = static_cast<unsigned>(__cvta_generic_to_shared(dst_shared));
     asm volatile(
         "cp.async.cg.shared.global [%0], [%1], 16, %2;\n"
         :
         : "r"(dst), "l"(src_global), "r"(src_bytes));
+#else
+    // cp.async first exists on sm_80: same contract, synchronous. The copy
+    // lands before commit/wait (below) turn into no-ops, so the tile rings
+    // simply lose their prefetch overlap on Turing, not their contents.
+    if (src_bytes >= 16) {
+        *static_cast<uint4 *>(dst_shared) =
+            *static_cast<const uint4 *>(src_global);
+    } else {
+        unsigned char * dst = static_cast<unsigned char *>(dst_shared);
+        const unsigned char * src = static_cast<const unsigned char *>(src_global);
+        for (int i = 0; i < 16; i++) {
+            dst[i] = i < src_bytes ? src[i] : 0;
+        }
+    }
+#endif
 }
 
 // Issue the cp.async copies for one 64x128 f16 tile: 4 threads per row, 64
@@ -1839,12 +1855,16 @@ static __device__ __forceinline__ void makepad_cuda_fa_tile_async(
 // col0..col0+128) into a shared f16 tile; rows past `seq` load as zeros.
 // 4 threads per row, 32 consecutive floats each (vectorized float4 reads).
 static __device__ __forceinline__ void makepad_cuda_fa_cp_commit() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
     asm volatile("cp.async.commit_group;\n");
+#endif
 }
 
 template <int PENDING>
 static __device__ __forceinline__ void makepad_cuda_fa_cp_wait() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
     asm volatile("cp.async.wait_group %0;\n" : : "n"(PENDING));
+#endif
 }
 
 // Synchronous f16 tile load (used once for the Q tile): 4 threads per row,
@@ -2141,22 +2161,34 @@ constexpr int FA2_STAGE = FA2_BC * FA_LDQ; // halves per K/V ring stage
 constexpr size_t FA2_SMEM_TOTAL =
     4 * static_cast<size_t>(FA2_STAGE) * sizeof(__half); // K ring x2 + V ring x2
 
+// The m16n8k16 mma shapes (f16 and bf16 alike) first exist on sm_80, so on
+// older devices these are compiled out and every FA2 kernel is a no-op —
+// which is why their extern "C" launchers refuse pre-sm_80 devices with
+// cudaErrorNotSupported instead of returning a buffer of unwritten zeros.
 static __device__ __forceinline__ void makepad_cuda_fa2_mma(
         float c[4], const uint32_t a[4], const uint32_t b0, const uint32_t b1) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
     asm volatile(
         "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
         "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
         : "+f"(c[0]), "+f"(c[1]), "+f"(c[2]), "+f"(c[3])
         : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b0), "r"(b1));
+#else
+    (void) c; (void) a; (void) b0; (void) b1;
+#endif
 }
 
 static __device__ __forceinline__ void makepad_cuda_fa2_mma_bf16(
         float c[4], const uint32_t a[4], const uint32_t b0, const uint32_t b1) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
     asm volatile(
         "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
         "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
         : "+f"(c[0]), "+f"(c[1]), "+f"(c[2]), "+f"(c[3])
         : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b0), "r"(b1));
+#else
+    (void) c; (void) a; (void) b0; (void) b1;
+#endif
 }
 
 static __device__ __forceinline__ void makepad_cuda_fa2_ldmatrix_x4(
@@ -2448,6 +2480,29 @@ static __global__ void makepad_cuda_flash_attention2_f32_kernel(
     }
 }
 
+// The FA2 family and the bf16 wmma kernel are built from sm_80-only pieces
+// (m16n8k16 mma, bf16 fragments); on an older device those bodies were
+// compiled out above, so launching one would return a buffer the kernel
+// never wrote. Refuse up front with the honest error instead.
+static cudaError_t makepad_cuda_require_sm80() {
+    static int has_sm80 = -1;
+    if (has_sm80 < 0) {
+        int device = 0;
+        cudaError_t err = cudaGetDevice(&device);
+        if (err != cudaSuccess) {
+            return err;
+        }
+        int major = 0;
+        err = cudaDeviceGetAttribute(
+            &major, cudaDevAttrComputeCapabilityMajor, device);
+        if (err != cudaSuccess) {
+            return err;
+        }
+        has_sm80 = major >= 8 ? 1 : 0;
+    }
+    return has_sm80 ? cudaSuccess : cudaErrorNotSupported;
+}
+
 template<bool Causal, bool UseBf16>
 static cudaError_t makepad_cuda_flash_attention2_launch(
         const uint16_t * q,
@@ -2461,6 +2516,10 @@ static cudaError_t makepad_cuda_flash_attention2_launch(
         float scale,
         int32_t window,
         cudaStream_t stream) {
+    const cudaError_t sm80 = makepad_cuda_require_sm80();
+    if (sm80 != cudaSuccess) {
+        return sm80;
+    }
     if (q_len == 0 || head_count == 0) {
         return cudaSuccess;
     }
@@ -2610,6 +2669,9 @@ constexpr size_t FAB_SMEM_S = static_cast<size_t>(FAB_BR) * FAB_LDS * sizeof(flo
 constexpr size_t FAB_SMEM_P = static_cast<size_t>(FAB_BR) * FAB_LDS * sizeof(__nv_bfloat16);
 constexpr size_t FAB_SMEM_TOTAL = FAB_SMEM_Q + FAB_SMEM_K + FAB_SMEM_V + FAB_SMEM_S + FAB_SMEM_P;
 
+// Only referenced from the sm_80-guarded kernel body below; guarded with it
+// so the pre-sm_80 pass does not warn about unreferenced helpers.
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 800
 static __device__ __forceinline__ void makepad_cuda_fab_tile_async(
         const __nv_bfloat16 * __restrict__ src,
         __nv_bfloat16 * __restrict__ dst,
@@ -2656,6 +2718,7 @@ static __device__ __forceinline__ void makepad_cuda_fab_load_tile(
         }
     }
 }
+#endif
 
 static __global__ void makepad_cuda_flash_attention_bf16_d64_f32_kernel(
         const __nv_bfloat16 * __restrict__ q,
@@ -2666,6 +2729,7 @@ static __global__ void makepad_cuda_flash_attention_bf16_d64_f32_kernel(
         uint32_t kv_len,
         uint32_t hidden,
         float scale) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
     extern __shared__ __align__(16) char fab_smem[];
     __nv_bfloat16 * q_sh = reinterpret_cast<__nv_bfloat16 *>(fab_smem);
     __nv_bfloat16 * k_ring = reinterpret_cast<__nv_bfloat16 *>(fab_smem + FAB_SMEM_Q);
@@ -2835,6 +2899,13 @@ static __global__ void makepad_cuda_flash_attention_bf16_d64_f32_kernel(
             *reinterpret_cast<float4 *>(dst + i) = values;
         }
     }
+#else
+    // bf16 wmma fragments do not exist before sm_80 (the type itself is
+    // incomplete at compile time), so this whole kernel is compiled out and
+    // the launcher below refuses pre-sm_80 devices.
+    (void) q; (void) k; (void) v; (void) out;
+    (void) q_len; (void) kv_len; (void) hidden; (void) scale;
+#endif
 }
 
 extern "C" cudaError_t makepad_cuda_flash_attention_bf16_d64_f32(
@@ -2848,6 +2919,10 @@ extern "C" cudaError_t makepad_cuda_flash_attention_bf16_d64_f32(
         uint32_t hidden,
         float scale,
         cudaStream_t stream) {
+    const cudaError_t sm80 = makepad_cuda_require_sm80();
+    if (sm80 != cudaSuccess) {
+        return sm80;
+    }
     if (q_len == 0 || kv_len == 0 || head_count == 0 || hidden != head_count * FAB_D) {
         return cudaErrorInvalidValue;
     }
@@ -6359,6 +6434,10 @@ extern "C" cudaError_t makepad_cuda_flash_attention2_d64_f32(
         uint32_t hidden,
         float scale,
         cudaStream_t stream) {
+    const cudaError_t sm80 = makepad_cuda_require_sm80();
+    if (sm80 != cudaSuccess) {
+        return sm80;
+    }
     if (seq == 0 || head_count == 0) {
         return cudaSuccess;
     }

--- a/libs/ai/cuda/kernels/llm/fattn/common.cuh
+++ b/libs/ai/cuda/kernels/llm/fattn/common.cuh
@@ -70,8 +70,11 @@
 #endif
 
 #define GGML_UNUSED(x) (void)(x)
+// constexpr because GGML_UNUSED_VARS is called from constexpr config helpers
+// (e.g. ggml_cuda_fattn_mma_get_nstages' no-cp.async branch); a non-constexpr
+// callee poisons those on the pre-Ampere device pass.
 template <typename... Args>
-static __host__ __device__ __forceinline__ void mkllm_unused_vars(Args && ...) {}
+static __host__ __device__ __forceinline__ constexpr void mkllm_unused_vars(Args && ...) {}
 #define GGML_UNUSED_VARS(...) mkllm_unused_vars(__VA_ARGS__)
 #define GGML_ASSERT(x) do { if (!(x)) { printf("GGML_ASSERT failed: %s\n", #x); } } while (0)
 #define GGML_ABORT(...) do { printf("GGML_ABORT %s\n", #__VA_ARGS__); } while (0)

--- a/widgets/src/slider.rs
+++ b/widgets/src/slider.rs
@@ -1324,6 +1324,29 @@ script_mod! {
 
 }
 
+/// Value delta for one scroll event: notch count (Windows wheels send 120
+/// units per notch; trackpads send smaller deltas that accumulate over the
+/// gesture) times the step fraction, scaled by the modifier ladder —
+/// Shift fine (x0.2), plain (x1), Ctrl coarse (x4), Ctrl+Shift (x10).
+/// Scroll up (negative y) raises the value; a zero step disables wheel input.
+pub(crate) fn wheel_value_delta(
+    scroll: Vec2d,
+    modifiers: &KeyModifiers,
+    scroll_step: f64,
+) -> f64 {
+    if scroll_step == 0.0 {
+        return 0.0;
+    }
+    let axis = if scroll.y != 0.0 { -scroll.y } else { -scroll.x };
+    let ladder = match (modifiers.control, modifiers.shift) {
+        (true, true) => 10.0,
+        (true, false) => 4.0,
+        (false, true) => 0.2,
+        (false, false) => 1.0,
+    };
+    (axis / 120.0) * scroll_step * ladder
+}
+
 #[derive(Copy, Clone, Debug, Script, ScriptHook)]
 pub enum DragAxis {
     #[pick]
@@ -1388,6 +1411,11 @@ pub struct Slider {
     step: f64,
     #[live]
     default: f64,
+
+    /// Fraction of the value range one scroll-wheel notch moves while the
+    /// pointer hovers this slider. 0.0 (the default) disables wheel input.
+    #[live]
+    scroll_step: f64,
 
     #[live]
     bind: String,
@@ -1497,6 +1525,13 @@ impl Slider {
             self.update_text_input(cx);
         }
     }
+
+    /// Snap back to the DSL `default:` value, as a title-click reset does.
+    pub fn reset_to_default(&mut self, cx: &mut Cx) {
+        self.set_internal(self.default);
+        self.update_text_input(cx);
+        self.draw_bg.redraw(cx);
+    }
 }
 
 impl Widget for Slider {
@@ -1588,6 +1623,19 @@ impl Widget for Slider {
             }
             Hit::FingerHoverOver(_) => {
                 cx.set_cursor(MouseCursor::Grab);
+            }
+            Hit::FingerScroll(e) => {
+                if self.scroll_step > 0.0 && !self.animator_in_state(cx, ids!(disabled.on)) {
+                    let delta = wheel_value_delta(e.scroll, &e.modifiers, self.scroll_step);
+                    if delta != 0.0 && self.dragging.is_none() {
+                        self.relative_value = (self.relative_value + delta).max(0.0).min(1.0);
+                        self.set_internal(self.to_external());
+                        self.draw_bg.redraw(cx);
+                        self.update_text_input(cx);
+                        cx.widget_action(uid, SliderAction::Slide(self.to_external()));
+                        cx.widget_action(uid, SliderAction::EndSlide(self.to_external()));
+                    }
+                }
             }
             Hit::FingerDown(FingerDownEvent {
                 // abs,
@@ -1689,6 +1737,14 @@ impl SliderRef {
         }
     }
 
+    /// Reset to the DSL default and return the value now in effect, so the
+    /// caller can push it into whatever the slider is bound to.
+    pub fn reset_to_default(&self, cx: &mut Cx) -> Option<f64> {
+        let mut inner = self.borrow_mut()?;
+        inner.reset_to_default(cx);
+        Some(inner.to_external())
+    }
+
     pub fn slided(&self, actions: &Actions) -> Option<f64> {
         if let Some(item) = actions.find_widget_action(self.widget_uid()) {
             match item.cast() {
@@ -1729,5 +1785,43 @@ impl SliderRef {
         } else {
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod wheel_tests {
+    use super::*;
+
+    fn mods(control: bool, shift: bool) -> KeyModifiers {
+        KeyModifiers { control, shift, alt: false, logo: false }
+    }
+
+    #[test]
+    fn wheel_ladder() {
+        // One Windows notch is scroll.y = -120 (wheel up) -> value moves UP.
+        let up = Vec2d { x: 0.0, y: -120.0 };
+        assert!((wheel_value_delta(up, &mods(false, false), 0.025) - 0.025).abs() < 1e-12);
+        assert!((wheel_value_delta(up, &mods(false, true), 0.025) - 0.005).abs() < 1e-12);
+        assert!((wheel_value_delta(up, &mods(true, false), 0.025) - 0.10).abs() < 1e-12);
+        assert!((wheel_value_delta(up, &mods(true, true), 0.025) - 0.25).abs() < 1e-12);
+    }
+
+    #[test]
+    fn wheel_down_decreases() {
+        let down = Vec2d { x: 0.0, y: 120.0 };
+        assert!((wheel_value_delta(down, &mods(false, false), 0.025) + 0.025).abs() < 1e-12);
+    }
+
+    #[test]
+    fn horizontal_axis_fallback() {
+        // Tilt wheels / horizontal trackpad gestures land on x when y is 0.
+        let tilt = Vec2d { x: -120.0, y: 0.0 };
+        assert!((wheel_value_delta(tilt, &mods(false, false), 0.025) - 0.025).abs() < 1e-12);
+    }
+
+    #[test]
+    fn zero_step_disables() {
+        let up = Vec2d { x: 0.0, y: -120.0 };
+        assert_eq!(wheel_value_delta(up, &mods(true, true), 0.0), 0.0);
     }
 }


### PR DESCRIPTION
Four independent changes, each verified on a Turing (sm_75) Windows box.

## 1. Pre-Ampere machines get their CUDA store back

On an RTX 2080 Ti (sm_75, CUDA 13.3), two kernel files failed to compile, and because one failed kernel build drops the whole `makepad-ai-cuda` store to the no-CUDA stub, the machine silently lost **all** GPU inference. It surfaced in the VJ as `stems: model error: no compiled-graph device`.

`diffusion_ops.cu` used three sm_80-only constructs unguarded: bf16 WMMA fragments (the type is *incomplete* before Ampere, so the frontend rejects the file), `cp.async`, and the `m16n8k16` mma shapes. `llm/fattn/common.cuh` had a subtler one — `mkllm_unused_vars` was not `constexpr`, and the no-cp.async branch of `ggml_cuda_fattn_mma_get_nstages` calls it, poisoning the constexpr config chain on exactly the pre-Ampere device pass.

- `cp.async` helpers get a synchronous fallback below sm_80 — the f16 WMMA flash/sdpa kernels lose their prefetch overlap on Turing, not their contents.
- The bf16 kernel and the FA2 `mma.sync` helpers compile out below sm_80, and their launchers refuse pre-sm_80 devices with `cudaErrorNotSupported` via a shared `makepad_cuda_require_sm80()` gate — an honest per-op error rather than a buffer the kernel never wrote, matching the store's fail-closed contract.

Verified: all 13 kernels compile for sm_75 and sm_80; `stems-ops-check` binds `cuda:NVIDIA GeForce RTX 2080 Ti sm_75 (kernels sm_75)` with all cases green (RoPE 147.3 dB, batched maskless attention 136.9 dB, batched mul_mat 138.6 dB SNR vs the CPU reference); two real tracks separated end to end.

> Note: this commit is also open against `dev` as #1192, since it is useful independently of the vj work.

## 2. DJ-tab knobs take the scroll wheel, titles reset them

Spec and plan included (`docs/superpowers/`).

- `Slider` gains an opt-in `scroll_step` (0.0 = off, so no slider outside the DJ tab changes behavior). Per wheel notch, as a fraction of range: **Shift 0.5% · plain 2.5% · Ctrl 10% · Ctrl+Shift 25%**. Scroll emits the same `Slide`/`EndSlide` actions as a drag and respects `step:` quantization, so bindings and text displays update through existing paths.
- The eight knob titles per deck (HIGH/MID/LOW/FILTER/DRUMS/BASS/VOCALS/OTHER) become flat `Button`s styled to render exactly like the old labels — click resets the knob to its DSL `default:` through the same handler that runs when the knob is turned. Stem-title clicks reset gain only; kill buttons are untouched.

## 3. The fade-to-A/B fader travels instead of teleporting

Clicking `◀ A` / `B ▶` landed the on-screen crossfader on the far side instantly, which read as "the fade did nothing" — the feature looked broken even though the audio was crossing correctly the whole time.

Two places jumped: `DeckEngine::fade_to` set `crossfader` straight to the target, and the button handler pushed the slider there with `set_value`. Neither waited for the fade they had just started. The surface now mirrors the mixer instead: `Mixer::crossfader_position` reports where the fader actually is mid-ramp, and the music pump walks both the engine field and the slider across until it lands — which also means the pump has to run for a fade with both decks paused, not only for a moving deck. Touching the fader clears the tracking, because the hand outranks a running fade, exactly as it does for the visual AUTOFADE.

Measured on the DJ tab, a 4-second fade to B at half-second samples: 0.32, 0.41, 0.50, 0.60, 0.69, 0.78, 0.88, 0.97. That readout is the mixer's own fader, so it is the audible crossfade, not a separate animation.

## 4. Stem lanes keep the peaks the separator produced

BS-RoFormer's masks are complex ratios, not a partition of unity, so a stem legitimately peaks above full scale — the reference vocals stem hits 1.12, and a drums stem measured off a real track hits 1.47. The playback lanes encoded straight to i16 with a full-scale clamp, flattening every one of those peaks: ~0.05% of that track's drum samples, which is precisely the transients.

The on-disk span cache already solved this with a per-span peak stored beside the samples; the in-memory format cannot carry side data (a chunk must stay indexable arithmetically), so it takes the other trade: `STEM_CHUNK_HEADROOM`, one bit of resolution for twice the range. The constant and `encode_stem_sample` live next to `TrackStems`, and every producer goes through them — including the sidecar WAV reader, which was copying full-scale audio straight in and would otherwise have played back twice as loud.

`rebuild_stem_colour` was already immune (`stem_column_shares` normalizes by the loudest lane, so a uniform scale cancels); it undoes the headroom once per lane anyway, because a value that claims to be an amplitude should be one.

## Testing

- `cargo build --release -p makepad-vj` clean.
- `cargo test -p makepad-vj`: **525 pass, 1 fail**. The failure — `media::mode_flip_tests::a_muted_loop_goes_resident_and_parks_the_decoder` — is **pre-existing**, confirmed by stashing these changes and watching it fail on a clean tree.
- New cases: `wheel_value_delta` ladder/direction/axis-fallback/disable (widgets), `a_timed_crossfade_takes_its_duration`, `stem_lanes_carry_peaks_above_full_scale`. Existing mixer stem fixtures now build lanes through the same encoder, so they measure what playback measures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
