### PR TITLE
widgets: set_visible belongs to every widget, not just View

### DIFF
--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -4,7 +4,7 @@ use {
         animator::*,
         makepad_derive_widget::*,
         makepad_draw::*,
-        makepad_script::{script_err_wrong_value, ScriptFnRef},
+        makepad_script::ScriptFnRef,
         scroll_bars::ScrollBars,
         widget::*,
         widget_async::{
@@ -749,36 +749,6 @@ impl Widget for View {
                     id!(render),
                 )
             });
-        }
-        if method == live_id!(set_visible) {
-            if let Some(args_obj) = args.as_object() {
-                let trap = vm.bx.threads.cur().trap.pass();
-                let value = vm.bx.heap.vec_value(args_obj, 0, trap);
-                let visible = value
-                    .as_bool()
-                    .or_else(|| value.as_number().map(|n| n != 0.0));
-                match visible {
-                    Some(visible) => {
-                        vm.with_cx_mut(|cx| {
-                            if self.visible != visible {
-                                self.visible = visible;
-                                self.redraw(cx);
-                            }
-                        });
-                    }
-                    // Never guess on a bad argument: a silent default (especially
-                    // `true`) turns script bugs into invisible misbehavior. Keep
-                    // the current visibility and surface an error instead.
-                    None => {
-                        return ScriptAsyncResult::Return(script_err_wrong_value!(
-                            vm.trap(),
-                            "set_visible expects a bool (or number), got {:?}",
-                            value.value_type()
-                        ));
-                    }
-                }
-            }
-            return ScriptAsyncResult::Return(NIL);
         }
         ScriptAsyncResult::MethodNotFound
     }

--- a/widgets/src/widget.rs
+++ b/widgets/src/widget.rs
@@ -1,6 +1,7 @@
 pub use crate::register_widget;
 use {
     crate::makepad_draw::*,
+    crate::makepad_script::script_err_wrong_value,
     crate::widget_async::{ScriptAsyncId, ScriptAsyncResult},
     crate::widget_tree::{set_ui_root, CxWidgetExt},
     std::any::{Any, TypeId},
@@ -719,8 +720,46 @@ impl WidgetRef {
         method: LiveId,
         args: ScriptValue,
     ) -> ScriptAsyncResult {
-        if let Some(inner) = self.0.borrow_mut().as_mut() {
-            return inner.widget.script_call(vm, method, args);
+        {
+            let mut borrow = self.0.borrow_mut();
+            let Some(inner) = borrow.as_mut() else {
+                return ScriptAsyncResult::MethodNotFound;
+            };
+            match inner.widget.script_call(vm, method, args) {
+                ScriptAsyncResult::MethodNotFound => {}
+                handled => return handled,
+            }
+        }
+        // Visibility is a property of EVERY widget (the `Widget` trait carries
+        // it, and `#[visible]` derives it), so a script gets it on every widget
+        // too. It used to live in `View::script_call` alone, which meant
+        // `ui.some_label.set_visible(false)` raised "method not found" — the
+        // one call a responsive layout leans on hardest, silently refused on
+        // every leaf widget.
+        if method == live_id!(set_visible) {
+            let Some(args_obj) = args.as_object() else {
+                return ScriptAsyncResult::Return(NIL);
+            };
+            let trap = vm.bx.threads.cur().trap.pass();
+            let value = vm.bx.heap.vec_value(args_obj, 0, trap);
+            let visible = value
+                .as_bool()
+                .or_else(|| value.as_number().map(|n| n != 0.0));
+            // Never guess on a bad argument: a silent default (especially
+            // `true`) turns script bugs into invisible misbehavior. Keep the
+            // current visibility and surface an error instead.
+            let Some(visible) = visible else {
+                return ScriptAsyncResult::Return(script_err_wrong_value!(
+                    vm.trap(),
+                    "set_visible expects a bool (or number), got {:?}",
+                    value.value_type()
+                ));
+            };
+            vm.with_cx_mut(|cx| self.set_visible(cx, visible));
+            return ScriptAsyncResult::Return(NIL);
+        }
+        if method == live_id!(visible) {
+            return ScriptAsyncResult::Return(self.visible().into());
         }
         ScriptAsyncResult::MethodNotFound
     }


### PR DESCRIPTION
`ui.some_label.set_visible(false)` raised `widget method set_visible not found for uid WidgetUid(..)` and did nothing. `set_visible` was implemented in `View::script_call`, so it resolved on a View and on nothing else — every leaf widget refused it, even though visibility is a `Widget`-trait property that `#[visible]` derives for exactly those widgets.

It hides well: the fixed-slot list pattern wraps its rows in Views, so the common case works. What breaks is anything toggling a bare `Label` — a responsive layout that silently never reflows, with one script error per resize as the only clue.

Handled once now, in `WidgetRef::script_call`, after the widget's own `script_call` declines the method. So `set_visible` works on any widget, a `visible()` getter comes with it, and `View`'s copy is gone. A bad argument still keeps the current visibility and returns a script error rather than defaulting to `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)