### PR TITLE
View: an on_item_tap hook for script-rendered lists

### DIFF
--- a/platform/src/event/finger.rs
+++ b/platform/src/event/finger.rs
@@ -487,6 +487,12 @@ impl CxFingers {
         self.captures.iter().find(|v| v.area == area).is_some()
     }
 
+    /// Whether `digit_id` is held by an area other than `area`, so a
+    /// capture-overload hit can tell a press a child already owns.
+    pub fn is_digit_captured_elsewhere(&self, digit_id: DigitId, area: Area) -> bool {
+        self.captures.iter().any(|v| v.digit_id == digit_id && v.area != area)
+    }
+
     /// The area that captured the touch with the given uid, if any.
     /// Lets a raw `Event::LongPress` handler check which widget owns the press.
     pub fn touch_capture_area(&self, uid: u64) -> Option<Area> {

--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -123,9 +123,15 @@ pub struct View {
 
     #[live]
     on_render: ScriptFnRef,
+    /// `|index|` of the direct child a tap landed on. Lives on the container
+    /// so `on_render` rows stay closure-free and drag scrolling keeps working.
+    #[live]
+    on_item_tap: ScriptFnRef,
 
     #[rust]
     script_async: ScriptAsyncCalls,
+    #[rust]
+    item_tap_live: bool,
 
     #[rust]
     scroll_bars_obj: Option<Box<ScrollBars>>,
@@ -919,6 +925,32 @@ impl Widget for View {
 
         if let Some(scroll_bars) = &mut self.scroll_bars_obj {
             scroll_bars.handle_scroll_event(cx, event, scope, &mut Vec::new());
+        }
+
+        // After the scroll bars so their drag capture comes first; the overload
+        // lets this view capture the same press alongside it.
+        if self.visible && self.on_item_tap.as_object() != ScriptObject::ZERO {
+            match event.hits_with_capture_overload(cx, self.area(), true) {
+                Hit::FingerDown(e) => {
+                    // A child that already owns this press (a Button) gets the tap.
+                    self.item_tap_live = !cx.fingers.is_digit_captured_elsewhere(e.digit_id, self.area());
+                }
+                Hit::FingerUp(e) if e.was_tap() && self.item_tap_live => {
+                    self.item_tap_live = false;
+                    let index = self.children.iter()
+                        .position(|(_, child)| child.area().rect(cx).contains(e.abs));
+                    if let Some(index) = index {
+                        cx.widget_to_script_call(
+                            uid,
+                            NIL,
+                            self.source.clone(),
+                            self.on_item_tap.clone(),
+                            &[(index as f64).into()],
+                        );
+                    }
+                }
+                _ => (),
+            }
         }
     }
 

--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -937,8 +937,9 @@ impl Widget for View {
                 }
                 Hit::FingerUp(e) if e.was_tap() && self.item_tap_live => {
                     self.item_tap_live = false;
+                    // clipped_rect: scrolled and clipped, like the hit test itself.
                     let index = self.children.iter()
-                        .position(|(_, child)| child.area().rect(cx).contains(e.abs));
+                        .position(|(_, child)| child.area().clipped_rect(cx).contains(e.abs));
                     if let Some(index) = index {
                         cx.widget_to_script_call(
                             uid,

--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -929,7 +929,9 @@ impl Widget for View {
 
         // After the scroll bars so their drag capture comes first; the overload
         // lets this view capture the same press alongside it.
-        if self.visible && self.on_item_tap.as_object() != ScriptObject::ZERO {
+        if fling_caught {
+            self.item_tap_live = false;
+        } else if self.visible && self.on_item_tap.as_object() != ScriptObject::ZERO {
             match event.hits_with_capture_overload(cx, self.area(), true) {
                 Hit::FingerDown(e) => {
                     // A child that already owns this press (a Button) gets the tap.


### PR DESCRIPTION
Rows built inside `on_render` can't carry `on_click` closures: attaching one stops the list re-rendering. So a script-rendered list had no way to be tappable at all.

* `on_item_tap: |index|` on the container fires with the direct child under the tap
* It runs after the scroll bars with capture overload, so a press still starts a drag scroll and a `Button` child keeps its own click
* Rows are hit-tested with `clipped_rect`, so a scrolled list maps a tap to the row actually under the finger
* A press that catches a fling stops the scroll and doesn't count as a tap

Three commits kept separate: the hook, then the two hit-testing fixes found while using it. Driving 12 list-based mini-apps in a Splash host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)