### PR TITLE
Splash: host->script hook calls find fns defined after a shadowing let

### DIFF
--- a/platform/script/src/opcodes_control.rs
+++ b/platform/script/src/opcodes_control.rs
@@ -44,6 +44,12 @@ impl<'a> ScriptVm<'a> {
             return;
         };
         self.bx.threads.cur().slot_base = call.prev_slot_base;
+        // A root frame's last scope holds everything the body defined after
+        // a shadowing let; keep it for host->script lookups.
+        if call.return_ip.is_none() {
+            let end = self.bx.threads.cur_ref().scopes.last().copied();
+            self.bx.threads.cur().root_end_scope = end.map(|s| self.bx.heap.new_object_ref(s));
+        }
         self.bx
             .threads
             .cur()

--- a/platform/script/src/thread.rs
+++ b/platform/script/src/thread.rs
@@ -111,6 +111,9 @@ pub struct ScriptThread {
     /// Base of the CURRENT slot frame (see CallFrame::prev_slot_base).
     pub(crate) slot_base: usize,
     pub(crate) instruction_limit_remaining: Option<usize>,
+    /// The innermost scope when the root frame returned, kept alive so
+    /// the body can hand it to host->script calls.
+    pub(crate) root_end_scope: Option<ScriptObjectRef>,
     pub trap: ScriptTrapInner,
     //pub(crate) last_err: ScriptValue,
     pub(crate) json_parser: JsonParserThread,
@@ -122,6 +125,7 @@ impl ScriptThread {
         Self {
             thread_id,
             is_paused: false,
+            root_end_scope: None,
             //last_err: NIL,
             // pre-reserve the hot stacks so steady-state execution never
             // pays Vec growth in the interpreter loop

--- a/platform/script/src/vm.rs
+++ b/platform/script/src/vm.rs
@@ -64,6 +64,9 @@ pub struct ScriptBody {
     pub parser: ScriptParser,
     pub scope: ScriptObjectRef,
     pub me: ScriptObjectRef,
+    /// The scope the body ended in, once it has run: `let`/`fn` that
+    /// shadow a name open child scopes below `scope`.
+    pub end_scope: Option<ScriptObjectRef>,
     pub checkpoint: Option<ParserCheckpoint>,
     pub source_len: usize,
 }
@@ -972,7 +975,11 @@ impl<'a> ScriptVm<'a> {
         self.bx.threads.cur().trap.ip.index = 0;
 
         // the main interpreter loop
-        self.run_core()
+        let value = self.run_core();
+        if let Some(end) = self.bx.threads.cur().root_end_scope.take() {
+            self.bx.code.bodies.borrow_mut()[body_id as usize].end_scope = Some(end);
+        }
+        value
     }
 
     /// Checks if the value has an apply transform and calls it, returning the transformed value.
@@ -1305,6 +1312,7 @@ impl<'a> ScriptVm<'a> {
             parser: ScriptParser::default(),
             scope,
             me,
+            end_scope: None,
             checkpoint: None,
             source_len: 0,
         };

--- a/platform/script/tests/hook_scope.rs
+++ b/platform/script/tests/hook_scope.rs
@@ -1,0 +1,53 @@
+//! Host->script hook lookups against a Splash-shaped body: the script is
+//! wrapped in an auto-closed object literal, and a `let`/`fn` that shadows
+//! an existing name opens a child scope the module scope cannot see into.
+//! The body remembers the scope it ended in for exactly that.
+
+use makepad_script::*;
+
+fn test_vm() -> ScriptVm<'static> {
+    let host = Box::leak(Box::new(0i32));
+    let std = Box::leak(Box::new(0i32));
+    ScriptVm { host, std, bx: Box::new(ScriptVmBase::new()) }
+}
+
+fn scopes(vm: &mut ScriptVm, file: &str) -> (ScriptObject, Option<ScriptObject>) {
+    let bodies = vm.bx.code.bodies.borrow();
+    bodies.iter().find_map(|body| match &body.source {
+        ScriptSource::Mod(m) if m.file == file => {
+            Some((body.scope.as_object(), body.end_scope.as_ref().map(|s| s.as_object())))
+        }
+        _ => None,
+    }).expect("body")
+}
+
+#[test]
+fn hooks_resolve_in_the_scope_the_body_ended_in() {
+    let mut vm = test_vm();
+    vm.bx.captured_errors = Some(Vec::new());
+    // `fs` is defined twice: the second `let` shadows and opens a child scope.
+    let code = "let fs = 1\n{height: 1, let fs = 2\nfn before(){ 7 }\nfn on_x(){ 42 }\n{}\n";
+    vm.with_instruction_limit(500_000, |vm| {
+        vm.eval(ScriptMod {
+            cargo_manifest_path: String::new(),
+            module_path: String::new(),
+            file: "hook_scope".to_string(),
+            line: 0, column: 0,
+            code: code.to_string(),
+            values: vec![],
+        })
+    });
+    let errors = vm.take_errors();
+    assert!(errors.is_empty(), "eval errored: {errors:?}");
+
+    let (module, end) = scopes(&mut vm, "hook_scope");
+    let end = end.expect("the body recorded the scope it ended in");
+    let from_module = vm.bx.heap.scope_value(module, id!(on_x), NoTrap);
+    assert!(from_module.is_nil() || from_module.is_err(), "the module scope should not see past the shadowing let");
+    let on_x = vm.bx.heap.scope_value(end, id!(on_x), NoTrap);
+    assert!(!on_x.is_nil() && !on_x.is_err(), "on_x not found in the end scope");
+    let result = vm.with_instruction_limit(500_000, |vm| vm.call(on_x, &[]));
+    assert_eq!(format!("{result:?}"), "42", "on_x returned {result:?}");
+    let before = vm.bx.heap.scope_value(end, id!(before), NoTrap);
+    assert!(!before.is_nil() && !before.is_err(), "before not found in the end scope");
+}

--- a/widgets/src/splash.rs
+++ b/widgets/src/splash.rs
@@ -552,6 +552,9 @@ impl Splash {
     /// The scope object holding this Splash body's top-level definitions, via
     /// the body id cached at eval time (with a pointer-identity fallback for
     /// robustness).
+    /// The scope the script's top-level names live in: the one its body
+    /// ended in, since a `let`/`fn` that shadows a prelude name opens a
+    /// child scope the module scope cannot see into.
     fn body_scope(&mut self, cx: &mut Cx) -> Option<ScriptObject> {
         if self.vm_id == MAIN_SPLASH_VM_ID {
             return None;
@@ -560,13 +563,14 @@ impl Splash {
         let body_id = self.body_id;
         cx.with_script_vm_id(self.vm_id, |vm| {
             let bodies = vm.bx.code.bodies.borrow();
+            let ended_in = |body: &ScriptBody| {
+                body.end_scope.as_ref().unwrap_or(&body.scope).as_object()
+            };
             if let Some(body) = body_id.and_then(|i| bodies.get(i as usize)) {
-                return Some(body.scope.as_object());
+                return Some(ended_in(body));
             }
             bodies.iter().find_map(|body| match &body.source {
-                ScriptSource::Mod(m) if m.module_path == body_key => {
-                    Some(body.scope.as_object())
-                }
+                ScriptSource::Mod(m) if m.module_path == body_key => Some(ended_in(body)),
                 _ => None,
             })
         })


### PR DESCRIPTION
`Splash::call_script_fn` looked hook names up in the module body scope. A `let`/`fn` that shadows a name already in scope makes `def_scope_value` open a child scope, and everything the script defines after it lands there, invisible from the module scope. The Splash prefix's own `let fs = mod.fs` / `let host = mod.host` are such shadows, so `on_app_resize`, the IPC hooks and every other host->script call silently found nothing, with no error anywhere. Closures kept working because they capture the innermost scope at definition, which hid the problem.

* The VM records the innermost scope when a root frame returns (`ScriptThread::root_end_scope`, stored as `ScriptBody::end_scope` by `run_root`)
* `Splash::body_scope` prefers that scope and falls back to the module scope
* Regression test `platform/script/tests/hook_scope.rs`: the module scope cannot see past the shadowing `let`, the end scope can, and the fn found there is callable
