### PR TITLE
script: a dead heap's resource handles must not outlive it

### DIFF
--- a/platform/src/script/res.rs
+++ b/platform/src/script/res.rs
@@ -70,6 +70,55 @@ impl CxScriptResources {
             .copied()
     }
 
+    /// Forget everything heaps in `dead` owned — call this the moment a script
+    /// heap is dropped WHOLESALE, rather than collected.
+    ///
+    /// A `heap_key` is an allocation address, so a heap that dies frees its key
+    /// for the next heap to land on. The per-handle [`CxScriptResourceGc`] only
+    /// runs when the owning heap's own GC sweeps that handle, which never
+    /// happens for a heap that is simply dropped — so its `(heap_key, path)`
+    /// entries outlive it, and the NEXT heap allocated at that address is
+    /// handed a dead heap's handle index for a path it asks about. That index
+    /// means nothing in the new heap's own (usually smaller) handle table, and
+    /// nothing notices at the time: the value sits in a font object until that
+    /// heap's next GC walks it and indexes out of bounds, in code that did
+    /// nothing wrong.
+    pub fn gc_heaps(&self, dead: &[usize]) {
+        if dead.is_empty() {
+            return;
+        }
+        let mut orphaned: Vec<(String, ScriptHandle)> = Vec::new();
+        self.handles_by_abs_path.borrow_mut().retain(|(heap_key, path), handle| {
+            if dead.contains(heap_key) {
+                orphaned.push((path.clone(), *handle));
+                return false;
+            }
+            true
+        });
+        if orphaned.is_empty() {
+            return;
+        }
+        // Handle VALUES are heap-local, so a dead heap's handle can be equal to
+        // a live heap's. Only detach one that no surviving heap still maps to.
+        let live: Vec<ScriptHandle> = self
+            .handles_by_abs_path
+            .borrow()
+            .values()
+            .copied()
+            .collect();
+        let mut resources = self.resources.borrow_mut();
+        for (abs_path, handle) in orphaned {
+            if live.contains(&handle) {
+                continue;
+            }
+            if let Some(res) = resources.iter_mut().find(|v| v.abs_path == abs_path) {
+                res.handles.retain(|h| *h != handle);
+            }
+        }
+        // An entry nobody references anymore goes with them.
+        resources.retain(|v| !v.handles.is_empty());
+    }
+
     pub fn insert_resource(&self, heap_key: usize, resource: CxScriptResource) {
         self.handles_by_abs_path.borrow_mut().insert(
             (heap_key, resource.abs_path.clone()),

--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -4,7 +4,7 @@ use {
         animator::*,
         makepad_derive_widget::*,
         makepad_draw::*,
-        makepad_script::{script_err_wrong_value, ScriptFnRef},
+        makepad_script::ScriptFnRef,
         scroll_bars::ScrollBars,
         widget::*,
         widget_async::{
@@ -749,36 +749,6 @@ impl Widget for View {
                     id!(render),
                 )
             });
-        }
-        if method == live_id!(set_visible) {
-            if let Some(args_obj) = args.as_object() {
-                let trap = vm.bx.threads.cur().trap.pass();
-                let value = vm.bx.heap.vec_value(args_obj, 0, trap);
-                let visible = value
-                    .as_bool()
-                    .or_else(|| value.as_number().map(|n| n != 0.0));
-                match visible {
-                    Some(visible) => {
-                        vm.with_cx_mut(|cx| {
-                            if self.visible != visible {
-                                self.visible = visible;
-                                self.redraw(cx);
-                            }
-                        });
-                    }
-                    // Never guess on a bad argument: a silent default (especially
-                    // `true`) turns script bugs into invisible misbehavior. Keep
-                    // the current visibility and surface an error instead.
-                    None => {
-                        return ScriptAsyncResult::Return(script_err_wrong_value!(
-                            vm.trap(),
-                            "set_visible expects a bool (or number), got {:?}",
-                            value.value_type()
-                        ));
-                    }
-                }
-            }
-            return ScriptAsyncResult::Return(NIL);
         }
         ScriptAsyncResult::MethodNotFound
     }

--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -737,6 +737,18 @@ impl Widget for View {
         args: ScriptValue,
     ) -> ScriptAsyncResult {
         if method == live_id!(render) {
+            // `me` protos off `self.source`, and the caller's `args` object
+            // travels into the VM that owns `on_render` — both are heap values,
+            // and a heap value means nothing outside the heap that minted it.
+            // Refuse when this view was minted somewhere else: rendering it
+            // would build `me` here holding another heap's object index (or
+            // plant these args over there), and nothing would notice until that
+            // heap's next GC walked the value and indexed out of bounds, in
+            // code that did nothing wrong. Includes the case that actually
+            // bites — a view whose isolate has since been torn down.
+            if !self.source.is_zero() && self.source.heap_key() != vm.bx.heap.heap_key() {
+                return ScriptAsyncResult::MethodNotFound;
+            }
             let me = self.make_render_me(vm);
             return vm.with_cx_mut(|cx| {
                 cx.widget_to_script_async_call_fwd(

--- a/widgets/src/widget.rs
+++ b/widgets/src/widget.rs
@@ -1,6 +1,7 @@
 pub use crate::register_widget;
 use {
     crate::makepad_draw::*,
+    crate::makepad_script::script_err_wrong_value,
     crate::widget_async::{ScriptAsyncId, ScriptAsyncResult},
     crate::widget_tree::{set_ui_root, CxWidgetExt},
     std::any::{Any, TypeId},
@@ -719,8 +720,46 @@ impl WidgetRef {
         method: LiveId,
         args: ScriptValue,
     ) -> ScriptAsyncResult {
-        if let Some(inner) = self.0.borrow_mut().as_mut() {
-            return inner.widget.script_call(vm, method, args);
+        {
+            let mut borrow = self.0.borrow_mut();
+            let Some(inner) = borrow.as_mut() else {
+                return ScriptAsyncResult::MethodNotFound;
+            };
+            match inner.widget.script_call(vm, method, args) {
+                ScriptAsyncResult::MethodNotFound => {}
+                handled => return handled,
+            }
+        }
+        // Visibility is a property of EVERY widget (the `Widget` trait carries
+        // it, and `#[visible]` derives it), so a script gets it on every widget
+        // too. It used to live in `View::script_call` alone, which meant
+        // `ui.some_label.set_visible(false)` raised "method not found" — the
+        // one call a responsive layout leans on hardest, silently refused on
+        // every leaf widget.
+        if method == live_id!(set_visible) {
+            let Some(args_obj) = args.as_object() else {
+                return ScriptAsyncResult::Return(NIL);
+            };
+            let trap = vm.bx.threads.cur().trap.pass();
+            let value = vm.bx.heap.vec_value(args_obj, 0, trap);
+            let visible = value
+                .as_bool()
+                .or_else(|| value.as_number().map(|n| n != 0.0));
+            // Never guess on a bad argument: a silent default (especially
+            // `true`) turns script bugs into invisible misbehavior. Keep the
+            // current visibility and surface an error instead.
+            let Some(visible) = visible else {
+                return ScriptAsyncResult::Return(script_err_wrong_value!(
+                    vm.trap(),
+                    "set_visible expects a bool (or number), got {:?}",
+                    value.value_type()
+                ));
+            };
+            vm.with_cx_mut(|cx| self.set_visible(cx, visible));
+            return ScriptAsyncResult::Return(NIL);
+        }
+        if method == live_id!(visible) {
+            return ScriptAsyncResult::Return(self.visible().into());
         }
         ScriptAsyncResult::MethodNotFound
     }

--- a/widgets/src/widget_async.rs
+++ b/widgets/src/widget_async.rs
@@ -92,6 +92,10 @@ pub fn gc_dead_splash_isolates(cx: &mut Cx) {
     // Sandbox roots and host-bridge state die with their isolates.
     crate::splash_storage::gc_roots(&dead_heaps);
     crate::splash_host::gc_bridge(&dead_heaps);
+    // And the resource cache, which is keyed by heap ADDRESS: dropping a heap
+    // frees that address for the next isolate, and a leftover entry would hand
+    // the newcomer a dead heap's handle. See `CxScriptResources::gc_heaps`.
+    cx.script_data.resources.gc_heaps(&dead_heaps);
     let state = cx.global::<CxWidgetAsync>();
     state.dead_heaps.extend(dead_heaps.iter().copied());
     for vm_id in dead {


### PR DESCRIPTION
A host that creates and drops Splash isolates dies intermittently — about one run in five here — always inside the GC and never anywhere near what caused it:

```
gc.rs:300: index out of bounds: the len is 21 but the index is 22
```

Only ever after an isolate had been torn down and another started.

**Cause.** `CxScriptResources` caches `(heap_key, abs_path) -> that heap's LOCAL handle`, and a `heap_key` is an allocation address (`Rc::as_ptr(&heap.root_objects)`). The only cleanup is `CxScriptResourceGc`, which runs when the owning heap's *own GC* sweeps that handle — and a heap that is dropped wholesale, as an isolate's is, never sweeps anything. So the entries outlive the heap, and the next isolate whose `root_objects` lands on that freed address asks for the same font and is handed the dead heap's handle index. It stores it in its own `FontMember{res, asc, desc}`, where `22` means nothing in a table of 21 handles.

Nothing notices at the time. The fault surfaces at that heap's next collection, walking a font object it had every right to walk.

**Fix.** `CxScriptResources::gc_heaps(&dead)` drops a dead heap's cache entries, and detaches handles that no surviving heap still maps to (handle values are heap-local, so two heaps' handles can be equal). Called from `gc_dead_splash_isolates` beside the storage and bridge purges — which already runs before a new isolate can allocate, so the address cannot be inherited with stale entries attached.

The general rule this is an instance of: anything keyed by `heap_key` has to be purged there, because the key is an address and addresses get reused.

**Second crossing, fixed here too.** `View::script_call(render)` built its `me` object in whatever VM happened to be calling, with the proto pointing into the *source* view's heap, and forwarded the caller's `args` object into the target VM. Render a view whose isolate has since been torn down and that object stays behind in the caller's heap holding a dead heap's index. It now refuses when `self.source.heap_key() != vm.bx.heap.heap_key()`.

Validated by looping the two reproducing tests 20× with no crash (previously ~1 in 5), then a full 71-test UI suite green.

Stacked on #1194 (both touch `View::script_call`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)