### PR TITLE
fix(widgets): validate show_bg + texture_caching at apply, not with a draw panic

### DIFF
--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -251,6 +251,20 @@ impl ScriptHook for View {
             self.optimize = ViewOptimize::DrawList;
         }
 
+        // A view cannot both paint its own background (`show_bg`) and be cached into a
+        // texture (`texture_caching`, or `optimize: Texture` directly): the two are
+        // mutually exclusive and would otherwise hit a hard `panic!` deep inside
+        // `draw_walk` on the first frame. Catch the conflict here, at apply/load time,
+        // with an actionable error and degrade gracefully — keep `show_bg`, drop the
+        // texture cache — so the live design still loads and the app keeps running.
+        if self.show_bg && self.optimize.is_texture() {
+            error!(
+                "View: `show_bg` and `texture_caching` are mutually exclusive; ignoring \
+                 `texture_caching` and keeping `show_bg`. Remove one of the two."
+            );
+            self.optimize = ViewOptimize::None;
+        }
+
         if self.optimize.needs_draw_list() && self.draw_list.is_none() {
             self.draw_list = Some(DrawList2d::script_new(vm));
         }


### PR DESCRIPTION
A `View` with both `show_bg: true` and `texture_caching: true` (or `optimize:
Texture` directly) hit `panic!("dont use show_bg and texture caching at the same
time")` in `draw_walk` on the first frame. The two options are statically
incompatible — known the moment the live design is applied — so panicking at draw
time is late and crashes the whole app over a config mistake.

Detect the conflict in `on_after_apply`, right after `optimize` is resolved, emit
an actionable `error!` (located at the apply site, like other widget config
errors) and degrade gracefully: keep `show_bg`, drop the texture cache
(`optimize = None`). The live design still loads and the app keeps running; the
existing `draw_walk` panic is no longer reachable from a live design.

