### PR TITLE
Splash: let the host pick the theme its isolates boot with

### DIFF
--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -221,7 +221,7 @@ pub use crate::{
         WidgetSet, WidgetSetIterator, WidgetUid,
     },
     widget_async::{
-        set_widget_async_trace, CxSplashVmExt, CxWidgetToScriptCallExt, ScriptAsyncCalls,
+        set_splash_theme, set_widget_async_trace, CxSplashVmExt, CxWidgetToScriptCallExt, ScriptAsyncCalls, SplashTheme,
         ScriptAsyncId, ScriptAsyncResult, SplashVmId, MAIN_SPLASH_VM_ID,
     },
     widget_match_event::WidgetMatchEvent,

--- a/widgets/src/widget_async.rs
+++ b/widgets/src/widget_async.rs
@@ -8,7 +8,7 @@ use {
     std::any::Any,
     std::cell::RefCell,
     std::collections::{HashMap, VecDeque},
-    std::sync::atomic::{AtomicU64, Ordering},
+    std::sync::atomic::{AtomicU64, AtomicU8, Ordering},
 };
 
 static SCRIPT_ASYNC_COUNTER: AtomicU64 = AtomicU64::new(1);
@@ -31,6 +31,30 @@ impl ScriptAsyncId {
 pub struct SplashVmId(pub u64);
 
 pub const MAIN_SPLASH_VM_ID: SplashVmId = SplashVmId(0);
+
+/// The widget theme a Splash isolate boots with. A host picks its own theme
+/// after `theme_mod`, which an isolate's prelude never sees, so it says here.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum SplashTheme {
+    #[default]
+    Dark,
+    Light,
+    Skeleton,
+}
+
+static SPLASH_THEME: AtomicU8 = AtomicU8::new(0);
+
+pub fn set_splash_theme(theme: SplashTheme) {
+    SPLASH_THEME.store(theme as u8, Ordering::Relaxed);
+}
+
+fn splash_theme() -> SplashTheme {
+    match SPLASH_THEME.load(Ordering::Relaxed) {
+        1 => SplashTheme::Light,
+        2 => SplashTheme::Skeleton,
+        _ => SplashTheme::Dark,
+    }
+}
 
 thread_local! {
     /// Splash isolate VMs whose owning `Splash` widget has been dropped, awaiting
@@ -394,7 +418,17 @@ impl CxSplashVmExt for Cx {
                 bx: Box::new(ScriptVmBase::new()),
             };
             crate::makepad_draw::makepad_platform::script::script_mod(&mut vm);
-            crate::script_mod(&mut vm);
+            crate::theme_mod(&mut vm);
+            match splash_theme() {
+                SplashTheme::Light => {
+                    vm.eval(crate::makepad_script::script! { mod.theme = mod.themes.light });
+                }
+                SplashTheme::Skeleton => {
+                    vm.eval(crate::makepad_script::script! { mod.theme = mod.themes.skeleton });
+                }
+                SplashTheme::Dark => {}
+            }
+            crate::widgets_mod(&mut vm);
             // Splash isolates run untrusted-ish mini-app script; strip the
             // ambient-authority modules from the isolate's namespace entirely:
             // filesystem access (`fs`), child processes (`run`), and the resource


### PR DESCRIPTION
An isolate's widget prelude snapshots `mod.theme` when it boots, and that snapshot was always the default dark theme. Under a light host every default-colored label in an isolate drew light-on-light: `Label{}` with no explicit `draw_text` color was invisible, and a `Button`'s label vanished once the button took focus, since `color_label_inner_focus` resolves against the isolate's theme, not the host's.

* `set_splash_theme(SplashTheme)` names the theme to apply for every new isolate, between `theme_mod` and `widgets_mod`
* Defaults to `Dark`, so existing hosts are unaffected

Found while hosting mini-apps in a light-themed app: app authors had to spell out a color on every label and could still not fix the focused-button case from script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)