### PR TITLE
Resources: search the executable's directory, not only the working directory

### DIFF
--- a/platform/src/os/cx_native.rs
+++ b/platform/src/os/cx_native.rs
@@ -1,6 +1,13 @@
 use {
     crate::cx::Cx,
-    std::{fs::File, io::prelude::*, rc::Rc, time::SystemTime},
+    std::{
+        fs::File,
+        io::prelude::*,
+        path::{Path, PathBuf},
+        rc::Rc,
+        sync::OnceLock,
+        time::SystemTime,
+    },
 };
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
@@ -10,21 +17,58 @@ pub enum EventFlow {
     Exit,
 }
 
+/// The directory holding the running executable, queried once.
+fn exe_dir() -> Option<&'static Path> {
+    static EXE_DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
+    EXE_DIR
+        .get_or_init(|| {
+            std::env::current_exe()
+                .ok()
+                .and_then(|exe| exe.parent().map(Path::to_path_buf))
+        })
+        .as_deref()
+}
+
+/// Resolves a relative resource path against the directory holding the executable.
+///
+/// Packaged desktop layouts ship resources beside the executable and address them through a
+/// relative package root, which a plain relative open resolves against the process working
+/// directory instead. Any launcher that does not set a working directory — a URL-protocol
+/// handler, a file association, a service, a shortcut without one — then starts the app in an
+/// unrelated directory and every resource open fails, leaving a window that draws its shapes
+/// but has no fonts, icons or images. Callers retry through here so the executable's own
+/// directory is searched as well. Returns `None` for an absolute path (already anchored) and
+/// when the executable path is unavailable.
+pub fn exe_relative_path(rel: impl AsRef<Path>) -> Option<PathBuf> {
+    let rel = rel.as_ref();
+    if rel.is_absolute() {
+        return None;
+    }
+    Some(exe_dir()?.join(rel))
+}
+
+/// Reads a file at `path`, falling back to the same path resolved against the executable's
+/// directory. Returns `None` when neither location holds a readable file.
+pub fn read_file_cwd_or_exe_relative(path: impl AsRef<Path>) -> Option<Vec<u8>> {
+    fn read(path: &Path) -> Option<Vec<u8>> {
+        let mut buffer = Vec::<u8>::new();
+        File::open(path).ok()?.read_to_end(&mut buffer).ok()?;
+        Some(buffer)
+    }
+    let path = path.as_ref();
+    read(path).or_else(|| read(&exe_relative_path(path)?))
+}
+
 // lets start a websocket thread
 
 impl Cx {
     pub fn native_load_dependencies(&mut self) {
         for (path, dep) in &mut self.dependencies {
-            if let Ok(mut file_handle) = File::open(path) {
-                let mut buffer = Vec::<u8>::new();
-                if file_handle.read_to_end(&mut buffer).is_ok() {
-                    dep.data = Some(Ok(Rc::new(buffer)));
-                } else {
-                    dep.data = Some(Err("read_to_end failed".to_string()));
-                }
+            if let Some(buffer) = read_file_cwd_or_exe_relative(path) {
+                dep.data = Some(Ok(Rc::new(buffer)));
             } else {
                 println!("Could not load resource {}", path);
-                dep.data = Some(Err("File! open failed".to_string()));
+                dep.data = Some(Err(format!("Could not read resource {}", path)));
             }
         }
     }

--- a/platform/src/script/res.rs
+++ b/platform/src/script/res.rs
@@ -247,6 +247,10 @@ fn load_packaged_resource(cx: &Cx, dep_path: &str) -> Option<Rc<Vec<u8>>> {
 
 /// Try to load a resource from the packaged location on desktop.
 /// Returns None when not in packaged mode (package_root is None).
+///
+/// A relative `package_root` (the desktop packagers use `.` beside the executable) is searched
+/// both from the working directory and from the executable's own directory, because a launcher
+/// is free to start the process anywhere — see `crate::os::cx_native::exe_relative_path`.
 #[cfg(all(
     not(target_arch = "wasm32"),
     not(any(target_os = "android", target_os = "ios", target_os = "tvos")),
@@ -255,10 +259,7 @@ fn load_packaged_resource(cx: &Cx, dep_path: &str) -> Option<Rc<Vec<u8>>> {
 fn load_packaged_resource(cx: &Cx, dep_path: &str) -> Option<Rc<Vec<u8>>> {
     let root = cx.package_root.as_deref()?;
     let full_path = format!("{}/{}", root, dep_path);
-    let mut file = File::open(&full_path).ok()?;
-    let mut data = Vec::new();
-    file.read_to_end(&mut data).ok()?;
-    Some(Rc::new(data))
+    crate::os::cx_native::read_file_cwd_or_exe_relative(&full_path).map(Rc::new)
 }
 
 /// Load a file directly from the filesystem (desktop/mobile only, not wasm).


### PR DESCRIPTION
A packaged desktop build addresses its resources through a relative package root -- `cargo packager` and `robius-packaging-commands` both use `.`, with the resource trees sitting beside the executable -- and a relative `File::open` resolves against the process working directory. Any launcher that sets no working directory therefore starts the app somewhere unrelated and every font, icon and image open fails: a URL-protocol handler (`HKCR\<scheme>\shell\open\ command` carries no working directory), a file association, a service, a shortcut created without one.

The result is not a clean failure. The window comes up and lays out correctly, shader-drawn shapes and buttons render, and network-loaded images appear, but every glyph and every bundled icon is missing, because those are the parts that need a file. It reads as a renderer bug rather than a missing directory.

macOS avoids this through `apple_bundle_load_dependencies`, and a Linux `deb` package uses an absolute `/usr/lib/<name>`, so Windows is the only desktop target whose resource lookup depends on where it was started from.

Retry a failed open against the directory holding the executable. This is purely additive -- a path that resolves today resolves identically, and only an open that would have failed reaches the fallback -- so a dev build's workspace-relative dependency paths keep working unchanged.