### PR TITLE
wayland: client-side decorations that cast a real shadow

### DIFF
--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -245,8 +245,8 @@ pub use {
         web_socket::{WebSocket, WebSocketMessage},
         window::{
             CxWindowPool, MacosWindowChrome, MacosWindowConfig, MacosWindowKind, MacosWindowLevel,
-            ScriptWindowHandle, WindowBackdrop, WindowHandle, WindowIcon, WindowIconBuffer,
-            WindowId, WindowVisuals,
+            ScriptWindowHandle, WaylandDecorationPreference, WindowBackdrop, WindowHandle,
+            WindowIcon, WindowIconBuffer, WindowId, WindowVisuals,
         },
         xr_tsdf::{
             ChunkKey, SparseTsdGridReadSnapshot, SparseTsdReadChunk, TsdfPublishedSnapshot,

--- a/platform/src/os/linux/opengl_cx.rs
+++ b/platform/src/os/linux/opengl_cx.rs
@@ -281,6 +281,31 @@ impl OpenglCx {
         }
     }
 
+    /// Makes this context current on `egl_surface` for both drawing and reading.
+    ///
+    /// Wayland must bind the target surface before resizing its `wl_egl_window`:
+    /// some EGL implementations defer a resize of a non-current surface until
+    /// the next swap, which would render one frame with mismatched buffer geometry.
+    pub(crate) fn make_current_with_surface(&self, egl_surface: egl_sys::EGLSurface) -> bool {
+        unsafe {
+            let ok = (self.libegl.eglMakeCurrent.unwrap())(
+                self.egl_display,
+                egl_surface,
+                egl_surface,
+                self.egl_context,
+            );
+            if ok == 0 {
+                // `eglGetError` is called outside the latch: it clears EGL's per-thread
+                // error, and skipping it would leak a stale code into the next report.
+                let egl_error = (self.libegl.eglGetError.unwrap())();
+                self.report_egl_error("eglMakeCurrent(window surface)", egl_error);
+                return false;
+            }
+            self.make_current_error_logged.set(false);
+            true
+        }
+    }
+
     /// Logs an `eglMakeCurrent` failure once per outage, naming a lost context explicitly
     /// so a report of "the window went black" arrives with its cause attached.
     fn report_egl_error(&self, what: &str, egl_error: egl_sys::EGLint) {
@@ -330,20 +355,9 @@ impl Cx {
         unsafe {
             let gl = self.os.gl();
             let opengl_cx = self.os.opengl_cx.as_ref().unwrap();
-            let make_current_ok = (opengl_cx.libegl.eglMakeCurrent.unwrap())(
-                opengl_cx.egl_display,
-                egl_surface,
-                egl_surface,
-                opengl_cx.egl_context,
-            );
-            if make_current_ok == 0 {
-                // `eglGetError` is called outside the latch: it clears EGL's per-thread
-                // error, and skipping it would leak a stale code into the next report.
-                let egl_error = (opengl_cx.libegl.eglGetError.unwrap())();
-                opengl_cx.report_egl_error("eglMakeCurrent", egl_error);
+            if !opengl_cx.make_current_with_surface(egl_surface) {
                 return false;
             }
-            opengl_cx.make_current_error_logged.set(false);
             // Apply the configured swap interval (vsync) on the now-current window surface.
             // Re-applied per frame because it is surface-scoped and surfaces are recreated
             // on resize; the call is cheap and idempotent.

--- a/platform/src/os/linux/wayland/linux_wayland.rs
+++ b/platform/src/os/linux/wayland/linux_wayland.rs
@@ -37,7 +37,8 @@ use crate::{
     gpu_info::GpuPerformance,
     texture::TextureFormat,
     Area, Cx, CxDrawPassParent, CxOsOp, CxWindowPool, Event, KeyModifiers, MouseButton,
-    MouseMoveEvent, MouseUpEvent, SignalToUI, WindowClosedEvent, WindowGeomChangeEvent,
+    MouseMoveEvent, MouseUpEvent, SignalToUI, WaylandDecorationPreference, WindowClosedEvent,
+    WindowGeomChangeEvent,
 };
 use wayland_client::protocol::{wl_keyboard, wl_pointer};
 use wayland_client::{Connection, Proxy};
@@ -48,6 +49,41 @@ fn log_linux_backdrop_unsupported_once() {
     LOG_ONCE.call_once(|| {
         crate::log!("Window backdrop requested on Linux/Wayland; compositor backdrop blur is not supported in M1 (no-op).");
     });
+}
+
+fn parse_decoration_preference(value: &str) -> Option<WaylandDecorationPreference> {
+    match value {
+        "server" | "server-side" => Some(WaylandDecorationPreference::ServerSide),
+        "client" | "client-side" => Some(WaylandDecorationPreference::ClientSide),
+        _ => None,
+    }
+}
+
+fn decoration_preference_override() -> Option<WaylandDecorationPreference> {
+    std::env::args_os()
+        .find_map(|arg| {
+            arg.to_str()
+                .and_then(|arg| arg.strip_prefix("--wayland-decoration="))
+                .and_then(parse_decoration_preference)
+        })
+        .or_else(|| {
+            std::env::var("MAKEPAD_WAYLAND_DECORATION")
+                .ok()
+                .as_deref()
+                .and_then(parse_decoration_preference)
+        })
+}
+
+/// Whether a window's surface may be promised opaque to the compositor.
+///
+/// This is the same decision the macOS backend makes from the same two fields for its
+/// layer's `opaque` flag, and the one the Windows backend makes before enabling
+/// composition, so a window that is opaque on one platform is opaque on all of them.
+/// `transparent` is the documented opt-in for a see-through window; a backdrop effect
+/// needs the surface translucent to sample what is behind it, so it forfeits the
+/// promise as well, whether or not this platform implements it yet.
+fn window_is_opaque(transparent: bool, backdrop: crate::window::WindowBackdrop) -> bool {
+    !transparent && backdrop == crate::window::WindowBackdrop::None
 }
 
 pub fn wayland_event_loop(cx: Rc<RefCell<Cx>>) {
@@ -64,6 +100,7 @@ pub(crate) struct WaylandCx {
     /// callbacks the compositor withholds) from wedging the event loop. Disabled by
     /// `MAKEPAD_NO_VSYNC` for uncapped benchmarking.
     frame_pacing: bool,
+    decoration_preference_override: Option<WaylandDecorationPreference>,
 }
 
 impl WaylandCx {
@@ -79,6 +116,7 @@ impl WaylandCx {
             cx: cx.clone(),
             qhandle: None,
             frame_pacing: std::env::var_os("MAKEPAD_NO_VSYNC").is_none(),
+            decoration_preference_override: decoration_preference_override(),
         }));
         let conn = Connection::connect_to_env().unwrap();
         let display = conn.display();
@@ -187,39 +225,31 @@ impl WaylandCx {
                 // do this here because mac
                 let mut cx = self.cx.borrow_mut();
 
-                // When drawing our own window chrome (no server-side decorations),
-                // populate the chrome buttons bounding box: three buttons right-aligned
-                // at the top of the caption bar, matching the Makepad widget layout.
-                if matches!(
-                    cx.os_type(),
-                    OsType::LinuxWindow(LinuxWindowParams {
-                        custom_window_chrome: true,
-                        ..
-                    })
-                ) {
-                    const BUTTONS_W: f64 = 46.0 * 3.0;
-                    const BUTTONS_H: f64 = 29.0;
-                    let w = re.new_geom.inner_size.x;
-                    re.new_geom.window_chrome_buttons = Rect {
-                        pos: Vec2d {
-                            x: w - BUTTONS_W,
-                            y: 0.0,
-                        },
-                        size: Vec2d {
-                            x: BUTTONS_W,
-                            y: BUTTONS_H,
-                        },
-                    };
-                }
-
-                if let Some(window) = state
+                let window_index = state
                     .windows
-                    .iter_mut()
-                    .find(|w| w.window_id == re.window_id)
-                {
+                    .iter()
+                    .position(|window| window.window_id == re.window_id);
+                // Wayland's native surface state does not know the geometry of
+                // Makepad-drawn buttons. Populate it after DPI conversion below.
+                re.new_geom.window_chrome_buttons = Rect::default();
+
+                if let Some(window_index) = window_index {
                     // compare in native units, before new_geom is converted below
-                    let geom_changed = re.old_geom.inner_size != re.new_geom.inner_size
-                        || re.old_geom.dpi_factor != re.new_geom.dpi_factor;
+                    let window = &mut state.windows[window_index];
+                    let uses_csd = window.uses_client_side_decorations;
+                    let is_fullscreen = window.is_fullscreen;
+                    let old_chrome_buttons =
+                        cx.windows[re.window_id].window_geom.window_chrome_buttons;
+                    let decoration_changed = {
+                        let cx_window = &cx.windows[re.window_id];
+                        cx_window.uses_client_side_decorations != uses_csd
+                            || cx_window.wayland_is_fullscreen != is_fullscreen
+                    };
+                    let geom_changed = decoration_changed
+                        || window.csd_shadow_needs_update()
+                        || re.old_geom.inner_size != re.new_geom.inner_size
+                        || re.old_geom.dpi_factor != re.new_geom.dpi_factor
+                        || re.old_geom.is_fullscreen != re.new_geom.is_fullscreen;
 
                     // Keep the wayland geom native (buffer/viewport size + the next resize's dpi come
                     // from it). Store the zoomed geom here and the next resize reads its dpi back as
@@ -228,9 +258,19 @@ impl WaylandCx {
                     window.window_geom = re.new_geom.clone();
                     {
                         let cx_window = &mut cx.windows[re.window_id];
+                        cx_window.uses_client_side_decorations = uses_csd;
+                        cx_window.wayland_is_fullscreen = is_fullscreen;
                         cx_window.os_dpi_factor = Some(re.new_geom.dpi_factor);
                         re.new_geom = cx_window.native_window_geom_to_layout(re.new_geom);
                     }
+                    if uses_csd && !is_fullscreen {
+                        const BUTTONS_SIZE: Vec2d = Vec2d { x: 138.0, y: 29.0 };
+                        re.new_geom.window_chrome_buttons = Rect {
+                            pos: dvec2(re.new_geom.inner_size.x - BUTTONS_SIZE.x, 0.0),
+                            size: BUTTONS_SIZE,
+                        };
+                    }
+                    re.old_geom.window_chrome_buttons = old_chrome_buttons;
                     cx.windows[re.window_id].window_geom = re.new_geom.clone();
                     // redraw when the size or scale changed
                     if geom_changed {
@@ -547,8 +587,17 @@ impl WaylandCx {
         }
         cx.call_event_handler(&Event::WindowClosed(WindowClosedEvent { window_id }));
         cx.windows[window_id].is_created = false;
-        if state.pointer_window == Some(window_id) {
+        // The pointer may have been over the window's shadow gutter rather than the
+        // window, which leaves no `pointer_window` to match on.
+        if state.pointer_window == Some(window_id)
+            || state
+                .pointer_shadow
+                .is_some_and(|(shadow_window, _)| shadow_window == window_id)
+        {
             state.pointer_window = None;
+            state.pointer_shadow = None;
+            state.pointer_enter_serial = None;
+            state.last_resize_edge = None;
         }
         if state.keyboard_window == Some(window_id) {
             state.keyboard_window = None;
@@ -576,8 +625,17 @@ impl WaylandCx {
         let mut cx = self.cx.borrow_mut();
         cx.call_event_handler(&Event::WindowClosed(event));
         cx.windows[window_id].is_created = false;
-        if state.pointer_window == Some(window_id) {
+        // The pointer may have been over the window's shadow gutter rather than the
+        // window, which leaves no `pointer_window` to match on.
+        if state.pointer_window == Some(window_id)
+            || state
+                .pointer_shadow
+                .is_some_and(|(shadow_window, _)| shadow_window == window_id)
+        {
             state.pointer_window = None;
+            state.pointer_shadow = None;
+            state.pointer_enter_serial = None;
+            state.last_resize_edge = None;
         }
         if state.keyboard_window == Some(window_id) {
             state.keyboard_window = None;
@@ -640,9 +698,13 @@ impl WaylandCx {
                     } else {
                         &window.create_app_id
                     };
+                    let decoration_preference = self
+                        .decoration_preference_override
+                        .unwrap_or(window.wayland_decorations);
                     let window = WaylandWindow::new(
                         window_id,
                         compositor,
+                        state.subcompositor.as_ref(),
                         wm_base,
                         state.decoration_manager.as_ref(),
                         state.scale_manager.as_ref(),
@@ -656,6 +718,7 @@ impl WaylandCx {
                         &window.create_title,
                         app_id,
                         window.is_fullscreen,
+                        decoration_preference,
                     );
                     if cx.windows[window_id].backdrop != crate::window::WindowBackdrop::None {
                         log_linux_backdrop_unsupported_once();
@@ -668,8 +731,12 @@ impl WaylandCx {
                     // Seed the geom too: the default `dpi_factor` is 0.0, which would make
                     // `get_pass_rect()` produce NaN once the flag is on.
                     let native_geom = window.window_geom.clone();
+                    let uses_client_side_decorations = window.uses_client_side_decorations;
+                    let is_fullscreen = window.is_fullscreen;
                     state.windows.push(window);
                     let cx_window = &mut cx.windows[window_id];
+                    cx_window.uses_client_side_decorations = uses_client_side_decorations;
+                    cx_window.wayland_is_fullscreen = is_fullscreen;
                     cx_window.os_dpi_factor = Some(native_geom.dpi_factor);
                     let layout_geom = cx_window.native_window_geom_to_layout(native_geom);
                     cx_window.window_geom = layout_geom;
@@ -766,25 +833,20 @@ impl WaylandCx {
                     }
                 }
                 CxOsOp::ResizeWindow(window_id, size) => {
-                    // A Wayland client has no "set my size" request. Window geometry is by
-                    // default whatever the surface commits -- `xdg_surface.set_window_geometry`:
-                    // "If never set, the value is the full bounds of the surface ... This
-                    // updates dynamically on every commit" -- and this backend never sets it,
-                    // so a self-resize is just the next frame committed at a different extent.
-                    // The paint path derives the EGL extent and the viewport destination from
-                    // `window_geom.inner_size`, so writing it here is the whole operation.
+                    // A Wayland client has no "set my size" request. A self-resize changes the
+                    // next EGL buffer, viewport destination, and explicit xdg window geometry;
+                    // the latter excludes any CSD shadow subsurfaces from placement and snapping.
                     //
                     // Only a floating toplevel may choose its own size. Under xdg_toplevel's
                     // `maximized` state the configured window geometry must be obeyed "or the
                     // xdg_wm_base.invalid_surface_state error is raised", which disconnects the
-                    // client; under `fullscreen` the configured geometry is a maximum. The
-                    // configure handler folds both states into `is_fullscreen`, so that one
-                    // flag gates the operation. Popups take their extent from their positioner
-                    // and are deliberately not matched here.
+                    // client; under `fullscreen` the configured geometry is a maximum. Popups
+                    // take their extent from their positioner and are deliberately not matched
+                    // here.
                     if let Some(window) =
                         state.windows.iter_mut().find(|w| w.window_id == window_id)
                     {
-                        if window.window_geom.is_fullscreen {
+                        if window.is_maximized || window.is_fullscreen {
                             crate::error!(
                                 "ResizeWindow ignored: a maximized or fullscreen Wayland toplevel \
                                  must keep the size the compositor configured."
@@ -818,9 +880,9 @@ impl WaylandCx {
                 // by a restored position the way it can be on Windows, macOS and X11.
                 // xdg_toplevel exposes no absolute-positioning request: `move` is
                 // interactive and serial-gated ("This request must be used in response to
-                // some sort of user action"), and `reposition` is an xdg_popup request
-                // requiring xdg_wm_base v3, which `wayland_state.rs` does not bind. This arm
-                // is correct as a permanent no-op.
+                // some sort of user action"). `xdg_popup.reposition` only moves a popup
+                // relative to its parent using a new positioner; it cannot place a toplevel at
+                // absolute screen coordinates. This arm is therefore a permanent no-op.
                 CxOsOp::RepositionWindow(_window_id, _size) => {}
                 CxOsOp::SetWindowTitle(window_id, title) => {
                     if let Some(window) = state.windows.iter().find(|w| w.window_id == window_id) {
@@ -865,9 +927,15 @@ impl WaylandCx {
                     cx.call_event_handler(&Event::DragEnd);
                 }
                 CxOsOp::SetCursor(cursor) => {
-                    if let Some(cursor_shape) = state.cursor_shape.as_ref() {
-                        if let Some(serial) = state.pointer_serial.as_ref() {
-                            cursor_shape.set_shape(*serial, cursor.into());
+                    state.requested_cursor = cursor;
+                    // Native CSD resize hit-testing owns the cursor at an edge, and in the
+                    // shadow gutter the pointer is outside the window entirely, so the app
+                    // has no say over it there either.
+                    if state.last_resize_edge.is_none() && state.pointer_shadow.is_none() {
+                        if let Some(cursor_shape) = state.cursor_shape.as_ref() {
+                            if let Some(serial) = state.pointer_enter_serial.as_ref() {
+                                cursor_shape.set_shape(*serial, cursor.into());
+                            }
                         }
                     }
                 }
@@ -1176,13 +1244,26 @@ impl WaylandCx {
                         continue;
                     }
                     let mut presented = false;
+                    let opaque = {
+                        let cx_window = &cx.windows[window_id];
+                        window_is_opaque(cx_window.transparent, cx_window.backdrop)
+                    };
+                    let compositor = state.compositor.clone();
                     if let Some(window) =
                         state.windows.iter_mut().find(|w| w.window_id == window_id)
                     {
                         if !window.configured {
                             continue;
                         }
-                        window.resize_buffers();
+                        if !window.prepare_buffer_size(cx.os.opengl_cx.as_ref().unwrap()) {
+                            continue;
+                        }
+                        window.prepare_csd_shadow();
+                        if let (Some(compositor), Some(qhandle)) =
+                            (compositor.as_ref(), self.qhandle.as_ref())
+                        {
+                            window.sync_opaque_region(compositor, qhandle, opaque);
+                        }
                         if std::env::var_os("MAKEPAD_WAYLAND_TRACE").is_some() {
                             crate::log!(
                                 "Wayland paint window={:?} inner=({}, {}) dpi={} pix=({}, {})",
@@ -1199,8 +1280,7 @@ impl WaylandCx {
                             // `wp_viewport.set_destination` raises the `bad_value` protocol
                             // error, which disconnects the client, on a zero or negative
                             // extent, and a float-to-int cast turns both a negative and a NaN
-                            // into zero. Floor the destination the way `resize_buffers` floors
-                            // the EGL extent.
+                            // into zero. Floor the destination the same way as the EGL extent.
                             viewport.set_destination(
                                 window.window_geom.inner_size.x.max(1.0) as i32,
                                 window.window_geom.inner_size.y.max(1.0) as i32,
@@ -1230,14 +1310,15 @@ impl WaylandCx {
                         if !window.configured {
                             continue;
                         }
-                        window.resize_buffers();
+                        if !window.prepare_buffer_size(cx.os.opengl_cx.as_ref().unwrap()) {
+                            continue;
+                        }
                         if let Some(viewport) = window.viewport.as_ref() {
                             viewport.set_source(-1., -1., -1., -1.);
                             // `wp_viewport.set_destination` raises the `bad_value` protocol
                             // error, which disconnects the client, on a zero or negative
                             // extent, and a float-to-int cast turns both a negative and a NaN
-                            // into zero. Floor the destination the way `resize_buffers` floors
-                            // the EGL extent.
+                            // into zero. Floor the destination the same way as the EGL extent.
                             viewport.set_destination(
                                 window.window_geom.inner_size.x.max(1.0) as i32,
                                 window.window_geom.inner_size.y.max(1.0) as i32,
@@ -1274,5 +1355,35 @@ impl WaylandCx {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_a_window_that_asked_for_translucency_gives_up_the_opaque_promise() {
+        use crate::window::WindowBackdrop;
+        assert!(window_is_opaque(false, WindowBackdrop::None));
+        // Promising opacity for a window that wanted to be see-through would leave
+        // whatever is behind it on screen, so both opt-ins must veto it.
+        assert!(!window_is_opaque(true, WindowBackdrop::None));
+        assert!(!window_is_opaque(false, WindowBackdrop::Blur));
+        assert!(!window_is_opaque(false, WindowBackdrop::Acrylic));
+        assert!(!window_is_opaque(true, WindowBackdrop::Blur));
+    }
+
+    #[test]
+    fn parses_wayland_decoration_override_values() {
+        assert_eq!(
+            parse_decoration_preference("server"),
+            Some(WaylandDecorationPreference::ServerSide)
+        );
+        assert_eq!(
+            parse_decoration_preference("client-side"),
+            Some(WaylandDecorationPreference::ClientSide)
+        );
+        assert_eq!(parse_decoration_preference("invalid"), None);
     }
 }

--- a/platform/src/os/linux/wayland/opengl_wayland.rs
+++ b/platform/src/os/linux/wayland/opengl_wayland.rs
@@ -1,16 +1,21 @@
 #![allow(unused_imports)]
 use std::fs::File;
 use std::os::fd::{AsFd, AsRawFd, FromRawFd};
+use std::sync::Once;
 
 use crate::egl_sys::{EGLNativeWindowType, EGLSurface, NativeWindowType};
 use crate::makepad_math::Vec2d;
 use wayland_client::protocol::__interfaces::WL_OUTPUT_INTERFACE;
-use wayland_client::protocol::{wl_buffer, wl_compositor, wl_shm, wl_shm_pool, wl_surface};
+use wayland_client::protocol::{
+    wl_buffer, wl_compositor, wl_region, wl_shm, wl_shm_pool, wl_subcompositor, wl_subsurface,
+    wl_surface,
+};
 use wayland_client::{Proxy, QueueHandle};
 use wayland_egl::WlEglSurface;
 use wayland_protocols::wp::fractional_scale::v1::client::{
     wp_fractional_scale_manager_v1, wp_fractional_scale_v1,
 };
+use wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1;
 use wayland_protocols::wp::viewporter::client::{wp_viewport, wp_viewporter};
 use wayland_protocols::xdg::decoration::zv1::client::{
     zxdg_decoration_manager_v1, zxdg_toplevel_decoration_v1,
@@ -26,7 +31,9 @@ use wayland_protocols::xdg::toplevel_icon::v1::client::{
 use crate::opengl_cx::OpenglCx;
 use crate::screen::DEFAULT_WINDOW_SIZE;
 use crate::wayland::wayland_state::WaylandState;
-use crate::{egl_sys, event::WindowGeom, WindowId};
+use crate::{
+    egl_sys, event::WindowGeom, WaylandDecorationPreference, WindowId,
+};
 
 /// Wraps a `wl_egl_window` in an `EGLSurface`, or returns null when the driver refuses it —
 /// which it does for an extent it cannot allocate a buffer for, however willingly
@@ -42,11 +49,540 @@ fn create_egl_window_surface(opengl_cx: &OpenglCx, wl_egl_surface: &WlEglSurface
     }
 }
 
+fn initially_uses_client_side_decorations(
+    decoration_manager_available: bool,
+    preference: WaylandDecorationPreference,
+) -> bool {
+    !decoration_manager_available || preference == WaylandDecorationPreference::ClientSide
+}
+
+// libadwaita 1.9's light-theme CSD profile. The 25 px margin is also what
+// native GNOME applications include around their xdg window geometry.
+const CSD_SHADOW_MARGIN: i32 = 25;
+// How far a corner tile reaches along each edge before the straight strips take
+// over. A square corner's influence dies out where the widest layer's coverage
+// reaches 1 within half a quantization step: 0.15 * (1 - phi((5 + k) / 7)) < 1/510
+// at k = 10.5, so 16 px leaves better than five px of margin on the seam.
+const CSD_SHADOW_CORNER_INSET: i32 = 16;
+const CSD_SHADOW_CORNER_SIZE: i32 = CSD_SHADOW_MARGIN + CSD_SHADOW_CORNER_INSET;
+// How far the resize grab reaches outward from the window edge into the gutter.
+// libadwaita sets its toplevel input region to the window rect grown by exactly
+// this much; the rest of the gutter stays click-through so a window's shadow
+// never steals a click from whatever is behind it.
+const CSD_SHADOW_GRAB: i32 = 12;
+static CSD_SHADOW_UNAVAILABLE_LOGGED: Once = Once::new();
+
+/// One CSS `box-shadow` layer: the window rectangle grown by `spread`, blurred by a
+/// Gaussian of standard deviation `sigma` (half the CSS blur radius), painted at
+/// `alpha`. A zero `sigma` is an unblurred hard edge.
+struct CsdShadowLayer {
+    sigma: f64,
+    spread: f64,
+    alpha: f64,
+}
+
+/// libadwaita 1.9 `window.csd`, the profile every GNOME 50 app on a stock desktop casts:
+/// `box-shadow: 0 0 14px 5px rgb(0 0 0/15%), 0 0 5px 2px rgb(0 0 0/10%), 0 0 0 1px rgb(0 0 0/5%)`
+const CSD_SHADOW_ACTIVE_LAYERS: &[CsdShadowLayer] = &[
+    CsdShadowLayer { sigma: 7.0, spread: 5.0, alpha: 0.15 },
+    CsdShadowLayer { sigma: 2.5, spread: 2.0, alpha: 0.10 },
+    CsdShadowLayer { sigma: 0.0, spread: 1.0, alpha: 0.05 },
+];
+
+/// libadwaita 1.9 `window.csd:backdrop`. Its first term is `0 0 14px 5px transparent`,
+/// which exists only to keep the shadow's extent identical to the focused profile, so
+/// losing focus never changes any geometry. Being transparent it is omitted here.
+const CSD_SHADOW_INACTIVE_LAYERS: &[CsdShadowLayer] = &[
+    CsdShadowLayer { sigma: 5.0, spread: 5.0, alpha: 0.08 },
+    CsdShadowLayer { sigma: 0.0, spread: 1.0, alpha: 0.05 },
+];
+
+/// Abramowitz & Stegun 7.1.26, whose 1.5e-7 worst-case error is three orders of
+/// magnitude below the 1/255 the result is quantized to.
+fn csd_erf(x: f64) -> f64 {
+    const P: f64 = 0.3275911;
+    const A: [f64; 5] = [
+        0.254829592,
+        -0.284496736,
+        1.421413741,
+        -1.453152027,
+        1.061405429,
+    ];
+    let sign = if x < 0.0 { -1.0 } else { 1.0 };
+    let x = x.abs();
+    let t = 1.0 / (1.0 + P * x);
+    let poly = A.iter().rev().fold(0.0, |acc, a| (acc + a) * t);
+    sign * (1.0 - poly * (-x * x).exp())
+}
+
+/// The fraction of one blurred half-plane covering a point `t` px outside its edge.
+/// `t` is signed, so a negative value is inside the shadow rectangle.
+fn csd_shadow_coverage(layer: &CsdShadowLayer, t: f64) -> f64 {
+    if layer.sigma <= 0.0 {
+        return if t < layer.spread { 1.0 } else { 0.0 };
+    }
+    let z = (layer.spread - t) / (layer.sigma * std::f64::consts::SQRT_2);
+    0.5 * (1.0 + csd_erf(z))
+}
+
+/// Composited shadow alpha at a point `tx` px outside the window's nearer vertical
+/// edge and `ty` px outside its nearer horizontal edge, both signed. A rectangle's
+/// Gaussian shadow is separable, so each layer's 2-D coverage is the product of its
+/// two 1-D coverages; `f64::NEG_INFINITY` means "far enough inside that this axis
+/// contributes full coverage", which is what an edge strip passes for the axis it
+/// is constant along.
+fn csd_shadow_alpha(layers: &[CsdShadowLayer], tx: f64, ty: f64) -> u32 {
+    let transmission = layers.iter().fold(1.0, |acc, layer| {
+        let coverage = csd_shadow_coverage(layer, tx) * csd_shadow_coverage(layer, ty);
+        acc * (1.0 - layer.alpha * coverage)
+    });
+    ((1.0 - transmission) * 255.0).round() as u32
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CsdShadowPieceKind {
+    TopLeft,
+    Top,
+    TopRight,
+    Left,
+    Right,
+    BottomLeft,
+    Bottom,
+    BottomRight,
+}
+
+const CSD_SHADOW_PIECES: [CsdShadowPieceKind; 8] = [
+    CsdShadowPieceKind::TopLeft,
+    CsdShadowPieceKind::Top,
+    CsdShadowPieceKind::TopRight,
+    CsdShadowPieceKind::Left,
+    CsdShadowPieceKind::Right,
+    CsdShadowPieceKind::BottomLeft,
+    CsdShadowPieceKind::Bottom,
+    CsdShadowPieceKind::BottomRight,
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct CsdShadowRect {
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+}
+
+fn csd_shadow_rect(kind: CsdShadowPieceKind, width: i32, height: i32) -> CsdShadowRect {
+    let m = CSD_SHADOW_MARGIN;
+    let i = CSD_SHADOW_CORNER_INSET;
+    let c = CSD_SHADOW_CORNER_SIZE;
+    match kind {
+        CsdShadowPieceKind::TopLeft => CsdShadowRect {
+            x: -m,
+            y: -m,
+            width: c,
+            height: c,
+        },
+        CsdShadowPieceKind::Top => CsdShadowRect {
+            x: i,
+            y: -m,
+            width: width - 2 * i,
+            height: m,
+        },
+        CsdShadowPieceKind::TopRight => CsdShadowRect {
+            x: width - i,
+            y: -m,
+            width: c,
+            height: c,
+        },
+        CsdShadowPieceKind::Left => CsdShadowRect {
+            x: -m,
+            y: i,
+            width: m,
+            height: height - 2 * i,
+        },
+        CsdShadowPieceKind::Right => CsdShadowRect {
+            x: width,
+            y: i,
+            width: m,
+            height: height - 2 * i,
+        },
+        CsdShadowPieceKind::BottomLeft => CsdShadowRect {
+            x: -m,
+            y: height - i,
+            width: c,
+            height: c,
+        },
+        CsdShadowPieceKind::Bottom => CsdShadowRect {
+            x: i,
+            y: height,
+            width: width - 2 * i,
+            height: m,
+        },
+        CsdShadowPieceKind::BottomRight => CsdShadowRect {
+            x: width - i,
+            y: height - i,
+            width: c,
+            height: c,
+        },
+    }
+}
+
+fn csd_shadow_buffer_size(kind: CsdShadowPieceKind) -> (i32, i32) {
+    match kind {
+        CsdShadowPieceKind::TopLeft
+        | CsdShadowPieceKind::TopRight
+        | CsdShadowPieceKind::BottomLeft
+        | CsdShadowPieceKind::BottomRight => (CSD_SHADOW_CORNER_SIZE, CSD_SHADOW_CORNER_SIZE),
+        CsdShadowPieceKind::Top | CsdShadowPieceKind::Bottom => (1, CSD_SHADOW_MARGIN),
+        CsdShadowPieceKind::Left | CsdShadowPieceKind::Right => (CSD_SHADOW_MARGIN, 1),
+    }
+}
+
+/// Where buffer pixel `(x, y)` of a piece sits relative to the window, as the signed
+/// distance outside the nearer vertical edge and the nearer horizontal edge. Sampling
+/// at pixel centres keeps the tiles seam-free against the strips they abut.
+///
+/// Makepad's window is a plain rectangle, so both distances are measured from a square
+/// corner. Sampling a rounded window's shadow here instead would leave the corners
+/// visibly washed out, because a rounded corner's geometry recedes from the square
+/// corner the shadow has to hug.
+fn csd_shadow_offsets(kind: CsdShadowPieceKind, x: i32, y: i32) -> (f64, f64) {
+    const INSIDE: f64 = f64::NEG_INFINITY;
+    let margin = CSD_SHADOW_MARGIN as f64;
+    let inset = CSD_SHADOW_CORNER_INSET as f64;
+    let x = x as f64 + 0.5;
+    let y = y as f64 + 0.5;
+    // Left-hand and top pieces start `margin` px before the window; right-hand and
+    // bottom corner pieces start `inset` px inside it, and their strips start on it.
+    let past_left = margin - x;
+    let past_top = margin - y;
+    let past_right_corner = x - inset;
+    let past_bottom_corner = y - inset;
+    match kind {
+        CsdShadowPieceKind::TopLeft => (past_left, past_top),
+        CsdShadowPieceKind::Top => (INSIDE, past_top),
+        CsdShadowPieceKind::TopRight => (past_right_corner, past_top),
+        CsdShadowPieceKind::Left => (past_left, INSIDE),
+        CsdShadowPieceKind::Right => (x, INSIDE),
+        CsdShadowPieceKind::BottomLeft => (past_left, past_bottom_corner),
+        CsdShadowPieceKind::Bottom => (INSIDE, y),
+        CsdShadowPieceKind::BottomRight => (past_right_corner, past_bottom_corner),
+    }
+}
+
+fn csd_shadow_pixel(kind: CsdShadowPieceKind, x: i32, y: i32, active: bool) -> u32 {
+    let layers = if active {
+        CSD_SHADOW_ACTIVE_LAYERS
+    } else {
+        CSD_SHADOW_INACTIVE_LAYERS
+    };
+    let (tx, ty) = csd_shadow_offsets(kind, x, y);
+    // Premultiplied ARGB8888 black: with all three colour channels at zero the alpha
+    // is already the premultiplied value wl_shm requires.
+    csd_shadow_alpha(layers, tx, ty) << 24
+}
+
+/// The part of a piece that grabs the pointer for a resize, in its own surface-local
+/// coordinates. The union of these across the eight pieces is the window rectangle
+/// grown by [`CSD_SHADOW_GRAB`], which is exactly the input region libadwaita gives
+/// its toplevels, minus the window itself (which the parent surface covers anyway).
+///
+/// Each piece maps to one resize edge, so where the pointer landed is enough to know
+/// which edge it grabbed and no coordinate hit-testing is needed.
+fn csd_shadow_grab_rect(kind: CsdShadowPieceKind) -> CsdShadowRect {
+    // `wl_surface.set_input_region` ignores whatever falls outside the surface, so a
+    // span longer than any window keeps the stretched axis correct without ever
+    // needing to be re-sent on resize.
+    const SPAN: i32 = 1 << 20;
+    let outer = CSD_SHADOW_MARGIN - CSD_SHADOW_GRAB;
+    let inner = CSD_SHADOW_CORNER_INSET + CSD_SHADOW_GRAB;
+    let grab = CSD_SHADOW_GRAB;
+    let rect = |x, y, width, height| CsdShadowRect { x, y, width, height };
+    match kind {
+        CsdShadowPieceKind::TopLeft => rect(outer, outer, SPAN, SPAN),
+        CsdShadowPieceKind::Top => rect(0, outer, SPAN, grab),
+        CsdShadowPieceKind::TopRight => rect(0, outer, inner, SPAN),
+        CsdShadowPieceKind::Left => rect(outer, 0, grab, SPAN),
+        CsdShadowPieceKind::Right => rect(0, 0, grab, SPAN),
+        CsdShadowPieceKind::BottomLeft => rect(outer, 0, SPAN, inner),
+        CsdShadowPieceKind::Bottom => rect(0, 0, SPAN, grab),
+        CsdShadowPieceKind::BottomRight => rect(0, 0, inner, inner),
+    }
+}
+
+/// The edge a grab on this piece resizes.
+fn csd_shadow_resize_edge(kind: CsdShadowPieceKind) -> xdg_toplevel::ResizeEdge {
+    use xdg_toplevel::ResizeEdge;
+    match kind {
+        CsdShadowPieceKind::TopLeft => ResizeEdge::TopLeft,
+        CsdShadowPieceKind::Top => ResizeEdge::Top,
+        CsdShadowPieceKind::TopRight => ResizeEdge::TopRight,
+        CsdShadowPieceKind::Left => ResizeEdge::Left,
+        CsdShadowPieceKind::Right => ResizeEdge::Right,
+        CsdShadowPieceKind::BottomLeft => ResizeEdge::BottomLeft,
+        CsdShadowPieceKind::Bottom => ResizeEdge::Bottom,
+        CsdShadowPieceKind::BottomRight => ResizeEdge::BottomRight,
+    }
+}
+
+struct CsdShadowPiece {
+    kind: CsdShadowPieceKind,
+    surface: wl_surface::WlSurface,
+    subsurface: wl_subsurface::WlSubsurface,
+    viewport: wp_viewport::WpViewport,
+    active_buffer: wl_buffer::WlBuffer,
+    inactive_buffer: wl_buffer::WlBuffer,
+}
+
+struct WaylandCsdShadow {
+    pieces: Vec<CsdShadowPiece>,
+    state: Option<(i32, i32, bool, bool)>,
+}
+
+fn csd_shadow_visible_at_size(visible: bool, width: i32, height: i32) -> bool {
+    visible
+        && width > 2 * CSD_SHADOW_CORNER_INSET
+        && height > 2 * CSD_SHADOW_CORNER_INSET
+}
+
+impl WaylandCsdShadow {
+    fn new(
+        compositor: &wl_compositor::WlCompositor,
+        subcompositor: Option<&wl_subcompositor::WlSubcompositor>,
+        shm: Option<&wl_shm::WlShm>,
+        viewporter: Option<&wp_viewporter::WpViewporter>,
+        parent: &wl_surface::WlSurface,
+        qhandle: &QueueHandle<WaylandState>,
+    ) -> Option<Self> {
+        let (Some(subcompositor), Some(shm), Some(viewporter)) =
+            (subcompositor, shm, viewporter)
+        else {
+            CSD_SHADOW_UNAVAILABLE_LOGGED.call_once(|| {
+                crate::warning!(
+                    "Wayland client-side shadow unavailable: wl_subcompositor, wl_shm, and \
+                     wp_viewporter are required; continuing with client-side window controls"
+                );
+            });
+            return None;
+        };
+        let Some(buffers) = Self::create_buffers(shm, qhandle) else {
+            CSD_SHADOW_UNAVAILABLE_LOGGED.call_once(|| {
+                crate::warning!(
+                    "Wayland client-side shadow unavailable: could not allocate shared-memory \
+                     buffers; continuing with client-side window controls"
+                );
+            });
+            return None;
+        };
+        let mut pieces = Vec::with_capacity(CSD_SHADOW_PIECES.len());
+        for (kind, (active_buffer, inactive_buffer)) in
+            CSD_SHADOW_PIECES.into_iter().zip(buffers)
+        {
+            let surface = compositor.create_surface(qhandle, ());
+            // The gutter is where this window is resized from, the way it is for every
+            // native app on the desktop: the pointer never has to compete with a widget
+            // for the edge, so the close button no longer swallows the top-right corner.
+            // Input regions are copied by the compositor at request time, and these are
+            // expressed so they survive any resize, so this is the only time they are set.
+            let grab = csd_shadow_grab_rect(kind);
+            let region = compositor.create_region(qhandle, ());
+            region.add(grab.x, grab.y, grab.width, grab.height);
+            surface.set_input_region(Some(&region));
+            region.destroy();
+            let subsurface = subcompositor.get_subsurface(&surface, parent, qhandle, ());
+            subsurface.set_sync();
+            subsurface.place_below(parent);
+            let viewport = viewporter.get_viewport(&surface, qhandle, ());
+            pieces.push(CsdShadowPiece {
+                kind,
+                surface,
+                subsurface,
+                viewport,
+                active_buffer,
+                inactive_buffer,
+            });
+        }
+        Some(Self {
+            pieces,
+            state: None,
+        })
+    }
+
+    /// The piece owning `surface`, if any. The pointer entering one means the pointer is
+    /// in this window's gutter rather than in the window.
+    fn piece_kind_for_surface(
+        &self,
+        surface_id: &wayland_client::backend::ObjectId,
+    ) -> Option<CsdShadowPieceKind> {
+        self.pieces
+            .iter()
+            .find(|piece| piece.surface.id() == *surface_id)
+            .map(|piece| piece.kind)
+    }
+
+    fn create_buffers(
+        shm: &wl_shm::WlShm,
+        qhandle: &QueueHandle<WaylandState>,
+    ) -> Option<Vec<(wl_buffer::WlBuffer, wl_buffer::WlBuffer)>> {
+        let mut offset = 0;
+        let layouts: Vec<_> = CSD_SHADOW_PIECES
+            .into_iter()
+            .map(|kind| {
+                let (width, height) = csd_shadow_buffer_size(kind);
+                let layout = (kind, width, height, offset);
+                offset += (width * height * 4) as usize;
+                layout
+            })
+            .collect();
+        let style_bytes = offset;
+        let total_bytes = style_bytes * 2;
+        let name = std::ffi::CString::new("makepad-csd-shadow").ok()?;
+        let raw_fd =
+            unsafe { crate::libc_sys::memfd_create(name.as_ptr(), crate::libc_sys::MFD_CLOEXEC) };
+        if raw_fd < 0 {
+            return None;
+        }
+        let fd = unsafe { std::os::fd::OwnedFd::from_raw_fd(raw_fd) };
+        if unsafe { crate::libc_sys::ftruncate(fd.as_raw_fd(), total_bytes as i64) } != 0 {
+            return None;
+        }
+        let map = unsafe {
+            crate::libc_sys::mmap(
+                std::ptr::null_mut(),
+                total_bytes,
+                crate::libc_sys::PROT_READ | crate::libc_sys::PROT_WRITE,
+                crate::libc_sys::MAP_SHARED,
+                fd.as_raw_fd(),
+                0,
+            )
+        };
+        if map == crate::libc_sys::MAP_FAILED {
+            return None;
+        }
+        let bytes = unsafe { std::slice::from_raw_parts_mut(map.cast::<u8>(), total_bytes) };
+        for (style_index, active) in [true, false].into_iter().enumerate() {
+            for &(kind, width, height, offset) in &layouts {
+                let piece_offset = style_index * style_bytes + offset;
+                for y in 0..height {
+                    for x in 0..width {
+                        let pixel_offset = piece_offset
+                            + ((y * width + x) * 4) as usize;
+                        bytes[pixel_offset..pixel_offset + 4]
+                            // wl_shm's ARGB8888 is defined as little endian regardless of
+                            // the host, so the byte order cannot follow the CPU's.
+                            .copy_from_slice(&csd_shadow_pixel(kind, x, y, active).to_le_bytes());
+                    }
+                }
+            }
+        }
+        unsafe {
+            crate::libc_sys::munmap(map, total_bytes);
+        }
+
+        let pool = shm.create_pool(fd.as_fd(), total_bytes as i32, qhandle, ());
+        let create_buffer = |offset: usize, width: i32, height: i32| {
+                pool.create_buffer(
+                    offset as i32,
+                    width,
+                    height,
+                    width * 4,
+                    wl_shm::Format::Argb8888,
+                    qhandle,
+                    (),
+                )
+        };
+        let buffers = layouts
+            .into_iter()
+            .map(|(_, width, height, offset)| {
+                (
+                    create_buffer(offset, width, height),
+                    create_buffer(style_bytes + offset, width, height),
+                )
+            })
+            .collect();
+        pool.destroy();
+        Some(buffers)
+    }
+
+    fn is_visible(&self) -> bool {
+        self.state.is_some_and(|state| state.2)
+    }
+
+    fn needs_update(&self, width: i32, height: i32, visible: bool, active: bool) -> bool {
+        let visible = csd_shadow_visible_at_size(visible, width, height);
+        let active = visible && active;
+        self.state != Some((width, height, visible, active))
+    }
+
+    fn update(&mut self, width: i32, height: i32, visible: bool, active: bool) -> bool {
+        // Nine-patch edge destinations must be positive. Makepad's 200x120 minimum is
+        // well above this; suppress the visual-only shadow for pathological sizes.
+        let visible = csd_shadow_visible_at_size(visible, width, height);
+        // Focus has no visual effect while detached. Ignoring it here also avoids
+        // repainting maximized, tiled, fullscreen, and server-decorated windows.
+        let active = visible && active;
+        let size_changed = self.state.map(|state| (state.0, state.1)) != Some((width, height));
+        if !self.needs_update(width, height, visible, active) {
+            return false;
+        }
+        let was_visible = self.state.is_some_and(|state| state.2);
+        let style_changed = self.state.map_or(true, |state| state.3 != active);
+        for (kind, piece) in CSD_SHADOW_PIECES.into_iter().zip(&self.pieces) {
+            if visible {
+                let rect = csd_shadow_rect(kind, width, height);
+                // Both are sticky surface state, so a focus change — which swaps buffers
+                // at an unchanged size — has no reason to re-send them.
+                if !was_visible || size_changed {
+                    piece.subsurface.set_position(rect.x, rect.y);
+                    piece.viewport.set_destination(rect.width, rect.height);
+                }
+                if !was_visible || style_changed {
+                    let buffer = if active {
+                        &piece.active_buffer
+                    } else {
+                        &piece.inactive_buffer
+                    };
+                    piece.surface.attach(Some(buffer), 0, 0);
+                }
+                if !was_visible || style_changed || size_changed {
+                    piece.surface.damage(0, 0, rect.width, rect.height);
+                }
+                piece.surface.commit();
+            } else if was_visible {
+                piece.surface.attach(None, 0, 0);
+                piece.surface.commit();
+            }
+        }
+        self.state = Some((width, height, visible, active));
+        size_changed
+    }
+
+    fn destroy(self) {
+        for piece in self.pieces {
+            piece.viewport.destroy();
+            piece.subsurface.destroy();
+            piece.surface.destroy();
+            piece.active_buffer.destroy();
+            piece.inactive_buffer.destroy();
+        }
+    }
+}
+
+fn should_show_csd_shadow(uses_csd: bool, maximized: bool, fullscreen: bool, tiled: bool) -> bool {
+    uses_csd && !maximized && !fullscreen && !tiled
+}
+
 pub(crate) struct WaylandWindow {
     pub window_id: WindowId,
     pub base_surface: wl_surface::WlSurface,
     pub toplevel: xdg_toplevel::XdgToplevel,
     pub decoration: Option<zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1>,
+    pub uses_client_side_decorations: bool,
+    pub pending_client_side_decorations: Option<bool>,
+    pub is_maximized: bool,
+    pub is_fullscreen: bool,
+    pub is_tiled: bool,
+    pub is_active: bool,
+    pub unavailable_resize_edges: u8,
     pub xdg_surface: xdg_surface::XdgSurface,
     pub viewport: Option<wp_viewport::WpViewport>,
     pub fractional_scale: Option<wp_fractional_scale_v1::WpFractionalScaleV1>,
@@ -55,12 +591,17 @@ pub(crate) struct WaylandWindow {
     pub cal_size: Vec2d,
     pub wl_egl_surface: WlEglSurface,
     pub egl_surface: EGLSurface,
+    csd_shadow: Option<WaylandCsdShadow>,
+    /// The `(width, height, opaque)` the surface's opaque region was last set from, so a
+    /// steady-state frame re-sends nothing.
+    opaque_region_state: Option<(i32, i32, bool)>,
 }
 
 impl WaylandWindow {
     pub fn new(
         window_id: WindowId,
         compositer: &wl_compositor::WlCompositor,
+        subcompositor: Option<&wl_subcompositor::WlSubcompositor>,
         wm_base: &xdg_wm_base::XdgWmBase,
         decoration_manager: Option<&zxdg_decoration_manager_v1::ZxdgDecorationManagerV1>,
         scale_manager: Option<&wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1>,
@@ -74,6 +615,7 @@ impl WaylandWindow {
         title: &str,
         app_id: &str,
         is_fullscreen: bool,
+        decoration_preference: WaylandDecorationPreference,
     ) -> WaylandWindow {
         // Checked "downcast" of the EGL platform display to a X11 display.
         assert_eq!(opengl_cx.egl_platform, egl_sys::EGL_PLATFORM_WAYLAND_KHR);
@@ -91,11 +633,52 @@ impl WaylandWindow {
         // Set window icon via xdg-toplevel-icon-v1 if compositor supports it
         Self::set_wayland_icon(icon_manager, shm, &toplevel, qhandle);
 
-        let decoration = decoration_manager.map(|manager| {
-            let decoration = manager.get_toplevel_decoration(&toplevel, qhandle, ());
-            decoration.set_mode(zxdg_toplevel_decoration_v1::Mode::ClientSide);
-            decoration
+        let uses_client_side_decorations = initially_uses_client_side_decorations(
+            decoration_manager.is_some(),
+            decoration_preference,
+        );
+        let decoration = decoration_manager.and_then(|manager| {
+            if decoration_preference == WaylandDecorationPreference::ClientSide {
+                // Without negotiation the protocol requires clients to self-decorate;
+                // set_mode(ClientSide) would only be a preference the compositor may reject.
+                return None;
+            }
+            let decoration = manager.get_toplevel_decoration(&toplevel, qhandle, window_id);
+            decoration.set_mode(zxdg_toplevel_decoration_v1::Mode::ServerSide);
+            Some(decoration)
         });
+
+        let surface_width = (inner_size.x as i32).max(1);
+        let surface_height = (inner_size.y as i32).max(1);
+        // Do not allocate eight shadow buffers and subsurfaces for a window that
+        // the compositor decorates. If negotiation later selects CSD, the
+        // configure handler creates them before the first client-decorated frame.
+        let mut csd_shadow = uses_client_side_decorations
+            .then(|| {
+                WaylandCsdShadow::new(
+                    compositer,
+                    subcompositor,
+                    shm,
+                    viewporter,
+                    &base_surface,
+                    qhandle,
+                )
+            })
+            .flatten();
+        if let Some(shadow) = csd_shadow.as_mut() {
+            shell_surface.set_window_geometry(0, 0, surface_width, surface_height);
+            shadow.update(
+                surface_width,
+                surface_height,
+                should_show_csd_shadow(
+                    uses_client_side_decorations,
+                    false,
+                    is_fullscreen,
+                    false,
+                ),
+                false,
+            );
+        }
 
         if is_fullscreen {
             toplevel.set_fullscreen(None);
@@ -105,8 +688,8 @@ impl WaylandWindow {
         // `wl_egl_window_create` rejects a non-positive extent, and a float-to-int cast turns
         // both a negative and a NaN into zero, so the requested size is floored before the
         // call rather than allowed to panic an app at startup over a bad saved size.
-        let egl_w = (inner_size.x as i32).max(1);
-        let egl_h = (inner_size.y as i32).max(1);
+        let egl_w = surface_width;
+        let egl_h = surface_height;
         let mut wl_egl_surface = match WlEglSurface::new(base_surface.id(), egl_w, egl_h) {
             Ok(surface) => surface,
             Err(e) => {
@@ -155,6 +738,13 @@ impl WaylandWindow {
             base_surface,
             toplevel,
             decoration,
+            uses_client_side_decorations,
+            pending_client_side_decorations: None,
+            is_maximized: false,
+            is_fullscreen,
+            is_tiled: false,
+            is_active: false,
+            unavailable_resize_edges: 0,
             viewport,
             fractional_scale,
             configured: false,
@@ -164,6 +754,8 @@ impl WaylandWindow {
             window_geom: geom,
             wl_egl_surface,
             egl_surface,
+            csd_shadow,
+            opaque_region_state: None,
         }
     }
     /// Set the toplevel icon via xdg-toplevel-icon-v1 protocol using shm pixel data.
@@ -254,26 +846,151 @@ impl WaylandWindow {
         // wl_buf kept alive until compositor reads it (destroyed on drop)
     }
 
-    pub fn resize_buffers(&mut self) -> bool {
+    pub fn prepare_buffer_size(&mut self, opengl_cx: &OpenglCx) -> bool {
         let cal_size = Vec2d {
             x: self.window_geom.inner_size.x * self.window_geom.dpi_factor,
             y: self.window_geom.inner_size.y * self.window_geom.dpi_factor,
         };
         if self.cal_size != cal_size {
-            self.cal_size = cal_size;
+            // NVIDIA's Wayland EGL platform may defer resizing a non-current
+            // EGLSurface until its next swap. Bind this exact surface first so
+            // the next frame cannot mix the old buffer with the new viewport.
+            if !opengl_cx.make_current_with_surface(self.egl_surface) {
+                return false;
+            }
             let pix_width = cal_size.x.max(1.0) as i32;
             let pix_height = cal_size.y.max(1.0) as i32;
             self.wl_egl_surface.resize(pix_width, pix_height, 0, 0);
-            true
+            // Cache only a resize that was actually issued. A failed bind is
+            // retried on the next paint rather than leaving stale buffers.
+            self.cal_size = cal_size;
+        }
+        true
+    }
+
+    /// Promises the compositor that the whole window rectangle is solid, so it can skip
+    /// blending this surface and cull everything the window covers, and can hand a
+    /// fullscreen buffer straight to the display controller instead of compositing it.
+    ///
+    /// The buffer is ARGB8888 — every EGL config Makepad accepts asks for 8 alpha bits —
+    /// so without this promise the compositor has no way to learn that the alpha channel
+    /// is uniformly opaque short of reading every pixel, and must assume it is not.
+    ///
+    /// `opaque` must be false for a window that actually wants translucency, or the
+    /// compositor will happily leave whatever was behind it on screen. The region covers
+    /// the base surface only: the shadow subsurfaces are genuinely translucent, and are
+    /// separate surfaces that keep their own (empty) opaque regions.
+    pub fn sync_opaque_region(
+        &mut self,
+        compositor: &wl_compositor::WlCompositor,
+        qhandle: &QueueHandle<WaylandState>,
+        opaque: bool,
+    ) {
+        let width = (self.window_geom.inner_size.x as i32).max(1);
+        let height = (self.window_geom.inner_size.y as i32).max(1);
+        if self.opaque_region_state == Some((width, height, opaque)) {
+            return;
+        }
+        self.opaque_region_state = Some((width, height, opaque));
+        if opaque {
+            let region = compositor.create_region(qhandle, ());
+            region.add(0, 0, width, height);
+            self.base_surface.set_opaque_region(Some(&region));
+            region.destroy();
         } else {
-            false
+            self.base_surface.set_opaque_region(None);
         }
     }
+
+    /// Whether the shadow gutter is currently mapped, and therefore carrying this window's
+    /// resize grabs. While it is, the interior bands are redundant: they would only compete
+    /// with the app's own widgets for the pointer, which is what let the close button
+    /// swallow the top-right corner. A tiled window has no gutter and falls back to them.
+    pub fn csd_shadow_gutter_active(&self) -> bool {
+        self.csd_shadow
+            .as_ref()
+            .is_some_and(|shadow| shadow.is_visible())
+    }
+
+    /// The resize edge and cursor for a pointer that has entered one of this window's
+    /// shadow surfaces, or `None` if `surface` is not part of this window's shadow.
+    /// Edges the compositor has declared unavailable — a tiled window's shared borders —
+    /// are narrowed to the components that remain resizable, so a half-tiled window
+    /// keeps the corner grabs on its free axis.
+    pub fn csd_shadow_resize_for_surface(
+        &self,
+        surface_id: &wayland_client::backend::ObjectId,
+    ) -> Option<(xdg_toplevel::ResizeEdge, wp_cursor_shape_device_v1::Shape)> {
+        let kind = self
+            .csd_shadow
+            .as_ref()?
+            .piece_kind_for_surface(surface_id)?;
+        let edge = crate::wayland::wayland_state::available_resize_edge(
+            csd_shadow_resize_edge(kind),
+            self.unavailable_resize_edges,
+        )?;
+        Some((edge, crate::wayland::wayland_state::resize_edge_cursor(edge)))
+    }
+
+    pub fn csd_shadow_needs_update(&self) -> bool {
+        let width = (self.window_geom.inner_size.x as i32).max(1);
+        let height = (self.window_geom.inner_size.y as i32).max(1);
+        let visible = should_show_csd_shadow(
+            self.uses_client_side_decorations,
+            self.is_maximized,
+            self.is_fullscreen,
+            self.is_tiled,
+        );
+        self.csd_shadow
+            .as_ref()
+            .is_some_and(|shadow| shadow.needs_update(width, height, visible, self.is_active))
+    }
+
+    pub(crate) fn ensure_csd_shadow(
+        &mut self,
+        compositor: &wl_compositor::WlCompositor,
+        subcompositor: Option<&wl_subcompositor::WlSubcompositor>,
+        shm: Option<&wl_shm::WlShm>,
+        viewporter: Option<&wp_viewporter::WpViewporter>,
+        qhandle: &QueueHandle<WaylandState>,
+    ) {
+        if self.csd_shadow.is_none() {
+            self.csd_shadow = WaylandCsdShadow::new(
+                compositor,
+                subcompositor,
+                shm,
+                viewporter,
+                &self.base_surface,
+                qhandle,
+            );
+        }
+    }
+
+    pub fn prepare_csd_shadow(&mut self) {
+        let width = (self.window_geom.inner_size.x as i32).max(1);
+        let height = (self.window_geom.inner_size.y as i32).max(1);
+        let visible = should_show_csd_shadow(
+            self.uses_client_side_decorations,
+            self.is_maximized,
+            self.is_fullscreen,
+            self.is_tiled,
+        );
+        if let Some(shadow) = self.csd_shadow.as_mut() {
+            if shadow.update(width, height, visible, self.is_active) {
+                self.xdg_surface
+                    .set_window_geometry(0, 0, width, height);
+            }
+        }
+    }
+
     pub fn close_window(&mut self) {
         // Destroy in protocol order: role-specific objects first, base
         // surface last.
         if let Some(decoration) = self.decoration.take() {
             decoration.destroy();
+        }
+        if let Some(shadow) = self.csd_shadow.take() {
+            shadow.destroy();
         }
         self.toplevel.destroy();
         self.xdg_surface.destroy();
@@ -405,20 +1122,21 @@ impl WaylandPopupWindow {
         }
     }
 
-    pub fn resize_buffers(&mut self) -> bool {
+    pub fn prepare_buffer_size(&mut self, opengl_cx: &OpenglCx) -> bool {
         let cal_size = Vec2d {
             x: self.window_geom.inner_size.x * self.window_geom.dpi_factor,
             y: self.window_geom.inner_size.y * self.window_geom.dpi_factor,
         };
         if self.cal_size != cal_size {
-            self.cal_size = cal_size;
+            if !opengl_cx.make_current_with_surface(self.egl_surface) {
+                return false;
+            }
             if let Some(ref wl_egl_surface) = self.wl_egl_surface {
                 wl_egl_surface.resize(cal_size.x.max(1.0) as i32, cal_size.y.max(1.0) as i32, 0, 0);
             }
-            true
-        } else {
-            false
+            self.cal_size = cal_size;
         }
+        true
     }
 
     pub fn close_window(&mut self) {
@@ -455,5 +1173,274 @@ impl Drop for WaylandWindow {
 impl Drop for WaylandPopupWindow {
     fn drop(&mut self) {
         self.close_window();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn alpha(pixel: u32) -> u8 {
+        (pixel >> 24) as u8
+    }
+
+    #[test]
+    fn decoration_initial_state_prefers_server_and_falls_back_without_protocol() {
+        assert!(!initially_uses_client_side_decorations(
+            true,
+            WaylandDecorationPreference::ServerSide
+        ));
+        assert!(initially_uses_client_side_decorations(
+            false,
+            WaylandDecorationPreference::ServerSide
+        ));
+        assert!(initially_uses_client_side_decorations(
+            true,
+            WaylandDecorationPreference::ClientSide
+        ));
+    }
+
+    #[test]
+    fn shadow_layout_tiles_the_gutter_without_gaps_or_overlap() {
+        let expected = [
+            (-25, -25, 41, 41),
+            (16, -25, 608, 25),
+            (624, -25, 41, 41),
+            (-25, 16, 25, 448),
+            (640, 16, 25, 448),
+            (-25, 464, 41, 41),
+            (16, 480, 608, 25),
+            (624, 464, 41, 41),
+        ];
+        for (kind, expected) in CSD_SHADOW_PIECES.into_iter().zip(expected) {
+            let rect = csd_shadow_rect(kind, 640, 480);
+            assert_eq!((rect.x, rect.y, rect.width, rect.height), expected);
+        }
+
+        // Every pixel of the ring around the window is covered exactly once. The pieces
+        // are translucent, so an overlap would double-blend into a visible seam.
+        // The smallest size `csd_shadow_visible_at_size` admits is checked too, since
+        // that is where the corner tiles come closest to colliding.
+        let smallest = 2 * CSD_SHADOW_CORNER_INSET + 1;
+        for (width, height) in [(640, 480), (smallest, smallest), (smallest, 480)] {
+            let rects: Vec<_> = CSD_SHADOW_PIECES
+                .into_iter()
+                .map(|kind| csd_shadow_rect(kind, width, height))
+                .collect();
+            for rect in &rects {
+                assert!(
+                    rect.width > 0 && rect.height > 0,
+                    "empty destination at {width}x{height}"
+                );
+            }
+            for y in -CSD_SHADOW_MARGIN..height + CSD_SHADOW_MARGIN {
+                for x in -CSD_SHADOW_MARGIN..width + CSD_SHADOW_MARGIN {
+                    let covers = rects
+                        .iter()
+                        .filter(|rect| {
+                            x >= rect.x
+                                && x < rect.x + rect.width
+                                && y >= rect.y
+                                && y < rect.y + rect.height
+                        })
+                        .count();
+                    let inside_window = (0..width).contains(&x) && (0..height).contains(&y);
+                    // The corner tiles reach `CSD_SHADOW_CORNER_INSET` px into the window,
+                    // where the parent surface covers them; everywhere else in the ring is
+                    // covered exactly once and nothing spills past the margin.
+                    if inside_window {
+                        assert!(
+                            covers <= 1,
+                            "overlap inside the {width}x{height} window at ({x}, {y})"
+                        );
+                    } else {
+                        assert_eq!(
+                            covers, 1,
+                            "gutter of {width}x{height} not covered once at ({x}, {y})"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn shadow_raster_is_monotonic_symmetric_and_seam_free() {
+        for i in 1..CSD_SHADOW_MARGIN {
+            let previous = alpha(csd_shadow_pixel(CsdShadowPieceKind::Top, 0, i - 1, true));
+            let current = alpha(csd_shadow_pixel(CsdShadowPieceKind::Top, 0, i, true));
+            assert!(current >= previous);
+        }
+        for i in 0..CSD_SHADOW_MARGIN {
+            assert_eq!(
+                alpha(csd_shadow_pixel(CsdShadowPieceKind::Top, 0, i, true)),
+                alpha(csd_shadow_pixel(
+                    CsdShadowPieceKind::Bottom,
+                    0,
+                    CSD_SHADOW_MARGIN - 1 - i,
+                    true,
+                ))
+            );
+        }
+        // The outermost row of the margin has faded to nothing, so the shadow does not
+        // end in a visible step.
+        assert_eq!(
+            alpha(csd_shadow_pixel(CsdShadowPieceKind::Top, 0, 0, true)),
+            0
+        );
+
+        // A square corner is where two half-covered edges meet, so it is lighter than a
+        // straight edge at the same distance but nowhere near the washed-out 14/255 that
+        // sampling a 15 px-rounded window's shadow here would give.
+        let corner = alpha(csd_shadow_pixel(CsdShadowPieceKind::TopLeft, 24, 24, true));
+        let straight = alpha(csd_shadow_pixel(CsdShadowPieceKind::Top, 0, 24, true));
+        assert_eq!((corner, straight), (44, 55));
+
+        let inner = csd_shadow_pixel(CsdShadowPieceKind::Top, 0, 24, true);
+        assert_eq!(inner & 0x00ff_ffff, 0, "must stay premultiplied black");
+        assert_eq!(alpha(inner), straight);
+    }
+
+    #[test]
+    fn shadow_corner_tiles_join_the_straight_edges_exactly() {
+        let last = CSD_SHADOW_CORNER_SIZE - 1;
+        for active in [false, true] {
+            // CSD_SHADOW_CORNER_INSET is chosen so the corner's second axis has reached
+            // full coverage by the time the strips take over: the join is not merely
+            // close, it is bit-identical, so no seam can appear at any scale.
+            for y in 0..CSD_SHADOW_MARGIN {
+                assert_eq!(
+                    csd_shadow_pixel(CsdShadowPieceKind::TopLeft, last, y, active),
+                    csd_shadow_pixel(CsdShadowPieceKind::Top, 0, y, active),
+                    "top join differs at y={y}"
+                );
+            }
+            for x in 0..CSD_SHADOW_MARGIN {
+                assert_eq!(
+                    csd_shadow_pixel(CsdShadowPieceKind::TopLeft, x, last, active),
+                    csd_shadow_pixel(CsdShadowPieceKind::Left, x, 0, active),
+                    "left join differs at x={x}"
+                );
+            }
+
+            for y in 0..CSD_SHADOW_CORNER_SIZE {
+                for x in 0..CSD_SHADOW_CORNER_SIZE {
+                    let mirror_x = last - x;
+                    let mirror_y = last - y;
+                    assert_eq!(
+                        csd_shadow_pixel(CsdShadowPieceKind::TopLeft, x, y, active),
+                        csd_shadow_pixel(CsdShadowPieceKind::TopRight, mirror_x, y, active)
+                    );
+                    assert_eq!(
+                        csd_shadow_pixel(CsdShadowPieceKind::TopLeft, x, y, active),
+                        csd_shadow_pixel(CsdShadowPieceKind::BottomLeft, x, mirror_y, active)
+                    );
+                    assert_eq!(
+                        csd_shadow_pixel(CsdShadowPieceKind::TopLeft, x, y, active),
+                        csd_shadow_pixel(
+                            CsdShadowPieceKind::BottomRight,
+                            mirror_x,
+                            mirror_y,
+                            active,
+                        )
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn shadow_grab_rects_reach_exactly_the_libadwaita_input_region() {
+        // libadwaita grows its toplevel input region by 12 px on every side. The union of
+        // the eight grab rects must be the same ring, with each piece owning the side it
+        // resizes and none of them claiming the outer half of the gutter.
+        let (width, height) = (640, 480);
+        for kind in CSD_SHADOW_PIECES {
+            let rect = csd_shadow_rect(kind, width, height);
+            let grab = csd_shadow_grab_rect(kind);
+            // Clip the grab rect to the piece the way the compositor does, then place it
+            // in window coordinates.
+            let x0 = rect.x + grab.x.max(0);
+            let y0 = rect.y + grab.y.max(0);
+            let x1 = rect.x + (grab.x + grab.width).min(rect.width);
+            let y1 = rect.y + (grab.y + grab.height).min(rect.height);
+            assert!(x0 < x1 && y0 < y1, "{kind:?} has an empty grab region");
+            assert!(
+                x0 >= -CSD_SHADOW_GRAB
+                    && y0 >= -CSD_SHADOW_GRAB
+                    && x1 <= width + CSD_SHADOW_GRAB
+                    && y1 <= height + CSD_SHADOW_GRAB,
+                "{kind:?} grabs outside the 12 px halo: ({x0},{y0})..({x1},{y1})"
+            );
+        }
+
+        // The top-right corner is grabbable strictly outside the window, which is what
+        // keeps the close button from swallowing it.
+        let rect = csd_shadow_rect(CsdShadowPieceKind::TopRight, width, height);
+        let grab = csd_shadow_grab_rect(CsdShadowPieceKind::TopRight);
+        assert!(rect.x + grab.x + grab.width > width);
+        assert!(rect.y + grab.y < 0);
+    }
+
+    #[test]
+    fn shadow_pieces_map_to_the_edge_they_sit_on() {
+        use xdg_toplevel::ResizeEdge;
+        for (kind, edge) in [
+            (CsdShadowPieceKind::TopLeft, ResizeEdge::TopLeft),
+            (CsdShadowPieceKind::Top, ResizeEdge::Top),
+            (CsdShadowPieceKind::TopRight, ResizeEdge::TopRight),
+            (CsdShadowPieceKind::Left, ResizeEdge::Left),
+            (CsdShadowPieceKind::Right, ResizeEdge::Right),
+            (CsdShadowPieceKind::BottomLeft, ResizeEdge::BottomLeft),
+            (CsdShadowPieceKind::Bottom, ResizeEdge::Bottom),
+            (CsdShadowPieceKind::BottomRight, ResizeEdge::BottomRight),
+        ] {
+            assert_eq!(csd_shadow_resize_edge(kind), edge);
+        }
+    }
+
+    #[test]
+    fn shadow_alpha_matches_the_installed_libadwaita_profile() {
+        let active = [54, 39, 34, 28, 24, 20, 17, 14, 12, 10, 8, 6, 5, 4, 3, 2, 1, 1, 1, 0];
+        let inactive = [28, 15, 14, 12, 11, 9, 8, 6, 5, 3, 2, 1, 1, 1, 0];
+        for (distance, expected) in active.into_iter().enumerate() {
+            let actual = alpha(csd_shadow_pixel(
+                CsdShadowPieceKind::Top,
+                0,
+                CSD_SHADOW_MARGIN - 1 - distance as i32,
+                true,
+            ));
+            assert!(actual.abs_diff(expected) <= 1);
+        }
+        for (distance, expected) in inactive.into_iter().enumerate() {
+            let actual = alpha(csd_shadow_pixel(
+                CsdShadowPieceKind::Top,
+                0,
+                CSD_SHADOW_MARGIN - 1 - distance as i32,
+                false,
+            ));
+            assert!(actual.abs_diff(expected) <= 1);
+        }
+        assert!(
+            alpha(csd_shadow_pixel(CsdShadowPieceKind::Top, 0, 24, true))
+                > alpha(csd_shadow_pixel(CsdShadowPieceKind::Top, 0, 24, false))
+        );
+    }
+
+    #[test]
+    fn shadow_avoids_invalid_nine_patch_destinations_for_tiny_windows() {
+        assert!(!csd_shadow_visible_at_size(true, 32, 480));
+        assert!(!csd_shadow_visible_at_size(true, 640, 32));
+        assert!(csd_shadow_visible_at_size(true, 33, 33));
+        assert!(!csd_shadow_visible_at_size(false, 640, 480));
+    }
+
+    #[test]
+    fn shadow_only_appears_on_floating_client_decorated_windows() {
+        assert!(should_show_csd_shadow(true, false, false, false));
+        assert!(!should_show_csd_shadow(false, false, false, false));
+        assert!(!should_show_csd_shadow(true, true, false, false));
+        assert!(!should_show_csd_shadow(true, false, true, false));
+        assert!(!should_show_csd_shadow(true, false, false, true));
     }
 }

--- a/platform/src/os/linux/wayland/wayland_state.rs
+++ b/platform/src/os/linux/wayland/wayland_state.rs
@@ -4,7 +4,7 @@ use crate::{
     makepad_math::{dvec2, Vec2d},
     wayland::{wayland_type, xkb_sys},
     Area, DragEvent, DragItem, DragResponse, DropEvent, KeyEvent, KeyModifiers, MouseButton,
-    MouseDownEvent, MouseMoveEvent, MouseUpEvent, TextClipboardEvent, TextInputEvent,
+    MouseCursor, MouseDownEvent, MouseMoveEvent, MouseUpEvent, TextClipboardEvent, TextInputEvent,
     WindowClosedEvent, WindowDragQueryEvent, WindowDragQueryResponse,
 };
 use std::{
@@ -21,7 +21,8 @@ use wayland_client::{
         wl_buffer, wl_callback, wl_compositor, wl_data_device, wl_data_device_manager,
         wl_data_offer, wl_data_source, wl_keyboard, wl_output,
         wl_pointer::{self, ButtonState},
-        wl_registry, wl_seat, wl_shm, wl_shm_pool, wl_surface,
+        wl_region, wl_registry, wl_seat, wl_shm, wl_shm_pool, wl_subcompositor, wl_subsurface,
+        wl_surface,
     },
     Connection, Dispatch, Proxy, QueueHandle, WEnum,
 };
@@ -49,7 +50,10 @@ use wayland_protocols::{
 
 use crate::{
     cx_native::EventFlow,
-    event::{PopupDismissReason, PopupDismissedEvent, ScrollEvent, ScrollPhase, WindowGeom},
+    event::{
+        PopupDismissReason, PopupDismissedEvent, ScrollEvent, ScrollPhase, WindowGeom,
+        TAP_COUNT_DISTANCE, TAP_COUNT_TIME,
+    },
     select_timer::SelectTimers,
     wayland::wayland_app::WaylandApp,
     x11::xlib_event::XlibEvent,
@@ -61,6 +65,131 @@ use super::opengl_wayland::{WaylandPopupWindow, WaylandWindow};
 
 /// Reserved timer ID for keyboard repeat. Uses a high value to avoid conflicts with app timers.
 const KEY_REPEAT_TIMER_ID: u64 = u64::MAX - 1;
+
+fn is_caption_double_click(
+    previous: Option<(WindowId, Vec2d, u32)>,
+    window_id: WindowId,
+    pos: Vec2d,
+    time: u32,
+) -> bool {
+    previous.is_some_and(|(last_window_id, last_pos, last_time)| {
+        last_window_id == window_id
+            && time.wrapping_sub(last_time) <= (TAP_COUNT_TIME * 1000.0) as u32
+            && (pos - last_pos).length() < TAP_COUNT_DISTANCE
+    })
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CaptionPress {
+    window_id: WindowId,
+    pos: Vec2d,
+    time: u32,
+    serial: u32,
+    drag_started: bool,
+}
+
+impl CaptionPress {
+    fn start_drag_if_needed(&mut self, window_id: WindowId, pos: Vec2d) -> Option<(WindowId, u32)> {
+        if self.drag_started {
+            return None;
+        }
+        if self.window_id != window_id {
+            self.drag_started = true;
+            return None;
+        }
+        if (pos - self.pos).length() < TAP_COUNT_DISTANCE {
+            return None;
+        }
+        self.drag_started = true;
+        Some((self.window_id, self.serial))
+    }
+
+    fn completed_click(self, window_id: WindowId, pos: Vec2d) -> Option<(WindowId, Vec2d, u32)> {
+        (self.window_id == window_id
+            && !self.drag_started
+            && (pos - self.pos).length() < TAP_COUNT_DISTANCE)
+            .then_some((self.window_id, self.pos, self.time))
+    }
+}
+
+const RESIZE_EDGE_LEFT: u8 = 1 << 0;
+const RESIZE_EDGE_RIGHT: u8 = 1 << 1;
+const RESIZE_EDGE_TOP: u8 = 1 << 2;
+const RESIZE_EDGE_BOTTOM: u8 = 1 << 3;
+
+fn xdg_toplevel_edge_mask(states: &[u8], first_state: u32) -> u8 {
+    [
+        (first_state, RESIZE_EDGE_LEFT),
+        (first_state + 1, RESIZE_EDGE_RIGHT),
+        (first_state + 2, RESIZE_EDGE_TOP),
+        (first_state + 3, RESIZE_EDGE_BOTTOM),
+    ]
+    .into_iter()
+    .filter_map(|(state, edge)| WaylandState::xdg_toplevel_has_state(states, state).then_some(edge))
+    .fold(0, |mask, edge| mask | edge)
+}
+
+fn resize_edge_mask(edge: xdg_toplevel::ResizeEdge) -> u8 {
+    match edge {
+        xdg_toplevel::ResizeEdge::Top => RESIZE_EDGE_TOP,
+        xdg_toplevel::ResizeEdge::Bottom => RESIZE_EDGE_BOTTOM,
+        xdg_toplevel::ResizeEdge::Left => RESIZE_EDGE_LEFT,
+        xdg_toplevel::ResizeEdge::TopLeft => RESIZE_EDGE_TOP | RESIZE_EDGE_LEFT,
+        xdg_toplevel::ResizeEdge::BottomLeft => RESIZE_EDGE_BOTTOM | RESIZE_EDGE_LEFT,
+        xdg_toplevel::ResizeEdge::Right => RESIZE_EDGE_RIGHT,
+        xdg_toplevel::ResizeEdge::TopRight => RESIZE_EDGE_TOP | RESIZE_EDGE_RIGHT,
+        xdg_toplevel::ResizeEdge::BottomRight => RESIZE_EDGE_BOTTOM | RESIZE_EDGE_RIGHT,
+        _ => 0,
+    }
+}
+
+fn resize_edge_from_mask(mask: u8) -> Option<xdg_toplevel::ResizeEdge> {
+    use xdg_toplevel::ResizeEdge;
+    Some(
+        match (
+            mask & (RESIZE_EDGE_LEFT | RESIZE_EDGE_RIGHT),
+            mask & (RESIZE_EDGE_TOP | RESIZE_EDGE_BOTTOM),
+        ) {
+            (RESIZE_EDGE_LEFT, RESIZE_EDGE_TOP) => ResizeEdge::TopLeft,
+            (RESIZE_EDGE_LEFT, RESIZE_EDGE_BOTTOM) => ResizeEdge::BottomLeft,
+            (RESIZE_EDGE_RIGHT, RESIZE_EDGE_TOP) => ResizeEdge::TopRight,
+            (RESIZE_EDGE_RIGHT, RESIZE_EDGE_BOTTOM) => ResizeEdge::BottomRight,
+            (RESIZE_EDGE_LEFT, 0) => ResizeEdge::Left,
+            (RESIZE_EDGE_RIGHT, 0) => ResizeEdge::Right,
+            (0, RESIZE_EDGE_TOP) => ResizeEdge::Top,
+            (0, RESIZE_EDGE_BOTTOM) => ResizeEdge::Bottom,
+            _ => return None,
+        },
+    )
+}
+
+/// Narrows `edge` to the components the compositor still allows. A tiled window shares
+/// its inner borders with a neighbour and cannot resize them, but its outer ones stay
+/// free; dropping the whole corner in that case would cost the user a grab they still
+/// have, so a corner degrades to whichever of its two edges survives.
+pub(crate) fn available_resize_edge(
+    edge: xdg_toplevel::ResizeEdge,
+    unavailable: u8,
+) -> Option<xdg_toplevel::ResizeEdge> {
+    resize_edge_from_mask(resize_edge_mask(edge) & !unavailable)
+}
+
+pub(crate) fn resize_edge_cursor(
+    edge: xdg_toplevel::ResizeEdge,
+) -> wp_cursor_shape_device_v1::Shape {
+    use wp_cursor_shape_device_v1::Shape;
+    match edge {
+        xdg_toplevel::ResizeEdge::Top => Shape::NResize,
+        xdg_toplevel::ResizeEdge::Bottom => Shape::SResize,
+        xdg_toplevel::ResizeEdge::Left => Shape::WResize,
+        xdg_toplevel::ResizeEdge::Right => Shape::EResize,
+        xdg_toplevel::ResizeEdge::TopLeft => Shape::NwResize,
+        xdg_toplevel::ResizeEdge::TopRight => Shape::NeResize,
+        xdg_toplevel::ResizeEdge::BottomLeft => Shape::SwResize,
+        xdg_toplevel::ResizeEdge::BottomRight => Shape::SeResize,
+        _ => Shape::Default,
+    }
+}
 
 /// State for tracking keyboard key repeat.
 struct KeyRepeatState {
@@ -82,6 +211,7 @@ struct PendingClipboardRead {
 
 pub(crate) struct WaylandState {
     pub(crate) compositor: Option<wl_compositor::WlCompositor>,
+    pub(crate) subcompositor: Option<wl_subcompositor::WlSubcompositor>,
     pub(crate) wm_base: Option<xdg_wm_base::XdgWmBase>,
     pub(crate) seat: Option<wl_seat::WlSeat>,
     pub(crate) shm: Option<wl_shm::WlShm>,
@@ -101,12 +231,19 @@ pub(crate) struct WaylandState {
     pub(crate) pointer: Option<wl_pointer::WlPointer>,
     pub(crate) last_mouse_pos: Vec2d,
     pub(crate) pointer_serial: Option<u32>,
+    pub(crate) pointer_enter_serial: Option<u32>,
+    pub(crate) requested_cursor: MouseCursor,
     pub(crate) keyboard_serial: Option<u32>,
     pub(crate) decoration_manager: Option<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1>,
     pub(crate) icon_manager: Option<xdg_toplevel_icon_manager_v1::XdgToplevelIconManagerV1>,
     pub(crate) windows: Vec<WaylandWindow>,
     pub(crate) popups: Vec<WaylandPopupWindow>,
     pub(crate) pointer_window: Option<WindowId>,
+    /// Set while the pointer is over a window's shadow gutter rather than the window
+    /// itself, together with the edge a press there would resize. Kept apart from
+    /// [`Self::pointer_window`] because the gutter is outside the window: the app must
+    /// not see hover or clicks at coordinates that fall outside its own surface.
+    pub(crate) pointer_shadow: Option<(WindowId, xdg_toplevel::ResizeEdge)>,
     /// The latest un-dispatched pointer motion `(window_id, pos)`, coalesced across a whole
     /// `dispatch_pending` batch. A high-Hz mouse queues many `wl_pointer` motion+frame pairs between
     /// paints; dispatching each as a `MouseMove` runs a redundant hover hit-test across the whole
@@ -137,6 +274,9 @@ pub(crate) struct WaylandState {
         Option<zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1>,
     pub(crate) primary_selection_text: String,
     pub(crate) last_resize_edge: Option<xdg_toplevel::ResizeEdge>,
+    caption_press: Option<CaptionPress>,
+    last_caption_click: Option<(WindowId, Vec2d, u32)>,
+    consumed_pointer_buttons: MouseButton,
     event_callback: Option<Box<dyn FnMut(&mut WaylandState, XlibEvent)>>,
 
     pub(crate) scroll_accumulator: Vec2d,
@@ -170,6 +310,7 @@ impl WaylandState {
     pub fn new(event_callback: Box<dyn FnMut(&mut WaylandState, XlibEvent)>) -> Self {
         Self {
             compositor: None,
+            subcompositor: None,
             wm_base: None,
             seat: None,
             shm: None,
@@ -193,9 +334,12 @@ impl WaylandState {
             windows: Vec::new(),
             popups: Vec::new(),
             pointer_window: None,
+            pointer_shadow: None,
             pending_motion: None,
             keyboard_window: None,
             pointer_serial: None,
+            pointer_enter_serial: None,
+            requested_cursor: MouseCursor::Default,
             keyboard_serial: None,
             modifiers: KeyModifiers::default(),
             xkb_state: None,
@@ -211,6 +355,9 @@ impl WaylandState {
             primary_selection_text: String::new(),
             last_mouse_pos: dvec2(0., 0.),
             last_resize_edge: None,
+            caption_press: None,
+            last_caption_click: None,
+            consumed_pointer_buttons: MouseButton::empty(),
             timers: SelectTimers::new(),
             event_callback: Some(event_callback),
             scroll_accumulator: dvec2(0.0, 0.0),
@@ -255,6 +402,114 @@ impl WaylandState {
                     .map(|win| win.xdg_surface.clone())
             })
     }
+
+    fn clear_resize_edge(&mut self, force_cursor_update: bool) {
+        if self.last_resize_edge.take().is_some() || force_cursor_update {
+            if let (Some(cursor), Some(serial)) =
+                (self.cursor_shape.as_ref(), self.pointer_enter_serial)
+            {
+                cursor.set_shape(serial, self.requested_cursor.into());
+            }
+        }
+    }
+
+    fn update_resize_edge(
+        &mut self,
+        window_id: WindowId,
+        pos: Vec2d,
+        force_cursor_update: bool,
+    ) {
+        self.last_mouse_pos = pos;
+        let window_state = self
+            .windows
+            .iter()
+            .find(|window| window.window_id == window_id)
+            .filter(|window| {
+                window.uses_client_side_decorations
+                    && !window.is_maximized
+                    && !window.is_fullscreen
+                    // The gutter already owns the grabs, and hit-testing here as well would
+                    // charge every pointer motion near an edge for a whole-widget-tree
+                    // `WindowDragQuery` dispatch that cannot change the answer.
+                    && !window.csd_shadow_gutter_active()
+            })
+            .map(|window| {
+                (
+                    window.window_geom.inner_size,
+                    window.unavailable_resize_edges,
+                )
+            });
+        // The gutter outside the window is the primary way to resize, so these interior
+        // bands only need to cover the case where the shadow could not be created and
+        // there is no gutter to aim at. They stay narrow because every pixel they claim
+        // is a pixel the app's own widgets do not get.
+        let mut edge = window_state.and_then(|(size, unavailable)| {
+            let mut mask = 0;
+            if pos.x < 10.0 {
+                mask |= RESIZE_EDGE_LEFT;
+            } else if pos.x >= size.x - 10.0 {
+                mask |= RESIZE_EDGE_RIGHT;
+            }
+            if pos.y < 10.0 {
+                mask |= RESIZE_EDGE_TOP;
+            } else if pos.y >= size.y - 10.0 {
+                mask |= RESIZE_EDGE_BOTTOM;
+            }
+            // Away from a corner the band narrows to 5 px, so a single-axis hit outside
+            // that has to fall through to the app.
+            if mask.count_ones() == 1
+                && pos.x >= 5.0
+                && pos.x < size.x - 5.0
+                && pos.y >= 5.0
+                && pos.y < size.y - 5.0
+            {
+                return None;
+            }
+            resize_edge_from_mask(mask & !unavailable)
+        });
+        if edge.is_some() {
+            let response = Rc::new(Cell::new(WindowDragQueryResponse::NoAnswer));
+            self.do_callback(XlibEvent::WindowDragQuery(WindowDragQueryEvent {
+                window_id,
+                abs: pos,
+                response: response.clone(),
+            }));
+            if matches!(response.get(), WindowDragQueryResponse::Client) {
+                edge = None;
+            }
+        }
+        if let Some(resize_edge) = edge {
+            self.last_resize_edge = Some(resize_edge);
+            if let (Some(cursor), Some(serial)) =
+                (self.cursor_shape.as_ref(), self.pointer_enter_serial)
+            {
+                cursor.set_shape(serial, resize_edge_cursor(resize_edge));
+            }
+        } else {
+            self.clear_resize_edge(force_cursor_update);
+        }
+    }
+
+    /// Handles the pointer entering one of a window's shadow surfaces: the pointer is in
+    /// the gutter, outside the window proper, where the only gesture is a resize. Returns
+    /// false when `surface` belongs to no shadow, leaving the caller's normal path intact.
+    fn enter_shadow_gutter(&mut self, surface: &wl_surface::WlSurface) -> bool {
+        let surface_id = surface.id();
+        let Some((window_id, edge, shape)) = self.windows.iter().find_map(|window| {
+            window
+                .csd_shadow_resize_for_surface(&surface_id)
+                .map(|(edge, shape)| (window.window_id, edge, shape))
+        }) else {
+            return false;
+        };
+        self.pointer_shadow = Some((window_id, edge));
+        if let (Some(cursor), Some(serial)) =
+            (self.cursor_shape.as_ref(), self.pointer_enter_serial)
+        {
+            cursor.set_shape(serial, shape);
+        }
+        true
+    }
 }
 
 impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
@@ -278,9 +533,19 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
                         wl_registry.bind::<wl_compositor::WlCompositor, _, _>(name, 1, qhandle, ());
                     state.compositor = Some(compositor);
                 }
+                "wl_subcompositor" => {
+                    let subcompositor = wl_registry
+                        .bind::<wl_subcompositor::WlSubcompositor, _, _>(name, 1, qhandle, ());
+                    state.subcompositor = Some(subcompositor);
+                }
                 "xdg_wm_base" => {
                     let wm_base =
-                        wl_registry.bind::<xdg_wm_base::XdgWmBase, _, _>(name, 1, qhandle, ());
+                        wl_registry.bind::<xdg_wm_base::XdgWmBase, _, _>(
+                            name,
+                            version.min(7),
+                            qhandle,
+                            (),
+                        );
                     state.wm_base = Some(wm_base);
                 }
                 "wl_seat" => {
@@ -453,7 +718,14 @@ impl Dispatch<xdg_toplevel::XdgToplevel, WindowId> for WaylandState {
                 height,
                 states,
             } => {
-                if let Some(window) = state.windows.iter().find(|win| win.window_id == *window_id) {
+                let mut geom_change = None;
+                let mut disable_client_resize = false;
+                let mut refresh_client_resize = false;
+                if let Some(window) = state
+                    .windows
+                    .iter_mut()
+                    .find(|win| win.window_id == *window_id)
+                {
                     let inner_size = if width > 0 && height > 0 {
                         dvec2(width as f64, height as f64)
                     } else {
@@ -463,13 +735,37 @@ impl Dispatch<xdg_toplevel::XdgToplevel, WindowId> for WaylandState {
                         WaylandState::xdg_toplevel_has_state(&states, 1 /* maximized */);
                     let is_fullscreen =
                         WaylandState::xdg_toplevel_has_state(&states, 2 /* fullscreen */);
-                    state.do_callback(XlibEvent::WindowGeomChange(WindowGeomChangeEvent {
+                    let is_active =
+                        WaylandState::xdg_toplevel_has_state(&states, 4 /* activated */);
+                    let tiled_edges = xdg_toplevel_edge_mask(&states, 5 /* tiled_left */);
+                    let constrained_edges =
+                        xdg_toplevel_edge_mask(&states, 10 /* constrained_left */);
+                    let unavailable_resize_edges = tiled_edges | constrained_edges;
+                    let resize_was_disabled = window.is_maximized || window.is_fullscreen;
+                    let resize_edges_changed =
+                        window.unavailable_resize_edges != unavailable_resize_edges;
+                    window.is_maximized = is_maximized;
+                    window.is_fullscreen = is_fullscreen;
+                    window.is_tiled = tiled_edges != 0;
+                    window.is_active = is_active;
+                    window.unavailable_resize_edges = unavailable_resize_edges;
+                    disable_client_resize = is_maximized || is_fullscreen;
+                    // A size change moves the right and bottom bands out from under a
+                    // stationary pointer. Without re-running the hit test the window keeps
+                    // a resize cursor it no longer has an edge for, and the next click is
+                    // swallowed starting a resize from nowhere.
+                    refresh_client_resize = resize_edges_changed
+                        || resize_was_disabled != disable_client_resize
+                        || window.window_geom.inner_size != inner_size;
+                    geom_change = Some(WindowGeomChangeEvent {
                         window_id: *window_id,
                         old_geom: window.window_geom.clone(),
                         new_geom: WindowGeom {
                             dpi_factor: window.window_geom.dpi_factor,
                             can_fullscreen: false,
                             xr_is_presenting: false,
+                            // Preserve the established Makepad API: on Wayland this
+                            // flag has always represented maximized or fullscreen.
                             is_fullscreen: is_fullscreen || is_maximized,
                             is_topmost: false,
                             position: dvec2(0., 0.),
@@ -477,7 +773,17 @@ impl Dispatch<xdg_toplevel::XdgToplevel, WindowId> for WaylandState {
                             outer_size: inner_size,
                             ..Default::default()
                         },
-                    }));
+                    });
+                }
+                if let Some(event) = geom_change {
+                    state.do_callback(XlibEvent::WindowGeomChange(event));
+                }
+                if state.pointer_window == Some(*window_id) {
+                    if disable_client_resize {
+                        state.clear_resize_edge(false);
+                    } else if refresh_client_resize {
+                        state.update_resize_edge(*window_id, state.last_mouse_pos, false);
+                    }
                 }
             }
             xdg_toplevel::Event::Close => {
@@ -488,6 +794,38 @@ impl Dispatch<xdg_toplevel::XdgToplevel, WindowId> for WaylandState {
                 }))
             }
             _ => {}
+        }
+    }
+}
+
+impl Dispatch<zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1, WindowId>
+    for WaylandState
+{
+    fn event(
+        state: &mut Self,
+        _decoration: &zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1,
+        event: zxdg_toplevel_decoration_v1::Event,
+        window_id: &WindowId,
+        _conn: &Connection,
+        _qhandle: &QueueHandle<Self>,
+    ) {
+        let zxdg_toplevel_decoration_v1::Event::Configure { mode } = event else {
+            return;
+        };
+        let uses_client_side_decorations = match mode {
+            WEnum::Value(zxdg_toplevel_decoration_v1::Mode::ServerSide) => false,
+            WEnum::Value(zxdg_toplevel_decoration_v1::Mode::ClientSide)
+            | WEnum::Value(_)
+            | WEnum::Unknown(_) => true,
+        };
+        if let Some(window) = state
+            .windows
+            .iter_mut()
+            .find(|window| window.window_id == *window_id)
+        {
+            // Decoration state is double-buffered with xdg_surface state. Keep
+            // only the latest mode and apply it at the matching surface configure.
+            window.pending_client_side_decorations = Some(uses_client_side_decorations);
         }
     }
 }
@@ -502,19 +840,57 @@ impl Dispatch<xdg_surface::XdgSurface, WindowId> for WaylandState {
     ) {
         if let xdg_surface::Event::Configure { serial, .. } = event {
             xdg_surface.ack_configure(serial);
-            let mut first_configure_event = None;
+            let mut configure_event = None;
+            let mut clear_resize_edge = false;
+            let mut update_resize_edge = false;
+            // Proxy clones are cheap handles and let us initialize CSD shadow
+            // resources while mutably borrowing the matching window.
+            let compositor = state.compositor.clone();
+            let subcompositor = state.subcompositor.clone();
+            let shm = state.shm.clone();
+            let viewporter = state.viewporter.clone();
             if let Some(window) = state
                 .windows
                 .iter_mut()
                 .find(|win| win.window_id == *window_id)
             {
+                let decoration_changed =
+                    if let Some(uses_csd) = window.pending_client_side_decorations.take() {
+                        if uses_csd == window.uses_client_side_decorations {
+                            false
+                        } else {
+                            if uses_csd {
+                                if let Some(compositor) = compositor.as_ref() {
+                                    window.ensure_csd_shadow(
+                                        compositor,
+                                        subcompositor.as_ref(),
+                                        shm.as_ref(),
+                                        viewporter.as_ref(),
+                                        qhandle,
+                                    );
+                                }
+                            }
+                            clear_resize_edge = !uses_csd;
+                            update_resize_edge = uses_csd;
+                            window.uses_client_side_decorations = uses_csd;
+                            true
+                        }
+                    } else {
+                        false
+                    };
                 if !window.configured {
                     let mut old_geom = window.window_geom.clone();
                     old_geom.inner_size = dvec2(0., 0.);
                     old_geom.outer_size = dvec2(0., 0.);
-                    first_configure_event = Some(WindowGeomChangeEvent {
+                    configure_event = Some(WindowGeomChangeEvent {
                         window_id: *window_id,
                         old_geom,
+                        new_geom: window.window_geom.clone(),
+                    });
+                } else if decoration_changed {
+                    configure_event = Some(WindowGeomChangeEvent {
+                        window_id: *window_id,
+                        old_geom: window.window_geom.clone(),
                         new_geom: window.window_geom.clone(),
                     });
                 }
@@ -528,7 +904,7 @@ impl Dispatch<xdg_surface::XdgSurface, WindowId> for WaylandState {
                     let mut old_geom = window.window_geom.clone();
                     old_geom.inner_size = dvec2(0., 0.);
                     old_geom.outer_size = dvec2(0., 0.);
-                    first_configure_event = Some(WindowGeomChangeEvent {
+                    configure_event = Some(WindowGeomChangeEvent {
                         window_id: *window_id,
                         old_geom,
                         new_geom: window.window_geom.clone(),
@@ -536,8 +912,13 @@ impl Dispatch<xdg_surface::XdgSurface, WindowId> for WaylandState {
                 }
                 window.configured = true;
             }
-            if let Some(event) = first_configure_event {
+            if let Some(event) = configure_event {
                 state.do_callback(XlibEvent::WindowGeomChange(event));
+            }
+            if clear_resize_edge && state.pointer_window == Some(*window_id) {
+                state.clear_resize_edge(false);
+            } else if update_resize_edge && state.pointer_window == Some(*window_id) {
+                state.update_resize_edge(*window_id, state.last_mouse_pos, false);
             }
         }
     }
@@ -1125,12 +1506,26 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandState {
             wl_pointer::Event::Enter {
                 serial,
                 surface,
-                surface_x: _,
-                surface_y: _,
+                surface_x,
+                surface_y,
             } => {
                 state.pointer_serial = Some(serial);
+                state.pointer_enter_serial = Some(serial);
                 state.flush_pending_clipboard_copy(qhandle, serial);
+                state.clear_resize_edge(true);
+                state.pointer_shadow = None;
+                state.pointer_window = None;
+                if state.enter_shadow_gutter(&surface) {
+                    return;
+                }
                 state.pointer_window = state.window_id_for_surface(&surface);
+                if let Some(window_id) = state.pointer_window {
+                    let pos = dvec2(surface_x as f64, surface_y as f64);
+                    state.last_mouse_pos = pos;
+                    // Deliver the enter position through the normal coalesced motion path so
+                    // stationary pointers establish hover state and the right app cursor.
+                    state.pending_motion = Some((window_id, pos));
+                }
             }
             wl_pointer::Event::Leave { serial, surface: _ } => {
                 // Dispatch any buffered motion before the pointer leaves, so the final hover
@@ -1139,93 +1534,40 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandState {
                 state.pointer_serial = Some(serial);
                 state.flush_pending_clipboard_copy(qhandle, serial);
                 state.pointer_window = None;
+                state.pointer_shadow = None;
+                state.pointer_enter_serial = None;
                 state.last_resize_edge = None;
+                state.caption_press = None;
+                state.last_caption_click = None;
             }
             wl_pointer::Event::Motion {
-                time,
+                time: _,
                 surface_x,
                 surface_y,
             } => {
                 if let Some(window_id) = state.pointer_window {
                     let pos = dvec2(surface_x as f64, surface_y as f64);
                     state.last_mouse_pos = pos;
-
-                    // Edge-resize detection (matches X11 backend thresholds)
-                    let window_size = state
-                        .windows
-                        .iter()
-                        .find(|w| w.window_id == window_id)
-                        .map(|w| w.window_geom.inner_size);
-                    if let Some(ws) = window_size {
-                        let edge = if pos.x < 10.0 && pos.y < 10.0 {
-                            Some((
-                                xdg_toplevel::ResizeEdge::TopLeft,
-                                wp_cursor_shape_device_v1::Shape::NwResize,
-                            ))
-                        } else if pos.x < 10.0 && pos.y >= ws.y - 10.0 {
-                            Some((
-                                xdg_toplevel::ResizeEdge::BottomLeft,
-                                wp_cursor_shape_device_v1::Shape::SwResize,
-                            ))
-                        } else if pos.x < 5.0 {
-                            Some((
-                                xdg_toplevel::ResizeEdge::Left,
-                                wp_cursor_shape_device_v1::Shape::WResize,
-                            ))
-                        } else if pos.x >= ws.x - 10.0 && pos.y < 10.0 {
-                            Some((
-                                xdg_toplevel::ResizeEdge::TopRight,
-                                wp_cursor_shape_device_v1::Shape::NeResize,
-                            ))
-                        } else if pos.x >= ws.x - 10.0 && pos.y >= ws.y - 10.0 {
-                            Some((
-                                xdg_toplevel::ResizeEdge::BottomRight,
-                                wp_cursor_shape_device_v1::Shape::SeResize,
-                            ))
-                        } else if pos.x >= ws.x - 5.0 {
-                            Some((
-                                xdg_toplevel::ResizeEdge::Right,
-                                wp_cursor_shape_device_v1::Shape::EResize,
-                            ))
-                        } else if pos.y < 5.0 {
-                            Some((
-                                xdg_toplevel::ResizeEdge::Top,
-                                wp_cursor_shape_device_v1::Shape::NResize,
-                            ))
-                        } else if pos.y >= ws.y - 5.0 {
-                            Some((
-                                xdg_toplevel::ResizeEdge::Bottom,
-                                wp_cursor_shape_device_v1::Shape::SResize,
-                            ))
-                        } else {
-                            None
-                        };
-                        if let Some((resize_edge, cursor_shape)) = edge {
-                            state.last_resize_edge = Some(resize_edge);
-                            if let (Some(cursor_dev), Some(serial)) =
-                                (state.cursor_shape.as_ref(), state.pointer_serial)
-                            {
-                                cursor_dev.set_shape(serial, cursor_shape);
-                            }
-                        } else {
-                            if state.last_resize_edge.is_some() {
-                                if let (Some(cursor_dev), Some(serial)) =
-                                    (state.cursor_shape.as_ref(), state.pointer_serial)
-                                {
-                                    cursor_dev.set_shape(
-                                        serial,
-                                        wp_cursor_shape_device_v1::Shape::Default,
-                                    );
-                                }
-                            }
-                            state.last_resize_edge = None;
+                    let drag_request = state
+                        .caption_press
+                        .as_mut()
+                        .and_then(|press| press.start_drag_if_needed(window_id, pos));
+                    if let Some((press_window, press_serial)) = drag_request {
+                        state.last_caption_click = None;
+                        if let (Some(seat), Some(window)) = (
+                            state.seat.as_ref(),
+                            state
+                                .windows
+                                .iter()
+                                .find(|window| window.window_id == press_window),
+                        ) {
+                            window.toplevel._move(seat, press_serial);
                         }
                     }
 
                     // Buffer this motion instead of dispatching immediately; the latest one is
                     // flushed as a single MouseMove once the whole event batch is drained (or before
-                    // an intervening button/leave). The edge-resize cursor above still updates per
-                    // motion so the resize cursor stays responsive. See `flush_pending_motion`.
+                    // an intervening button/leave). See `flush_pending_motion`.
                     state.pending_motion = Some((window_id, pos));
                 }
             }
@@ -1243,7 +1585,12 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandState {
                 // Outside-click popup dismissal: if press lands on a
                 // regular window while popups are open, fire dismiss.
                 if let WEnum::Value(ButtonState::Pressed) = key_state {
-                    if let Some(win_id) = state.pointer_window {
+                    // A press in the shadow gutter is as much "outside" as one on the
+                    // window, so it dismisses popups too.
+                    if let Some(win_id) = state.pointer_window.or(state
+                        .pointer_shadow
+                        .map(|(window_id, _)| window_id))
+                    {
                         if state.windows.iter().any(|w| w.window_id == win_id)
                             && !state.popups.is_empty()
                         {
@@ -1258,26 +1605,47 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandState {
                         }
                     }
                 }
+                // In the gutter the only gesture is a resize, and the app is not told about
+                // it: these coordinates are outside its surface, and the compositor takes
+                // the pointer grab for the duration of the drag.
+                if let Some((window_id, resize_edge)) = state.pointer_shadow {
+                    if let (WEnum::Value(ButtonState::Pressed), Some(MouseButton::PRIMARY)) =
+                        (key_state, wayland_type::from_mouse(button))
+                    {
+                        if let (Some(seat), Some(window)) = (
+                            state.seat.as_ref(),
+                            state.windows.iter().find(|win| win.window_id == window_id),
+                        ) {
+                            window.toplevel.resize(seat, serial, resize_edge);
+                        }
+                    }
+                    return;
+                }
                 if let Some(btn) = wayland_type::from_mouse(button) {
                     if let Some(window_id) = state.pointer_window {
                         match key_state {
                             WEnum::Value(ButtonState::Pressed) => {
-                                if btn == MouseButton::PRIMARY {
-                                    if state.windows.iter().any(|win| win.window_id == window_id) {
-                                        // Edge resize takes priority
-                                        if let Some(resize_edge) = state.last_resize_edge.take() {
-                                            if let (Some(seat), Some(window)) = (
-                                                state.seat.as_ref(),
-                                                state
-                                                    .windows
-                                                    .iter()
-                                                    .find(|win| win.window_id == window_id),
-                                            ) {
-                                                window.toplevel.resize(seat, serial, resize_edge);
-                                                return;
-                                            }
-                                        }
-
+                                // A surface can disappear before delivering a release. Do not let
+                                // that stale bit consume the next independent press/release pair.
+                                state.consumed_pointer_buttons.remove(btn);
+                                let previous_caption_click = if btn == MouseButton::PRIMARY {
+                                    state.last_caption_click.take()
+                                } else {
+                                    state.last_caption_click = None;
+                                    None
+                                };
+                                state.caption_press = None;
+                                if btn == MouseButton::PRIMARY
+                                    || btn == MouseButton::SECONDARY
+                                {
+                                    let uses_client_side_decorations = state
+                                        .windows
+                                        .iter()
+                                        .find(|win| win.window_id == window_id)
+                                        .is_some_and(|win| {
+                                            win.uses_client_side_decorations && !win.is_fullscreen
+                                        });
+                                    if uses_client_side_decorations {
                                         let response =
                                             Rc::new(Cell::new(WindowDragQueryResponse::NoAnswer));
                                         state.do_callback(XlibEvent::WindowDragQuery(
@@ -1287,10 +1655,41 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandState {
                                                 response: response.clone(),
                                             },
                                         ));
+                                        let response = response.get();
+                                        // The top resize zone overlaps the caption vertically, but
+                                        // caption buttons must keep their full-height click target.
+                                        if btn == MouseButton::PRIMARY
+                                            && !matches!(
+                                                response,
+                                                WindowDragQueryResponse::Client
+                                            )
+                                        {
+                                            if let Some(resize_edge) = state.last_resize_edge {
+                                                if let (Some(seat), Some(window)) = (
+                                                    state.seat.as_ref(),
+                                                    state
+                                                        .windows
+                                                        .iter()
+                                                        .find(|win| win.window_id == window_id),
+                                                ) {
+                                                    window
+                                                        .toplevel
+                                                        .resize(seat, serial, resize_edge);
+                                                    state.consumed_pointer_buttons.insert(btn);
+                                                    return;
+                                                }
+                                            }
+                                        }
                                         if matches!(
-                                            response.get(),
+                                            response,
                                             WindowDragQueryResponse::Caption
                                         ) {
+                                            let is_double_click = is_caption_double_click(
+                                                previous_caption_click,
+                                                window_id,
+                                                state.last_mouse_pos,
+                                                time,
+                                            );
                                             if let (Some(seat), Some(window)) = (
                                                 state.seat.as_ref(),
                                                 state
@@ -1298,7 +1697,33 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandState {
                                                     .iter()
                                                     .find(|win| win.window_id == window_id),
                                             ) {
-                                                window.toplevel._move(seat, serial);
+                                                if btn == MouseButton::SECONDARY {
+                                                    window.toplevel.show_window_menu(
+                                                        seat,
+                                                        serial,
+                                                        state.last_mouse_pos.x as i32,
+                                                        state.last_mouse_pos.y as i32,
+                                                    );
+                                                    state.consumed_pointer_buttons.insert(btn);
+                                                    return;
+                                                }
+                                                if is_double_click {
+                                                    if window.is_maximized {
+                                                        window.toplevel.unset_maximized();
+                                                    } else {
+                                                        window.toplevel.set_maximized();
+                                                    }
+                                                    state.consumed_pointer_buttons.insert(btn);
+                                                    return;
+                                                }
+                                                state.caption_press = Some(CaptionPress {
+                                                    window_id,
+                                                    pos: state.last_mouse_pos,
+                                                    time,
+                                                    serial,
+                                                    drag_started: false,
+                                                });
+                                                state.consumed_pointer_buttons.insert(btn);
                                                 return;
                                             }
                                         }
@@ -1314,6 +1739,20 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandState {
                                 }))
                             }
                             WEnum::Value(ButtonState::Released) => {
+                                let consumed = state.consumed_pointer_buttons.contains(btn);
+                                if consumed {
+                                    state.consumed_pointer_buttons.remove(btn);
+                                }
+                                if btn == MouseButton::PRIMARY {
+                                    if let Some(press) = state.caption_press.take() {
+                                        state.last_caption_click =
+                                            press.completed_click(window_id, state.last_mouse_pos);
+                                        return;
+                                    }
+                                }
+                                if consumed {
+                                    return;
+                                }
                                 state.do_callback(XlibEvent::MouseUp(MouseUpEvent {
                                     abs: state.last_mouse_pos,
                                     button: btn,
@@ -1502,8 +1941,10 @@ delegate_noop!(WaylandState: ignore wl_surface::WlSurface);
 delegate_noop!(WaylandState: ignore wp_cursor_shape_device_v1::WpCursorShapeDeviceV1);
 delegate_noop!(WaylandState: ignore wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1);
 delegate_noop!(WaylandState: ignore wl_compositor::WlCompositor);
+delegate_noop!(WaylandState: ignore wl_region::WlRegion);
+delegate_noop!(WaylandState: ignore wl_subcompositor::WlSubcompositor);
+delegate_noop!(WaylandState: ignore wl_subsurface::WlSubsurface);
 delegate_noop!(WaylandState: ignore zxdg_decoration_manager_v1::ZxdgDecorationManagerV1);
-delegate_noop!(WaylandState: ignore zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1);
 delegate_noop!(WaylandState: ignore xdg_toplevel_icon_v1::XdgToplevelIconV1);
 delegate_noop!(WaylandState: ignore wl_shm::WlShm);
 delegate_noop!(WaylandState: ignore wl_shm_pool::WlShmPool);
@@ -1766,6 +2207,7 @@ impl WaylandState {
         {
             return;
         }
+        self.update_resize_edge(window_id, pos, false);
         self.do_callback(XlibEvent::MouseMove(MouseMoveEvent {
                 lock_delta: Default::default(),
             abs: pos,
@@ -1859,5 +2301,149 @@ impl WaylandState {
     }
     pub fn time_now(&self) -> f64 {
         self.timers.time_now()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encoded_states(states: &[u32]) -> Vec<u8> {
+        states
+            .iter()
+            .flat_map(|state| state.to_ne_bytes())
+            .collect()
+    }
+
+    #[test]
+    fn caption_double_click_requires_matching_window_time_and_position() {
+        let window = WindowId(2, 1);
+        let previous = Some((window, dvec2(10.0, 10.0), u32::MAX - 100));
+        assert!(is_caption_double_click(
+            previous,
+            window,
+            dvec2(12.0, 11.0),
+            50
+        ));
+        assert!(!is_caption_double_click(
+            previous,
+            WindowId(3, 1),
+            dvec2(12.0, 11.0),
+            50
+        ));
+        assert!(!is_caption_double_click(
+            previous,
+            window,
+            dvec2(20.0, 10.0),
+            50
+        ));
+        assert!(!is_caption_double_click(
+            previous,
+            window,
+            dvec2(12.0, 11.0),
+            600
+        ));
+    }
+
+    #[test]
+    fn caption_press_waits_for_drag_threshold_before_requesting_move() {
+        let window = WindowId(2, 1);
+        let mut press = CaptionPress {
+            window_id: window,
+            pos: dvec2(10.0, 10.0),
+            time: 100,
+            serial: 77,
+            drag_started: false,
+        };
+
+        assert_eq!(
+            press.start_drag_if_needed(window, dvec2(13.0, 13.0)),
+            None
+        );
+        assert!(!press.drag_started);
+        assert_eq!(
+            press.completed_click(window, dvec2(13.0, 13.0)),
+            Some((window, dvec2(10.0, 10.0), 100))
+        );
+    }
+
+    #[test]
+    fn caption_drag_requests_move_once_and_cannot_complete_as_click() {
+        let window = WindowId(2, 1);
+        let mut press = CaptionPress {
+            window_id: window,
+            pos: dvec2(10.0, 10.0),
+            time: 100,
+            serial: 77,
+            drag_started: false,
+        };
+
+        assert_eq!(
+            press.start_drag_if_needed(window, dvec2(15.0, 10.0)),
+            Some((window, 77))
+        );
+        assert!(press.drag_started);
+        assert_eq!(
+            press.start_drag_if_needed(window, dvec2(20.0, 10.0)),
+            None
+        );
+        assert_eq!(press.completed_click(window, dvec2(10.0, 10.0)), None);
+    }
+
+    #[test]
+    fn tiled_and_constrained_states_disable_only_their_resize_edges() {
+        let states = encoded_states(&[5, 7, 11, 13]);
+        let tiled = xdg_toplevel_edge_mask(&states, 5);
+        let constrained = xdg_toplevel_edge_mask(&states, 10);
+        assert_eq!(tiled, RESIZE_EDGE_LEFT | RESIZE_EDGE_TOP);
+        assert_eq!(constrained, RESIZE_EDGE_RIGHT | RESIZE_EDGE_BOTTOM);
+        // A corner whose edges are both free is kept whole.
+        assert_eq!(
+            available_resize_edge(xdg_toplevel::ResizeEdge::BottomRight, tiled),
+            Some(xdg_toplevel::ResizeEdge::BottomRight)
+        );
+        // A corner with one tiled edge degrades to the edge that is still free,
+        // rather than losing the grab entirely.
+        assert_eq!(
+            available_resize_edge(xdg_toplevel::ResizeEdge::TopLeft, constrained),
+            Some(xdg_toplevel::ResizeEdge::TopLeft)
+        );
+        assert_eq!(
+            available_resize_edge(xdg_toplevel::ResizeEdge::TopRight, tiled),
+            Some(xdg_toplevel::ResizeEdge::Right)
+        );
+        assert_eq!(
+            available_resize_edge(xdg_toplevel::ResizeEdge::BottomLeft, constrained),
+            Some(xdg_toplevel::ResizeEdge::Left)
+        );
+        // Both components gone means no grab at all.
+        assert_eq!(
+            available_resize_edge(xdg_toplevel::ResizeEdge::TopLeft, tiled),
+            None
+        );
+        assert_eq!(
+            available_resize_edge(xdg_toplevel::ResizeEdge::Top, tiled),
+            None
+        );
+    }
+
+    #[test]
+    fn resize_edge_cursor_matches_every_edge() {
+        use wp_cursor_shape_device_v1::Shape;
+        use xdg_toplevel::ResizeEdge;
+        for (edge, shape) in [
+            (ResizeEdge::Top, Shape::NResize),
+            (ResizeEdge::Bottom, Shape::SResize),
+            (ResizeEdge::Left, Shape::WResize),
+            (ResizeEdge::Right, Shape::EResize),
+            (ResizeEdge::TopLeft, Shape::NwResize),
+            (ResizeEdge::TopRight, Shape::NeResize),
+            (ResizeEdge::BottomLeft, Shape::SwResize),
+            (ResizeEdge::BottomRight, Shape::SeResize),
+        ] {
+            assert_eq!(resize_edge_cursor(edge), shape);
+            // Every edge must survive a round trip through the mask it degrades with.
+            assert_eq!(available_resize_edge(edge, 0), Some(edge));
+        }
     }
 }

--- a/platform/src/script/draw.rs
+++ b/platform/src/script/draw.rs
@@ -9,6 +9,7 @@ use crate::window::MacosWindowKind;
 use crate::window::MacosWindowLevel;
 use crate::window::ScriptWindowHandle;
 use crate::window::WindowBackdrop;
+use crate::window::WaylandDecorationPreference;
 use crate::*;
 
 pub fn script_mod(vm: &mut ScriptVm) -> ScriptValue {
@@ -20,6 +21,7 @@ pub fn script_mod(vm: &mut ScriptVm) -> ScriptValue {
     set_script_value_to_pod!(vm, draw.DrawPassUniforms);
     set_script_value_to_api!(vm, draw.MouseCursor);
     set_script_value_to_api!(vm, draw.WindowBackdrop);
+    set_script_value_to_api!(vm, draw.WaylandDecorationPreference);
     set_script_value_to_api!(vm, draw.MacosWindowKind);
     set_script_value_to_api!(vm, draw.MacosWindowChrome);
     set_script_value_to_api!(vm, draw.MacosWindowLevel);

--- a/platform/src/window.rs
+++ b/platform/src/window.rs
@@ -50,6 +50,21 @@ pub enum MacosWindowLevel {
     StatusBar,
 }
 
+/// The decoration mode a Wayland toplevel asks the compositor to use.
+///
+/// `ServerSide` requests compositor decorations, but the compositor may select
+/// client-side mode instead. `ClientSide` explicitly uses Makepad's frame. If
+/// xdg-decoration is unavailable, Makepad always uses client-side decorations.
+/// `MAKEPAD_WAYLAND_DECORATION=client|server` can override it for all windows
+/// in a process. `--wayland-decoration=client|server` is also recognized when
+/// the application's own argument parser accepts framework arguments.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Script, ScriptHook, Default)]
+pub enum WaylandDecorationPreference {
+    #[default]
+    ServerSide,
+    ClientSide,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Script)]
 pub struct MacosWindowConfig {
     #[live]
@@ -353,6 +368,9 @@ impl WindowHandle {
         cxwindow.popup_position = None;
         cxwindow.popup_size = None;
         cxwindow.popup_grab_keyboard = true;
+        cxwindow.wayland_decorations = WaylandDecorationPreference::default();
+        cxwindow.uses_client_side_decorations = false;
+        cxwindow.wayland_is_fullscreen = false;
         cx.platform_ops
             .push_back(CxOsOp::CreateWindow(window.window_id()));
         window
@@ -379,6 +397,9 @@ impl WindowHandle {
             cxwindow.popup_position = Some(position);
             cxwindow.popup_size = Some(size);
             cxwindow.popup_grab_keyboard = true;
+            cxwindow.wayland_decorations = WaylandDecorationPreference::default();
+            cxwindow.uses_client_side_decorations = false;
+            cxwindow.wayland_is_fullscreen = false;
             cxwindow.popup_grab_keyboard
         };
         cx.platform_ops.push_back(CxOsOp::CreatePopupWindow {
@@ -420,6 +441,10 @@ pub struct ScriptWindowHandle {
     pub backdrop_intensity: f32,
     #[live(MacosWindowConfig::default())]
     pub macos: MacosWindowConfig,
+    /// Wayland only. Server-side decorations are requested by default; set
+    /// this to `ClientSide` to explicitly use Makepad's window frame.
+    #[live(WaylandDecorationPreference::ServerSide)]
+    pub wayland_decorations: WaylandDecorationPreference,
     /// Optionally override the caption bar height.
     /// * If `None` (the default), the caption bar's height is based on a system-calculated height
     ///   derived from window chrome button geometry, which will make the window chrome buttons
@@ -470,6 +495,9 @@ impl ScriptHook for ScriptWindowHandle {
         .normalized();
         let macos = self.macos.normalized();
         cx.windows[window_id].macos = macos;
+        if !cx.windows[window_id].is_created {
+            cx.windows[window_id].wayland_decorations = self.wayland_decorations;
+        }
         if cx.windows[window_id].window_visuals() != visuals {
             cx.windows[window_id].transparent = visuals.transparent;
             cx.windows[window_id].backdrop = visuals.backdrop;
@@ -521,6 +549,19 @@ impl WindowHandle {
     pub fn configure_macos_window(&mut self, cx: &mut Cx, config: MacosWindowConfig) {
         cx.windows[self.window_id()].macos = config.normalized();
     }
+
+    /// Selects the decoration mode requested when a Wayland window is created.
+    /// This has no effect after the native window has been created.
+    pub fn configure_wayland_decorations(
+        &mut self,
+        cx: &mut Cx,
+        preference: WaylandDecorationPreference,
+    ) {
+        let window = &mut cx.windows[self.window_id()];
+        if !window.is_created {
+            window.wayland_decorations = preference;
+        }
+    }
     pub fn get_inner_size(&self, cx: &Cx) -> Vec2d {
         cx.windows[self.window_id()].get_inner_size()
     }
@@ -561,6 +602,17 @@ impl WindowHandle {
 
     pub fn is_fullscreen(&self, cx: &Cx) -> bool {
         cx.windows[self.window_id()].window_geom.is_fullscreen
+    }
+
+    /// Whether this Wayland window is using Makepad-drawn decorations.
+    pub fn uses_wayland_client_side_decorations(&self, cx: &Cx) -> bool {
+        cx.windows[self.window_id()].uses_client_side_decorations
+    }
+
+    /// Whether this Wayland window is in true compositor fullscreen, as
+    /// distinct from the legacy `is_fullscreen` maximize-or-fullscreen flag.
+    pub fn is_wayland_fullscreen(&self, cx: &Cx) -> bool {
+        cx.windows[self.window_id()].wayland_is_fullscreen
     }
 
     pub fn xr_is_presenting(&mut self, cx: &mut Cx) -> bool {
@@ -683,6 +735,11 @@ pub struct CxWindow {
     pub backdrop: WindowBackdrop,
     pub backdrop_intensity: f32,
     pub macos: MacosWindowConfig,
+    pub wayland_decorations: WaylandDecorationPreference,
+    /// Effective Wayland decoration mode selected by the compositor.
+    pub(crate) uses_client_side_decorations: bool,
+    /// True compositor fullscreen, kept separate so CSD remains visible when maximized.
+    pub(crate) wayland_is_fullscreen: bool,
 }
 
 impl Default for CxWindow {
@@ -709,6 +766,9 @@ impl Default for CxWindow {
             backdrop: WindowBackdrop::None,
             backdrop_intensity: 1.0,
             macos: MacosWindowConfig::default(),
+            wayland_decorations: WaylandDecorationPreference::default(),
+            uses_client_side_decorations: false,
+            wayland_is_fullscreen: false,
         }
     }
 }
@@ -924,6 +984,32 @@ mod tests {
         assert!(!cx_window.transparent);
         assert_eq!(cx_window.backdrop, WindowBackdrop::None);
         assert_eq!(cx_window.backdrop_intensity, 1.0);
+        assert_eq!(
+            cx_window.wayland_decorations,
+            WaylandDecorationPreference::ServerSide
+        );
+    }
+
+    #[test]
+    fn reused_window_slot_resets_wayland_decoration_state() {
+        let mut cx = test_cx();
+        let first = WindowHandle::new(&mut cx);
+        let first_id = first.window_id();
+        cx.windows[first_id].wayland_decorations = WaylandDecorationPreference::ClientSide;
+        cx.windows[first_id].uses_client_side_decorations = true;
+        cx.windows[first_id].wayland_is_fullscreen = true;
+        drop(first);
+
+        let second = WindowHandle::new(&mut cx);
+        let second_id = second.window_id();
+        assert_eq!(second_id.0, first_id.0);
+        assert_ne!(second_id.1, first_id.1);
+        assert_eq!(
+            cx.windows[second_id].wayland_decorations,
+            WaylandDecorationPreference::ServerSide
+        );
+        assert!(!cx.windows[second_id].uses_client_side_decorations);
+        assert!(!cx.windows[second_id].wayland_is_fullscreen);
     }
 
     #[test]
@@ -1084,6 +1170,7 @@ mod tests {
             backdrop: WindowBackdrop::Blur,
             backdrop_intensity: 0.5,
             macos: MacosWindowConfig::floating_panel(),
+            wayland_decorations: WaylandDecorationPreference::ClientSide,
             caption_bar_height_override: None,
         };
 
@@ -1106,6 +1193,10 @@ mod tests {
             }
         );
         assert_eq!(cx_window.macos, MacosWindowConfig::floating_panel());
+        assert_eq!(
+            cx_window.wayland_decorations,
+            WaylandDecorationPreference::ClientSide
+        );
     }
 
     #[test]

--- a/widgets/src/desktop_button.rs
+++ b/widgets/src/desktop_button.rs
@@ -60,10 +60,7 @@ script_mod! {
                         return sdf.result
                     }
                     DesktopButtonType.WindowsMaxToggled => {
-                        let sz = 5.
-                        sdf.rect(c.x - sz + 1., c.y - sz - 1., 2. * sz, 2. * sz)
-                        sdf.stroke(#f, 0.5 + 0.5 * self.draw_pass.dpi_dilate)
-                        sdf.rect(c.x - sz - 1., c.y - sz + 1., 2. * sz, 2. * sz)
+                        sdf.rect(c.x - sz, c.y - sz, 2. * sz, 2. * sz)
                         sdf.stroke(color, 0.5 + 0.5 * self.draw_pass.dpi_dilate)
                         return sdf.result
                     }

--- a/widgets/src/window.rs
+++ b/widgets/src/window.rs
@@ -163,7 +163,7 @@ script_mod! {
                     draw_bg.button_type: DesktopButtonType.WindowsMin
                     width: 46 height: 29
                     draw_bg +: {
-                        color: #000, color_hover: #000, color_down: #000
+                        color: theme.color_label_inner, color_hover: #000, color_down: #000
                         bg_color_hover: #E9E9E9, bg_color_down: #CCCCCC
                     }
                 }
@@ -171,7 +171,7 @@ script_mod! {
                     draw_bg.button_type: DesktopButtonType.WindowsMax
                     width: 46 height: 29
                     draw_bg +: {
-                        color: #000, color_hover: #000, color_down: #000
+                        color: theme.color_label_inner, color_hover: #000, color_down: #000
                         bg_color_hover: #E9E9E9, bg_color_down: #CCCCCC
                     }
                 }
@@ -179,7 +179,7 @@ script_mod! {
                     draw_bg.button_type: DesktopButtonType.WindowsClose
                     width: 46 height: 29
                     draw_bg +: {
-                        color: #000, color_hover: #FFF, color_down: #FFF
+                        color: theme.color_label_inner, color_hover: #FFF, color_down: #FFF
                         bg_color_hover: #E81123, bg_color_down: #F1707A
                     }
                 }
@@ -374,13 +374,17 @@ pub struct Window {
     /// Used to only emit a platform op when the resolved value actually changes.
     #[rust]
     system_bar_dark_icons: Option<bool>,
-    /// Cached `(caption_bar visible, caption rect, buttons rect)` for `WindowDragQuery`. That event
-    /// fires once per `WM_NCHITTEST` — i.e. on every mouse move on Windows — and resolving the
-    /// views + their areas each time runs widget-tree lookups, a real source of scroll jitter when
-    /// the mouse is moved during a fling. These only change on relayout, so we recompute lazily and
-    /// invalidate on `WindowGeomChange`.
+    /// Cached `(caption_bar visible, caption rect, buttons rect)` for `WindowDragQuery`. It is
+    /// refreshed only after layout finishes, so a synchronous native hit-test between configure
+    /// and redraw cannot preserve rectangles from the previous window size.
     #[rust]
     drag_query_cache: Option<(bool, Rect, Rect)>,
+    /// Whether a completed draw has made this frame's areas authoritative, so a geometry
+    /// computed now may be cached. Between a configure and the redraw that answers it the
+    /// areas still describe the previous size, and a query in that window is answered live
+    /// without being stored.
+    #[rust]
+    drag_query_layout_valid: bool,
     /// The caption-layout inputs (show_caption_bar, height override, system caption height) that
     /// `drag_query_cache` was last computed against. When they change without a platform
     /// `WindowGeomChange` (e.g. a live/DSL reload toggling the caption), we drop the cache in
@@ -503,6 +507,54 @@ fn gauss_render_texture_y_flip_for_os(os_type: &OsType) -> f32 {
     match os_type {
         OsType::Android(_) => 1.0,
         _ => 0.0,
+    }
+}
+
+fn classify_window_drag_query(
+    visible: bool,
+    caption_rect: Rect,
+    buttons_rect: Rect,
+    transitional_buttons_rect: Rect,
+    point: Vec2d,
+) -> WindowDragQueryResponse {
+    if !visible {
+        return WindowDragQueryResponse::NoAnswer;
+    }
+    let hits_buttons = (buttons_rect.size != Vec2d::default() && buttons_rect.contains(point))
+        || (transitional_buttons_rect.size != Vec2d::default()
+            && transitional_buttons_rect.contains(point));
+    if hits_buttons {
+        WindowDragQueryResponse::Client
+    } else if caption_rect.contains(point) {
+        WindowDragQueryResponse::Caption
+    } else {
+        WindowDragQueryResponse::NoAnswer
+    }
+}
+
+fn configured_window_buttons_rect(buttons_rect: Rect, configured_rect: Rect) -> Rect {
+    if buttons_rect.size == Vec2d::default() || configured_rect.size == Vec2d::default() {
+        return configured_rect;
+    }
+    Rect {
+        pos: dvec2(
+            configured_rect.pos.x + configured_rect.size.x - buttons_rect.size.x,
+            buttons_rect.pos.y,
+        ),
+        size: buttons_rect.size,
+    }
+}
+
+fn configured_window_caption_rect(caption_rect: Rect, configured_size: Vec2d) -> Rect {
+    if caption_rect.size == Vec2d::default() || configured_size == Vec2d::default() {
+        return caption_rect;
+    }
+    Rect {
+        pos: caption_rect.pos,
+        size: dvec2(
+            (configured_size.x - caption_rect.pos.x).max(0.0),
+            caption_rect.size.y,
+        ),
     }
 }
 
@@ -984,15 +1036,20 @@ impl Window {
                     .set_visible(cx, self.show_caption_bar && !is_fullscreen);
             }
             OsType::LinuxWindow(params) => {
-                // Only show the caption bar if we're drawing our own window chrome
-                // (e.g. Wayland without server-side decorations). On X11 the WM
-                // provides native decorations, so we hide the in-app caption bar.
-                let custom_chrome = params.custom_window_chrome;
+                // X11 uses WM decorations. Wayland decides per window from the
+                // compositor's xdg-decoration configure event.
+                let custom_chrome = params.custom_window_chrome
+                    && self
+                        .window
+                        .handle
+                        .uses_wayland_client_side_decorations(cx);
+                let visible = self.show_caption_bar
+                    && custom_chrome
+                    && !self.window.handle.is_wayland_fullscreen(cx);
                 self.view(cx, ids!(caption_bar))
-                    .set_visible(cx, self.show_caption_bar && custom_chrome);
-                if custom_chrome {
-                    self.view(cx, ids!(windows_buttons)).set_visible(cx, true);
-                }
+                    .set_visible(cx, visible);
+                self.view(cx, ids!(windows_buttons))
+                    .set_visible(cx, visible);
             }
             OsType::LinuxDirect | OsType::Android(_) => {
                 //self.frame.get_view(ids!(caption_bar)).set_visible(false);
@@ -1002,6 +1059,21 @@ impl Window {
             }
             _ => (),
         }
+    }
+
+    fn caption_drag_geometry(&self, cx: &mut Cx) -> (bool, Rect, Rect) {
+        // Each `self.view` is a widget-tree walk, so the caption bar is resolved once
+        // rather than once per field read.
+        let caption = self.view(cx, ids!(caption_bar));
+        let visible = caption.visible();
+        let caption_rect = caption.area().rect(cx);
+        let buttons = self.view(cx, ids!(windows_buttons));
+        let buttons_rect = if buttons.visible() {
+            buttons.area().rect(cx)
+        } else {
+            Rect::default()
+        };
+        (visible, caption_rect, buttons_rect)
     }
 
     fn sync_caption_bar_height(&mut self, cx: &mut Cx) {
@@ -1117,6 +1189,7 @@ impl Window {
         if self.caption_query_sig != Some(caption_sig) {
             self.caption_query_sig = Some(caption_sig);
             self.drag_query_cache = None;
+            self.drag_query_layout_valid = false;
         }
 
         self.sync_caption_bar_state(cx);
@@ -1313,6 +1386,14 @@ impl Window {
 
         cx.end_pass_sized_turtle();
 
+        // Areas are authoritative only after this frame's layout has completed, so this is
+        // where a cached answer becomes allowed. Computing it here instead would charge
+        // every frame for three widget-tree walks that only a drag query ever reads, and
+        // most frames never see one. Dropping last frame's answer rather than keeping it
+        // means the first query after any relayout still recomputes, whether or not the
+        // relayout was one of the two that invalidate explicitly.
+        self.drag_query_cache = None;
+        self.drag_query_layout_valid = true;
         self.main_draw_list.end(cx);
         cx.end_pass(&self.pass.handle);
     }
@@ -1342,6 +1423,16 @@ impl Window {
         self.window.handle.configure_macos_window(cx, config);
     }
 
+    pub fn configure_wayland_decorations(
+        &mut self,
+        cx: &mut Cx,
+        preference: WaylandDecorationPreference,
+    ) {
+        self.window
+            .handle
+            .configure_wayland_decorations(cx, preference);
+    }
+
     pub fn window_index(&self) -> usize {
         self.window.handle.window_id().id()
     }
@@ -1362,6 +1453,66 @@ mod tests {
             gauss_render_texture_y_flip_for_os(&OsType::Android(Default::default())),
             1.0
         );
+    }
+
+    #[test]
+    fn native_button_geometry_wins_during_configure_to_draw_transition() {
+        let stale_caption = Rect {
+            pos: dvec2(0.0, 0.0),
+            size: dvec2(800.0, 29.0),
+        };
+        let stale_buttons = Rect {
+            pos: dvec2(662.0, 0.0),
+            size: dvec2(138.0, 29.0),
+        };
+        let configured_buttons = Rect {
+            pos: dvec2(1782.0, 0.0),
+            size: dvec2(138.0, 29.0),
+        };
+        assert!(matches!(
+            classify_window_drag_query(
+                true,
+                stale_caption,
+                stale_buttons,
+                configured_buttons,
+                dvec2(1851.0, 14.0),
+            ),
+            WindowDragQueryResponse::Client
+        ));
+        assert!(matches!(
+            classify_window_drag_query(
+                true,
+                stale_caption,
+                stale_buttons,
+                Rect::default(),
+                dvec2(400.0, 14.0),
+            ),
+            WindowDragQueryResponse::Caption
+        ));
+
+        let zoomed_buttons = Rect {
+            pos: dvec2(708.0, 0.0),
+            size: dvec2(92.0, 19.0),
+        };
+        assert_eq!(
+            configured_window_buttons_rect(zoomed_buttons, configured_buttons),
+            Rect {
+                pos: dvec2(1828.0, 0.0),
+                size: dvec2(92.0, 19.0),
+            }
+        );
+        let configured_caption =
+            configured_window_caption_rect(stale_caption, dvec2(1920.0, 1080.0));
+        assert!(matches!(
+            classify_window_drag_query(
+                true,
+                configured_caption,
+                stale_buttons,
+                configured_buttons,
+                dvec2(1200.0, 14.0),
+            ),
+            WindowDragQueryResponse::Caption
+        ));
     }
 }
 
@@ -1478,6 +1629,16 @@ impl WindowRef {
             inner.configure_macos_window(cx, config);
         }
     }
+
+    pub fn configure_wayland_decorations(
+        &self,
+        cx: &mut Cx,
+        preference: WaylandDecorationPreference,
+    ) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.configure_wayland_decorations(cx, preference);
+        }
+    }
 }
 
 impl Widget for Window {
@@ -1538,8 +1699,10 @@ impl Widget for Window {
             Event::WindowGeomChange(ev) => {
                 if ev.window_id == self.window.window_id() {
                     // The caption / buttons may have been re-laid-out; drop the WindowDragQuery
-                    // geometry cache so it is recomputed on the next hit-test.
+                    // geometry cache so it is recomputed on the next hit-test, and mark the
+                    // areas non-authoritative until the redraw that answers this configure.
                     self.drag_query_cache = None;
+                    self.drag_query_layout_valid = false;
                     match cx.os_type() {
                         OsType::Windows | OsType::Macos => {
                             if self.hide_caption_on_fullscreen && !cx.in_makepad_studio() {
@@ -1600,42 +1763,51 @@ impl Widget for Window {
             }
             Event::WindowDragQuery(dq) => {
                 if dq.window_id == self.window.window_id() {
-                    // Resolve the caption / buttons geometry at most once per relayout; this event
-                    // arrives per mouse-move (per WM_NCHITTEST) and the view lookups are not free.
-                    let (visible, caption_rect, buttons_rect) = match self.drag_query_cache {
-                        Some(c) => c,
+                    // A native query can arrive synchronously after configure but before redraw.
+                    // Use live areas for that one query, but only a completed draw may cache them.
+                    let cache_ready = self.drag_query_cache.is_some() || self.drag_query_layout_valid;
+                    let geometry = match self.drag_query_cache {
+                        Some(cached) => cached,
                         None => {
-                            let visible = self.view(cx, ids!(caption_bar)).visible();
-                            let caption_rect = self.view(cx, ids!(caption_bar)).area().rect(cx);
-                            let buttons_view = self.view(cx, ids!(windows_buttons));
-                            let buttons_visible = buttons_view.visible();
-                            let buttons_rect = buttons_view.area().rect(cx);
-                            // Only cache once the caption bar AND its (visible) buttons have actually
-                            // been laid out, so an early query doesn't pin a stale rect. Pinning a
-                            // zero buttons_rect while the buttons are visible-but-not-yet-laid-out
-                            // would make the min/max/close strip respond as draggable Caption (a
-                            // click on Close would drag the window) until the next geometry change. A
-                            // window with no (hidden) buttons keeps a zero buttons_rect, which is fine.
-                            let caption_ready = caption_rect.size != Vec2d::default();
-                            let buttons_ready =
-                                !buttons_visible || buttons_rect.size != Vec2d::default();
-                            if !visible || (caption_ready && buttons_ready) {
-                                self.drag_query_cache = Some((visible, caption_rect, buttons_rect));
+                            let live = self.caption_drag_geometry(cx);
+                            if self.drag_query_layout_valid {
+                                self.drag_query_cache = Some(live);
                             }
-                            (visible, caption_rect, buttons_rect)
+                            live
                         }
                     };
-                    if visible {
-                        if caption_rect.contains(dq.abs) {
-                            if buttons_rect.size != Vec2d::default()
-                                && buttons_rect.contains(dq.abs)
-                            {
-                                dq.response.set(WindowDragQueryResponse::Client);
-                            } else {
-                                dq.response.set(WindowDragQueryResponse::Caption);
-                            }
+                    let (visible, mut caption_rect, buttons_rect) = geometry;
+                    if !cache_ready {
+                        caption_rect = configured_window_caption_rect(
+                            caption_rect,
+                            cx.windows[dq.window_id].window_geom.inner_size,
+                        );
+                    }
+                    let transitional_buttons = if cache_ready {
+                        Rect::default()
+                    } else {
+                        configured_window_buttons_rect(
+                            buttons_rect,
+                            cx.windows[dq.window_id].window_geom.window_chrome_buttons,
+                        )
+                    };
+                    match classify_window_drag_query(
+                        visible,
+                        caption_rect,
+                        buttons_rect,
+                        transitional_buttons,
+                        dq.abs,
+                    ) {
+                        WindowDragQueryResponse::Client => {
+                            // Button geometry wins even if the stale caption rect still has the
+                            // previous width, and therefore also blocks native top-edge resize.
+                            dq.response.set(WindowDragQueryResponse::Client);
+                        }
+                        WindowDragQueryResponse::Caption => {
+                            dq.response.set(WindowDragQueryResponse::Caption);
                             cx.set_cursor(MouseCursor::Default);
                         }
+                        WindowDragQueryResponse::NoAnswer | WindowDragQueryResponse::SysMenu => {}
                     }
                 }
                 true


### PR DESCRIPTION
Makepad windows on Wayland don't cast a drop shadow, which on GNOME reads as broken next to everything else on the desktop.

Mutter implements **no** server-side decoration protocol at all — it advertises neither `zxdg_decoration_manager_v1` nor any KDE equivalent, and its shadow code (`MetaShadowFactory`) lives in `src/x11/` and isn't even in the introspection surface. Every shadow on that desktop is drawn by the application that owns the window. So this draws one.

## How

Eight `wl_subsurface`s hung outside the toplevel — four corner tiles, four edge strips — backed by a single memfd `wl_shm` pool, sized with `wp_viewport`, with `xdg_surface.set_window_geometry` keeping them out of the window's logical bounds.

GTK takes the other approach: it oversizes its own surface and paints the shadow into a transparent margin. Subsurfaces fit better here:

- the GL surface stays exactly window-sized, so the shadow adds no per-frame GPU fill — it's a static shm buffer the compositor blends
- no margin ever crosses the platform/widget boundary, so no size, DPI factor or pointer coordinate needs adjusting anywhere; that's the whole class of off-by-a-margin bugs the other approach invites
- the base surface stays exactly the visible rect, which is what makes an opaque region trivially declarable below — something GTK's design can never fully have

## The profile

libadwaita 1.9's, computed rather than sampled:

```
box-shadow: 0 0 14px 5px rgb(0 0 0/15%), 0 0 5px 2px rgb(0 0 0/10%), 0 0 0 1px rgb(0 0 0/5%)
```

A rectangle's Gaussian shadow is separable, so each layer's 2-D coverage is the product of two 1-D normal CDFs (erf via A&S 7.1.26, error 1.5e-7 against a 1/255 quantization). Evaluating that for a **square** rectangle is what makes the corners hug the window: sampling a rounded window's shadow instead gives 14/255 where a square corner needs 44/255, and fades the edge out over the last 20px before every corner.

`shadow_alpha_matches_the_installed_libadwaita_profile` pins the generated straight-edge profile against a capture of real libadwaita output — they agree to within 1/255. Corner tiles reach 16px along each edge, far enough that they join the strips bit-identically.

## Resizing

In the gutter, the way every native app does it. The shadow surfaces carry input regions whose union is the window rect grown by 12px — the same halo libadwaita gives its toplevels (measured: `input_region (13,13,824,624)` against `geometry (25,25,800,600)`). Each piece maps to exactly one edge, so landing on a surface *is* the hit test.

That also resolves window controls competing with corner grabs: previously the close button covered the entire top-right corner box, so that corner could never be grabbed.

## Also here

- **Server-side decorations requested** wherever a compositor offers them, overridable per process with `--wayland-decoration=client|server` or `MAKEPAD_WAYLAND_DECORATION`, falling back to the frame above. KWin and wlroots grant them; GNOME cannot.
- **Caption bar**: double-click-to-maximize, right-click window menu, resize cursors keyed off the `wl_pointer.enter` serial the protocol actually requires, and tiled/constrained edges that suppress the grabs they can't service — degrading a corner to its free axis rather than dropping it.
- **Opaque region declared** on the toplevel, under the same `!transparent && backdrop == None` condition macOS already uses for its layer's `opaque` flag. The buffer is ARGB8888, so without that promise a compositor cannot learn the alpha is uniformly solid short of reading every pixel: it must blend the whole window, cannot cull what the window covers, and cannot scan a fullscreen buffer out directly.

## Cost

Verified against a `WAYLAND_DEBUG=1` trace of a real run, not by inspection. Over **67 committed frames**: the shadow issues **zero** protocol traffic in steady state, `set_window_geometry` and `set_opaque_region` are sent **once each**, and `wl_region` create/destroy comes out **9/9** — balanced, no leak, no protocol errors.

Everything is memoized on `(width, height, visible, active)`. Per window: 13,648 pixels rasterized once into 53 KB of shm, with both focused and backdrop styles pre-baked so a focus change is a re-attach rather than a re-raster. Maximized, tiled and fullscreen windows detach the shadow entirely.

## Testing

`cargo test -p makepad-platform` — 105 pass. New coverage: gutter tiling with no gaps or overlap (including the smallest permitted window size), bit-identical corner-to-strip joins, 4-way corner symmetry, grab rects staying within the 12px halo, edge/cursor round trips, and the opaque-region predicate.

Two `makepad-widgets` tests fail — `widget_tree::tests::test_observe_and_find_single_node` and `test_property_patch_no_structural_rebuild`. Both reproduce identically on a clean `dev` worktree, so they're pre-existing and unrelated to this change.

## Known gaps

- Window corners are square, where GNOME neighbours have a 15px radius. The shadow is correct *for a square window*; rounding would be a separate widget-layer change (content clipping plus alpha at the corners).
- Popup surfaces don't declare an opaque region — they're small, and menus are the likeliest thing to want translucency.
