### PR TITLE
windows: publish shader-cache entries atomically, and unwind a cancelled resize

### DIFF
--- a/platform/src/os/windows/d3d11.rs
+++ b/platform/src/os/windows/d3d11.rs
@@ -3376,10 +3376,40 @@ fn d3d_compile_hlsl(target: &str, entry: &str, shader: &str) -> Result<Vec<u8>, 
     }
 }
 
-// Cheap existence check used to decide whether a shader can go through the
-// synchronous fast path (disk reads only) or needs the async background
-// compile path. We only check existence, not contents — if the files are
-// present but corrupt/short, the subsequent read path will catch that.
+/// Whether a blob looks like a complete DXBC container.
+///
+/// The header is a `DXBC` magic, a 16-byte digest, a version, the total size and a chunk count
+/// — 32 bytes before any payload. The cache is a plain directory that any number of processes
+/// read and write, so a blob can also be a file another process is still writing; handing a
+/// truncated one to `CreateVertexShader` is how that turns into a broken window rather than a
+/// recompile.
+fn is_complete_dxbc(bytes: &[u8]) -> bool {
+    bytes.len() >= 32 && bytes.starts_with(b"DXBC")
+}
+
+/// Publishes a cache entry by writing a temporary file and renaming it into place.
+///
+/// A rename is atomic, so a concurrently starting process sees either no file or the whole
+/// one, never a prefix. Writing straight to the destination truncates it first, which is
+/// precisely the window in which a second instance reads a partial shader. The temporary name
+/// carries the process id so two writers cannot collide on it either.
+fn publish_shader_cache_entry(path: &std::path::Path, bytes: &[u8]) {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let tmp = path.with_extension(format!(
+        "{}.{}.tmp",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    if std::fs::write(&tmp, bytes).is_ok() && std::fs::rename(&tmp, path).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+}
+
+// Cheap check used to decide whether a shader can go through the synchronous fast path (disk
+// reads only) or needs the async background compile path. A file that turns out to be
+// incomplete is recompiled by the read path below, so this only has to be right often enough
+// to be worth it.
 fn shader_bytes_cached(cache_dir: Option<&std::path::Path>, cache_key: u64) -> bool {
     let Some(dir) = cache_dir else {
         return false;
@@ -3402,11 +3432,14 @@ fn get_or_compile_shader_bytes(
 ) -> Result<Vec<u8>, String> {
     if let Some(dir) = cache_dir {
         let path = dir.join(format!("{:016x}{}.dxbc", cache_key, suffix));
-        if let Ok(bytes) = std::fs::read(&path) {
-            return Ok(bytes);
+        match std::fs::read(&path) {
+            // A short read is not an error: the entry can be mid-write by another process, or
+            // left over from one that died. Recompiling costs a few milliseconds and replaces it.
+            Ok(bytes) if is_complete_dxbc(&bytes) => return Ok(bytes),
+            _ => {}
         }
         let bytes = d3d_compile_hlsl(target, entry, hlsl)?;
-        let _ = std::fs::write(&path, &bytes);
+        publish_shader_cache_entry(&path, &bytes);
         return Ok(bytes);
     }
     d3d_compile_hlsl(target, entry, hlsl)

--- a/platform/src/os/windows/d3d11.rs
+++ b/platform/src/os/windows/d3d11.rs
@@ -3376,15 +3376,21 @@ fn d3d_compile_hlsl(target: &str, entry: &str, shader: &str) -> Result<Vec<u8>, 
     }
 }
 
-/// Whether a blob looks like a complete DXBC container.
+/// Whether a blob is a complete DXBC container.
 ///
-/// The header is a `DXBC` magic, a 16-byte digest, a version, the total size and a chunk count
-/// — 32 bytes before any payload. The cache is a plain directory that any number of processes
-/// read and write, so a blob can also be a file another process is still writing; handing a
-/// truncated one to `CreateVertexShader` is how that turns into a broken window rather than a
+/// The header is a `DXBC` magic, a 16-byte digest, a version, the container's own total size
+/// and a chunk count — 32 bytes before any payload. The cache is a plain directory that any
+/// number of processes read and write, so a blob can also be a file another process is still
+/// writing, or one an older build left behind before entries were published atomically. The
+/// size field is what catches a blob truncated after its header; handing either kind to
+/// `CreateVertexShader` is how a shared cache turns into a broken window rather than a
 /// recompile.
 fn is_complete_dxbc(bytes: &[u8]) -> bool {
-    bytes.len() >= 32 && bytes.starts_with(b"DXBC")
+    if bytes.len() < 32 || !bytes.starts_with(b"DXBC") {
+        return false;
+    }
+    let total = u32::from_le_bytes([bytes[24], bytes[25], bytes[26], bytes[27]]) as usize;
+    total == bytes.len()
 }
 
 /// Publishes a cache entry by writing a temporary file and renaming it into place.
@@ -3890,5 +3896,41 @@ impl CxOsDrawShader {
             custom_uniform_buffer_ids,
             scope_uniform_buffer_id,
         })
+    }
+}
+
+#[cfg(test)]
+mod shader_cache_tests {
+    use super::is_complete_dxbc;
+
+    /// A minimal well-formed container: magic, digest, version, total size, chunk count.
+    fn dxbc(total_len: usize, payload: usize) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(b"DXBC");
+        v.extend_from_slice(&[0u8; 16]);
+        v.extend_from_slice(&1u32.to_le_bytes());
+        v.extend_from_slice(&(total_len as u32).to_le_bytes());
+        v.extend_from_slice(&0u32.to_le_bytes());
+        v.extend(std::iter::repeat(0u8).take(payload));
+        v
+    }
+
+    #[test]
+    fn a_whole_container_is_accepted() {
+        assert!(is_complete_dxbc(&dxbc(48, 16)));
+    }
+
+    #[test]
+    fn a_container_cut_short_after_its_header_is_rejected() {
+        // The shape a half-written cache entry takes: header intact, payload missing.
+        assert!(!is_complete_dxbc(&dxbc(4096, 16)));
+    }
+
+    #[test]
+    fn anything_that_is_not_a_container_is_rejected() {
+        assert!(!is_complete_dxbc(b""));
+        assert!(!is_complete_dxbc(b"DXBC"));
+        assert!(!is_complete_dxbc(&[0u8; 64]));
+        assert!(!is_complete_dxbc(&dxbc(48, 16)[..31]));
     }
 }

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -611,11 +611,20 @@ impl Win32Window {
         let style = WS_POPUP | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
         let style_ex = WS_EX_TOPMOST | WS_EX_TOOLWINDOW;
 
-        let dpi = with_win32_app(|app| app.dpi_functions.system_dpi_factor() as f64);
-        let x = (position.x * dpi) as i32;
-        let y = (position.y * dpi) as i32;
-        let w = (size.x * dpi) as i32;
-        let h = (size.y * dpi) as i32;
+        // `position` is already in physical screen pixels: the caller builds it by adding the
+        // parent window's physical origin to an offset it has itself scaled by the parent's
+        // per-monitor DPI. Scaling it again here placed the popup at `dpi` times its intended
+        // screen coordinates — exact at 100%, and progressively further away above it.
+        //
+        // The size is deliberately passed through unscaled. It is provisional: `init` runs
+        // `set_inner_size` immediately afterwards, which scales by the window's own
+        // per-monitor DPI now that the HWND exists on its target display. The system DPI used
+        // here before was the primary display's, so on a second display of a different scale
+        // it was the wrong number twice over.
+        let x = position.x as i32;
+        let y = position.y as i32;
+        let w = size.x as i32;
+        let h = size.y as i32;
 
         let hwnd = unsafe {
             CreateWindowExW(

--- a/platform/src/os/windows/win32_window.rs
+++ b/platform/src/os/windows/win32_window.rs
@@ -1093,11 +1093,19 @@ impl Win32Window {
             }
             // WM_CANCELMODE (0x001F): the system is telling the window to abandon any internal
             // mode it is in. DefWindowProc normally still leaves the move/size loop through
-            // WM_EXITSIZEMOVE, so this is a failsafe: `in_size_move` is the only thing gating
-            // position publication, and a stuck `true` would silently stop it for the window's
-            // lifetime.
+            // WM_EXITSIZEMOVE, so this is a failsafe for the state that loop arms and only that
+            // loop disarms. A stuck `in_size_move` silently stops publishing the window's
+            // position for its lifetime; a stuck resize is worse still, because the 8 ms resize
+            // timer keeps forcing repaints and `is_in_resize` keeps presenting unpaced, so the
+            // window never returns to vsync. `replace` is what keeps this precise: WM_CANCELMODE
+            // also arrives for menus and capture changes, and unwinding a resize that was not
+            // running would cost a needless `ResizeBuffers` every time one opened.
             0x001F => {
-                window.in_size_move.set(false);
+                if window.in_size_move.replace(false) {
+                    with_win32_app(|app| app.stop_resize());
+                    window.do_callback(Win32Event::WindowResizeLoopStop(window.window_id));
+                    window.send_move_event();
+                }
             }
             WM_EXITSIZEMOVE => {
                 window.in_size_move.set(false);


### PR DESCRIPTION
Just found two other ways a second instance, or an interrupted drag, leaves a window permanently degraded. Both were found auditing the backend rather than reported, and both are cheap.

The DXBC cache is a plain per-user directory that every makepad process on the machine reads and writes, and entries were written straight to their final path. `fs::write` truncates first, so a second instance starting at the same moment could read the prefix of a shader the first was still writing -- the file exists and the read succeeds, so nothing notices until `CreateVertexShader` is handed a truncated blob. `shader_bytes_cached` even documented the read path as catching this, which it did not. Entries are now written to a temporary file and renamed into place, which is atomic, and a blob that is not a complete DXBC container (the 32-byte header and its magic) is recompiled instead of used. The temporary name carries the process id so two writers cannot collide on it either.

`is_in_resize` and the 8 ms resize timer are armed by WM_ENTERSIZEMOVE and were disarmed only by WM_EXITSIZEMOVE. Win32 does not guarantee that pairing, and a drag that ends without it leaves the timer forcing repaints forever and the window presenting unpaced for the rest of its life -- it never returns to vsync. WM_CANCELMODE now unwinds the loop, gated on having actually been in it, since that message also arrives for menus and capture changes and unwinding a resize that was not running would cost a needless ResizeBuffers each time.

Verified against a release build: two instances launched simultaneously on a cold cache both come up correctly with no panics and no temporary files left behind, and window resizing is unaffected.