### PR TITLE
Linux: expose custom window chrome on Linux X11

### DIFF
--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -852,6 +852,15 @@ impl Cx {
         &self.os_type
     }
 
+    /// Linux X11: hide WM decorations (the system title bar) so the app can
+    /// draw its own chrome. Wayland already requests client-side decorations.
+    /// Call from `Startup` before the window is created.
+    pub fn set_linux_custom_window_chrome(&mut self, enable: bool) {
+        if let OsType::LinuxWindow(params) = &mut self.os_type {
+            params.custom_window_chrome = enable;
+        }
+    }
+
     /// Returns the app's writable data directory path.
     ///
     /// On Android, this is the directory returned by Activity's getFilesDir().

--- a/platform/src/os/linux/x11/linux_x11.rs
+++ b/platform/src/os/linux/x11/linux_x11.rs
@@ -551,6 +551,10 @@ impl X11Cx {
                     let gl_cx = cx.os.opengl_cx.as_ref().unwrap();
                     let window = &cx.windows[window_id];
                     let (create_position, create_inner_size) = window.create_geom();
+                    let custom_window_chrome = match &cx.os_type {
+                        OsType::LinuxWindow(params) => params.custom_window_chrome,
+                        _ => false,
+                    };
                     let opengl_window = OpenglWindow::new(
                         window_id,
                         gl_cx,
@@ -559,6 +563,7 @@ impl X11Cx {
                         &window.create_title,
                         &window.create_app_id,
                         window.is_fullscreen,
+                        custom_window_chrome,
                     );
                     let window = &mut cx.windows[window_id];
                     window.window_geom = opengl_window.window_geom.clone();

--- a/platform/src/os/linux/x11/opengl_x11.rs
+++ b/platform/src/os/linux/x11/opengl_x11.rs
@@ -347,6 +347,7 @@ impl OpenglWindow {
         title: &str,
         app_id: &str,
         is_fullscreen: bool,
+        custom_window_chrome: bool,
     ) -> OpenglWindow {
         // Checked "downcast" of the EGL platform display to a X11 display.
         assert_eq!(opengl_cx.egl_platform, egl_sys::EGL_PLATFORM_X11_EXT);
@@ -387,7 +388,6 @@ impl OpenglWindow {
             visual_info
         };
 
-        let custom_window_chrome = false;
         xlib_window.init(
             title,
             app_id,


### PR DESCRIPTION
## Summary

Wayland already requests client-side decorations (`LinuxWindowParams.custom_window_chrome = true`). X11 had the same Motif-hints path in `XlibWindow::init`, but `OpenglWindow::new` always passed `false`, so apps could not hide the window-manager title bar.

This change threads the existing `LinuxWindowParams.custom_window_chrome` flag into X11 window creation and adds a public setter:

```rust
cx.set_linux_custom_window_chrome(true);
```

Call it from `Startup` before the window is created. Other platforms ignore it.

## Motivation

Apps that draw their own caption bar (minimize / maximize / close, drag region, in-content title) need the OS frame gone. On Wayland that is the default. On X11 the WM still painted a system title bar on top of the in-app chrome, or the in-app chrome stayed hidden because `Window` keys off `params.custom_window_chrome`.

The plumbing was already there:

- `LinuxWindowParams.custom_window_chrome`
- `XlibWindow::init(..., custom_window_chrome)` writes `_MOTIF_WM_HINTS` with `decorations = 0`
- `Window` shows `caption_bar` / `windows_buttons` when the flag is set

Only the X11 create path discarded the flag.

## Public API

```rust
impl Cx {
    /// Linux X11: hide WM decorations (the system title bar) so the app can
    /// draw its own chrome. Wayland already requests client-side decorations.
    /// Call from `Startup` before the window is created.
    pub fn set_linux_custom_window_chrome(&mut self, enable: bool);
}
```

- Writes `OsType::LinuxWindow(params).custom_window_chrome`.
- No-op when `os_type` is not `LinuxWindow` (desktop other than Linux, mobile, web).
- Not a `CxOsOp`. The value must be set before `CreateWindow` runs; X11 reads it once at map time.

Default remains `false` on X11 (`X11Cx::event_loop_impl`). Wayland still starts at `true`.

## Implementation

### `cx_api.rs`

New setter next to `os_type()`. Pattern-matches `OsType::LinuxWindow` and stores the bool on `LinuxWindowParams`.

### `linux_x11.rs`

On `CxOsOp::CreateWindow`, read the flag from `cx.os_type` and pass it into `OpenglWindow::new`. Non-`LinuxWindow` variants fall back to `false`.

### `opengl_x11.rs`

`OpenglWindow::new` takes `custom_window_chrome: bool` instead of the previous hardcoded `let custom_window_chrome = false`. That value is forwarded to `XlibWindow::init`, which already applies Motif hints:

```text
_MOTIF_WM_HINTS  flags = MWM_HINTS_DECORATIONS  decorations = 0
```

No change to `xlib_window.rs`. WMs that honor Motif hints drop the frame; others may still show a border.

## How an app uses it

```rust
fn handle_startup(&mut self, cx: &mut Cx) {
    cx.set_linux_custom_window_chrome(true);
    // then create / show the Window widget as usual
}
```

After that:

| Backend | Decorations | In-app caption bar (`Window`) |
|---|---|---|
| X11, flag `false` (default) | WM title bar | Hidden |
| X11, flag `true` | Hidden (Motif hints) | Shown, with Windows-style buttons |
| Wayland | Client-side (unchanged) | Shown |

Timing matters. Setting the flag after the X11 window is mapped does not update Motif hints. Recreate the window, or add a follow-up that re-applies `_MOTIF_WM_HINTS` on an already-mapped window.