### PR TITLE
mpwm: improve Linux desktop integration and VJ startup

### DIFF
--- a/apps/mpterm/src/widget.rs
+++ b/apps/mpterm/src/widget.rs
@@ -126,7 +126,24 @@ script_mod! {
         }
         draw_text +: {
             draw_call_group: @term_text
-            text_style: theme.font_code
+            // The shell and Omarchy prompts are designed around JetBrains
+            // Mono. Liberation Mono lacks even common prompt symbols such as
+            // U+276F; keep Font Awesome as a fallback for the icon codepoints
+            // it does cover. The distro package can add a full Nerd Font
+            // member here without making mpterm depend on host fontconfig.
+            text_style: TextStyle{
+                font_family: FontFamily{
+                    latin := FontMember{
+                        res: crate_resource("self:../../widgets/resources/jetbrains_mono_variable.ttf")
+                        asc: 0.0 desc: 0.0 weight: 400.0
+                    }
+                    icons := FontMember{
+                        res: crate_resource("self:../../widgets/resources/fa-solid-900.ttf")
+                        asc: 0.0 desc: 0.0
+                    }
+                }
+                line_spacing: 1.35
+            }
         }
         draw_cell_bg +: {}
         draw_underline +: {}

--- a/apps/mpwm/src/binds.rs
+++ b/apps/mpwm/src/binds.rs
@@ -1,10 +1,10 @@
 //! The Omarchy keymap (`default/hypr/bindings/*.lua`, read from source),
 //! carried over binding-for-binding where the host OS allows.
 //!
-//! SUPER mapping: on a Linux session mpwm will own the Super key. Nested on
-//! macOS/Windows the OS reserves most Cmd/Win combos, so SUPER maps to
-//! **Ctrl+Alt** there, and Omarchy's SUPER+CTRL layer maps to
-//! **Ctrl+Alt+Cmd** (Cmd is the only modifier left).
+//! SUPER mapping: the Logo key is the direct spelling on every desktop.
+//! When mpwm is nested inside another window manager, that manager commonly
+//! consumes Logo-key chords first, so **Ctrl+Alt** is accepted as a fallback;
+//! Omarchy's SUPER+CTRL layer then maps to **Ctrl+Alt+Logo**.
 //!
 //! That leaves Omarchy's SUPER+ALT layer with no bits of its own —
 //! `KeyModifiers` carries exactly four (shift/control/alt/logo) and SUPER
@@ -251,10 +251,9 @@ pub fn keymap() -> Vec<Bind> {
     binds
 }
 
-/// How SUPER is spelled on this keyboard. macOS/Windows accept both: the
-/// Logo key (⌘, exactly Hyprland's SUPER) and Ctrl+Alt, which is the way
-/// in for the chords the host OS keeps for itself (⌘Space is Spotlight,
-/// ⌘Tab the app switcher, ⌘⇧3/4/5 screenshots).
+/// How SUPER is spelled on this keyboard. Every desktop accepts both: the
+/// Logo key (⌘ on macOS) and Ctrl+Alt, which is the way in for chords the
+/// host desktop or compositor keeps for itself.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Spelling {
     /// SUPER = the Logo key; the other three modifiers mean themselves.
@@ -265,15 +264,13 @@ pub enum Spelling {
 }
 
 /// Every spelling this OS understands, best first.
+///
+/// Linux needs the Ctrl+Alt spelling too when mpwm is nested inside a real
+/// desktop compositor: Hyprland consumes its SUPER bindings before the key
+/// event can reach mpwm. Keeping Logo first preserves direct/session use,
+/// while Ctrl+Alt provides an unclaimed way to operate the inner WM.
 pub fn spellings() -> &'static [Spelling] {
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    {
-        &[Spelling::Logo, Spelling::CtrlAlt]
-    }
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    {
-        &[Spelling::Logo]
-    }
+    &[Spelling::Logo, Spelling::CtrlAlt]
 }
 
 /// True when the event's modifiers form the given layer, read in one
@@ -428,6 +425,10 @@ mod tests {
         mods(false, true, false, true)
     }
 
+    fn fallback_sup() -> KeyModifiers {
+        mods(false, true, true, false)
+    }
+
     #[test]
     fn the_three_fullscreen_layers_are_distinct() {
         assert_eq!(
@@ -488,13 +489,25 @@ mod tests {
     fn the_alt_prefix_reaches_the_alt_layer() {
         // Without the prefix, SUPER+S toggles the scratchpad...
         assert_eq!(
-            match_bind(KeyCode::KeyS, &sup()),
+            match_bind(KeyCode::KeyS, &fallback_sup()),
             Some(WmAction::ToggleScratchpad)
         );
         // ...with it, the same chord moves the window there.
         assert_eq!(
-            match_bind_armed(KeyCode::KeyS, &sup(), true),
+            match_bind_armed(KeyCode::KeyS, &fallback_sup(), true),
             Some(WmAction::MoveToScratchpad)
+        );
+    }
+
+    #[test]
+    fn ctrl_alt_is_a_nested_super_fallback() {
+        assert_eq!(
+            match_bind(KeyCode::KeyQ, &fallback_sup()),
+            Some(WmAction::CloseWindow)
+        );
+        assert_eq!(
+            match_bind(KeyCode::ArrowLeft, &fallback_sup()),
+            Some(WmAction::FocusDir(Dir::Left))
         );
     }
 

--- a/apps/mpwm/src/main.rs
+++ b/apps/mpwm/src/main.rs
@@ -158,9 +158,56 @@ script_mod! {
 /// Windows, and macOS before the first geometry event).
 const BAR_HEIGHT_FALLBACK: f64 = 26.0;
 
-/// The bar's height and the left padding its content starts at, both
-/// derived from the OS window-button rect.
+/// The bar's height and the left padding its content starts at. macOS puts
+/// its traffic lights on the left; Linux and Windows put caption buttons on
+/// the right, where they must not push the left cluster off screen.
 type BarMetrics = (f64, f64);
+
+fn bar_metrics_for_geom(geom: &WindowGeom) -> BarMetrics {
+    let buttons = geom.window_chrome_buttons;
+    if buttons.size.y <= 0.0 {
+        return (BAR_HEIGHT_FALLBACK, 84.0);
+    }
+    let height = (buttons.pos.y * 2.0 + buttons.size.y).ceil();
+    let buttons_are_on_left = buttons.pos.x + buttons.size.x <= geom.inner_size.x * 0.5;
+    let pad_left = if buttons_are_on_left {
+        buttons.pos.x + buttons.size.x + 12.0
+    } else {
+        8.0
+    };
+    (height, pad_left)
+}
+
+#[cfg(test)]
+mod bar_chrome_tests {
+    use super::*;
+
+    #[test]
+    fn left_caption_buttons_move_the_left_cluster_past_them() {
+        let geom = WindowGeom {
+            inner_size: dvec2(1000.0, 700.0),
+            window_chrome_buttons: Rect {
+                pos: dvec2(12.0, 9.0),
+                size: dvec2(72.0, 24.0),
+            },
+            ..Default::default()
+        };
+        assert_eq!(bar_metrics_for_geom(&geom), (42.0, 96.0));
+    }
+
+    #[test]
+    fn right_caption_buttons_do_not_push_the_left_cluster_off_screen() {
+        let geom = WindowGeom {
+            inner_size: dvec2(917.0, 1030.0),
+            window_chrome_buttons: Rect {
+                pos: dvec2(779.0, 0.0),
+                size: dvec2(138.0, 29.0),
+            },
+            ..Default::default()
+        };
+        assert_eq!(bar_metrics_for_geom(&geom), (29.0, 8.0));
+    }
+}
 
 #[derive(Script, ScriptHook)]
 pub struct App {
@@ -1848,17 +1895,11 @@ impl App {
     /// The bar IS this window's caption, so it has to be tall enough to
     /// center the OS window buttons and start its own content after them.
     /// Both numbers come from the platform's traffic-light rect (points,
-    /// top-left origin) exactly like the stock caption bar does.
+    /// top-left origin) exactly like the stock caption bar does. Right-side
+    /// caption buttons affect the height only; the bar's left cluster stays
+    /// at its normal edge inset.
     fn update_bar_chrome(&mut self, cx: &mut Cx, geom: &WindowGeom) {
-        let buttons = geom.window_chrome_buttons;
-        let (height, pad_left) = if buttons.size.y > 0.0 {
-            (
-                (buttons.pos.y * 2.0 + buttons.size.y).ceil(),
-                buttons.pos.x + buttons.size.x + 12.0,
-            )
-        } else {
-            (BAR_HEIGHT_FALLBACK, 84.0)
-        };
+        let (height, pad_left) = bar_metrics_for_geom(geom);
         if self.bar_metrics == Some((height, pad_left)) {
             return;
         }

--- a/apps/mpwm/src/run_view.rs
+++ b/apps/mpwm/src/run_view.rs
@@ -386,10 +386,20 @@ impl MpRunView {
         draw_app
             .draw_vars
             .set_dyn_instance(cx, id!(packed_header), &[1.0f32]);
+        // Linux's software fallback is copied row-for-row from a top-left
+        // framebuffer and needs the historical shader flip. A GPU-shared
+        // DMA-BUF texture already has the orientation expected by the GL
+        // sampler; flipping that path turns every hosted app upside down.
         #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
-        draw_app
-            .draw_vars
-            .set_dyn_instance(cx, id!(y_flip), &[1.0f32]);
+        draw_app.draw_vars.set_dyn_instance(
+            cx,
+            id!(y_flip),
+            &[if drawn.software_buffer.is_some() {
+                1.0f32
+            } else {
+                0.0f32
+            }],
+        );
         #[cfg(not(all(target_os = "linux", not(target_env = "ohos"))))]
         draw_app
             .draw_vars


### PR DESCRIPTION
## Summary

This makes the mpwm desktop and its hosted applications usable on a nested Linux/Wayland session, and fixes the VJ shader failure encountered while validating that setup.

- accept `Ctrl+Alt` as the nested spelling of mpwm `SUPER` on Linux, because Hyprland consumes Logo-key chords before they reach the inner window manager
- keep the shell bar aligned when native caption buttons are on the right, while preserving the macOS left-side traffic-light inset
- only apply the Linux texture Y flip to software buffers; shared DMA-BUF textures are already in the orientation expected by the GL sampler
- use bundled JetBrains Mono for mpterm, with Font Awesome as an icon fallback, so common prompt symbols render consistently without depending on host fontconfig
- fix the missing separator between consecutive shader prototype spreads in `DrawSceneCube`, which caused the VJ scene shaders to cascade into hundreds of type and field errors

## User-visible results

On Arch Linux with Hyprland/Wayland:

- hosted applications render right-side up
- the mpwm menu remains visible beside right-aligned caption buttons
- `Ctrl+Alt+Q`, `Ctrl+Alt+Arrow`, workspace shortcuts, and the other nested SUPER bindings reach mpwm
- terminal text and the standard prompt glyph render with the bundled monospace font
- VJ starts without the `DrawSceneCube` / `DrawSceneAlpha` shader compilation cascade

## Validation

- `cargo test --release -p mpwm binds::tests` (8 passed)
- `cargo test --release -p mpwm bar_chrome_tests` (2 passed)
- `cargo build --release -p mpwm -p makepad-vj -p mpterm`
- `git diff --check origin/work...HEAD`
- manually launched release mpwm and VJ on Arch/Hyprland/Wayland with Intel Mesa; hosted VJ rendered upright and reached its first frame without the shader error cascade
