### PR TITLE
Add Apply::Rebake so inset-driven script_mod re-runs preserve imperative widget state

### DIFF
--- a/platform/script/derive/src/derive_scriptable.rs
+++ b/platform/script/derive/src/derive_scriptable.rs
@@ -140,6 +140,21 @@ fn derive_script_impl_inner(
                 .iter()
                 .any(|a| a.name == "live" || a.name == "apply_default")
             {
+                // A field whose canonical mutation path is an imperative
+                // setter (`#[visible]` → `set_visible`, `#[imperative]` for
+                // the rest) shares its storage with the DSL value, so a
+                // re-walk that carries no authored change must leave it alone.
+                // Otherwise `script_mod` re-runs that exist only to re-bake
+                // heap primitives — every safe-area inset change, i.e. every
+                // Android system-bar hide and every rotation — silently put
+                // the DSL default back over the runtime state.
+                let imperative = field
+                    .attrs
+                    .iter()
+                    .any(|a| a.name == "imperative" || a.name == "visible");
+                if imperative {
+                    tb.add("if !apply.preserves_runtime_state() {");
+                }
                 tb.add("{ let mut __field_value = vm.bx.heap.value_for_apply(value, id!(")
                     .ident(&field.name)
                     .add(").into(), apply);");
@@ -159,6 +174,9 @@ fn derive_script_impl_inner(
                     .add(",vm, apply, scope, v);");
                 tb.add("}");
                 tb.add("}");
+                if imperative {
+                    tb.add("}");
+                }
             }
             if field
                 .attrs

--- a/platform/script/derive/src/lib.rs
+++ b/platform/script/derive/src/lib.rs
@@ -36,6 +36,7 @@ pub fn script_err_gen(input: TokenStream) -> TokenStream {
         source,
         new,
         live,
+        imperative,
         rust,
         pick,
         splat,

--- a/platform/script/src/apply.rs
+++ b/platform/script/src/apply.rs
@@ -132,6 +132,21 @@ pub enum Apply {
     /// is the new source of truth and template values should override
     /// any prior runtime state.
     Reload,
+    /// `script_mod` was re-run and the fresh template re-walked, but the DSL
+    /// source did NOT change — the re-run exists only to re-bake heap
+    /// primitives that are evaluated at `script_mod` time and are therefore
+    /// unreachable to `ScriptReapply` (canonical case:
+    /// `mod.widgets.SAFE_INSET_PAD_*` after a safe-area inset change, which
+    /// `cx.request_live_edit()` triggers on every Android system-bar hide and
+    /// every rotation).
+    ///
+    /// Structurally this is a reload — children lists are rebuilt and the
+    /// `#[source]` object is re-bound, because the template really is a new
+    /// object. Semantically it is a `ScriptReapply` — nothing the developer
+    /// wrote changed, so imperative runtime state must survive. Routing it
+    /// through `Reload` is what used to wipe every `set_text`, every
+    /// `set_visible`, and every animator state on each inset change.
+    Rebake,
     /// Heap-mutation broadcast triggered by `cx.request_script_reapply()`
     /// (e.g. preference change, safe-area inset change). The template has
     /// NOT changed — the same cached `app_value` is being re-walked so
@@ -150,6 +165,7 @@ impl Apply {
         match self {
             Self::New => true,
             Self::Reload => true,
+            Self::Rebake => true,
             Self::ScriptReapply => true,
             Self::Eval => true,
             _ => false,
@@ -161,11 +177,13 @@ impl Apply {
     /// creates temporary objects that would become dangling after GC.
     /// Excludes ScriptReapply because the template hasn't changed —
     /// the same source object is being re-walked, so re-binding it is
-    /// unnecessary work.
+    /// unnecessary work. Includes `Rebake`: `script_mod` re-ran, so the
+    /// source object really is new even though the DSL text is unchanged.
     pub fn is_template_apply(&self) -> bool {
         match self {
             Self::New => true,
             Self::Reload => true,
+            Self::Rebake => true,
             _ => false,
         }
     }
@@ -192,13 +210,15 @@ impl Apply {
     pub fn is_reload(&self) -> bool {
         match self {
             Self::Reload => true,
+            Self::Rebake => true,
             Self::ScriptReapply => true,
             _ => false,
         }
     }
 
     /// True only for `Apply::Reload` — a LiveEdit-driven hot-reload where
-    /// the DSL itself changed. Excludes `Apply::ScriptReapply`. Use this
+    /// the DSL itself changed. Excludes `Apply::ScriptReapply` and
+    /// `Apply::Rebake` (a `script_mod` re-run with unchanged source). Use this
     /// (rather than `is_reload`) when behavior should fire only when the
     /// template source has actually changed (e.g. re-running script_mod
     /// scaffolding, invalidating template-derived caches).
@@ -210,13 +230,48 @@ impl Apply {
     }
 
     /// True only for `Apply::ScriptReapply` — a `request_script_reapply`-driven
-    /// re-walk where the template has NOT changed. Field impls whose value
-    /// should not be clobbered by template defaults on this kind of re-walk
-    /// should early-return when this is true (canonical example:
-    /// `ArcStringMut::script_apply`).
+    /// re-walk where the template has NOT changed.
+    ///
+    /// Prefer `preserves_runtime_state()` when the question is "may I clobber
+    /// the runtime value here?"; this predicate exists for the narrower cases
+    /// that care about the specific trigger.
     pub fn is_script_reapply(&self) -> bool {
         match self {
             Self::ScriptReapply => true,
+            _ => false,
+        }
+    }
+
+    /// True for the walks that follow a `script_mod` re-run (`Reload`,
+    /// `Rebake`). The re-run builds a fresh object heap, so any script object
+    /// reference a widget cached during an earlier walk is now dangling —
+    /// `Animator`'s cached state objects are the canonical example. Code
+    /// holding such references must re-resolve them from the incoming value
+    /// rather than reuse what it stored.
+    ///
+    /// `ScriptReapply` is excluded: it re-walks the same cached `app_value`,
+    /// so cached references stay alive.
+    pub fn follows_script_rerun(&self) -> bool {
+        match self {
+            Self::Reload => true,
+            Self::Rebake => true,
+            _ => false,
+        }
+    }
+
+    /// True for the re-apply walks where nothing the developer wrote changed,
+    /// so template values must NOT overwrite state that was set through an
+    /// imperative setter (`Label::set_text`, `set_visible`, animator state).
+    /// Field impls whose canonical mutation path is such a setter should
+    /// early-return when this is true (canonical example:
+    /// `ArcStringMut::script_apply`).
+    ///
+    /// Excludes `Apply::Reload`, where the DSL genuinely changed and the new
+    /// template is meant to win.
+    pub fn preserves_runtime_state(&self) -> bool {
+        match self {
+            Self::ScriptReapply => true,
+            Self::Rebake => true,
             _ => false,
         }
     }

--- a/platform/script/src/prims.rs
+++ b/platform/script/src/prims.rs
@@ -340,13 +340,14 @@ script_primitive!(
     ) {
         // Same rationale as `ArcStringMut::script_apply`: text-bearing fields
         // (`TextInput.text`, `TextInput.empty_text`, etc.) are canonically
-        // mutated through imperative setters at runtime. A ScriptReapply
-        // walk fired by `cx.request_script_reapply()` (preference broadcast,
-        // safe-area inset change) would otherwise clobber that runtime value
-        // with the stale DSL literal. Strings are not part of the shared-
-        // heap-object propagation pipeline (which uses `Size`/numerics), so
-        // bailing here is safe.
-        if apply.is_script_reapply() {
+        // mutated through imperative setters at runtime. A re-walk that
+        // carries no authored change (`cx.request_script_reapply()` preference
+        // broadcast, or the `script_mod` re-run a safe-area inset change
+        // forces) would otherwise clobber that runtime value with the stale
+        // DSL literal. Strings are not part of the shared-heap-object
+        // propagation pipeline (which uses `Size`/numerics), so bailing here
+        // is safe.
+        if apply.preserves_runtime_state() {
             return;
         }
         self.clear();

--- a/platform/script/src/traits.rs
+++ b/platform/script/src/traits.rs
@@ -39,7 +39,9 @@ pub trait ScriptHook {
             // Widgets that need to differentiate can branch on
             // `apply.is_live_edit_reload()` or `apply.is_script_reapply()`
             // inside the hook.
-            Apply::Reload | Apply::ScriptReapply => self.on_before_reload_scoped(vm, scope),
+            Apply::Reload | Apply::Rebake | Apply::ScriptReapply => {
+                self.on_before_reload_scoped(vm, scope)
+            }
             _ => (),
         }
     }
@@ -62,7 +64,9 @@ pub trait ScriptHook {
     ) {
         match apply {
             Apply::New => self.on_after_new_scoped(vm, scope),
-            Apply::Reload | Apply::ScriptReapply => self.on_after_reload_scoped(vm, scope),
+            Apply::Reload | Apply::Rebake | Apply::ScriptReapply => {
+                self.on_after_reload_scoped(vm, scope)
+            }
             _ => (),
         }
         self.on_alive()

--- a/platform/src/app_main.rs
+++ b/platform/src/app_main.rs
@@ -287,6 +287,9 @@ macro_rules! _app_main_event_closure {
             if let Event::LiveEdit = event {
                 let mut app_ref = app.borrow_mut();
                 if let Some(app) = app_ref.as_mut() {
+                    // `Reload` when the DSL changed on disk, `Rebake` when
+                    // `script_mod` only re-ran to pick up new heap primitives.
+                    let live_edit_apply = cx.live_edit_apply();
                     cx.with_vm(|vm| {
                         let value = vm.with_reload(|vm| <$app as AppMain>::script_mod(vm));
                         if let Some(obj) = value.as_object() {
@@ -295,7 +298,7 @@ macro_rules! _app_main_event_closure {
                         <$app as $crate::ScriptApply>::script_apply(
                             app,
                             vm,
-                            &$crate::Apply::Reload,
+                            &live_edit_apply,
                             &mut $crate::Scope::empty(),
                             value,
                         );

--- a/platform/src/arc_string_mut.rs
+++ b/platform/src/arc_string_mut.rs
@@ -92,11 +92,11 @@ impl ScriptApply for ArcStringMut {
     ) {
         // Same rationale as `String::script_apply` (see `prims.rs`):
         // text-bearing fields are canonically mutated by imperative setters
-        // (`Label::set_text`, `Button::set_text`, etc.), so a ScriptReapply
-        // walk should not clobber the runtime value with the stale DSL
-        // literal. `Apply::Reload` (LiveEdit) still applies — DSL just
-        // changed, so the new template wins.
-        if apply.is_script_reapply() {
+        // (`Label::set_text`, `Button::set_text`, etc.), so a re-walk that
+        // carries no authored change should not clobber the runtime value with
+        // the stale DSL literal. Only `Apply::Reload` gets to win, because
+        // there the DSL itself changed.
+        if apply.preserves_runtime_state() {
             return;
         }
         // Convert to owned String using the heap's cast method

--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -145,15 +145,24 @@ pub struct Cx {
     pub pending_script_reapply: bool,
 
     /// When true, the next event-loop iteration will fire `Event::LiveEdit`,
-    /// which re-runs `script_mod` and re-applies with `Apply::Reload`. Use
+    /// which re-runs `script_mod` and re-applies with `Apply::Rebake`. Use
     /// this when a primitive heap value (e.g. `mod.widgets.SAFE_INSET_PAD_TOP`)
     /// has changed and needs to be re-baked into widget definitions that
     /// reference it via expressions like `top: (mod.widgets.SAFE_INSET_PAD_TOP)`
     /// — those expressions are only re-evaluated when `script_mod` re-runs.
-    /// `Apply::Reload` clobbers runtime widget state (animator values, etc.),
-    /// so prefer `pending_script_reapply` whenever the change can be modeled
-    /// as a shared-heap-object mutation instead.
+    /// The re-run is still a full-tree walk, so prefer
+    /// `pending_script_reapply` whenever the change can be modeled as a
+    /// shared-heap-object mutation instead.
     pub pending_live_edit_request: bool,
+
+    /// Which `Apply` variant the pending `Event::LiveEdit` should re-apply
+    /// the freshly re-run `script_mod` value with. A file-change hot reload
+    /// means the DSL actually changed, so the new template wins
+    /// (`Apply::Reload`). A `request_live_edit()` re-bake did not change the
+    /// DSL, so imperative runtime state must survive (`Apply::Rebake`) —
+    /// otherwise every safe-area inset change wipes each `set_text`,
+    /// `set_visible` and animator state in the tree.
+    pub(crate) live_edit_apply: Apply,
 
     /// `WindowGeomChange` events queued up during an event dispatch.
     pub(crate) pending_window_geom_changes: Vec<WindowGeomChangeEvent>,
@@ -525,6 +534,7 @@ impl Cx {
             display_context: Default::default(),
             pending_script_reapply: false,
             pending_live_edit_request: false,
+            live_edit_apply: Apply::Reload,
             pending_window_geom_changes: Default::default(),
             clear_hover_queued: false,
 

--- a/platform/src/cx_api.rs
+++ b/platform/src/cx_api.rs
@@ -576,17 +576,24 @@ impl Cx {
     /// Requests a deferred `Event::LiveEdit` on the next event-loop iteration.
     /// The handler re-runs `script_mod` (re-evaluating any expressions that
     /// reference primitive heap values like `mod.widgets.SAFE_INSET_PAD_TOP`)
-    /// and then re-applies the widget tree with `Apply::Reload`.
+    /// and then re-applies the widget tree with `Apply::Rebake`, which
+    /// preserves imperative runtime state since the DSL itself is unchanged.
     ///
     /// Use this only when a primitive heap value has changed and that value
     /// is consumed by `script_mod!` block expressions — those expressions are
-    /// not re-evaluated by `Apply::ScriptReapply`. `Apply::Reload` walks
-    /// clobber runtime widget state (animator values, dynamic instance
-    /// buffers, user-typed text in widgets that don't early-return on
-    /// LiveEdit), so prefer `request_script_reapply` when the change can be
+    /// not re-evaluated by `Apply::ScriptReapply`. The re-run is still a full
+    /// tree walk, so prefer `request_script_reapply` when the change can be
     /// modeled as a shared-heap-object mutation instead.
     pub fn request_live_edit(&mut self) {
         self.pending_live_edit_request = true;
+    }
+
+    /// The `Apply` variant the currently dispatching `Event::LiveEdit` should
+    /// be re-applied with — `Reload` for a file-change hot reload, `Rebake`
+    /// for a `request_live_edit()` re-bake. `app_main!` reads this; app code
+    /// has no reason to.
+    pub fn live_edit_apply(&self) -> crate::makepad_script::Apply {
+        self.live_edit_apply.clone()
     }
 
     /// Remap an absolute coordinate from the OS-reported logical-point space

--- a/platform/src/os/cx_shared.rs
+++ b/platform/src/os/cx_shared.rs
@@ -890,6 +890,7 @@ impl Cx {
             LiveEditTrigger::FileChange => {
                 self.draw_shaders.reset_for_live_reload();
                 self.pending_script_reapply = false;
+                self.live_edit_apply = crate::makepad_script::Apply::Reload;
                 self.call_event_handler(&Event::LiveEdit);
                 self.redraw_all();
                 if self.pending_script_reapply {
@@ -904,6 +905,10 @@ impl Cx {
                 // app-level handler that re-broadcasts sets a fresh flag
                 // that lands on the next tick.
                 self.pending_script_reapply = false;
+                // The DSL did not change, so re-apply with `Rebake`: the
+                // re-run only exists to pick up new `SAFE_INSET_PAD_*`
+                // values, and imperative runtime state must survive it.
+                self.live_edit_apply = crate::makepad_script::Apply::Rebake;
                 self.call_event_handler(&Event::LiveEdit);
                 self.redraw_all();
             }

--- a/widgets/derive_widget/src/lib.rs
+++ b/widgets/derive_widget/src/lib.rs
@@ -23,6 +23,7 @@ pub fn derive_widget(input: TokenStream) -> TokenStream {
         area,
         event,
         visible,
+        imperative,
         action_data,
         uid,
         cast,

--- a/widgets/src/animator.rs
+++ b/widgets/src/animator.rs
@@ -254,8 +254,12 @@ struct AnimatorTrack {
     play: Play,
     /// The ease function
     ease: Ease,
-    /// The target apply object (what we're animating to)
-    target_apply: ScriptObject,
+    /// The target apply object (what we're animating to).
+    /// Held as a `ScriptObjectRef` for the same reason as `from_snapshot`: a
+    /// bare `ScriptObject` into the template dangles as soon as `script_mod`
+    /// re-runs (safe-area inset change, hot reload), and `interpolate_object`
+    /// walks it every frame.
+    target_apply: ScriptObjectRef,
     /// The starting values SNAPSHOT (captured/copied when animation begins)
     /// This is a SEPARATE object from state_object - it must not be mutated during animation
     /// Uses ScriptObjectRef to prevent GC from freeing it
@@ -318,6 +322,16 @@ impl ScriptHook for Animator {
         let Some(obj) = value.as_object() else {
             return false;
         };
+        // A `script_mod` re-run replaces every template object an in-flight
+        // track is animating against. The track's refs keep those objects
+        // alive, so walking them is safe, but they now describe the previous
+        // template — and a `Play::Loop` track would pin them for good. Drop
+        // the tracks instead. `current_states` is kept: the logical state is
+        // still meaningful, and the next `cut`/`play` re-resolves its objects
+        // from the new heap.
+        if apply.follows_script_rerun() {
+            self.tracks.clear();
+        }
         let obj_ref = vm.bx.heap.new_object_ref(obj);
         // Minted from the VM we are running in, so this always resolves; the
         // fallback only exists because the lookup is fallible in general.
@@ -362,7 +376,11 @@ impl ScriptApplyDefault for Animator {
         _scope: &mut Scope,
         _value: ScriptValue,
     ) -> Option<ScriptValue> {
-        if apply.is_live_edit_reload() || apply.is_animate() || apply.is_eval() {
+        // `follows_script_rerun` rather than `is_live_edit_reload`: what makes
+        // injecting the current state unsafe is not that the DSL changed, it
+        // is that `script_mod` re-ran and freed the objects `state_object` and
+        // `groups` point at. Both `Reload` and `Rebake` re-run it.
+        if apply.follows_script_rerun() || apply.is_animate() || apply.is_eval() {
             return None;
         }
 
@@ -542,7 +560,7 @@ impl Animator {
         // The snapshot must be a separate object that won't be mutated during animation.
         // We sample from state_object (current animated values) or fall back to static state apply.
         let vm_id = self.vm_id;
-        let from_snapshot = cx.with_script_vm_id(vm_id, |vm| {
+        let (from_snapshot, target_apply_ref) = cx.with_script_vm_id(vm_id, |vm| {
             let snapshot = vm.bx.heap.new_object();
 
             // Get the default state's apply for fallback values
@@ -586,8 +604,12 @@ impl Animator {
                 },
             );
 
-            // Create a ScriptObjectRef to prevent GC from freeing the snapshot
-            vm.bx.heap.new_object_ref(snapshot)
+            // Create ScriptObjectRefs to prevent GC from freeing either object
+            // out from under the running animation.
+            (
+                vm.bx.heap.new_object_ref(snapshot),
+                vm.bx.heap.new_object_ref(target_apply),
+            )
         });
 
         // Get the object before moving into track (for return value)
@@ -601,7 +623,7 @@ impl Animator {
             start_time: f64::NEG_INFINITY,
             play,
             ease,
-            target_apply,
+            target_apply: target_apply_ref,
             from_snapshot,
             redraw: target_state.redraw,
         };
@@ -852,7 +874,7 @@ impl Animator {
                         vm,
                         state_obj,
                         track.from_snapshot.as_object(),
-                        track.target_apply,
+                        track.target_apply.as_object(),
                         mix,
                     );
                 }

--- a/widgets/src/drop_down.rs
+++ b/widgets/src/drop_down.rs
@@ -420,6 +420,7 @@ pub struct DropDown {
     #[rust]
     popup_global: PopupMenuGlobal,
 
+    #[imperative]
     #[live]
     selected_item: usize,
 

--- a/widgets/src/page_flip.rs
+++ b/widgets/src/page_flip.rs
@@ -22,6 +22,7 @@ pub struct PageFlip {
     layout: Layout,
     #[live(false)]
     lazy_init: bool,
+    #[imperative]
     #[live]
     active_page: LiveId,
     #[rust]

--- a/widgets/src/view.rs
+++ b/widgets/src/view.rs
@@ -99,6 +99,7 @@ pub struct View {
     #[live]
     event_order: EventOrder,
 
+    #[imperative]
     #[live(true)]
     pub visible: bool,
     #[live(false)]


### PR DESCRIPTION
# Add `Apply::Rebake` so `script_mod` re-runs stop clobbering imperative state

| | |
|---|---|
| **Scope** | `platform/script/src/{apply,traits,prims}.rs`, `platform/script/derive/src/{lib,derive_scriptable}.rs`, `platform/src/{cx,cx_api,app_main,arc_string_mut}.rs`, `platform/src/os/cx_shared.rs`, `widgets/src/{animator,view,page_flip,drop_down}.rs` |
| **Diff** | +167 / −38 across 14 files |
| **Fixes** | Safe-area inset changes reverting every `set_text` and `set_visible` in the tree; plus a pre-existing animator use-after-free on any `script_mod` re-run |
| **Verified** | Android, hardware device |

## Summary

`cx.request_live_edit()` re-runs `script_mod!` and re-applies the widget tree with `Apply::Reload`, whose contract is "the DSL changed, so the template overrides runtime state". But the canonical caller of `request_live_edit()` is a safe-area inset change, where the DSL did **not** change — the re-run only exists to re-bake `mod.widgets.SAFE_INSET_PAD_*`.

Every guard that protects imperative state checks `is_script_reapply()` or `is_live_edit_reload()`, so all of them stand down under `Reload`. On Android that means hiding the system bars reverts every `set_text`, every `set_visible`, every `CheckBox` state and every animator visual in the tree. On iOS, every rotation does.

This adds a distinct `Apply::Rebake` variant for "script re-ran, source unchanged", so each existing predicate answers the question it was written to answer.

Background and reproduction: [#1218 ](https://github.com/makepad/makepad/issues/1218)

## Motivation

The two live-edit triggers already disagree about whether the DSL changed — `run_live_edit_if_needed` documents `Manual` as "The DSL did NOT change" — but they shared one `Apply` variant, and that variant is the one that grants the template authority over runtime state.

Fixing this per field does not scale. The affected state falls into four unrelated categories: string primitives, `ArcStringMut`, animator-driven state, and plain `#[live]` fields written by imperative setters (the `#[visible]` derive plus `PageFlip.active_page` and `DropDown.selected_item`). One variant at the trigger fixes all of them.

## Design

`Apply::Rebake` is structurally a reload and semantically a re-apply:

- **Structurally a reload** — `script_mod` really did re-run, so the value is a new object. Children lists must be rebuilt and `#[source]` re-bound.
- **Semantically a re-apply** — nothing the developer wrote changed, so imperative runtime state must survive.

```rust
/// `script_mod` was re-run and the fresh template re-walked, but the DSL
/// source did NOT change — the re-run exists only to re-bake heap
/// primitives that are evaluated at `script_mod` time and are therefore
/// unreachable to `ScriptReapply` (canonical case:
/// `mod.widgets.SAFE_INSET_PAD_*` after a safe-area inset change ...).
Rebake,
```

### Predicate matrix

| Predicate | `New` | `Reload` | `Rebake` | `ScriptReapply` | `Eval` |
|---|---|---|---|---|---|
| `is_new` | ✓ | | | | |
| `is_from_script` | ✓ | ✓ | ✓ | ✓ | ✓ |
| `is_template_apply` | ✓ | ✓ | ✓ | | |
| `is_reload` | | ✓ | ✓ | ✓ | |
| `is_live_edit_reload` | | ✓ | | | |
| `is_script_reapply` | | | | ✓ | |
| `preserves_runtime_state` *(new)* | | | ✓ | ✓ | |
| `follows_script_rerun` *(new)* | | ✓ | ✓ | | |

Two orthogonal questions need two predicates, and conflating them is what made our first attempt crash:

- `preserves_runtime_state()` — "may I overwrite the runtime value here?" Answered by whether anything the developer authored changed.
- `follows_script_rerun()` — "are my cached script object references still valid?" Answered by whether `script_mod` re-ran and built a fresh heap. `ScriptReapply` re-walks the same cached `app_value`, so refs survive; `Reload` and `Rebake` both invalidate them.

`is_script_reapply()` keeps its exact meaning for the narrower cases that care about the specific trigger. `Animate` and `Default(_)` are unchanged.

### Why the animator needs the second predicate

`Animator::script_apply_default` gates on `is_live_edit_reload()`, which reads like a policy check ("the template wins on hot reload") but is really a lifetime check: after a `script_mod` re-run, `state_object` and `groups` point into a heap that no longer exists. Treating `Rebake` as a re-apply there panicked immediately:

```
GenVec<ScriptObjectData> use-after-free detected! index=13454 ref_gen=0 slot_gen=1
  at ScriptVm::proto_map_iter_mut_with::<Animator::interpolate_object::{closure#0}>
  from Animator::handle_event ← Button::handle_event
```

So the animator now gates on `follows_script_rerun()` instead, which covers `Reload` and `Rebake` alike. Animator state is therefore *not* preserved across an inset-driven re-bake — see "Risks and follow-ups".

## Implementation

### `platform/script/src/apply.rs`

New `Rebake` variant plus the `preserves_runtime_state()` predicate. `is_from_script`, `is_template_apply` and `is_reload` gain the variant; `is_live_edit_reload` and `is_script_reapply` deliberately do not.

### `platform/script/src/traits.rs`

`on_before_dispatch` / `on_after_dispatch` route `Rebake` to the reload hooks alongside `Reload` and `ScriptReapply`, matching `is_reload()`.

### `platform/src/arc_string_mut.rs`, `platform/script/src/prims.rs`

The two text guards switch from `is_script_reapply()` to `preserves_runtime_state()`. This is where `Label::set_text` / `Button::set_text` / `TextInput.text` stop being reverted.

### `platform/src/os/cx_shared.rs`

`run_live_edit_if_needed` records which variant the dispatch should use: `Reload` for `LiveEditTrigger::FileChange`, `Rebake` for `LiveEditTrigger::Manual`.

### `platform/src/cx.rs`, `platform/src/cx_api.rs`

New `Cx::live_edit_apply` field with a public accessor for `app_main!`. Doc comments on `pending_live_edit_request` and `request_live_edit()` updated — the warning about clobbering runtime state no longer applies, only the cost of a full-tree walk.

### `platform/src/app_main.rs`

The `Event::LiveEdit` handler reads `cx.live_edit_apply()` instead of hardcoding `Apply::Reload`.

### `widgets/src/animator.rs`

Two changes, both about object lifetime across a `script_mod` re-run:

- `script_apply_default` gates on `follows_script_rerun()` instead of `is_live_edit_reload()`, per the section above.
- `AnimatorTrack.target_apply` becomes a `ScriptObjectRef` instead of a bare `ScriptObject`, and `on_custom_apply` drops in-flight tracks on a re-run.

The second one is a **pre-existing upstream bug**, independent of this PR. `from_snapshot` is already a `ScriptObjectRef` with a comment saying it must be, but `target_apply` — walked by `interpolate_object` on every animation frame — was unpinned. Any `script_mod` re-run while an animation is in flight frees it: a hot reload during a hover transition on desktop is enough. It reproduces reliably on Android because an inset change fires a re-run at a moment when button animators are typically running.

Dropping the tracks then bounds how long a pinned object from the previous heap stays alive; without it a `Play::Loop` track would hold one forever.

### New `#[imperative]` field attribute

`Rebake` alone does not save plain `#[live] bool` / `usize` / `LiveId` fields, because those primitives have no guard of their own — and `visible` cannot be guarded at the `bool` impl level, since most bools are ordinary DSL properties.

So the `Script` derive gains an `#[imperative]` attribute meaning "this field's canonical mutation path is an imperative setter". `derive_scriptable` skips such a field when `apply.preserves_runtime_state()`:

```rust
if !apply.preserves_runtime_state() {
    // ... normal field apply ...
}
```

`#[visible]` implies `#[imperative]`, so every widget that already carries it is covered without edits: `Label`, `Button`, `Image`, `CheckBox`, `RadioButton`, `DesktopButton`, `VoiceWave`, `Browser`, and the `GlassRadio` / `GlassButton` / `GlassSlider` / `GlassSegmented` family.

Three fields are marked explicitly:

| Field | Setter |
|---|---|
| `View.visible` | `set_visible` (hand-written `Widget` impl, so no `#[visible]`) |
| `PageFlip.active_page` | `set_active_page` |
| `DropDown.selected_item` | `set_selected_item` |

## Behavior change

| Trigger | Before | After |
|---|---|---|
| File-change hot reload | `Apply::Reload`, template wins | unchanged |
| `request_script_reapply()` | `Apply::ScriptReapply`, runtime state preserved | unchanged |
| `request_live_edit()` (inset change) | `Apply::Reload`, runtime state lost | `Apply::Rebake`, runtime state preserved |

Inset-driven re-bakes still re-evaluate `SAFE_INSET_PAD_*` expressions, still rebuild children lists, and still re-bind `#[source]`. What changes is which state survives:

| State | Survives an inset change? |
|---|---|
| `set_text` on `Label` / `Button` / `TextInput` | yes (was: reverted to the DSL literal) |
| `set_visible` on any widget | yes (was: reverted to the DSL default) |
| `PageFlip.active_page`, `DropDown.selected_item` | yes (was: reverted) |
| Animator state (`CheckBox.active`, hover, focus, `disabled`) | no — unchanged from before |

Animator state is the one category this PR does not rescue. Its objects live in the heap that the re-run replaces, so preserving it needs the animator to re-resolve `state_object` and `groups` against the new heap rather than reuse what it cached. That is a larger change and belongs in its own PR.

## Files

| File | Role |
|---|---|
| `platform/script/src/apply.rs` | `Rebake` variant, `preserves_runtime_state()` |
| `platform/script/src/traits.rs` | Route `Rebake` to reload hooks |
| `platform/script/src/prims.rs` | `String` guard uses the new predicate |
| `platform/script/derive/src/lib.rs` | Register `imperative` attribute |
| `platform/script/derive/src/derive_scriptable.rs` | Skip `#[imperative]` / `#[visible]` fields on preserving walks |
| `platform/src/arc_string_mut.rs` | `ArcStringMut` guard uses the new predicate |
| `platform/src/cx.rs` | `live_edit_apply` field |
| `platform/src/cx_api.rs` | `Cx::live_edit_apply()` accessor, doc updates |
| `platform/src/os/cx_shared.rs` | Pick the variant per trigger |
| `platform/src/app_main.rs` | Apply with the recorded variant |
| `widgets/src/animator.rs` | Gate on `follows_script_rerun()`; pin `target_apply`; drop tracks on a re-run |
| `widgets/src/view.rs` | `#[imperative]` on `visible` |
| `widgets/src/page_flip.rs` | `#[imperative]` on `active_page` |
| `widgets/src/drop_down.rs` | `#[imperative]` on `selected_item` |

Unchanged but part of the path: `widgets/src/window.rs` (still calls `request_live_edit()` on inset change), `widgets/derive_widget/src/derive_widget.rs` (`#[visible]` setter generation).

## Risks and follow-ups

- **`is_reload()` now includes a third variant.** Widgets branching on it treat `Rebake` like any other re-apply, which is the intent documented on the predicate ("the template is being re-applied for whatever reason"). Anything that assumed `is_reload()` implied a source change should use `is_live_edit_reload()`; nothing in-tree did.
- **`#[imperative]` is opt-in.** Any future `#[live]` field written by a setter needs the attribute. The three in this PR plus the `#[visible]` family are the ones we found by auditing every `set_*` method in `widgets/src`; a field whose setter is rarely used on mobile could still be missed.
- **Fields hidden behind non-obvious setters.** We only audited `widgets/`. Third-party widgets with the same `#[live]`-plus-setter shape will need the attribute too, and would benefit from a note in the widget-authoring docs.
- **The full-tree walk remains.** `Rebake` fixes correctness, not cost — an inset change still walks and re-applies the whole tree. Narrowing that to nodes which actually reference `SAFE_INSET_PAD_*` would be a separate optimization.
- **Animator state still resets on an inset change.** Preserving it means re-resolving the animator's cached objects against the new heap; see "Behavior change". Until then, mobile apps that rely on animator-held state (`CheckBox::active` is the common one) should re-assert it, and `CheckBox::set_active`'s own doc already tells them to use `Animate::No` for exactly that.
- **In-flight animations are dropped on any re-run.** Correct for a hot reload, slightly heavy-handed for a re-bake: now that `target_apply` is pinned, the track could be allowed to finish against the previous template instead. Left conservative here because `Play::Loop` tracks would otherwise pin an old-heap object indefinitely.
- **Two changes could be split out.** The `target_apply` pin and the animator's `follows_script_rerun()` gate fix a pre-existing crash and stand alone; the `Rebake` variant depends on neither. Happy to land them as separate PRs if preferred.