### PR TITLE
Html: fix collapsed details with void tags corrupting table layout

### DIFF
--- a/libs/html/src/lib.rs
+++ b/libs/html/src/lib.rs
@@ -86,18 +86,28 @@ impl<'a> HtmlWalker<'a> {
         let Some(open_lc) = self.open_tag_lc() else {
             return;
         };
-        let mut depth = 0u32;
+        // Elements opened inside this one and not yet closed. Empty for the
+        // common case of an element whose content is plain text, so this
+        // usually does not allocate.
+        let mut inner: Vec<LiveId> = Vec::new();
         for i in self.index + 1..self.nodes.len() {
             match &self.nodes[i] {
-                HtmlNode::OpenTag { lc, .. } if *lc == open_lc => {
-                    depth += 1;
-                }
-                HtmlNode::CloseTag { lc, .. } if *lc == open_lc => {
-                    if depth == 0 {
+                HtmlNode::OpenTag { lc, .. } => inner.push(*lc),
+                HtmlNode::CloseTag { lc, .. } => {
+                    if let Some(pos) = inner.iter().rposition(|t| t == lc) {
+                        // Closes a descendant. Anything still above it was
+                        // void or left unclosed, so it ends here too.
+                        inner.truncate(pos);
+                    } else if *lc == open_lc {
                         self.index = i;
                         return;
+                    } else {
+                        // An enclosing element closes first, so this one never
+                        // had a close tag of its own. Stop here rather than
+                        // reading to the end of the document for every void
+                        // element, which would make a draw quadratic.
+                        return;
                     }
-                    depth -= 1;
                 }
                 _ => (),
             }
@@ -367,6 +377,7 @@ pub fn parse_html(
         saved_last_non_whitespace: usize,
     }
 
+    #[inline]
     fn process_entity(
         c: char,
         in_entity: &mut Option<InEntity>,
@@ -448,7 +459,11 @@ pub fn parse_html(
         last_non_whitespace: 0,
         collapse_ws: true,
     };
-    let mut decoded = String::new();
+    // Decoded output never exceeds the source length, and reserving it up
+    // front measurably beats growing it. `nodes` deliberately gets no such
+    // hint: its length tracks tag count, not byte count, so sizing it from
+    // `body.len()` made a tag-sparse document pay a large pointless alloc.
+    let mut decoded = String::with_capacity(body.len());
     let mut in_entity = None;
 
     for (i, c) in body.char_indices() {
@@ -1040,6 +1055,11 @@ pub fn parse_html(
 }
 
 pub fn match_entity(what: &str) -> Result<u32, String> {
+    // A numeric reference shares no prefix with any name, so check for it
+    // before the table rather than after ~1500 failed comparisons.
+    if what.starts_with('#') {
+        return match_numeric_entity(what);
+    }
     Ok(match what {
         "dollar" => 36,
         "DOLLAR" => 36,
@@ -2550,31 +2570,35 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "UFISHT" => 10622,
         "dfisht" => 10623,
         "DFISHT" => 10623,
-        x => {
-            // Not a named entity: it may be a numeric character reference.
-            // Everything here is validated rather than cast, because the
-            // caller turns the result into a `char`: an out-of-range value,
-            // a surrogate, or a negative number would otherwise panic.
-            let Some(digits) = x.strip_prefix('#') else {
-                return Err("unknown html entity".into());
-            };
-            // `&#x..;` / `&#X..;` are hex, anything else is decimal. Parsing
-            // as `u32` (not `i64`) rejects a leading `-` or `+` outright.
-            let num = match digits.strip_prefix(['x', 'X']) {
-                Some(hex) => u32::from_str_radix(hex, 16)
-                    .map_err(|_| String::from("Cannot parse hex html entity"))?,
-                None => digits
-                    .parse::<u32>()
-                    .map_err(|_| String::from("Cannot parse digit html entity"))?,
-            };
-            // Reject anything that is not a Unicode scalar value: beyond
-            // U+10FFFF, or a UTF-16 surrogate half.
-            if char::from_u32(num).is_none() {
-                return Err("Html entity is not a valid unicode scalar".into());
-            }
-            num
-        }
+        _ => return Err("unknown html entity".into()),
     })
+}
+
+/// Decodes `&#38;` / `&#x26;` style references, given the text between the
+/// `&` and the `;`.
+///
+/// Everything is validated rather than cast, because the caller turns the
+/// result into a `char`: an out-of-range value, a surrogate, or a negative
+/// number would otherwise panic.
+fn match_numeric_entity(what: &str) -> Result<u32, String> {
+    let Some(digits) = what.strip_prefix('#') else {
+        return Err("unknown html entity".into());
+    };
+    // `&#x..;` / `&#X..;` are hex, anything else is decimal. Parsing as `u32`
+    // (not `i64`) rejects a leading `-` or `+` outright.
+    let num = match digits.strip_prefix(['x', 'X']) {
+        Some(hex) => u32::from_str_radix(hex, 16)
+            .map_err(|_| String::from("Cannot parse hex html entity"))?,
+        None => digits
+            .parse::<u32>()
+            .map_err(|_| String::from("Cannot parse digit html entity"))?,
+    };
+    // Reject anything that is not a Unicode scalar value: beyond U+10FFFF, or
+    // a UTF-16 surrogate half.
+    if char::from_u32(num).is_none() {
+        return Err("Html entity is not a valid unicode scalar".into());
+    }
+    Ok(num)
 }
 
 #[cfg(test)]

--- a/libs/html/src/lib.rs
+++ b/libs/html/src/lib.rs
@@ -431,9 +431,12 @@ struct Builder {
     ends: Vec<usize>,
     /// Node index of each open element, outermost first.
     open: Vec<usize>,
-    /// How many elements of each name are open, so a close tag with nothing
-    /// to close is rejected without walking the stack.
-    counts: LiveIdMap<u32>,
+    /// For each name, the stack depths of its open elements, ascending. A
+    /// close tag finds the innermost element of its name, and a start tag
+    /// finds the outermost element it implicitly closes above the nearest
+    /// scope boundary, in constant time either way; scanning the stack for
+    /// them made a document of nested `<div>`s quadratic.
+    depths: LiveIdMap<Vec<usize>>,
     /// How many `<pre>`/`<code>` are open.
     preserving: usize,
     /// Attribute names already seen on the tag being parsed; a repeated one
@@ -442,6 +445,9 @@ struct Builder {
     /// Node index of the tag being parsed, so input ending inside it can
     /// drop it whole.
     tag_start: usize,
+    /// A `<pre>` (or `<listing>`/`<textarea>`) just opened: the tree builder
+    /// ignores a newline that immediately follows it.
+    skip_leading_lf: bool,
 }
 
 impl Builder {
@@ -451,10 +457,11 @@ impl Builder {
             closes: Vec::new(),
             ends: Vec::new(),
             open: Vec::new(),
-            counts: LiveIdMap::with_hasher(SeededLiveIdHasher::new_seed()),
+            depths: LiveIdMap::with_hasher(SeededLiveIdHasher::new_seed()),
             preserving: 0,
             attrs_seen: LiveIdSet::with_hasher(SeededLiveIdHasher::new_seed()),
             tag_start: 0,
+            skip_leading_lf: false,
         }
         .with_capacity_hint(body_len)
     }
@@ -495,18 +502,27 @@ impl Builder {
     /// Starts a tag; `tag_start` remembers where, for `drop_tag`.
     fn begin_tag(&mut self) {
         self.tag_start = self.nodes.len();
-        self.attrs_seen.clear();
+        // `clear` is O(buckets) unless the set is empty, and the table never
+        // shrinks, so after one tag with thousands of attributes every later
+        // tag with an attribute would pay that memset. Drop an oversized
+        // table instead; the seed is reused, so hashing stays the same.
+        if self.attrs_seen.capacity() > 64 {
+            self.attrs_seen = LiveIdSet::with_hasher(*self.attrs_seen.hasher());
+        } else {
+            self.attrs_seen.clear();
+        }
     }
 
     fn open_tag(&mut self, name: &str, intern: InternLiveId) {
         let lc = LiveId::from_str_lc(name);
+        self.implicitly_close_for(lc);
         let index = self.push(HtmlNode::OpenTag {
             lc,
             nc: LiveId::from_str_with_intern(name, intern),
         });
         if !is_void_element(lc) {
+            self.depths.entry(lc).or_default().push(self.open.len());
             self.open.push(index);
-            *self.counts.entry(lc).or_insert(0) += 1;
             if preserves_whitespace(lc) {
                 self.preserving += 1;
             }
@@ -521,10 +537,19 @@ impl Builder {
 
     /// The start tag that began at `tag_start` is complete.
     fn end_open_tag(&mut self) {
-        if is_void_element(self.name_at(self.tag_start)) {
+        let lc = self.name_at(self.tag_start);
+        if is_void_element(lc) {
             // Whole at its open tag: it ends right after its attributes.
             self.ends[self.tag_start] = self.nodes.len();
         }
+        self.skip_leading_lf =
+            lc == live_id!(pre) || lc == live_id!(listing) || lc == live_id!(textarea);
+    }
+
+    /// Whether the character that follows should be dropped if it is a
+    /// newline; asking consumes the request.
+    fn take_skip_leading_lf(&mut self) -> bool {
+        std::mem::take(&mut self.skip_leading_lf)
     }
 
     /// `<x/>`: the start tag that began at `tag_start` closes itself. A
@@ -547,6 +572,14 @@ impl Builder {
 
     fn close_tag(&mut self, name: &str, intern: InternLiveId) {
         let lc = LiveId::from_str_lc(name);
+        if lc == live_id!(br) {
+            // The tree builder reads `</br>` as `<br>`: `x</br>y` breaks the
+            // line, where a stray close tag would have closed nothing.
+            self.begin_tag();
+            self.open_tag(name, intern);
+            self.end_open_tag();
+            return;
+        }
         let index = self.push(HtmlNode::CloseTag {
             lc,
             nc: LiveId::from_str_with_intern(name, intern),
@@ -557,41 +590,147 @@ impl Builder {
     /// The close tag at `index` ends the innermost open `lc`, and everything
     /// opened inside it.
     fn close(&mut self, lc: LiveId, index: usize) {
-        if !self.counts.get(&lc).is_some_and(|n| *n > 0) {
-            return;
-        }
-        let Some(pos) = self.open.iter().rposition(|&j| self.name_at(j) == lc) else {
+        // The innermost open element of this name, or nothing to close.
+        let Some(pos) = self.innermost(lc) else {
             return;
         };
-        for depth in pos..self.open.len() {
-            let j = self.open[depth];
-            let name = self.name_at(j);
-            if let Some(n) = self.counts.get_mut(&name) {
-                *n = n.saturating_sub(1);
-            }
-            if preserves_whitespace(name) {
-                self.preserving = self.preserving.saturating_sub(1);
-            }
-            // Its own close tag, or an enclosing element's: either way this
-            // is where the element ends.
-            self.ends[j] = if depth == pos { index + 1 } else { index };
-        }
         self.closes[self.open[pos]] = index;
-        self.open.truncate(pos);
+        self.ends[self.open[pos]] = index + 1;
+        self.end_from(pos + 1, index);
+        self.end_open_element(pos);
+    }
+
+    /// Ends every open element from stack depth `from` up, at node `at` —
+    /// they never had a close tag of their own — and drops them.
+    fn end_from(&mut self, from: usize, at: usize) {
+        for depth in (from..self.open.len()).rev() {
+            self.ends[self.open[depth]] = at;
+            self.end_open_element(depth);
+        }
+    }
+
+    /// Drops the element at stack depth `depth` (which must be the top) from
+    /// the bookkeeping.
+    fn end_open_element(&mut self, depth: usize) {
+        let name = self.name_at(self.open[depth]);
+        if let Some(depths) = self.depths.get_mut(&name) {
+            depths.pop();
+        }
+        if preserves_whitespace(name) {
+            self.preserving = self.preserving.saturating_sub(1);
+        }
+        self.open.truncate(depth);
+    }
+
+    /// Stack depth of the innermost open element named `lc`.
+    fn innermost(&self, lc: LiveId) -> Option<usize> {
+        self.depths.get(&lc).and_then(|d| d.last().copied())
+    }
+
+    /// Ends the outermost open element named in `targets` that lies above
+    /// the nearest open element named in `scope`, and everything inside it,
+    /// at the node about to be pushed. With `current_only`, only the
+    /// innermost open element is considered.
+    fn close_in_scope(&mut self, targets: &[LiveId], scope: &[LiveId], current_only: bool) {
+        let at = self.nodes.len();
+        if current_only {
+            if let Some(&top) = self.open.last() {
+                if targets.contains(&self.name_at(top)) {
+                    self.end_from(self.open.len() - 1, at);
+                }
+            }
+            return;
+        }
+        // Everything at or below the nearest scope boundary is out of reach.
+        let floor = scope
+            .iter()
+            .filter_map(|&name| self.innermost(name))
+            .max()
+            .map_or(0, |boundary| boundary + 1);
+        // The outermost target above it; each name's depths are ascending.
+        let found = targets
+            .iter()
+            .filter_map(|name| {
+                let depths = self.depths.get(name)?;
+                let first_above = depths.partition_point(|&depth| depth < floor);
+                depths.get(first_above).copied()
+            })
+            .min();
+        if let Some(depth) = found {
+            self.end_from(depth, at);
+        }
+    }
+
+    /// What a start tag implicitly closes, per the tree builder's "in body"
+    /// and table insertion modes: a block start tag closes an open `<p>`;
+    /// a heading closes a heading that is the current node; `<li>` closes
+    /// an open item up to its list; `<dd>`/`<dt>` likewise; a cell closes an
+    /// open cell up to its row; a row closes an open row and its cells; a
+    /// table section closes an open section, row and cells; a second `<a>`
+    /// closes the first. This is what makes `<li>a<li>b` two items and
+    /// `<a href=1>x<a href=2>y</a>` two links, for every consumer alike.
+    fn implicitly_close_for(&mut self, lc: LiveId) {
+        const CLOSES_P: &[LiveId] = &[
+            live_id!(address), live_id!(article), live_id!(aside), live_id!(blockquote),
+            live_id!(center), live_id!(details), live_id!(dialog), live_id!(dir),
+            live_id!(div), live_id!(dl), live_id!(fieldset), live_id!(figcaption),
+            live_id!(figure), live_id!(footer), live_id!(form), live_id!(header),
+            live_id!(hgroup), live_id!(hr), live_id!(main), live_id!(menu), live_id!(nav),
+            live_id!(ol), live_id!(p), live_id!(pre), live_id!(listing), live_id!(search),
+            live_id!(section), live_id!(summary), live_id!(table), live_id!(ul),
+            live_id!(xmp), live_id!(plaintext), live_id!(li), live_id!(dd), live_id!(dt),
+            live_id!(h1), live_id!(h2), live_id!(h3), live_id!(h4), live_id!(h5), live_id!(h6),
+        ];
+        const P: &[LiveId] = &[live_id!(p)];
+        // The tree builder's "button scope" and "default scope" boundaries,
+        // restricted to elements this parser's consumers use.
+        const BUTTON_SCOPE: &[LiveId] = &[live_id!(table), live_id!(td), live_id!(th), live_id!(button)];
+        const DEFAULT_SCOPE: &[LiveId] = &[live_id!(table), live_id!(td), live_id!(th)];
+        const HEADINGS: &[LiveId] = &[
+            live_id!(h1), live_id!(h2), live_id!(h3), live_id!(h4), live_id!(h5), live_id!(h6),
+        ];
+        const ITEM: &[LiveId] = &[live_id!(li)];
+        const LIST_ITEM_SCOPE: &[LiveId] = &[live_id!(ul), live_id!(ol), live_id!(table), live_id!(td), live_id!(th)];
+        const DEFINITION: &[LiveId] = &[live_id!(dd), live_id!(dt)];
+        const CELLS: &[LiveId] = &[live_id!(td), live_id!(th)];
+        const ROW_CONTEXT: &[LiveId] = &[live_id!(tr), live_id!(table)];
+        const ROW_AND_CELLS: &[LiveId] = &[live_id!(tr), live_id!(td), live_id!(th)];
+        const SECTIONS: &[LiveId] = &[live_id!(thead), live_id!(tbody), live_id!(tfoot)];
+        const TABLE_BODY_CONTEXT: &[LiveId] = &[live_id!(table), live_id!(thead), live_id!(tbody), live_id!(tfoot)];
+        const SECTION_ROW_AND_CELLS: &[LiveId] = &[
+            live_id!(thead), live_id!(tbody), live_id!(tfoot), live_id!(tr), live_id!(td), live_id!(th),
+        ];
+        const TABLE_CONTEXT: &[LiveId] = &[live_id!(table)];
+        const ANCHOR: &[LiveId] = &[live_id!(a)];
+        const BUTTON: &[LiveId] = &[live_id!(button)];
+
+        if CLOSES_P.contains(&lc) {
+            self.close_in_scope(P, BUTTON_SCOPE, false);
+        }
+        if HEADINGS.contains(&lc) {
+            self.close_in_scope(HEADINGS, &[], true);
+        } else if lc == live_id!(li) {
+            self.close_in_scope(ITEM, LIST_ITEM_SCOPE, false);
+        } else if DEFINITION.contains(&lc) {
+            self.close_in_scope(DEFINITION, DEFAULT_SCOPE, false);
+        } else if CELLS.contains(&lc) {
+            self.close_in_scope(CELLS, ROW_CONTEXT, false);
+        } else if lc == live_id!(tr) {
+            self.close_in_scope(ROW_AND_CELLS, TABLE_BODY_CONTEXT, false);
+        } else if SECTIONS.contains(&lc) {
+            self.close_in_scope(SECTION_ROW_AND_CELLS, TABLE_CONTEXT, false);
+        } else if lc == live_id!(a) {
+            self.close_in_scope(ANCHOR, DEFAULT_SCOPE, false);
+        } else if lc == live_id!(button) {
+            self.close_in_scope(BUTTON, DEFAULT_SCOPE, false);
+        }
     }
 
     /// Input ended inside the tag that began at `tag_start`: drop it whole,
     /// as a browser drops a tag cut off by end of input.
     fn drop_tag(&mut self) {
         if self.open.last() == Some(&self.tag_start) {
-            self.open.pop();
-            let name = self.name_at(self.tag_start);
-            if let Some(n) = self.counts.get_mut(&name) {
-                *n = n.saturating_sub(1);
-            }
-            if preserves_whitespace(name) {
-                self.preserving = self.preserving.saturating_sub(1);
-            }
+            self.end_open_element(self.open.len() - 1);
         }
         self.nodes.truncate(self.tag_start);
         self.closes.truncate(self.tag_start);
@@ -644,6 +783,9 @@ pub fn parse_html(
             /// was never content.
             last_non_whitespace: usize,
             collapse_ws: bool,
+            /// This run follows `<pre>`: a newline as its first character
+            /// is not content, as the tree builder specifies.
+            skip_lf: bool,
         },
         /// `<` seen; holds the byte index after it.
         TagOpen(usize),
@@ -899,11 +1041,12 @@ pub fn parse_html(
     }
 
     /// The text state that follows an element's tag.
-    fn text_after_tag(decoded: &str, builder: &Builder) -> State {
+    fn text_after_tag(decoded: &str, builder: &mut Builder) -> State {
         State::Text {
             dec_start: decoded.len(),
             last_non_whitespace: decoded.len(),
             collapse_ws: builder.collapses(),
+            skip_lf: builder.take_skip_leading_lf(),
         }
     }
 
@@ -915,6 +1058,7 @@ pub fn parse_html(
             dec_start: decoded.len(),
             last_non_whitespace,
             collapse_ws: builder.collapses(),
+            skip_lf: false,
         }
     }
 
@@ -943,30 +1087,45 @@ pub fn parse_html(
         dec_start: 0,
         last_non_whitespace: 0,
         collapse_ws: true,
+        skip_lf: false,
     };
 
-    for (i, c) in body.char_indices() {
-        let c = match c {
-            '\r' => {
-                after_cr = true;
-                '\n'
-            }
-            '\n' if after_cr => {
-                after_cr = false;
+    for (i, mut c) in body.char_indices() {
+        // The input stream's preprocessing: `\r\n` and `\r` become `\n`,
+        // and NUL is dropped from text and replaced in attribute values, as
+        // the tree builder and tokenizer respectively do. Kept to a couple of
+        // compares per character: this is the hot loop.
+        if after_cr {
+            after_cr = false;
+            if c == '\n' {
                 continue;
             }
-            c => {
-                after_cr = false;
-                c
+        }
+        if c == '\r' {
+            after_cr = true;
+            c = '\n';
+        } else if c == '\0' {
+            if matches!(state, State::Text { .. }) {
+                continue;
             }
-        };
+            c = '\u{fffd}';
+        }
         state = match state {
             State::Text {
                 dec_start,
                 mut last_non_whitespace,
                 collapse_ws,
+                skip_lf,
             } => {
-                if c == '<' {
+                if skip_lf && c == '\n' {
+                    // The newline right after `<pre>` is not content.
+                    State::Text {
+                        dec_start,
+                        last_non_whitespace,
+                        collapse_ws,
+                        skip_lf: false,
+                    }
+                } else if c == '<' {
                     end_entity(
                         &mut in_entity,
                         &mut decoded,
@@ -992,6 +1151,7 @@ pub fn parse_html(
                         dec_start,
                         last_non_whitespace,
                         collapse_ws,
+                        skip_lf: false,
                     }
                 }
             }
@@ -1034,6 +1194,7 @@ pub fn parse_html(
                             dec_start,
                             last_non_whitespace,
                             collapse_ws,
+                            skip_lf: false,
                         }
                     }
                 }
@@ -1048,7 +1209,7 @@ pub fn parse_html(
                 } else if c == '>' {
                     b.open_tag(&body[start..i], intern);
                     b.end_open_tag();
-                    text_after_tag(&decoded, &b)
+                    text_after_tag(&decoded, &mut b)
                 } else {
                     State::TagName(start)
                 }
@@ -1069,7 +1230,7 @@ pub fn parse_html(
             State::EndTagName(start) => {
                 if c == '>' {
                     b.close_tag(&body[start..i], intern);
-                    text_after_tag(&decoded, &b)
+                    text_after_tag(&decoded, &mut b)
                 } else if is_html_whitespace(c) || c == '/' {
                     State::AfterEndTagName(start, i)
                 } else {
@@ -1079,7 +1240,7 @@ pub fn parse_html(
             State::AfterEndTagName(start, end) => {
                 if c == '>' {
                     b.close_tag(&body[start..end], intern);
-                    text_after_tag(&decoded, &b)
+                    text_after_tag(&decoded, &mut b)
                 } else if is_html_whitespace(c) || c == '/' {
                     State::AfterEndTagName(start, end)
                 } else {
@@ -1092,7 +1253,7 @@ pub fn parse_html(
             State::SelfClosingStartTag => {
                 if c == '>' {
                     b.self_close();
-                    text_after_tag(&decoded, &b)
+                    text_after_tag(&decoded, &mut b)
                 } else {
                     // `<a/b>`: the slash was not a self-closing marker after
                     // all. Read on as `<a b>`.
@@ -1113,7 +1274,7 @@ pub fn parse_html(
                     State::SelfClosingStartTag
                 } else if c == '>' {
                     b.end_open_tag();
-                    text_after_tag(&decoded, &b)
+                    text_after_tag(&decoded, &mut b)
                 } else {
                     State::AttributeName(i)
                 }
@@ -1133,7 +1294,7 @@ pub fn parse_html(
                     let (lc, nc) = attribute_ids(&body[start..i], intern);
                     b.attribute(lc, nc, 0, 0);
                     b.end_open_tag();
-                    text_after_tag(&decoded, &b)
+                    text_after_tag(&decoded, &mut b)
                 } else {
                     State::AttributeName(start)
                 }
@@ -1149,7 +1310,7 @@ pub fn parse_html(
                 } else if c == '>' {
                     b.attribute(lc, nc, 0, 0);
                     b.end_open_tag();
-                    text_after_tag(&decoded, &b)
+                    text_after_tag(&decoded, &mut b)
                 } else {
                     b.attribute(lc, nc, 0, 0);
                     State::AttributeName(i)
@@ -1167,7 +1328,7 @@ pub fn parse_html(
                     report(errors, "Missing attribute value", i);
                     b.attribute(lc, nc, 0, 0);
                     b.end_open_tag();
-                    text_after_tag(&decoded, &b)
+                    text_after_tag(&decoded, &mut b)
                 } else {
                     let start = decoded.len();
                     attr_lnw = start;
@@ -1204,7 +1365,7 @@ pub fn parse_html(
                     end_entity(&mut in_entity, &mut decoded, &mut attr_lnw, false, errors);
                     b.attribute(lc, nc, start, decoded.len());
                     b.end_open_tag();
-                    text_after_tag(&decoded, &b)
+                    text_after_tag(&decoded, &mut b)
                 } else {
                     // Everything else, `/` included, is part of the value:
                     // `<a href=http://host/path>`.
@@ -1311,6 +1472,7 @@ pub fn parse_html(
             dec_start,
             mut last_non_whitespace,
             collapse_ws,
+            ..
         } => {
             end_entity(
                 &mut in_entity,
@@ -3485,6 +3647,12 @@ mod tests {
         fn len_of(body: &str) -> usize {
             parse_html(body, &mut None, InternLiveId::No).nodes.len()
         }
+        fn doc_positions(body: &str, tag: LiveId) -> Vec<usize> {
+            let doc = parse_html(body, &mut None, InternLiveId::No);
+            (0..doc.nodes.len())
+                .filter(|&i| matches!(&doc.nodes[i], HtmlNode::OpenTag { lc, .. } if *lc == tag))
+                .collect()
+        }
 
         let body = "<p>hello<b>x</b></p>tail";
         let (p_close, b_close) = (close_of(body, live_id!(p)), close_of(body, live_id!(b)));
@@ -3492,20 +3660,24 @@ mod tests {
             (live_id!(p), Some(p_close), p_close + 1),
             (live_id!(b), Some(b_close), b_close + 1),
         ]);
-        // the tokenizer does not know `<li>` closes `<li>` (that is the
-        // widget's tree-builder rule), so both items end at `</ul>`
+        // `<li>` implicitly closes an open `<li>`: the first item ends where
+        // the second begins, and the second at `</ul>`
         let body = "<ul><li>one<li>two</ul>";
         let ul_close = close_of(body, live_id!(ul));
+        let second_li = doc_positions(body, live_id!(li))[1];
         assert_eq!(ends(body), vec![
             (live_id!(ul), Some(ul_close), ul_close + 1),
-            (live_id!(li), None, ul_close),
+            (live_id!(li), None, second_li),
             (live_id!(li), None, ul_close),
         ]);
         // a void element is whole at its open tag, however it is written
-        for body in ["<br>x", "<br/>x", "<br></br>x"] {
+        for body in ["<br>x", "<br/>x"] {
             let br = open_of(body, live_id!(br));
             assert_eq!(ends(body), vec![(live_id!(br), None, br + 1)], "{body:?}");
         }
+        // `</br>` is a second `<br>`, not a close tag
+        let brs = doc_positions("<br></br>x", live_id!(br));
+        assert_eq!(ends("<br></br>x"), vec![(live_id!(br), None, brs[0] + 1), (live_id!(br), None, brs[1] + 1)]);
         let body = "<img src=x alt=y>t";
         let img = open_of(body, live_id!(img));
         assert_eq!(ends(body), vec![(live_id!(img), None, img + 3)]);
@@ -3518,6 +3690,96 @@ mod tests {
             (live_id!(td), Some(td_close), td_close + 1),
             (live_id!(a), None, td_close),
         ]);
+    }
+
+    /// The tree builder's implicit closes are applied as the element stack
+    /// is built, so every consumer sees the same tree a browser would:
+    /// `<li>a<li>b` is two items, `<td>a<td>b` two cells, a block start tag
+    /// closes an open `<p>`, a heading closes a heading it directly follows,
+    /// and a second `<a>` closes the first.
+    #[test]
+    fn start_tags_close_what_the_tree_builder_closes() {
+        fn content(body: &str, tag: LiveId, nth: usize) -> String {
+            let doc = parse_html(body, &mut None, InternLiveId::No);
+            let open = (0..doc.nodes.len())
+                .filter(|&i| matches!(&doc.nodes[i], HtmlNode::OpenTag { lc, .. } if *lc == tag))
+                .nth(nth)
+                .unwrap();
+            let at = doc.new_walker_with_index(open);
+            let end = at.close_index().or(at.end_index()).unwrap();
+            doc.nodes[open + 1..end]
+                .iter()
+                .filter_map(|n| match n {
+                    HtmlNode::Text { start, end, .. } => Some(&doc.decoded[*start..*end]),
+                    _ => None,
+                })
+                .collect()
+        }
+        let li = live_id!(li);
+        assert_eq!(content("<ul><li>one<li>two<li>three</ul>", li, 0), "one");
+        assert_eq!(content("<ul><li>one<li>two<li>three</ul>", li, 1), "two");
+        assert_eq!(content("<ul><li>one<li>two<li>three</ul>", li, 2), "three");
+        // an item's nested list keeps its own items separate from the outer one
+        assert_eq!(content("<ul><li>a<ul><li>b<li>c</ul>d<li>e</ul>", li, 0), "abcd");
+        assert_eq!(content("<ul><li>a<ul><li>b<li>c</ul>d<li>e</ul>", li, 1), "b");
+        let (td, tr) = (live_id!(td), live_id!(tr));
+        let table = "<table><tr><td>a<td>b<tr><td>c<td>d</table>";
+        assert_eq!(content(table, td, 0), "a");
+        assert_eq!(content(table, td, 1), "b");
+        assert_eq!(content(table, tr, 0), "ab");
+        assert_eq!(content(table, tr, 1), "cd");
+        assert_eq!(content("<table><tr><td>a<tbody><tr><td>b</table>", tr, 0), "a");
+        let p = live_id!(p);
+        assert_eq!(content("<p>one<p>two<p>three", p, 0), "one");
+        assert_eq!(content("<p>text<ul><li>x</ul>after", p, 0), "text");
+        assert_eq!(content("<p>text<div>block</div>", p, 0), "text");
+        assert_eq!(content("<p>text<h2>head</h2>", p, 0), "text");
+        assert_eq!(content("<p>a<b>bold<p>b", p, 0), "abold");
+        // but not by an inline element
+        assert_eq!(content("<p>text<b>bold</b>more</p>", p, 0), "textboldmore");
+        assert_eq!(content("<h1>one<h2>two</h2>", live_id!(h1), 0), "one");
+        assert_eq!(content("<h1><b>x<h2>two</h2></b></h1>", live_id!(h1), 0), "xtwo");
+        let a = live_id!(a);
+        assert_eq!(content("<a href=1>x<a href=2>y</a>", a, 0), "x");
+        assert_eq!(content("<a href=1>x<a href=2>y</a>", a, 1), "y");
+        assert_eq!(content("<dl><dt>t<dd>d<dt>u</dl>", live_id!(dt), 0), "t");
+        assert_eq!(content("<dl><dt>t<dd>d<dt>u</dl>", live_id!(dd), 0), "d");
+        // a `<td>` does not reach across its row's boundary
+        assert_eq!(content("<table><tr><td><ul><li>a<li>b</ul><td>c</table>", td, 0), "ab");
+        assert_eq!(content("<table><tr><td><ul><li>a<li>b</ul><td>c</table>", li, 0), "a");
+    }
+
+    /// `</br>` is read as `<br>`, so `x</br>y` breaks the line, and the
+    /// newline right after `<pre>` is not content.
+    #[test]
+    fn br_end_tag_and_pre_newline_follow_the_tree_builder() {
+        let doc = parse_html("x</br>y", &mut None, InternLiveId::No);
+        let tags: Vec<_> = doc.nodes.iter().filter_map(|n| match n {
+            HtmlNode::OpenTag { lc, .. } => Some(("open", *lc)),
+            HtmlNode::CloseTag { lc, .. } => Some(("close", *lc)),
+            _ => None,
+        }).collect();
+        assert_eq!(tags, vec![("open", live_id!(br))]);
+        assert_eq!(text_of("<pre>\nx</pre>"), "x");
+        assert_eq!(text_of("<pre>\n\nx</pre>"), "\nx");
+        assert_eq!(text_of("<pre>\r\nx</pre>"), "x");
+        assert_eq!(text_of("<pre>x\n</pre>"), "x\n");
+        assert_eq!(text_of("<pre class=c>\nx</pre>"), "x");
+        // only pre-like elements do this
+        assert_eq!(text_of("<p>\nx</p>"), " x");
+    }
+
+    /// NUL is dropped from text and replaced in attribute values.
+    #[test]
+    fn nul_is_dropped_from_text_and_replaced_in_values() {
+        assert_eq!(text_of("a\0b"), "ab");
+        let doc = parse_html("<a b=\"x\0y\">t</a>", &mut None, InternLiveId::No);
+        let mut w = doc.new_walker();
+        while !w.done() && w.open_tag_lc().is_none() {
+            w.walk();
+        }
+        assert_eq!(w.find_attr_lc(live_id!(b)), Some("x\u{fffd}y"));
+        assert_nodes_consistent("a\0b<c\0 d=\0>\0</c>");
     }
 
     /// `<pre>` is tracked on the same stack as every other element, so an

--- a/libs/html/src/lib.rs
+++ b/libs/html/src/lib.rs
@@ -327,6 +327,8 @@ pub fn parse_html(
         ElementClose(usize),
         ElementAttrs,
         ElementCloseScanSpaces,
+        /// Discarding a malformed tag up to its `>`.
+        BogusTag,
         ElementSelfClose,
         AttribName(usize),
         AttribValueEq(LiveId, LiveId),
@@ -591,7 +593,26 @@ pub fn parse_html(
                 }
             }
             State::ElementClose(start) => {
-                if c == '>' {
+                if i == start && !c.is_ascii_alphabetic() {
+                    // `</3`, `</ ` — not a close tag, so keep it as text.
+                    let dec_start = decoded.len();
+                    decoded.push('<');
+                    decoded.push('/');
+                    let mut last_non_whitespace = decoded.len();
+                    process_entity(
+                        c,
+                        &mut in_entity,
+                        &mut decoded,
+                        &mut last_non_whitespace,
+                        pre_depth == 0,
+                    );
+                    State::Text {
+                        start,
+                        dec_start,
+                        last_non_whitespace,
+                        collapse_ws: pre_depth == 0,
+                    }
+                } else if c == '>' {
                     let lc = LiveId::from_str_lc(&body[start..i]);
                     let nc = LiveId::from_str_with_intern(&body[start..i], intern);
                     if preserves_whitespace(lc) {
@@ -630,18 +651,14 @@ pub fn parse_html(
                     if let Some(errors) = errors {
                         errors.push(HtmlError{message:"Unexpected character after whitespace whilst looking for closing tag >".into(), position:i})
                     };
-                    State::Text {
-                        start: i + 1,
-                        dec_start: decoded.len(),
-                        last_non_whitespace: decoded.len(),
-                        collapse_ws: pre_depth == 0,
-                    }
+                    State::BogusTag
                 } else {
                     State::ElementCloseScanSpaces
                 }
             }
             State::ElementSelfClose => {
-                if c != '>' {
+                let malformed = c != '>';
+                if malformed {
                     if let Some(errors) = errors {
                         errors.push(HtmlError {
                             message: "Expected > after / self closed tag".into(),
@@ -666,11 +683,29 @@ pub fn parse_html(
                     }
                     nodes.push(HtmlNode::CloseTag { lc, nc });
                 }
-                State::Text {
-                    start: i + 1,
-                    dec_start: decoded.len(),
-                    last_non_whitespace: decoded.len(),
-                    collapse_ws: pre_depth == 0,
+                if malformed {
+                    // Drop the rest of the malformed tag instead of resuming
+                    // text inside it, which leaked its `>` into the output.
+                    State::BogusTag
+                } else {
+                    State::Text {
+                        start: i + 1,
+                        dec_start: decoded.len(),
+                        last_non_whitespace: decoded.len(),
+                        collapse_ws: pre_depth == 0,
+                    }
+                }
+            }
+            State::BogusTag => {
+                if c == '>' {
+                    State::Text {
+                        start: i + 1,
+                        dec_start: decoded.len(),
+                        last_non_whitespace: decoded.len(),
+                        collapse_ws: pre_depth == 0,
+                    }
+                } else {
+                    State::BogusTag
                 }
             }
             State::ElementAttrs => {
@@ -2878,6 +2913,25 @@ mod tests {
         assert_eq!(text_of("<p>x</p>"), "x");
         assert_eq!(text_of("<P>x</P>"), "x");
         for body in ["5<10 and 6<12", "a < b", "<>", "<1a>x", "i <3 you", "<é>t"] {
+            assert_nodes_consistent(body);
+        }
+    }
+
+    /// Junk inside a tag is discarded up to its `>` instead of resuming text
+    /// in the middle of it, and `</` that cannot name an element is text.
+    #[test]
+    fn malformed_tags_do_not_leak_their_markup_into_the_text() {
+        assert_eq!(text_of("a</p x>b"), "ab");
+        assert_eq!(text_of("a<br/x>b"), "ab");
+        assert_eq!(text_of("<p>x</p junk>y"), "xy");
+        assert_eq!(text_of("</3 you"), "</3 you");
+        assert_eq!(text_of("i </3 u"), "i </3 u");
+        assert_eq!(text_of("a</ b"), "a</ b");
+        // well-formed close tags are unaffected
+        assert_eq!(text_of("<p>x</p >y"), "xy");
+        assert_eq!(text_of("<br/>ok"), "ok");
+        assert_eq!(text_of("<a href=u>t</a>tail"), "ttail");
+        for body in ["a</p x>b", "a<br/x>b", "</3 you", "a</ b", "a</>b"] {
             assert_nodes_consistent(body);
         }
     }

--- a/libs/html/src/lib.rs
+++ b/libs/html/src/lib.rs
@@ -1,4 +1,29 @@
 use makepad_live_id::*;
+use std::collections::HashMap;
+use std::hash::{BuildHasherDefault, Hasher};
+
+/// A `LiveId` is already a 64-bit hash, so hashing it again with SipHash only
+/// costs time. This hasher passes the id through unchanged.
+#[derive(Default)]
+struct LiveIdHasher(u64);
+
+impl Hasher for LiveIdHasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+    fn write(&mut self, bytes: &[u8]) {
+        // Only reached if something other than a `LiveId` is hashed; fold
+        // the bytes in so the map still behaves.
+        for &b in bytes {
+            self.0 = self.0.rotate_left(8) ^ u64::from(b);
+        }
+    }
+    fn write_u64(&mut self, id: u64) {
+        self.0 = id;
+    }
+}
+
+type LiveIdMap<V> = HashMap<LiveId, V, BuildHasherDefault<LiveIdHasher>>;
 
 #[derive(Debug)]
 pub struct HtmlError {
@@ -6,10 +31,18 @@ pub struct HtmlError {
     pub position: usize,
 }
 
+/// Marks a node in [`HtmlDoc::closes`] that opens no element, or opens one
+/// that has no close tag of its own.
+const NO_CLOSE: usize = usize::MAX;
+
 #[derive(Default, PartialEq)]
 pub struct HtmlDoc {
     pub decoded: String,
     pub nodes: Vec<HtmlNode>,
+    /// For each node, the index of the close tag ending the element it opens,
+    /// or [`NO_CLOSE`]. Computed once by `compute_closes` so that finding an
+    /// element's end is a lookup rather than a scan.
+    closes: Vec<usize>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -48,6 +81,7 @@ pub struct HtmlAttribute {
 
 pub struct HtmlWalker<'a> {
     decoded: &'a str,
+    closes: &'a [usize],
     pub nodes: &'a [HtmlNode],
     pub index: usize,
 }
@@ -71,46 +105,28 @@ impl<'a> HtmlWalker<'a> {
         }
     }
 
+    /// Index of the close tag that ends the element whose open tag the
+    /// walker is on, or `None` when the walker is not on an open tag or the
+    /// element has no close tag of its own — a void element such as `<br>`,
+    /// or one the document never closed.
+    pub fn close_index(&self) -> Option<usize> {
+        match self.closes.get(self.index) {
+            Some(&close) if close != NO_CLOSE => Some(close),
+            _ => None,
+        }
+    }
+
     /// Advances to the close tag matching the open tag the walker is on.
     ///
-    /// Only tags with the *same* id affect nesting depth. Counting every
-    /// open tag would over-consume, because a void element written without a
-    /// slash (`<br>`, `<img src=x>`, `<hr>`) emits an `OpenTag` with no
-    /// matching `CloseTag`, so each one would leave the depth permanently
-    /// unbalanced and swallow the rest of the document.
-    ///
-    /// The walker does not move when the element has no close tag of its own
-    /// — it is void, or unclosed — so the caller's own `walk()` still visits
-    /// the following nodes and any enclosing close tag is still delivered.
+    /// The walker does not move when the element has no close tag of its own,
+    /// so the caller's own `walk()` still visits the following nodes and any
+    /// enclosing close tag is still delivered. It used to count every open tag
+    /// toward a nesting depth; a void element written without a slash emits
+    /// no close tag, so each one left the depth unbalanced and the jump
+    /// swallowed the rest of the document.
     pub fn jump_to_close(&mut self) {
-        let Some(open_lc) = self.open_tag_lc() else {
-            return;
-        };
-        // Elements opened inside this one and not yet closed. Empty for the
-        // common case of an element whose content is plain text, so this
-        // usually does not allocate.
-        let mut inner: Vec<LiveId> = Vec::new();
-        for i in self.index + 1..self.nodes.len() {
-            match &self.nodes[i] {
-                HtmlNode::OpenTag { lc, .. } => inner.push(*lc),
-                HtmlNode::CloseTag { lc, .. } => {
-                    if let Some(pos) = inner.iter().rposition(|t| t == lc) {
-                        // Closes a descendant. Anything still above it was
-                        // void or left unclosed, so it ends here too.
-                        inner.truncate(pos);
-                    } else if *lc == open_lc {
-                        self.index = i;
-                        return;
-                    } else {
-                        // An enclosing element closes first, so this one never
-                        // had a close tag of its own. Stop here rather than
-                        // reading to the end of the document for every void
-                        // element, which would make a draw quadratic.
-                        return;
-                    }
-                }
-                _ => (),
-            }
+        if let Some(close) = self.close_index() {
+            self.index = close;
         }
     }
 
@@ -296,16 +312,13 @@ impl<'a> HtmlWalker<'a> {
 
 impl HtmlDoc {
     pub fn new_walker(&self) -> HtmlWalker<'_> {
-        HtmlWalker {
-            decoded: &self.decoded,
-            index: 0,
-            nodes: &self.nodes,
-        }
+        self.new_walker_with_index(0)
     }
 
     pub fn new_walker_with_index(&self, index: usize) -> HtmlWalker<'_> {
         HtmlWalker {
             decoded: &self.decoded,
+            closes: &self.closes,
             index,
             nodes: &self.nodes,
         }
@@ -321,40 +334,77 @@ fn is_html_whitespace(c: char) -> bool {
     matches!(c, ' ' | '\t' | '\n' | '\r' | '\u{c}')
 }
 
+/// Parses `body` into a flat node list.
+///
+/// The tokenizer follows the WHATWG HTML tokenizer's states and its recovery
+/// rules for malformed input, so a broken document produces the same tokens a
+/// browser would build from it. There is one deliberate departure: `<x/>`
+/// emits a close tag for `x`, where HTML would ignore the slash on a non-void
+/// element, because the SVG parser is built on this walker and XML needs it.
+///
+/// Parsing never fails. When `errors` is `Some`, everything that was wrong
+/// with the input is recorded there with its byte offset in `body`.
 pub fn parse_html(
     body: &str,
     errors: &mut Option<Vec<HtmlError>>,
     intern: InternLiveId,
 ) -> HtmlDoc {
+    /// Tokenizer states, named after their WHATWG counterparts where one
+    /// exists.
     enum State {
+        /// Between tags.
         Text {
-            start: usize,
+            /// Where this text run starts in `decoded`.
             dec_start: usize,
+            /// One past the last non-whitespace character in `decoded`, or
+            /// `dec_start` while there has been none. Drives whitespace
+            /// collapsing and the node's `all_ws` flag.
             last_non_whitespace: usize,
             collapse_ws: bool,
         },
-        ElementName(usize),
-        ElementClose(usize),
-        ElementAttrs,
-        ElementCloseScanSpaces,
-        /// Discarding a malformed tag up to its `>`.
-        BogusTag,
-        ElementSelfClose,
-        AttribName(usize),
-        AttribValueEq(LiveId, LiveId),
-        AttribValueStart(LiveId, LiveId),
-        AttribValueSq(LiveId, LiveId, usize),
-        AttribValueDq(LiveId, LiveId, usize),
-        AttribValueBare(LiveId, LiveId, usize),
-        AttribValueBareSlash(LiveId, LiveId, usize),
-        CommentStartDash1,
-        CommentStartDash2,
+        /// `<` seen; holds the byte index after it.
+        TagOpen(usize),
+        /// Inside a start tag's name; holds the name's first byte index.
+        TagName(usize),
+        /// `</` seen; holds the byte index after it.
+        EndTagOpen(usize),
+        /// Inside an end tag's name; holds the name's first byte index.
+        EndTagName(usize),
+        /// After an end tag's name. End tags carry no attributes, so
+        /// everything up to `>` is discarded.
+        AfterEndTagName,
+        /// `/` seen inside a start tag; `>` now self-closes it.
+        SelfClosingStartTag,
+        /// Between attributes.
+        BeforeAttributeName,
+        /// Inside an attribute name; holds its first byte index.
+        AttributeName(usize),
+        /// After an attribute name, before knowing whether `=` follows.
+        AfterAttributeName(LiveId, LiveId),
+        /// `=` seen; waiting for the value to begin.
+        BeforeAttributeValue(LiveId, LiveId),
+        /// Inside a value; the index is where it starts in `decoded`.
+        AttributeValueDq(LiveId, LiveId, usize),
+        AttributeValueSq(LiveId, LiveId, usize),
+        AttributeValueUnquoted(LiveId, LiveId, usize),
+        /// `<!` seen.
+        MarkupDeclarationOpen,
+        /// `<!-` seen.
+        MarkupDeclarationDash,
+        /// `<!--` seen; a `>` here closes the comment straight away.
+        CommentStart,
+        /// `<!---` seen.
+        CommentStartDash,
+        Comment,
+        /// `-` seen inside a comment.
         CommentEndDash,
+        /// `--` seen inside a comment.
         CommentEnd,
-        DocType,
-        HeaderQuestion,
-        HeaderAngle,
-        CommentBody,
+        /// `--!` seen inside a comment.
+        CommentEndBang,
+        /// Discarding everything up to `>`: a doctype, `<?...>`, `<!x...>`,
+        /// `</3...>`, or junk after an end tag's name.
+        BogusComment,
     }
 
     /// The longest name in `match_entity` is `DownLeftRightVector`. A run of
@@ -365,11 +415,13 @@ pub fn parse_html(
     /// a longer budget than a name would.
     const MAX_ENTITY_NUMERIC: usize = 32;
 
-    /// State for an entity currently being scanned.
+    /// An entity currently being scanned.
     #[derive(Copy, Clone)]
     struct InEntity {
         /// Index in `decoded` of the opening `&`.
         start: usize,
+        /// Index in `body` of the opening `&`, for error reporting.
+        src_start: usize,
         /// `last_non_whitespace` as it was *before* the `&` was appended.
         /// The entity's own characters are appended to `decoded` while it is
         /// being scanned and then truncated away again on a match, so the
@@ -377,42 +429,47 @@ pub fn parse_html(
         saved_last_non_whitespace: usize,
     }
 
+    /// Appends `c` to `decoded`, collapsing whitespace when asked to and
+    /// decoding character references as they complete.
     #[inline]
     fn process_entity(
         c: char,
+        src_pos: usize,
         in_entity: &mut Option<InEntity>,
         decoded: &mut String,
         last_non_whitespace: &mut usize,
         collapse_ws: bool,
     ) {
-        if let Some(InEntity { start, saved_last_non_whitespace }) = *in_entity {
-            // scan entity
+        if let Some(InEntity {
+            start,
+            saved_last_non_whitespace,
+            ..
+        }) = *in_entity
+        {
             if c == ';' {
-                // potential end of entity
-                match match_entity(&decoded[start + 1..]) {
-                    Err(_e) => {
-                        *in_entity = None;
-                    }
-                    Ok(entity) => {
-                        *in_entity = None;
-                        // `match_entity` only yields Unicode scalar values,
-                        // but fall back to leaving the text as-is rather than
-                        // panicking if that ever stops holding.
-                        if let Some(ch) = char::from_u32(entity) {
-                            decoded.truncate(start);
+                // Whether or not the name matches, the scan is over.
+                *in_entity = None;
+                if let Some(ch) = match_entity(&decoded[start + 1..])
+                    .ok()
+                    .and_then(char::from_u32)
+                {
+                    decoded.truncate(start);
+                    if is_html_whitespace(ch) {
+                        // A decoded space is subject to the same collapsing
+                        // as a literal one: `a &#32; b` reads "a b".
+                        *last_non_whitespace = saved_last_non_whitespace;
+                        if !collapse_ws {
                             decoded.push(ch);
-                            *last_non_whitespace = if is_html_whitespace(ch) {
-                                saved_last_non_whitespace
-                            } else {
-                                decoded.len()
-                            };
-                            return;
+                        } else if *last_non_whitespace == decoded.len() {
+                            decoded.push(' ');
                         }
+                    } else {
+                        decoded.push(ch);
+                        *last_non_whitespace = decoded.len();
                     }
+                    return;
                 }
-            }
-            // definitely not an entity
-            else {
+            } else {
                 let scanned = decoded.len() - start;
                 let budget = if decoded.as_bytes().get(start + 1) == Some(&b'#') {
                     MAX_ENTITY_NUMERIC
@@ -420,6 +477,7 @@ pub fn parse_html(
                     MAX_ENTITY_NAME
                 };
                 if is_html_whitespace(c) || scanned > budget {
+                    // Definitely not an entity; what was scanned stays text.
                     *in_entity = None;
                 }
             }
@@ -427,6 +485,7 @@ pub fn parse_html(
         if c == '&' {
             *in_entity = Some(InEntity {
                 start: decoded.len(),
+                src_start: src_pos,
                 saved_last_non_whitespace: *last_non_whitespace,
             });
         }
@@ -442,616 +501,594 @@ pub fn parse_html(
         }
     }
 
-    /// `<pre>` and `<code>` keep their whitespace verbatim.
-    fn preserves_whitespace(lc: LiveId) -> bool {
-        lc == live_id!(pre) || lc == live_id!(code)
+    fn report(errors: &mut Option<Vec<HtmlError>>, message: &str, position: usize) {
+        if let Some(errors) = errors {
+            errors.push(HtmlError {
+                message: message.into(),
+                position,
+            });
+        }
+    }
+
+    /// Forgets an entity still being scanned when its text run ends, and
+    /// reports it. Letting it survive across a tag or a closing quote is what
+    /// used to let a later `;` truncate `decoded` back past text already
+    /// committed to a node.
+    fn drop_entity(in_entity: &mut Option<InEntity>, errors: &mut Option<Vec<HtmlError>>) {
+        if let Some(InEntity { src_start, .. }) = in_entity.take() {
+            report(errors, "Unterminated entity", src_start);
+        }
+    }
+
+    /// The whitespace-preserving elements (`<pre>`, `<code>`) currently open.
+    ///
+    /// A stack rather than a flag or a counter: any tag nested inside `<pre>`
+    /// used to switch collapsing back on for the rest of the element, and a
+    /// bare counter lets a stray `</code>` cancel an enclosing `<pre>`.
+    #[derive(Default)]
+    struct PreserveStack {
+        open: Vec<LiveId>,
+        pre: usize,
+        code: usize,
+    }
+
+    impl PreserveStack {
+        fn slot(&mut self, lc: LiveId) -> Option<&mut usize> {
+            if lc == live_id!(pre) {
+                Some(&mut self.pre)
+            } else if lc == live_id!(code) {
+                Some(&mut self.code)
+            } else {
+                None
+            }
+        }
+
+        fn open_tag(&mut self, lc: LiveId) {
+            if let Some(n) = self.slot(lc) {
+                *n += 1;
+                self.open.push(lc);
+            }
+        }
+
+        /// Closes the innermost open `lc`, and anything opened inside it.
+        fn close_tag(&mut self, lc: LiveId) {
+            // Reject a close tag with nothing to close in O(1), so a run of
+            // stray `</pre>`s cannot make this quadratic.
+            if !matches!(self.slot(lc), Some(n) if *n > 0) {
+                return;
+            }
+            if let Some(pos) = self.open.iter().rposition(|t| *t == lc) {
+                while self.open.len() > pos {
+                    if let Some(t) = self.open.pop() {
+                        if let Some(n) = self.slot(t) {
+                            *n = n.saturating_sub(1);
+                        }
+                    }
+                }
+            }
+        }
+
+        fn collapses(&self) -> bool {
+            self.open.is_empty()
+        }
+    }
+
+    /// The text state that follows a tag.
+    fn text_state(decoded: &str, preserve: &PreserveStack) -> State {
+        State::Text {
+            dec_start: decoded.len(),
+            last_non_whitespace: decoded.len(),
+            collapse_ws: preserve.collapses(),
+        }
+    }
+
+    fn push_open_tag(
+        nodes: &mut Vec<HtmlNode>,
+        preserve: &mut PreserveStack,
+        name: &str,
+        intern: InternLiveId,
+    ) {
+        let lc = LiveId::from_str_lc(name);
+        preserve.open_tag(lc);
+        nodes.push(HtmlNode::OpenTag {
+            lc,
+            nc: LiveId::from_str_with_intern(name, intern),
+        });
+    }
+
+    fn push_close_tag(
+        nodes: &mut Vec<HtmlNode>,
+        preserve: &mut PreserveStack,
+        lc: LiveId,
+        nc: LiveId,
+    ) {
+        preserve.close_tag(lc);
+        nodes.push(HtmlNode::CloseTag { lc, nc });
+    }
+
+    /// `<x/>`: a close tag for the start tag that began at `tag_node_start`.
+    fn push_self_close(
+        nodes: &mut Vec<HtmlNode>,
+        preserve: &mut PreserveStack,
+        tag_node_start: usize,
+    ) {
+        if let Some(HtmlNode::OpenTag { lc, nc }) = nodes.get(tag_node_start) {
+            let (lc, nc) = (*lc, *nc);
+            push_close_tag(nodes, preserve, lc, nc);
+        }
+    }
+
+    fn push_attribute(nodes: &mut Vec<HtmlNode>, lc: LiveId, nc: LiveId, start: usize, end: usize) {
+        nodes.push(HtmlNode::Attribute { lc, nc, start, end });
+    }
+
+    fn attribute_ids(name: &str, intern: InternLiveId) -> (LiveId, LiveId) {
+        (
+            LiveId::from_str_lc(name),
+            LiveId::from_str_with_intern(name, intern),
+        )
     }
 
     let mut nodes = Vec::new();
-    // How many whitespace-preserving elements are currently open. A single
-    // flag would be wrong: any tag nested inside `<pre>` used to reset
-    // collapsing for the rest of the element, so `<pre>a  <b>b  b</b>  c</pre>`
-    // lost every space after the first text run.
-    let mut pre_depth = 0usize;
-    let mut state = State::Text {
-        start: 0,
-        dec_start: 0,
-        last_non_whitespace: 0,
-        collapse_ws: true,
-    };
     // Decoded output never exceeds the source length, and reserving it up
     // front measurably beats growing it. `nodes` deliberately gets no such
     // hint: its length tracks tag count, not byte count, so sizing it from
     // `body.len()` made a tag-sparse document pay a large pointless alloc.
     let mut decoded = String::with_capacity(body.len());
+    let mut preserve = PreserveStack::default();
     let mut in_entity = None;
+    // Attribute values are never whitespace-collapsed, so this only exists to
+    // satisfy `process_entity`; it is reset whenever a value begins.
+    let mut attr_lnw = 0usize;
+    // Index in `nodes` where the tag being parsed began. If the input ends
+    // inside the tag, everything from here on is dropped, as a browser drops
+    // a tag cut off by end of input.
+    let mut tag_node_start = 0usize;
+    let mut state = State::Text {
+        dec_start: 0,
+        last_non_whitespace: 0,
+        collapse_ws: true,
+    };
 
     for (i, c) in body.char_indices() {
         state = match state {
-            State::DocType => {
-                if c == '>' {
-                    State::Text {
-                        start: i + 1,
-                        dec_start: decoded.len(),
-                        last_non_whitespace: decoded.len(),
-                        collapse_ws: pre_depth == 0,
-                    }
-                } else {
-                    State::DocType
-                }
-            }
-            State::HeaderQuestion => {
-                if c == '?' {
-                    State::HeaderAngle
-                } else {
-                    State::HeaderQuestion
-                }
-            }
-            State::HeaderAngle => {
-                if c == '>' {
-                    State::Text {
-                        start: i + 1,
-                        dec_start: decoded.len(),
-                        last_non_whitespace: decoded.len(),
-                        collapse_ws: pre_depth == 0,
-                    }
-                } else {
-                    State::HeaderQuestion
-                }
-            }
             State::Text {
-                start,
                 dec_start,
-                last_non_whitespace,
+                mut last_non_whitespace,
                 collapse_ws,
             } => {
                 if c == '<' {
-                    if let Some(InEntity { start, .. }) = in_entity {
-                        if let Some(errors) = errors {
-                            errors.push(HtmlError {
-                                message: "Unterminated entity".into(),
-                                position: start,
-                            })
-                        };
-                    }
-                    // An entity cannot span this boundary. Dropping it here is
-                    // what keeps a later `;` from truncating `decoded` back
-                    // past text that has already been committed to a node.
-                    in_entity = None;
+                    drop_entity(&mut in_entity, errors);
                     nodes.push(HtmlNode::Text {
                         start: dec_start,
                         end: decoded.len(),
                         all_ws: dec_start == last_non_whitespace,
                     });
-                    State::ElementName(i + 1)
+                    tag_node_start = nodes.len();
+                    State::TagOpen(i + 1)
                 } else {
-                    let mut last_non_whitespace = last_non_whitespace;
                     process_entity(
                         c,
+                        i,
                         &mut in_entity,
                         &mut decoded,
                         &mut last_non_whitespace,
                         collapse_ws,
                     );
                     State::Text {
-                        start,
                         dec_start,
                         last_non_whitespace,
                         collapse_ws,
                     }
                 }
             }
-            State::ElementName(start) => {
-                if c == '/' && i == start {
-                    State::ElementClose(i + 1)
-                } else if c == '!' && i == start {
-                    State::CommentStartDash1
-                } else if c == '?' && i == start {
-                    State::HeaderQuestion
-                } else if i == start && !c.is_ascii_alphabetic() {
-                    // A tag name has to start with an ASCII letter. Anything
-                    // else means the `<` was never markup — `5<10`, `a < b`,
-                    // `<>` — so put it back as literal text instead of
-                    // parsing a bogus element and losing the rest of the
-                    // line to it.
-                    let dec_start = decoded.len();
-                    decoded.push('<');
-                    let mut last_non_whitespace = decoded.len();
-                    process_entity(
-                        c,
-                        &mut in_entity,
-                        &mut decoded,
-                        &mut last_non_whitespace,
-                        pre_depth == 0,
-                    );
-                    State::Text {
-                        start,
-                        dec_start,
-                        last_non_whitespace,
-                        collapse_ws: pre_depth == 0,
-                    }
-                } else if is_html_whitespace(c) {
-                    let lc = LiveId::from_str_lc(&body[start..i]);
-                    if preserves_whitespace(lc) {
-                        pre_depth += 1;
-                    }
-                    nodes.push(HtmlNode::OpenTag {
-                        lc,
-                        nc: LiveId::from_str_with_intern(&body[start..i], intern),
-                    });
-                    State::ElementAttrs
+            State::TagOpen(start) => {
+                if c == '!' {
+                    State::MarkupDeclarationOpen
                 } else if c == '/' {
-                    let lc = LiveId::from_str_lc(&body[start..i]);
-                    if preserves_whitespace(lc) {
-                        pre_depth += 1;
-                    }
-                    nodes.push(HtmlNode::OpenTag {
-                        lc,
-                        nc: LiveId::from_str_with_intern(&body[start..i], intern),
-                    });
-                    State::ElementSelfClose
-                } else if c == '>' {
-                    let lc = LiveId::from_str_lc(&body[start..i]);
-                    let nc = LiveId::from_str_with_intern(&body[start..i], intern);
-                    if preserves_whitespace(lc) {
-                        pre_depth += 1;
-                    }
-                    nodes.push(HtmlNode::OpenTag { lc, nc });
-                    State::Text {
-                        start: i + 1,
-                        dec_start: decoded.len(),
-                        last_non_whitespace: decoded.len(),
-                        collapse_ws: pre_depth == 0,
-                    }
+                    State::EndTagOpen(i + 1)
+                } else if c.is_ascii_alphabetic() {
+                    State::TagName(start)
+                } else if c == '?' {
+                    report(errors, "Unexpected `?` after `<`", i);
+                    State::BogusComment
                 } else {
-                    State::ElementName(start)
-                }
-            }
-            State::ElementClose(start) => {
-                if i == start && !c.is_ascii_alphabetic() {
-                    // `</3`, `</ ` — not a close tag, so keep it as text.
+                    // A tag name has to start with an ASCII letter, so this
+                    // `<` was never markup — `5<10`, `a < b`, `<>` — and it
+                    // goes back into the text rather than starting a bogus
+                    // element that would eat the rest of the line.
                     let dec_start = decoded.len();
                     decoded.push('<');
-                    decoded.push('/');
                     let mut last_non_whitespace = decoded.len();
-                    process_entity(
-                        c,
-                        &mut in_entity,
-                        &mut decoded,
-                        &mut last_non_whitespace,
-                        pre_depth == 0,
-                    );
-                    State::Text {
-                        start,
-                        dec_start,
-                        last_non_whitespace,
-                        collapse_ws: pre_depth == 0,
-                    }
-                } else if c == '>' {
-                    let lc = LiveId::from_str_lc(&body[start..i]);
-                    let nc = LiveId::from_str_with_intern(&body[start..i], intern);
-                    if preserves_whitespace(lc) {
-                        pre_depth = pre_depth.saturating_sub(1);
-                    }
-                    nodes.push(HtmlNode::CloseTag { lc, nc });
-                    State::Text {
-                        start: i + 1,
-                        dec_start: decoded.len(),
-                        last_non_whitespace: decoded.len(),
-                        collapse_ws: pre_depth == 0,
-                    }
-                } else if is_html_whitespace(c) {
-                    let lc = LiveId::from_str_lc(&body[start..i]);
-                    if preserves_whitespace(lc) {
-                        pre_depth = pre_depth.saturating_sub(1);
-                    }
-                    nodes.push(HtmlNode::CloseTag {
-                        lc,
-                        nc: LiveId::from_str_with_intern(&body[start..i], intern),
-                    });
-                    State::ElementCloseScanSpaces
-                } else {
-                    State::ElementClose(start)
-                }
-            }
-            State::ElementCloseScanSpaces => {
-                if c == '>' {
-                    State::Text {
-                        start: i + 1,
-                        dec_start: decoded.len(),
-                        last_non_whitespace: decoded.len(),
-                        collapse_ws: pre_depth == 0,
-                    }
-                } else if !is_html_whitespace(c) {
-                    if let Some(errors) = errors {
-                        errors.push(HtmlError{message:"Unexpected character after whitespace whilst looking for closing tag >".into(), position:i})
-                    };
-                    State::BogusTag
-                } else {
-                    State::ElementCloseScanSpaces
-                }
-            }
-            State::ElementSelfClose => {
-                let malformed = c != '>';
-                if malformed {
-                    if let Some(errors) = errors {
-                        errors.push(HtmlError {
-                            message: "Expected > after / self closed tag".into(),
-                            position: i,
-                        })
-                    };
-                }
-                // look backwards to the OpenTag
-                let begin = nodes.iter().rev().find_map(|v| {
-                    if let HtmlNode::OpenTag { lc, nc } = v {
-                        Some((*lc, *nc))
+                    let collapse_ws = preserve.collapses();
+                    if c == '<' {
+                        // `<<b>`: the second `<` may still open a tag.
+                        nodes.push(HtmlNode::Text {
+                            start: dec_start,
+                            end: decoded.len(),
+                            all_ws: false,
+                        });
+                        tag_node_start = nodes.len();
+                        State::TagOpen(i + 1)
                     } else {
-                        None
-                    }
-                });
-                // Always present in a well-formed transition into this state,
-                // but a parser fed arbitrary input should not carry an
-                // `unwrap` that a future edit could make reachable.
-                if let Some((lc, nc)) = begin {
-                    if preserves_whitespace(lc) {
-                        pre_depth = pre_depth.saturating_sub(1);
-                    }
-                    nodes.push(HtmlNode::CloseTag { lc, nc });
-                }
-                if malformed {
-                    // Drop the rest of the malformed tag instead of resuming
-                    // text inside it, which leaked its `>` into the output.
-                    State::BogusTag
-                } else {
-                    State::Text {
-                        start: i + 1,
-                        dec_start: decoded.len(),
-                        last_non_whitespace: decoded.len(),
-                        collapse_ws: pre_depth == 0,
+                        process_entity(
+                            c,
+                            i,
+                            &mut in_entity,
+                            &mut decoded,
+                            &mut last_non_whitespace,
+                            collapse_ws,
+                        );
+                        State::Text {
+                            dec_start,
+                            last_non_whitespace,
+                            collapse_ws,
+                        }
                     }
                 }
             }
-            State::BogusTag => {
-                if c == '>' {
-                    State::Text {
-                        start: i + 1,
-                        dec_start: decoded.len(),
-                        last_non_whitespace: decoded.len(),
-                        collapse_ws: pre_depth == 0,
-                    }
-                } else {
-                    State::BogusTag
-                }
-            }
-            State::ElementAttrs => {
-                if c == '/' {
-                    //nodes.push(HtmlNode::BeginElement(HtmlId::new(&body, start, i)));
-                    State::ElementSelfClose
-                } else if c == '>' {
-                    State::Text {
-                        start: i + 1,
-                        dec_start: decoded.len(),
-                        last_non_whitespace: decoded.len(),
-                        collapse_ws: pre_depth == 0,
-                    }
-                } else if !is_html_whitespace(c) {
-                    State::AttribName(i)
-                } else {
-                    State::ElementAttrs
-                }
-            }
-            State::AttribName(start) => {
+            State::TagName(start) => {
                 if is_html_whitespace(c) {
-                    State::AttribValueEq(
-                        LiveId::from_str_lc(&body[start..i]),
-                        LiveId::from_str_with_intern(&body[start..i], intern),
-                    )
-                } else if c == '=' {
-                    State::AttribValueStart(
-                        LiveId::from_str_lc(&body[start..i]),
-                        LiveId::from_str_with_intern(&body[start..i], intern),
-                    )
+                    push_open_tag(&mut nodes, &mut preserve, &body[start..i], intern);
+                    State::BeforeAttributeName
                 } else if c == '/' {
-                    nodes.push(HtmlNode::Attribute {
-                        lc: LiveId::from_str_lc(&body[start..i]),
-                        nc: LiveId::from_str_with_intern(&body[start..i], intern),
-                        start: 0,
-                        end: 0,
-                    });
-                    State::ElementSelfClose
+                    push_open_tag(&mut nodes, &mut preserve, &body[start..i], intern);
+                    State::SelfClosingStartTag
                 } else if c == '>' {
-                    nodes.push(HtmlNode::Attribute {
-                        lc: LiveId::from_str_lc(&body[start..i]),
-                        nc: LiveId::from_str_with_intern(&body[start..i], intern),
-                        start: 0,
-                        end: 0,
-                    });
-                    State::Text {
-                        start: i + 1,
-                        dec_start: decoded.len(),
-                        last_non_whitespace: decoded.len(),
-                        collapse_ws: pre_depth == 0,
-                    }
+                    push_open_tag(&mut nodes, &mut preserve, &body[start..i], intern);
+                    text_state(&decoded, &preserve)
                 } else {
-                    State::AttribName(start)
+                    State::TagName(start)
                 }
             }
-            State::AttribValueEq(lc, nc) => {
-                if c == '/' {
-                    nodes.push(HtmlNode::Attribute {
-                        lc,
-                        nc,
-                        start: 0,
-                        end: 0,
-                    });
-                    State::ElementSelfClose
+            State::EndTagOpen(start) => {
+                if c.is_ascii_alphabetic() {
+                    State::EndTagName(start)
                 } else if c == '>' {
-                    nodes.push(HtmlNode::Attribute {
-                        lc,
-                        nc,
-                        start: 0,
-                        end: 0,
-                    });
-                    State::Text {
-                        start: i + 1,
-                        dec_start: decoded.len(),
-                        last_non_whitespace: decoded.len(),
-                        collapse_ws: pre_depth == 0,
+                    // `</>` has no name to close. Ignored, as a browser does.
+                    report(errors, "Missing end tag name", i);
+                    text_state(&decoded, &preserve)
+                } else {
+                    // `</3`: a bogus comment running to the next `>`.
+                    report(errors, "Invalid first character of end tag name", i);
+                    State::BogusComment
+                }
+            }
+            State::EndTagName(start) => {
+                if c == '>' {
+                    let (lc, nc) = attribute_ids(&body[start..i], intern);
+                    push_close_tag(&mut nodes, &mut preserve, lc, nc);
+                    text_state(&decoded, &preserve)
+                } else if is_html_whitespace(c) || c == '/' {
+                    let (lc, nc) = attribute_ids(&body[start..i], intern);
+                    push_close_tag(&mut nodes, &mut preserve, lc, nc);
+                    State::AfterEndTagName
+                } else {
+                    State::EndTagName(start)
+                }
+            }
+            State::AfterEndTagName => {
+                if c == '>' {
+                    text_state(&decoded, &preserve)
+                } else if is_html_whitespace(c) || c == '/' {
+                    State::AfterEndTagName
+                } else {
+                    report(errors, "Attributes on an end tag are ignored", i);
+                    State::BogusComment
+                }
+            }
+            State::SelfClosingStartTag => {
+                if c == '>' {
+                    push_self_close(&mut nodes, &mut preserve, tag_node_start);
+                    text_state(&decoded, &preserve)
+                } else {
+                    // `<a/b>`: the slash was not a self-closing marker after
+                    // all. Read on as `<a b>`.
+                    report(errors, "Unexpected `/` in tag", i);
+                    if is_html_whitespace(c) {
+                        State::BeforeAttributeName
+                    } else if c == '/' {
+                        State::SelfClosingStartTag
+                    } else {
+                        State::AttributeName(i)
                     }
+                }
+            }
+            State::BeforeAttributeName => {
+                if is_html_whitespace(c) {
+                    State::BeforeAttributeName
+                } else if c == '/' {
+                    State::SelfClosingStartTag
+                } else if c == '>' {
+                    text_state(&decoded, &preserve)
+                } else {
+                    State::AttributeName(i)
+                }
+            }
+            State::AttributeName(start) => {
+                if is_html_whitespace(c) {
+                    let (lc, nc) = attribute_ids(&body[start..i], intern);
+                    State::AfterAttributeName(lc, nc)
                 } else if c == '=' {
-                    State::AttribValueStart(lc, nc)
-                } else if !is_html_whitespace(c) {
-                    nodes.push(HtmlNode::Attribute {
-                        lc,
-                        nc,
-                        start: 0,
-                        end: 0,
-                    });
-                    State::AttribName(i)
-                } else {
-                    State::AttribValueEq(lc, nc)
-                }
-            }
-            State::AttribValueStart(lc, nc) => {
-                if c == '>' {
-                    // An empty unquoted value: the tag ends here.
-                    nodes.push(HtmlNode::Attribute {
-                        lc,
-                        nc,
-                        start: 0,
-                        end: 0,
-                    });
-                    State::Text {
-                        start: i + 1,
-                        dec_start: decoded.len(),
-                        last_non_whitespace: decoded.len(),
-                        collapse_ws: pre_depth == 0,
-                    }
-                } else if c == '\"' {
-                    // double quoted attrib
-                    State::AttribValueDq(lc, nc, decoded.len())
-                } else if c == '\'' {
-                    // single quoted attrib
-                    State::AttribValueSq(lc, nc, decoded.len())
-                } else if !is_html_whitespace(c) {
-                    // Route the first character through `process_entity` too,
-                    // otherwise a value starting with `&` never begins an
-                    // entity scan and `&amp;x` decodes as literal `&amp;x`.
-                    let start = decoded.len();
-                    process_entity(c, &mut in_entity, &mut decoded, &mut 0, false);
-                    State::AttribValueBare(lc, nc, start)
-                } else {
-                    State::AttribValueStart(lc, nc)
-                }
-            }
-            State::AttribValueSq(lc, nc, start) => {
-                if c == '\'' {
-                    if let Some(InEntity { start, .. }) = in_entity {
-                        if let Some(errors) = errors {
-                            errors.push(HtmlError {
-                                message: "Unterminated entity".into(),
-                                position: start,
-                            })
-                        };
-                    }
-                    // An entity cannot span this boundary. Dropping it here is
-                    // what keeps a later `;` from truncating `decoded` back
-                    // past text that has already been committed to a node.
-                    in_entity = None;
-                    nodes.push(HtmlNode::Attribute {
-                        lc,
-                        nc,
-                        start,
-                        end: decoded.len(),
-                    });
-                    State::ElementAttrs
-                } else {
-                    process_entity(c, &mut in_entity, &mut decoded, &mut 0, false);
-                    State::AttribValueSq(lc, nc, start)
-                }
-            }
-            State::AttribValueDq(lc, nc, start) => {
-                if c == '\"' {
-                    if let Some(InEntity { start, .. }) = in_entity {
-                        if let Some(errors) = errors {
-                            errors.push(HtmlError {
-                                message: "Unterminated entity".into(),
-                                position: start,
-                            })
-                        };
-                    }
-                    // An entity cannot span this boundary. Dropping it here is
-                    // what keeps a later `;` from truncating `decoded` back
-                    // past text that has already been committed to a node.
-                    in_entity = None;
-                    nodes.push(HtmlNode::Attribute {
-                        lc,
-                        nc,
-                        start,
-                        end: decoded.len(),
-                    });
-                    State::ElementAttrs
-                } else {
-                    process_entity(c, &mut in_entity, &mut decoded, &mut 0, false);
-                    State::AttribValueDq(lc, nc, start)
-                }
-            }
-            State::AttribValueBareSlash(lc, nc, start) => {
-                if c == '>' {
-                    // The slash really was the self-closing marker.
-                    in_entity = None;
-                    nodes.push(HtmlNode::Attribute {
-                        lc,
-                        nc,
-                        start,
-                        end: decoded.len(),
-                    });
-                    let begin = nodes.iter().rev().find_map(|v| {
-                        if let HtmlNode::OpenTag { lc, nc } = v {
-                            Some((*lc, *nc))
-                        } else {
-                            None
-                        }
-                    });
-                    if let Some((lc, nc)) = begin {
-                        if preserves_whitespace(lc) {
-                            pre_depth = pre_depth.saturating_sub(1);
-                        }
-                        nodes.push(HtmlNode::CloseTag { lc, nc });
-                    }
-                    State::Text {
-                        start: i + 1,
-                        dec_start: decoded.len(),
-                        last_non_whitespace: decoded.len(),
-                        collapse_ws: pre_depth == 0,
-                    }
-                } else if is_html_whitespace(c) {
-                    // `<a href=x/ y=2>`: the slash belongs to the value.
-                    decoded.push('/');
-                    in_entity = None;
-                    nodes.push(HtmlNode::Attribute {
-                        lc,
-                        nc,
-                        start,
-                        end: decoded.len(),
-                    });
-                    State::ElementAttrs
-                } else {
-                    // `<a href=http://host/path>`: an ordinary value character.
-                    decoded.push('/');
-                    process_entity(c, &mut in_entity, &mut decoded, &mut 0, false);
-                    State::AttribValueBare(lc, nc, start)
-                }
-            }
-            State::AttribValueBare(lc, nc, start) => {
-                if c == '/' {
-                    // Only a slash immediately before `>` closes the tag, so
-                    // decide once the next character is known.
-                    State::AttribValueBareSlash(lc, nc, start)
+                    let (lc, nc) = attribute_ids(&body[start..i], intern);
+                    State::BeforeAttributeValue(lc, nc)
+                } else if c == '/' {
+                    let (lc, nc) = attribute_ids(&body[start..i], intern);
+                    push_attribute(&mut nodes, lc, nc, 0, 0);
+                    State::SelfClosingStartTag
                 } else if c == '>' {
-                    in_entity = None;
-                    nodes.push(HtmlNode::Attribute {
-                        lc,
-                        nc,
-                        start,
-                        end: decoded.len(),
-                    });
-                    State::Text {
-                        start: i + 1,
-                        dec_start: decoded.len(),
-                        last_non_whitespace: decoded.len(),
-                        collapse_ws: pre_depth == 0,
-                    }
-                } else if is_html_whitespace(c) {
-                    in_entity = None;
-                    nodes.push(HtmlNode::Attribute {
-                        lc,
-                        nc,
-                        start,
-                        end: decoded.len(),
-                    });
-                    State::ElementAttrs
+                    let (lc, nc) = attribute_ids(&body[start..i], intern);
+                    push_attribute(&mut nodes, lc, nc, 0, 0);
+                    text_state(&decoded, &preserve)
                 } else {
-                    process_entity(c, &mut in_entity, &mut decoded, &mut 0, false);
-                    State::AttribValueBare(lc, nc, start)
+                    State::AttributeName(start)
                 }
             }
-            State::CommentStartDash1 => {
-                if c != '-' {
-                    // we should scan for >
-                    State::DocType
-                    // if let Some(errors) = errors{errors.push(HtmlError{message:"Unexpected //character looking for - after <!".into(), position:i})};
+            State::AfterAttributeName(lc, nc) => {
+                if is_html_whitespace(c) {
+                    State::AfterAttributeName(lc, nc)
+                } else if c == '=' {
+                    State::BeforeAttributeValue(lc, nc)
+                } else if c == '/' {
+                    push_attribute(&mut nodes, lc, nc, 0, 0);
+                    State::SelfClosingStartTag
+                } else if c == '>' {
+                    push_attribute(&mut nodes, lc, nc, 0, 0);
+                    text_state(&decoded, &preserve)
                 } else {
-                    State::CommentStartDash2
+                    push_attribute(&mut nodes, lc, nc, 0, 0);
+                    State::AttributeName(i)
                 }
             }
-            State::CommentStartDash2 => {
-                if c != '-' {
-                    if let Some(errors) = errors {
-                        errors.push(HtmlError {
-                            message: "Unexpected character looking for - after <!-".into(),
-                            position: i,
-                        })
-                    };
-                    State::CommentBody
+            State::BeforeAttributeValue(lc, nc) => {
+                if is_html_whitespace(c) {
+                    State::BeforeAttributeValue(lc, nc)
+                } else if c == '"' {
+                    State::AttributeValueDq(lc, nc, decoded.len())
+                } else if c == '\'' {
+                    State::AttributeValueSq(lc, nc, decoded.len())
+                } else if c == '>' {
+                    // `<a href=>`: an empty value, and the tag ends here.
+                    report(errors, "Missing attribute value", i);
+                    push_attribute(&mut nodes, lc, nc, 0, 0);
+                    text_state(&decoded, &preserve)
                 } else {
-                    // `<!--` is complete: a `>` now closes an empty comment.
+                    let start = decoded.len();
+                    attr_lnw = start;
+                    process_entity(c, i, &mut in_entity, &mut decoded, &mut attr_lnw, false);
+                    State::AttributeValueUnquoted(lc, nc, start)
+                }
+            }
+            State::AttributeValueDq(lc, nc, start) => {
+                if c == '"' {
+                    drop_entity(&mut in_entity, errors);
+                    push_attribute(&mut nodes, lc, nc, start, decoded.len());
+                    State::BeforeAttributeName
+                } else {
+                    process_entity(c, i, &mut in_entity, &mut decoded, &mut attr_lnw, false);
+                    State::AttributeValueDq(lc, nc, start)
+                }
+            }
+            State::AttributeValueSq(lc, nc, start) => {
+                if c == '\'' {
+                    drop_entity(&mut in_entity, errors);
+                    push_attribute(&mut nodes, lc, nc, start, decoded.len());
+                    State::BeforeAttributeName
+                } else {
+                    process_entity(c, i, &mut in_entity, &mut decoded, &mut attr_lnw, false);
+                    State::AttributeValueSq(lc, nc, start)
+                }
+            }
+            State::AttributeValueUnquoted(lc, nc, start) => {
+                if is_html_whitespace(c) {
+                    drop_entity(&mut in_entity, errors);
+                    push_attribute(&mut nodes, lc, nc, start, decoded.len());
+                    State::BeforeAttributeName
+                } else if c == '>' {
+                    drop_entity(&mut in_entity, errors);
+                    push_attribute(&mut nodes, lc, nc, start, decoded.len());
+                    text_state(&decoded, &preserve)
+                } else {
+                    // Everything else, `/` included, is part of the value:
+                    // `<a href=http://host/path>`.
+                    process_entity(c, i, &mut in_entity, &mut decoded, &mut attr_lnw, false);
+                    State::AttributeValueUnquoted(lc, nc, start)
+                }
+            }
+            State::MarkupDeclarationOpen => {
+                if c == '-' {
+                    State::MarkupDeclarationDash
+                } else {
+                    // `<!DOCTYPE ...>`, `<![CDATA[...]]>`, `<!x`: none of them
+                    // produce a node, and all of them end at the next `>`.
+                    State::BogusComment
+                }
+            }
+            State::MarkupDeclarationDash => {
+                if c == '-' {
+                    State::CommentStart
+                } else {
+                    report(errors, "Expected `--` after `<!`", i);
+                    State::BogusComment
+                }
+            }
+            State::CommentStart => {
+                if c == '-' {
+                    State::CommentStartDash
+                } else if c == '>' {
+                    // `<!-->` is a complete, empty comment.
+                    report(errors, "Abruptly closed empty comment", i);
+                    text_state(&decoded, &preserve)
+                } else {
+                    State::Comment
+                }
+            }
+            State::CommentStartDash => {
+                if c == '-' {
                     State::CommentEnd
+                } else if c == '>' {
+                    // `<!--->` likewise.
+                    report(errors, "Abruptly closed empty comment", i);
+                    text_state(&decoded, &preserve)
+                } else {
+                    State::Comment
                 }
             }
-            State::CommentBody => {
+            State::Comment => {
                 if c == '-' {
                     State::CommentEndDash
                 } else {
-                    State::CommentBody
+                    State::Comment
                 }
             }
             State::CommentEndDash => {
                 if c == '-' {
                     State::CommentEnd
                 } else {
-                    State::CommentBody
+                    State::Comment
                 }
             }
             State::CommentEnd => {
-                if c == '-' {
-                    // A run of dashes keeps `>` able to close the comment.
+                if c == '>' {
+                    text_state(&decoded, &preserve)
+                } else if c == '!' {
+                    State::CommentEndBang
+                } else if c == '-' {
+                    // A longer run of dashes still lets `>` close the comment.
                     State::CommentEnd
-                } else if c == '>' {
-                    State::Text {
-                        start: i + 1,
-                        dec_start: decoded.len(),
-                        last_non_whitespace: decoded.len(),
-                        collapse_ws: pre_depth == 0,
-                    }
                 } else {
-                    State::CommentBody
+                    State::Comment
+                }
+            }
+            State::CommentEndBang => {
+                if c == '-' {
+                    State::CommentEndDash
+                } else if c == '>' {
+                    // `--!>` closes a comment, with a complaint.
+                    report(errors, "Incorrectly closed comment", i);
+                    text_state(&decoded, &preserve)
+                } else {
+                    State::Comment
+                }
+            }
+            State::BogusComment => {
+                if c == '>' {
+                    text_state(&decoded, &preserve)
+                } else {
+                    State::BogusComment
                 }
             }
         }
     }
-    if let State::Text {
-        start: _,
-        dec_start,
-        last_non_whitespace,
-        collapse_ws: _,
-    } = state
-    {
-        nodes.push(HtmlNode::Text {
-            start: dec_start,
-            end: decoded.len(),
-            all_ws: dec_start == last_non_whitespace,
-        });
-    } else {
-        // if we didnt end in text state something is wrong
-        if let Some(errors) = errors {
-            errors.push(HtmlError {
-                message: "HTML Parsing endstate is not HtmlNode::Text".into(),
-                position: body.len(),
-            })
-        };
+
+    match state {
+        State::Text {
+            dec_start,
+            last_non_whitespace,
+            ..
+        } => {
+            drop_entity(&mut in_entity, errors);
+            nodes.push(HtmlNode::Text {
+                start: dec_start,
+                end: decoded.len(),
+                all_ws: dec_start == last_non_whitespace,
+            });
+        }
+        // `a<` and `a</`: the `<` never became a tag, so it is text.
+        State::TagOpen(_) | State::EndTagOpen(_) => {
+            let start = decoded.len();
+            decoded.push('<');
+            if matches!(state, State::EndTagOpen(_)) {
+                decoded.push('/');
+            }
+            nodes.push(HtmlNode::Text {
+                start,
+                end: decoded.len(),
+                all_ws: false,
+            });
+        }
+        State::TagName(_)
+        | State::EndTagName(_)
+        | State::AfterEndTagName
+        | State::SelfClosingStartTag
+        | State::BeforeAttributeName
+        | State::AttributeName(_)
+        | State::AfterAttributeName(..)
+        | State::BeforeAttributeValue(..)
+        | State::AttributeValueDq(..)
+        | State::AttributeValueSq(..)
+        | State::AttributeValueUnquoted(..) => {
+            report(errors, "Unexpected end of input inside a tag", body.len());
+            // A tag cut off by the end of input is dropped whole, as a
+            // browser drops it.
+            nodes.truncate(tag_node_start);
+        }
+        State::MarkupDeclarationOpen
+        | State::MarkupDeclarationDash
+        | State::CommentStart
+        | State::CommentStartDash
+        | State::Comment
+        | State::CommentEndDash
+        | State::CommentEnd
+        | State::CommentEndBang
+        | State::BogusComment => {
+            report(errors, "Unexpected end of input inside a comment", body.len());
+        }
     }
-    HtmlDoc { nodes, decoded }
+
+    let closes = compute_closes(&nodes);
+    HtmlDoc {
+        nodes,
+        decoded,
+        closes,
+    }
+}
+
+/// For each node, the index of the close tag that ends the element opened
+/// there, or [`NO_CLOSE`] for every other node.
+///
+/// A close tag ends the innermost open element of its name. Anything opened
+/// inside that element and still open — a void element such as `<br>`, or an
+/// element the document never closed — ends there as well, without a close
+/// tag of its own. A close tag with no open element of its name is ignored.
+/// This is the recovery a browser applies, and it is what makes the walker's
+/// `jump_to_close` immune to void elements.
+fn compute_closes(nodes: &[HtmlNode]) -> Vec<usize> {
+    let mut closes = vec![NO_CLOSE; nodes.len()];
+    // Indices of the open tags currently unclosed, outermost first.
+    let mut open: Vec<usize> = Vec::new();
+    // How many elements of each name are open, so a stray close tag is
+    // rejected without walking the stack: a message can combine deep nesting
+    // with many stray close tags, and walking would be quadratic.
+    let mut counts: LiveIdMap<u32> = LiveIdMap::default();
+    let name_of = |i: usize| match &nodes[i] {
+        HtmlNode::OpenTag { lc, .. } => *lc,
+        _ => LiveId::empty(),
+    };
+    for (i, node) in nodes.iter().enumerate() {
+        match node {
+            HtmlNode::OpenTag { lc, .. } => {
+                open.push(i);
+                *counts.entry(*lc).or_insert(0) += 1;
+            }
+            HtmlNode::CloseTag { lc, .. } => {
+                if !counts.get(lc).is_some_and(|n| *n > 0) {
+                    continue;
+                }
+                if let Some(pos) = open.iter().rposition(|&j| name_of(j) == *lc) {
+                    closes[open[pos]] = i;
+                    for &j in &open[pos..] {
+                        if let Some(n) = counts.get_mut(&name_of(j)) {
+                            *n = n.saturating_sub(1);
+                        }
+                    }
+                    open.truncate(pos);
+                }
+            }
+            _ => {}
+        }
+    }
+    closes
 }
 
 pub fn match_entity(what: &str) -> Result<u32, String> {
@@ -2575,30 +2612,66 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
 }
 
 /// Decodes `&#38;` / `&#x26;` style references, given the text between the
-/// `&` and the `;`.
+/// `&` and the `;`, the way the HTML tokenizer's numeric character reference
+/// states do.
 ///
-/// Everything is validated rather than cast, because the caller turns the
-/// result into a `char`: an out-of-range value, a surrogate, or a negative
-/// number would otherwise panic.
+/// Values that name no character — zero, a UTF-16 surrogate, or anything past
+/// U+10FFFF — become U+FFFD rather than an error, and the C1 control range is
+/// read as Windows-1252, because that is what legacy content means by it:
+/// `&#151;` is an em dash. Malformed references (`&#;`, `&#x;`, `&#-1;`) are
+/// errors, and the caller leaves them as literal text.
 fn match_numeric_entity(what: &str) -> Result<u32, String> {
     let Some(digits) = what.strip_prefix('#') else {
         return Err("unknown html entity".into());
     };
-    // `&#x..;` / `&#X..;` are hex, anything else is decimal. Parsing as `u32`
-    // (not `i64`) rejects a leading `-` or `+` outright.
-    let num = match digits.strip_prefix(['x', 'X']) {
-        Some(hex) => u32::from_str_radix(hex, 16)
-            .map_err(|_| String::from("Cannot parse hex html entity"))?,
-        None => digits
-            .parse::<u32>()
-            .map_err(|_| String::from("Cannot parse digit html entity"))?,
+    let (radix, digits) = match digits.strip_prefix(['x', 'X']) {
+        Some(hex) => (16, hex),
+        None => (10, digits),
     };
-    // Reject anything that is not a Unicode scalar value: beyond U+10FFFF, or
-    // a UTF-16 surrogate half.
-    if char::from_u32(num).is_none() {
-        return Err("Html entity is not a valid unicode scalar".into());
+    if digits.is_empty() {
+        return Err("Numeric html entity has no digits".into());
     }
-    Ok(num)
+    // Saturate rather than overflow: anything past U+10FFFF is U+FFFD, so a
+    // 40-digit reference must land there too, not in an error and not wrapped.
+    let mut value = 0u32;
+    for digit in digits.chars() {
+        let Some(digit) = digit.to_digit(radix) else {
+            return Err("Cannot parse numeric html entity".into());
+        };
+        value = value.saturating_mul(radix).saturating_add(digit);
+    }
+    Ok(match value {
+        0 | 0xD800..=0xDFFF => 0xFFFD,
+        v if v > 0x10FFFF => 0xFFFD,
+        0x80 => 0x20AC,
+        0x82 => 0x201A,
+        0x83 => 0x0192,
+        0x84 => 0x201E,
+        0x85 => 0x2026,
+        0x86 => 0x2020,
+        0x87 => 0x2021,
+        0x88 => 0x02C6,
+        0x89 => 0x2030,
+        0x8A => 0x0160,
+        0x8B => 0x2039,
+        0x8C => 0x0152,
+        0x8E => 0x017D,
+        0x91 => 0x2018,
+        0x92 => 0x2019,
+        0x93 => 0x201C,
+        0x94 => 0x201D,
+        0x95 => 0x2022,
+        0x96 => 0x2013,
+        0x97 => 0x2014,
+        0x98 => 0x02DC,
+        0x99 => 0x2122,
+        0x9A => 0x0161,
+        0x9B => 0x203A,
+        0x9C => 0x0153,
+        0x9E => 0x017E,
+        0x9F => 0x0178,
+        v => v,
+    })
 }
 
 #[cfg(test)]
@@ -2659,23 +2732,36 @@ mod tests {
 
     /// Numeric character references that do not name a Unicode scalar value
     /// used to reach `char::from_u32(..).unwrap()` and abort the process. Any
-    /// of these is reachable from a hostile chat message.
+    /// of these is reachable from a hostile chat message. The tokenizer's
+    /// rule is U+FFFD for a value that names no character, and literal text
+    /// for a reference that is not well-formed at all.
     #[test]
-    fn out_of_range_numeric_entities_are_left_as_text() {
+    fn numeric_entities_follow_the_tokenizer_rules() {
         for body in [
             "&#xD800;",           // high surrogate
             "&#xDFFF;",           // low surrogate
             "&#55296;",           // the same, in decimal
             "&#x110000;",         // one past the last scalar value
-            "&#-1;",              // negative
-            "&#x-1;",
             "&#99999999999999;",  // overflows every integer width
-            "&#;",
-            "&#x;",
+            "&#0;",
         ] {
+            assert_eq!(text_of(body), "\u{fffd}", "{body:?}");
+            assert_nodes_consistent(body);
+        }
+        for body in ["&#-1;", "&#x-1;", "&#;", "&#x;", "&#12a;", "&#xZZ;"] {
             assert_eq!(text_of(body), body, "{body:?} should survive as literal text");
             assert_nodes_consistent(body);
         }
+        // the C1 range is read as Windows-1252, which is what legacy content
+        // means by it
+        assert_eq!(text_of("&#151;"), "\u{2014}");
+        assert_eq!(text_of("&#x96;"), "\u{2013}");
+        assert_eq!(text_of("&#146;"), "\u{2019}");
+        assert_eq!(text_of("&#128;"), "\u{20ac}");
+        // and a decoded space collapses like a literal one
+        assert_eq!(text_of("a &#32; b"), "a b");
+        assert_eq!(text_of("a&#32;&#32;b"), "a b");
+        assert_eq!(text_of("<pre>a&#32;&#32;b</pre>"), "a  b");
     }
 
     /// A `&` that never terminates must not stay pending across a tag or a
@@ -2897,10 +2983,10 @@ mod tests {
         assert_eq!(all_ws, vec![false]);
     }
 
-    /// A `/` only closes the tag when `>` follows it, so unquoted URLs keep
-    /// their path.
+    /// In an unquoted value a `/` is just another character, so unquoted URLs
+    /// keep their path — and `<img src=x/>` is `src="x/"`, not a self-close.
     #[test]
-    fn an_unquoted_value_keeps_slashes_that_are_not_the_self_closing_marker() {
+    fn an_unquoted_value_keeps_its_slashes() {
         fn attr(body: &str, key: LiveId) -> Option<String> {
             let doc = parse_html(body, &mut None, InternLiveId::No);
             let mut walker = doc.new_walker();
@@ -2915,11 +3001,13 @@ mod tests {
         );
         assert_eq!(text_of("<a href=http://example.com/page>x</a> rest"), "x rest");
         assert_eq!(attr("<img src=/media/pic.png>", live_id!(src)).as_deref(), Some("/media/pic.png"));
-        // and the self-closing form still self-closes
-        assert_eq!(attr("<img src=x/>", live_id!(src)).as_deref(), Some("x"));
+        assert_eq!(attr("<img src=x/>", live_id!(src)).as_deref(), Some("x/"));
         let doc = parse_html("<img src=x/>", &mut None, InternLiveId::No);
-        assert!(doc.nodes.iter().any(|n| matches!(n, HtmlNode::CloseTag { lc, .. } if *lc == live_id!(img))));
+        assert!(!doc.nodes.iter().any(|n| matches!(n, HtmlNode::CloseTag { .. })));
         assert_eq!(attr("<a href=x/ y=2>t</a>", live_id!(href)).as_deref(), Some("x/"));
+        // quoted values still self-close, which the SVG parser relies on
+        let doc = parse_html("<img src=\"x\"/>", &mut None, InternLiveId::No);
+        assert!(doc.nodes.iter().any(|n| matches!(n, HtmlNode::CloseTag { lc, .. } if *lc == live_id!(img))));
     }
 
     /// A `<` that cannot begin a tag is literal text, the way a browser
@@ -2942,22 +3030,56 @@ mod tests {
     }
 
     /// Junk inside a tag is discarded up to its `>` instead of resuming text
-    /// in the middle of it, and `</` that cannot name an element is text.
+    /// in the middle of it, which leaked the tag's own `>` into the output.
     #[test]
     fn malformed_tags_do_not_leak_their_markup_into_the_text() {
         assert_eq!(text_of("a</p x>b"), "ab");
-        assert_eq!(text_of("a<br/x>b"), "ab");
         assert_eq!(text_of("<p>x</p junk>y"), "xy");
-        assert_eq!(text_of("</3 you"), "</3 you");
-        assert_eq!(text_of("i </3 u"), "i </3 u");
-        assert_eq!(text_of("a</ b"), "a</ b");
-        // well-formed close tags are unaffected
         assert_eq!(text_of("<p>x</p >y"), "xy");
+        assert_eq!(text_of("<p>x</p/>y"), "xy");
         assert_eq!(text_of("<br/>ok"), "ok");
         assert_eq!(text_of("<a href=u>t</a>tail"), "ttail");
         for body in ["a</p x>b", "a<br/x>b", "</3 you", "a</ b", "a</>b"] {
             assert_nodes_consistent(body);
         }
+    }
+
+    /// The tokenizer's end-tag-open rules: `</` followed by a letter names an
+    /// element, `</>` is dropped, and `</` followed by anything else opens a
+    /// bogus comment that runs to the next `>`. That last one really does
+    /// eat text — `i </3 u` renders as `i ` in a browser too.
+    #[test]
+    fn end_tag_open_follows_the_tokenizer() {
+        assert_eq!(text_of("a</>b"), "ab");
+        assert_eq!(text_of("i </3 u"), "i ");
+        assert_eq!(text_of("i </3 u> x"), "i  x");
+        assert_eq!(text_of("a</ b>c"), "ac");
+        // but `</` at the very end of input is text
+        assert_eq!(text_of("a</"), "a</");
+        assert_eq!(text_of("a<"), "a<");
+    }
+
+    /// `<a/b>` reads as `<a b>`: the slash was not a self-closing marker, so
+    /// no close tag is synthesized and `b` is an attribute.
+    #[test]
+    fn a_stray_slash_in_a_start_tag_is_not_a_self_close() {
+        let doc = parse_html("<a/b>x</a>", &mut None, InternLiveId::No);
+        let closes = doc.nodes.iter().filter(|n| matches!(n, HtmlNode::CloseTag { .. })).count();
+        assert_eq!(closes, 1, "only the explicit </a> closes anything");
+        let mut walker = doc.new_walker();
+        while !walker.done() && walker.open_tag_lc().is_none() {
+            walker.walk();
+        }
+        assert_eq!(walker.find_attr_lc(live_id!(b)), Some(""));
+        assert_eq!(text_of("a<br/x>b"), "ab");
+        // a tag the input cuts off is dropped whole, as a browser drops it
+        let doc = parse_html("<b>text<a href=\"x", &mut None, InternLiveId::No);
+        let opens: Vec<_> = doc.nodes.iter().filter_map(|n| match n {
+            HtmlNode::OpenTag { lc, .. } => Some(*lc),
+            _ => None,
+        }).collect();
+        assert_eq!(opens, vec![live_id!(b)]);
+        assert_eq!(text_of("<b>text<a href=\"x"), "text");
     }
 
     /// `<!-->` is a complete comment rather than the start of an
@@ -2970,7 +3092,70 @@ mod tests {
         assert_eq!(text_of("a<!----->b"), "ab");
         assert_eq!(text_of("a<!--c-->b"), "ab");
         assert_eq!(text_of("a<!--c--->b"), "ab");
+        assert_eq!(text_of("a<!--c--!>b"), "ab");
+        assert_eq!(text_of("a<!--c--!-->b"), "ab");
+        assert_eq!(text_of("a<!-x>b"), "ab");
+        assert_eq!(text_of("a<!DOCTYPE html>b"), "ab");
+        assert_eq!(text_of("a<![CDATA[x]]>b"), "ab");
         assert_eq!(text_of("a<?xml version='1'?>b"), "ab");
+        assert_eq!(text_of("a<?php echo 1 ?>b"), "ab");
+        // a comment cut off by end of input takes nothing else with it
+        assert_eq!(text_of("a<!-- unterminated"), "a");
+    }
+
+    /// The close of every element is resolved once, at parse time, with the
+    /// same recovery a browser applies: a close tag ends the innermost open
+    /// element of its name, anything left open inside ends with it, and a
+    /// close tag that matches nothing is ignored.
+    #[test]
+    fn close_indices_follow_browser_recovery() {
+        fn closes_of(body: &str) -> Vec<(LiveId, Option<LiveId>)> {
+            let doc = parse_html(body, &mut None, InternLiveId::No);
+            let mut walker = doc.new_walker();
+            let mut out = Vec::new();
+            while !walker.done() {
+                if let Some(lc) = walker.open_tag_lc() {
+                    let close = walker.close_index().map(|i| match &doc.nodes[i] {
+                        HtmlNode::CloseTag { lc, .. } => *lc,
+                        _ => unreachable!(),
+                    });
+                    out.push((lc, close));
+                }
+                walker.walk();
+            }
+            out
+        }
+        let (a, b, br, div, span) =
+            (live_id!(a), live_id!(b), live_id!(br), live_id!(div), live_id!(span));
+        assert_eq!(closes_of("<div><b>x</b></div>"), vec![(div, Some(div)), (b, Some(b))]);
+        // a void element ends with its parent
+        assert_eq!(closes_of("<div><br>x</div>"), vec![(div, Some(div)), (br, None)]);
+        // a stray close tag matches nothing and is ignored, so `</a>` still
+        // closes the link rather than being consumed by the `</span>`
+        assert_eq!(
+            closes_of("<div><a>x</span>y</a></div>"),
+            vec![(div, Some(div)), (a, Some(a))]
+        );
+        // an unclosed element ends with its parent, or never
+        assert_eq!(closes_of("<div><span>x</div>y"), vec![(div, Some(div)), (span, None)]);
+        assert_eq!(closes_of("<p>unclosed"), vec![(live_id!(p), None)]);
+        // same-name nesting resolves innermost-first
+        assert_eq!(closes_of("<b>x<b>y</b>z</b>"), vec![(b, Some(b)), (b, Some(b))]);
+        let doc = parse_html("<b>x<b>y</b>z</b>", &mut None, InternLiveId::No);
+        let outer = doc.new_walker_with_index(1).close_index().unwrap();
+        assert!(matches!(doc.nodes[outer], HtmlNode::CloseTag { .. }));
+        assert_eq!(outer, doc.nodes.len() - 2);
+    }
+
+    /// `<pre>` and `<code>` are tracked as a stack: a stray `</code>` cannot
+    /// cancel an enclosing `<pre>`, and `</pre>` closes a `<code>` left open
+    /// inside it.
+    #[test]
+    fn whitespace_preservation_is_a_stack() {
+        assert_eq!(text_of("<pre>a  </code>b  c</pre>d  e"), "a  b  cd e");
+        assert_eq!(text_of("<pre><code>a  b</pre>c  d"), "a  bc d");
+        assert_eq!(text_of("<code>a  <pre>b  c</code>d  e</pre>"), "a  b  cd e");
+        assert_eq!(text_of("</pre>a  b"), "a b");
     }
 
     #[test]

--- a/libs/html/src/lib.rs
+++ b/libs/html/src/lib.rs
@@ -1,29 +1,52 @@
 use makepad_live_id::*;
-use std::collections::HashMap;
-use std::hash::{BuildHasherDefault, Hasher};
+use std::collections::{HashMap, HashSet};
+use std::hash::{BuildHasher, Hasher, RandomState};
 
-/// A `LiveId` is already a 64-bit hash, so hashing it again with SipHash only
-/// costs time. This hasher passes the id through unchanged.
-#[derive(Default)]
-struct LiveIdHasher(u64);
+/// Hashes a `LiveId` — already a 64-bit hash of a name — by mixing it with a
+/// per-parse random seed. Hashing it through the identity let crafted tag
+/// names collide and made the close-tag pass quadratic; hashing it with
+/// SipHash cost a quarter of the parse time. The seed keeps the collisions
+/// unpredictable, and the multiply-fold keeps the cost to a few cycles.
+#[derive(Clone, Copy)]
+struct SeededLiveIdHasher {
+    seed: u64,
+    state: u64,
+}
 
-impl Hasher for LiveIdHasher {
-    fn finish(&self) -> u64 {
-        self.0
-    }
-    fn write(&mut self, bytes: &[u8]) {
-        // Only reached if something other than a `LiveId` is hashed; fold
-        // the bytes in so the map still behaves.
-        for &b in bytes {
-            self.0 = self.0.rotate_left(8) ^ u64::from(b);
+impl SeededLiveIdHasher {
+    fn new_seed() -> Self {
+        SeededLiveIdHasher {
+            seed: RandomState::new().hash_one(0u64),
+            state: 0,
         }
-    }
-    fn write_u64(&mut self, id: u64) {
-        self.0 = id;
     }
 }
 
-type LiveIdMap<V> = HashMap<LiveId, V, BuildHasherDefault<LiveIdHasher>>;
+impl Hasher for SeededLiveIdHasher {
+    fn finish(&self) -> u64 {
+        self.state
+    }
+    fn write(&mut self, bytes: &[u8]) {
+        // Only reached if something other than a `LiveId` is hashed.
+        for &b in bytes {
+            self.write_u64(u64::from(b));
+        }
+    }
+    fn write_u64(&mut self, id: u64) {
+        let mixed = (id ^ self.seed ^ self.state).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        self.state = mixed ^ (mixed >> 29);
+    }
+}
+
+impl BuildHasher for SeededLiveIdHasher {
+    type Hasher = SeededLiveIdHasher;
+    fn build_hasher(&self) -> SeededLiveIdHasher {
+        *self
+    }
+}
+
+type LiveIdMap<V> = HashMap<LiveId, V, SeededLiveIdHasher>;
+type LiveIdSet = HashSet<LiveId, SeededLiveIdHasher>;
 
 #[derive(Debug)]
 pub struct HtmlError {
@@ -31,18 +54,24 @@ pub struct HtmlError {
     pub position: usize,
 }
 
-/// Marks a node in [`HtmlDoc::closes`] that opens no element, or opens one
-/// that has no close tag of its own.
+/// Marks a node in [`HtmlDoc::closes`] / [`HtmlDoc::ends`] that opens no
+/// element, or (for `closes`) opens one that has no close tag of its own.
 const NO_CLOSE: usize = usize::MAX;
 
 #[derive(Default, PartialEq)]
 pub struct HtmlDoc {
     pub decoded: String,
     pub nodes: Vec<HtmlNode>,
-    /// For each node, the index of the close tag ending the element it opens,
-    /// or [`NO_CLOSE`]. Computed once by `compute_closes` so that finding an
-    /// element's end is a lookup rather than a scan.
+    /// For each open tag, the index of its own close tag, or [`NO_CLOSE`]
+    /// when it has none: a void element, or one ended by an enclosing
+    /// element's close tag or by the end of input.
     closes: Vec<usize>,
+    /// For each open tag, one past the last node of the element: past its
+    /// own close tag, or the index of the enclosing close tag that ended it,
+    /// or `nodes.len()`; for a void element, just past its attributes.
+    /// Resolved by the parser as it goes (see `Builder`), so an element's
+    /// extent is a lookup rather than a scan.
+    ends: Vec<usize>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -82,6 +111,7 @@ pub struct HtmlAttribute {
 pub struct HtmlWalker<'a> {
     decoded: &'a str,
     closes: &'a [usize],
+    ends: &'a [usize],
     pub nodes: &'a [HtmlNode],
     pub index: usize,
 }
@@ -105,13 +135,38 @@ impl<'a> HtmlWalker<'a> {
         }
     }
 
+    /// A walker over the same document positioned at `index`.
+    pub fn at(&self, index: usize) -> HtmlWalker<'a> {
+        HtmlWalker {
+            decoded: self.decoded,
+            closes: self.closes,
+            ends: self.ends,
+            nodes: self.nodes,
+            index,
+        }
+    }
+
     /// Index of the close tag that ends the element whose open tag the
     /// walker is on, or `None` when the walker is not on an open tag or the
     /// element has no close tag of its own — a void element such as `<br>`,
-    /// or one the document never closed.
+    /// or one ended by an enclosing element's close tag or by the end of
+    /// input. See [`HtmlWalker::end_index`] for where such an element ends.
     pub fn close_index(&self) -> Option<usize> {
         match self.closes.get(self.index) {
             Some(&close) if close != NO_CLOSE => Some(close),
+            _ => None,
+        }
+    }
+
+    /// One past the last node of the element whose open tag the walker is
+    /// on: past its own close tag; or the index of the enclosing close tag
+    /// that ended it, or the end of the document, when it has none; or, for
+    /// a void element, just past its attributes. `None` when the walker is
+    /// not on an open tag. The element's content is
+    /// `nodes[index + 1..close_index().unwrap_or(end_index())]`.
+    pub fn end_index(&self) -> Option<usize> {
+        match self.ends.get(self.index) {
+            Some(&end) if end != NO_CLOSE => Some(end),
             _ => None,
         }
     }
@@ -230,31 +285,21 @@ impl<'a> HtmlWalker<'a> {
         None
     }
 
-    /// Returns the text directly inside the next `tag` open tag at or after
-    /// the current position. `tag` is matched against the lowercased tag id,
-    /// since HTML tag names are case-insensitive.
+    /// Returns the first text inside the next `tag` element at or after the
+    /// current position — anywhere in that element, not only before its
+    /// first child — or `None` if that element has no text. It does not
+    /// move on to a later element of the same name. `tag` is matched
+    /// against the lowercased tag id, since HTML tag names are
+    /// case-insensitive.
     pub fn find_tag_text(&self, tag: LiveId) -> Option<&'a str> {
-        for i in self.index..self.nodes.len() {
-            match &self.nodes[i] {
-                HtmlNode::OpenTag { lc, .. } if *lc == tag => {
-                    // Attributes sit between the open tag and its text, and
-                    // the parser emits a zero-length text node before any
-                    // nested markup; skip both to reach the real content.
-                    for candidate in &self.nodes[i + 1..] {
-                        match candidate {
-                            HtmlNode::Attribute { .. } => (),
-                            HtmlNode::Text { start, end, .. } if start == end => (),
-                            HtmlNode::Text { start, end, .. } => {
-                                return Some(&self.decoded[*start..*end]);
-                            }
-                            _ => break,
-                        }
-                    }
-                }
-                _ => (),
-            }
-        }
-        None
+        let open = (self.index..self.nodes.len())
+            .find(|&i| matches!(&self.nodes[i], HtmlNode::OpenTag { lc, .. } if *lc == tag))?;
+        let at = self.at(open);
+        let content_end = at.close_index().or(at.end_index()).unwrap_or(self.nodes.len());
+        self.nodes[open + 1..content_end].iter().find_map(|node| match node {
+            HtmlNode::Text { start, end, .. } if start != end => Some(&self.decoded[*start..*end]),
+            _ => None,
+        })
     }
 
     pub fn text(&self) -> Option<&'a str> {
@@ -319,6 +364,7 @@ impl HtmlDoc {
         HtmlWalker {
             decoded: &self.decoded,
             closes: &self.closes,
+            ends: &self.ends,
             index,
             nodes: &self.nodes,
         }
@@ -334,13 +380,247 @@ fn is_html_whitespace(c: char) -> bool {
     matches!(c, ' ' | '\t' | '\n' | '\r' | '\u{c}')
 }
 
+/// The elements HTML defines as void: they never have content or an end tag,
+/// so an open tag is the whole element. Written `<br>` or `<br/>`, they
+/// produce the same single node.
+fn is_void_element(lc: LiveId) -> bool {
+    const VOID: &[LiveId] = &[
+        live_id!(area),
+        live_id!(base),
+        live_id!(basefont),
+        live_id!(bgsound),
+        live_id!(br),
+        live_id!(col),
+        live_id!(embed),
+        live_id!(frame),
+        live_id!(hr),
+        live_id!(img),
+        live_id!(input),
+        live_id!(keygen),
+        live_id!(link),
+        live_id!(meta),
+        live_id!(param),
+        live_id!(source),
+        live_id!(track),
+        live_id!(wbr),
+    ];
+    VOID.contains(&lc)
+}
+
+/// `<pre>` and `<code>` keep their whitespace verbatim.
+fn preserves_whitespace(lc: LiveId) -> bool {
+    lc == live_id!(pre) || lc == live_id!(code)
+}
+
+/// Accumulates the node list while tracking which elements are open, so that
+/// each element's end is resolved as the tags stream past — the recovery a
+/// browser's tree builder applies, in one pass:
+///
+/// - a close tag ends the innermost open element of its name, and everything
+///   still open inside that element ends there too, without a close tag of
+///   its own;
+/// - a close tag that matches nothing is ignored;
+/// - a void element is whole at its open tag;
+/// - whatever is still open at the end of input ends there.
+///
+/// Whitespace collapsing follows the same stack, so a `<pre>` ended by an
+/// enclosing element's close tag stops preserving whitespace at that tag.
+struct Builder {
+    nodes: Vec<HtmlNode>,
+    closes: Vec<usize>,
+    ends: Vec<usize>,
+    /// Node index of each open element, outermost first.
+    open: Vec<usize>,
+    /// How many elements of each name are open, so a close tag with nothing
+    /// to close is rejected without walking the stack.
+    counts: LiveIdMap<u32>,
+    /// How many `<pre>`/`<code>` are open.
+    preserving: usize,
+    /// Attribute names already seen on the tag being parsed; a repeated one
+    /// is dropped, as the tokenizer specifies.
+    attrs_seen: LiveIdSet,
+    /// Node index of the tag being parsed, so input ending inside it can
+    /// drop it whole.
+    tag_start: usize,
+}
+
+impl Builder {
+    fn new(body_len: usize) -> Self {
+        Builder {
+            nodes: Vec::new(),
+            closes: Vec::new(),
+            ends: Vec::new(),
+            open: Vec::new(),
+            counts: LiveIdMap::with_hasher(SeededLiveIdHasher::new_seed()),
+            preserving: 0,
+            attrs_seen: LiveIdSet::with_hasher(SeededLiveIdHasher::new_seed()),
+            tag_start: 0,
+        }
+        .with_capacity_hint(body_len)
+    }
+
+    fn with_capacity_hint(self, _body_len: usize) -> Self {
+        // `nodes` deliberately gets no capacity hint: its length tracks tag
+        // count, not byte count, and sizing it from the body length made a
+        // tag-sparse document pay a large pointless allocation.
+        self
+    }
+
+    fn collapses(&self) -> bool {
+        self.preserving == 0
+    }
+
+    fn push(&mut self, node: HtmlNode) -> usize {
+        self.nodes.push(node);
+        self.closes.push(NO_CLOSE);
+        self.ends.push(NO_CLOSE);
+        self.nodes.len() - 1
+    }
+
+    fn text(&mut self, start: usize, end: usize, all_ws: bool) {
+        self.push(HtmlNode::Text {
+            start,
+            end,
+            all_ws,
+        });
+    }
+
+    fn name_at(&self, index: usize) -> LiveId {
+        match &self.nodes[index] {
+            HtmlNode::OpenTag { lc, .. } => *lc,
+            _ => LiveId::empty(),
+        }
+    }
+
+    /// Starts a tag; `tag_start` remembers where, for `drop_tag`.
+    fn begin_tag(&mut self) {
+        self.tag_start = self.nodes.len();
+        self.attrs_seen.clear();
+    }
+
+    fn open_tag(&mut self, name: &str, intern: InternLiveId) {
+        let lc = LiveId::from_str_lc(name);
+        let index = self.push(HtmlNode::OpenTag {
+            lc,
+            nc: LiveId::from_str_with_intern(name, intern),
+        });
+        if !is_void_element(lc) {
+            self.open.push(index);
+            *self.counts.entry(lc).or_insert(0) += 1;
+            if preserves_whitespace(lc) {
+                self.preserving += 1;
+            }
+        }
+    }
+
+    fn attribute(&mut self, lc: LiveId, nc: LiveId, start: usize, end: usize) {
+        if self.attrs_seen.insert(lc) {
+            self.push(HtmlNode::Attribute { lc, nc, start, end });
+        }
+    }
+
+    /// The start tag that began at `tag_start` is complete.
+    fn end_open_tag(&mut self) {
+        if is_void_element(self.name_at(self.tag_start)) {
+            // Whole at its open tag: it ends right after its attributes.
+            self.ends[self.tag_start] = self.nodes.len();
+        }
+    }
+
+    /// `<x/>`: the start tag that began at `tag_start` closes itself. A
+    /// close tag is synthesized for it — HTML would ignore the slash on a
+    /// non-void element, but the SVG parser is built on this walker and XML
+    /// needs it — except for a void element, which has no close tag by
+    /// definition and whose `<br/>` and `<br>` must be the same node.
+    fn self_close(&mut self) {
+        let Some(HtmlNode::OpenTag { lc, nc }) = self.nodes.get(self.tag_start) else {
+            return;
+        };
+        let (lc, nc) = (*lc, *nc);
+        if is_void_element(lc) {
+            self.ends[self.tag_start] = self.nodes.len();
+        } else {
+            let index = self.push(HtmlNode::CloseTag { lc, nc });
+            self.close(lc, index);
+        }
+    }
+
+    fn close_tag(&mut self, name: &str, intern: InternLiveId) {
+        let lc = LiveId::from_str_lc(name);
+        let index = self.push(HtmlNode::CloseTag {
+            lc,
+            nc: LiveId::from_str_with_intern(name, intern),
+        });
+        self.close(lc, index);
+    }
+
+    /// The close tag at `index` ends the innermost open `lc`, and everything
+    /// opened inside it.
+    fn close(&mut self, lc: LiveId, index: usize) {
+        if !self.counts.get(&lc).is_some_and(|n| *n > 0) {
+            return;
+        }
+        let Some(pos) = self.open.iter().rposition(|&j| self.name_at(j) == lc) else {
+            return;
+        };
+        for depth in pos..self.open.len() {
+            let j = self.open[depth];
+            let name = self.name_at(j);
+            if let Some(n) = self.counts.get_mut(&name) {
+                *n = n.saturating_sub(1);
+            }
+            if preserves_whitespace(name) {
+                self.preserving = self.preserving.saturating_sub(1);
+            }
+            // Its own close tag, or an enclosing element's: either way this
+            // is where the element ends.
+            self.ends[j] = if depth == pos { index + 1 } else { index };
+        }
+        self.closes[self.open[pos]] = index;
+        self.open.truncate(pos);
+    }
+
+    /// Input ended inside the tag that began at `tag_start`: drop it whole,
+    /// as a browser drops a tag cut off by end of input.
+    fn drop_tag(&mut self) {
+        if self.open.last() == Some(&self.tag_start) {
+            self.open.pop();
+            let name = self.name_at(self.tag_start);
+            if let Some(n) = self.counts.get_mut(&name) {
+                *n = n.saturating_sub(1);
+            }
+            if preserves_whitespace(name) {
+                self.preserving = self.preserving.saturating_sub(1);
+            }
+        }
+        self.nodes.truncate(self.tag_start);
+        self.closes.truncate(self.tag_start);
+        self.ends.truncate(self.tag_start);
+    }
+
+    fn finish(mut self, decoded: String) -> HtmlDoc {
+        let end = self.nodes.len();
+        for &j in &self.open {
+            self.ends[j] = end;
+        }
+        HtmlDoc {
+            decoded,
+            nodes: self.nodes,
+            closes: self.closes,
+            ends: self.ends,
+        }
+    }
+}
+
 /// Parses `body` into a flat node list.
 ///
 /// The tokenizer follows the WHATWG HTML tokenizer's states and its recovery
 /// rules for malformed input, so a broken document produces the same tokens a
-/// browser would build from it. There is one deliberate departure: `<x/>`
-/// emits a close tag for `x`, where HTML would ignore the slash on a non-void
-/// element, because the SVG parser is built on this walker and XML needs it.
+/// browser would build from it, and each element's end is resolved as the tree
+/// builder would resolve it (see [`Builder`]). Two deliberate departures:
+/// `<x/>` emits a close tag for a non-void `x`, because the SVG parser is
+/// built on this walker and XML needs it; and named character references
+/// require their `;` — the legacy no-semicolon names are not supported.
 ///
 /// Parsing never fails. When `errors` is `Some`, everything that was wrong
 /// with the input is recorded there with its byte offset in `body`.
@@ -356,9 +636,12 @@ pub fn parse_html(
         Text {
             /// Where this text run starts in `decoded`.
             dec_start: usize,
-            /// One past the last non-whitespace character in `decoded`, or
-            /// `dec_start` while there has been none. Drives whitespace
-            /// collapsing and the node's `all_ws` flag.
+            /// One past the last non-whitespace character in `decoded`.
+            /// Drives whitespace collapsing, and the node's `all_ws` flag
+            /// (`last_non_whitespace <= dec_start` means none in this run).
+            /// It may sit before `dec_start`: a run that follows a comment
+            /// continues the previous run's collapsing, since the comment
+            /// was never content.
             last_non_whitespace: usize,
             collapse_ws: bool,
         },
@@ -371,8 +654,9 @@ pub fn parse_html(
         /// Inside an end tag's name; holds the name's first byte index.
         EndTagName(usize),
         /// After an end tag's name. End tags carry no attributes, so
-        /// everything up to `>` is discarded.
-        AfterEndTagName,
+        /// everything up to `>` is discarded — and the tag is only emitted
+        /// once its `>` arrives.
+        AfterEndTagName(usize, usize),
         /// `/` seen inside a start tag; `>` now self-closes it.
         SelfClosingStartTag,
         /// Between attributes.
@@ -409,13 +693,23 @@ pub fn parse_html(
 
     /// The longest name in `match_entity` is `DownLeftRightVector`. A run of
     /// characters longer than this cannot become a named entity, so scanning
-    /// stops there rather than buffering unbounded text.
+    /// stops there rather than buffering unbounded text. Numeric references
+    /// have no such limit: their digits are consumed until something that
+    /// is not a digit ends them.
     const MAX_ENTITY_NAME: usize = "DownLeftRightVector".len();
-    /// Numeric references (`&#38;`, `&#x26;`) may be zero-padded, so they get
-    /// a longer budget than a name would.
-    const MAX_ENTITY_NUMERIC: usize = 32;
 
-    /// An entity currently being scanned.
+    /// How far a numeric reference has got.
+    #[derive(Copy, Clone, PartialEq)]
+    enum Numeric {
+        /// Not a numeric reference.
+        No,
+        /// `&#` seen; `x`/`X` may still follow.
+        Hash,
+        /// Reading digits in this radix; the count is how many so far.
+        Digits(u32, usize),
+    }
+
+    /// A character reference currently being scanned.
     #[derive(Copy, Clone)]
     struct InEntity {
         /// Index in `decoded` of the opening `&`.
@@ -423,10 +717,59 @@ pub fn parse_html(
         /// Index in `body` of the opening `&`, for error reporting.
         src_start: usize,
         /// `last_non_whitespace` as it was *before* the `&` was appended.
-        /// The entity's own characters are appended to `decoded` while it is
-        /// being scanned and then truncated away again on a match, so the
-        /// index has to be restored rather than recomputed.
+        /// The reference's own characters are appended to `decoded` while
+        /// it is being scanned and then truncated away again on a match, so
+        /// the index has to be restored rather than recomputed.
         saved_last_non_whitespace: usize,
+        numeric: Numeric,
+    }
+
+    /// Replaces the scanned reference text with `ch`, applying the same
+    /// whitespace collapsing a literal character would get: `a &#32; b`
+    /// reads "a b".
+    fn emit_decoded(
+        entity: InEntity,
+        ch: char,
+        decoded: &mut String,
+        last_non_whitespace: &mut usize,
+        collapse_ws: bool,
+    ) {
+        decoded.truncate(entity.start);
+        if is_html_whitespace(ch) {
+            *last_non_whitespace = entity.saved_last_non_whitespace;
+            if !collapse_ws {
+                decoded.push(ch);
+            } else if *last_non_whitespace == decoded.len() {
+                decoded.push(' ');
+            }
+        } else {
+            decoded.push(ch);
+            *last_non_whitespace = decoded.len();
+        }
+    }
+
+    /// Ends a numeric reference that has at least one digit, decoding it.
+    /// The tokenizer decodes at the first non-digit whether or not a `;`
+    /// follows; a missing `;` is only a parse error.
+    fn finish_numeric(
+        entity: InEntity,
+        decoded: &mut String,
+        last_non_whitespace: &mut usize,
+        collapse_ws: bool,
+    ) -> bool {
+        if !matches!(entity.numeric, Numeric::Digits(_, n) if n > 0) {
+            return false;
+        }
+        match match_entity(&decoded[entity.start + 1..])
+            .ok()
+            .and_then(char::from_u32)
+        {
+            Some(ch) => {
+                emit_decoded(entity, ch, decoded, last_non_whitespace, collapse_ws);
+                true
+            }
+            None => false,
+        }
     }
 
     /// Appends `c` to `decoded`, collapsing whitespace when asked to and
@@ -439,46 +782,65 @@ pub fn parse_html(
         decoded: &mut String,
         last_non_whitespace: &mut usize,
         collapse_ws: bool,
+        errors: &mut Option<Vec<HtmlError>>,
     ) {
-        if let Some(InEntity {
-            start,
-            saved_last_non_whitespace,
-            ..
-        }) = *in_entity
-        {
-            if c == ';' {
-                // Whether or not the name matches, the scan is over.
-                *in_entity = None;
-                if let Some(ch) = match_entity(&decoded[start + 1..])
-                    .ok()
-                    .and_then(char::from_u32)
-                {
-                    decoded.truncate(start);
-                    if is_html_whitespace(ch) {
-                        // A decoded space is subject to the same collapsing
-                        // as a literal one: `a &#32; b` reads "a b".
-                        *last_non_whitespace = saved_last_non_whitespace;
-                        if !collapse_ws {
-                            decoded.push(ch);
-                        } else if *last_non_whitespace == decoded.len() {
-                            decoded.push(' ');
+        if let Some(entity) = *in_entity {
+            match entity.numeric {
+                Numeric::No => {
+                    if c == ';' {
+                        // Whether or not the name matches, the scan is over.
+                        *in_entity = None;
+                        if let Some(ch) = match_entity(&decoded[entity.start + 1..])
+                            .ok()
+                            .and_then(char::from_u32)
+                        {
+                            emit_decoded(entity, ch, decoded, last_non_whitespace, collapse_ws);
+                            return;
                         }
-                    } else {
-                        decoded.push(ch);
-                        *last_non_whitespace = decoded.len();
+                    } else if c == '#' && decoded.len() == entity.start + 1 {
+                        in_entity.as_mut().unwrap().numeric = Numeric::Hash;
+                    } else if !c.is_ascii_alphanumeric()
+                        || decoded.len() - entity.start > MAX_ENTITY_NAME
+                    {
+                        // Definitely not a reference; what was scanned stays text.
+                        *in_entity = None;
                     }
-                    return;
                 }
-            } else {
-                let scanned = decoded.len() - start;
-                let budget = if decoded.as_bytes().get(start + 1) == Some(&b'#') {
-                    MAX_ENTITY_NUMERIC
-                } else {
-                    MAX_ENTITY_NAME
-                };
-                if is_html_whitespace(c) || scanned > budget {
-                    // Definitely not an entity; what was scanned stays text.
-                    *in_entity = None;
+                Numeric::Hash => {
+                    if c == 'x' || c == 'X' {
+                        in_entity.as_mut().unwrap().numeric = Numeric::Digits(16, 0);
+                    } else if c.is_ascii_digit() {
+                        in_entity.as_mut().unwrap().numeric = Numeric::Digits(10, 1);
+                    } else {
+                        // `&#` followed by no digits: literal text.
+                        *in_entity = None;
+                    }
+                }
+                Numeric::Digits(radix, count) => {
+                    if c.to_digit(radix).is_some() {
+                        in_entity.as_mut().unwrap().numeric = Numeric::Digits(radix, count + 1);
+                    } else {
+                        *in_entity = None;
+                        if count > 0 {
+                            let decoded_ok =
+                                finish_numeric(entity, decoded, last_non_whitespace, collapse_ws);
+                            if c == ';' {
+                                // The `;` belongs to the reference, decoded or not.
+                                if !decoded_ok {
+                                    decoded.push(c);
+                                    *last_non_whitespace = decoded.len();
+                                }
+                                return;
+                            }
+                            if decoded_ok {
+                                report(
+                                    errors,
+                                    "Missing semicolon after character reference",
+                                    src_pos,
+                                );
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -487,6 +849,7 @@ pub fn parse_html(
                 start: decoded.len(),
                 src_start: src_pos,
                 saved_last_non_whitespace: *last_non_whitespace,
+                numeric: Numeric::No,
             });
         }
         if collapse_ws && is_html_whitespace(c) {
@@ -510,116 +873,49 @@ pub fn parse_html(
         }
     }
 
-    /// Forgets an entity still being scanned when its text run ends, and
-    /// reports it. Letting it survive across a tag or a closing quote is what
-    /// used to let a later `;` truncate `decoded` back past text already
-    /// committed to a node.
-    fn drop_entity(in_entity: &mut Option<InEntity>, errors: &mut Option<Vec<HtmlError>>) {
-        if let Some(InEntity { src_start, .. }) = in_entity.take() {
-            report(errors, "Unterminated entity", src_start);
-        }
-    }
-
-    /// The whitespace-preserving elements (`<pre>`, `<code>`) currently open.
-    ///
-    /// A stack rather than a flag or a counter: any tag nested inside `<pre>`
-    /// used to switch collapsing back on for the rest of the element, and a
-    /// bare counter lets a stray `</code>` cancel an enclosing `<pre>`.
-    #[derive(Default)]
-    struct PreserveStack {
-        open: Vec<LiveId>,
-        pre: usize,
-        code: usize,
-    }
-
-    impl PreserveStack {
-        fn slot(&mut self, lc: LiveId) -> Option<&mut usize> {
-            if lc == live_id!(pre) {
-                Some(&mut self.pre)
-            } else if lc == live_id!(code) {
-                Some(&mut self.code)
+    /// Ends a reference still being scanned when its text run ends. A
+    /// numeric reference with digits is decoded, as the tokenizer would; a
+    /// named one is reported and left as text. Letting it survive across a
+    /// tag or a closing quote is what used to let a later `;` truncate
+    /// `decoded` back past text already committed to a node.
+    fn end_entity(
+        in_entity: &mut Option<InEntity>,
+        decoded: &mut String,
+        last_non_whitespace: &mut usize,
+        collapse_ws: bool,
+        errors: &mut Option<Vec<HtmlError>>,
+    ) {
+        if let Some(entity) = in_entity.take() {
+            if finish_numeric(entity, decoded, last_non_whitespace, collapse_ws) {
+                report(
+                    errors,
+                    "Missing semicolon after character reference",
+                    entity.src_start,
+                );
             } else {
-                None
+                report(errors, "Unterminated entity", entity.src_start);
             }
-        }
-
-        fn open_tag(&mut self, lc: LiveId) {
-            if let Some(n) = self.slot(lc) {
-                *n += 1;
-                self.open.push(lc);
-            }
-        }
-
-        /// Closes the innermost open `lc`, and anything opened inside it.
-        fn close_tag(&mut self, lc: LiveId) {
-            // Reject a close tag with nothing to close in O(1), so a run of
-            // stray `</pre>`s cannot make this quadratic.
-            if !matches!(self.slot(lc), Some(n) if *n > 0) {
-                return;
-            }
-            if let Some(pos) = self.open.iter().rposition(|t| *t == lc) {
-                while self.open.len() > pos {
-                    if let Some(t) = self.open.pop() {
-                        if let Some(n) = self.slot(t) {
-                            *n = n.saturating_sub(1);
-                        }
-                    }
-                }
-            }
-        }
-
-        fn collapses(&self) -> bool {
-            self.open.is_empty()
         }
     }
 
-    /// The text state that follows a tag.
-    fn text_state(decoded: &str, preserve: &PreserveStack) -> State {
+    /// The text state that follows an element's tag.
+    fn text_after_tag(decoded: &str, builder: &Builder) -> State {
         State::Text {
             dec_start: decoded.len(),
             last_non_whitespace: decoded.len(),
-            collapse_ws: preserve.collapses(),
+            collapse_ws: builder.collapses(),
         }
     }
 
-    fn push_open_tag(
-        nodes: &mut Vec<HtmlNode>,
-        preserve: &mut PreserveStack,
-        name: &str,
-        intern: InternLiveId,
-    ) {
-        let lc = LiveId::from_str_lc(name);
-        preserve.open_tag(lc);
-        nodes.push(HtmlNode::OpenTag {
-            lc,
-            nc: LiveId::from_str_with_intern(name, intern),
-        });
-    }
-
-    fn push_close_tag(
-        nodes: &mut Vec<HtmlNode>,
-        preserve: &mut PreserveStack,
-        lc: LiveId,
-        nc: LiveId,
-    ) {
-        preserve.close_tag(lc);
-        nodes.push(HtmlNode::CloseTag { lc, nc });
-    }
-
-    /// `<x/>`: a close tag for the start tag that began at `tag_node_start`.
-    fn push_self_close(
-        nodes: &mut Vec<HtmlNode>,
-        preserve: &mut PreserveStack,
-        tag_node_start: usize,
-    ) {
-        if let Some(HtmlNode::OpenTag { lc, nc }) = nodes.get(tag_node_start) {
-            let (lc, nc) = (*lc, *nc);
-            push_close_tag(nodes, preserve, lc, nc);
+    /// The text state that follows something that produced no node — a
+    /// comment, a doctype, `</>` — so it continues the run it interrupted:
+    /// `a <!-- c --> b` has one space, not two.
+    fn text_after_nothing(decoded: &str, builder: &Builder, last_non_whitespace: usize) -> State {
+        State::Text {
+            dec_start: decoded.len(),
+            last_non_whitespace,
+            collapse_ws: builder.collapses(),
         }
-    }
-
-    fn push_attribute(nodes: &mut Vec<HtmlNode>, lc: LiveId, nc: LiveId, start: usize, end: usize) {
-        nodes.push(HtmlNode::Attribute { lc, nc, start, end });
     }
 
     fn attribute_ids(name: &str, intern: InternLiveId) -> (LiveId, LiveId) {
@@ -629,21 +925,20 @@ pub fn parse_html(
         )
     }
 
-    let mut nodes = Vec::new();
+    let mut b = Builder::new(body.len());
     // Decoded output never exceeds the source length, and reserving it up
-    // front measurably beats growing it. `nodes` deliberately gets no such
-    // hint: its length tracks tag count, not byte count, so sizing it from
-    // `body.len()` made a tag-sparse document pay a large pointless alloc.
+    // front measurably beats growing it.
     let mut decoded = String::with_capacity(body.len());
-    let mut preserve = PreserveStack::default();
     let mut in_entity = None;
     // Attribute values are never whitespace-collapsed, so this only exists to
     // satisfy `process_entity`; it is reset whenever a value begins.
     let mut attr_lnw = 0usize;
-    // Index in `nodes` where the tag being parsed began. If the input ends
-    // inside the tag, everything from here on is dropped, as a browser drops
-    // a tag cut off by end of input.
-    let mut tag_node_start = 0usize;
+    // `last_non_whitespace` of the text run that the current `<` interrupted,
+    // for a construct that turns out to produce no node.
+    let mut lnw_before_tag = 0usize;
+    // A `\r` was just read: the tokenizer's input stream turns `\r\n` and
+    // lone `\r` into `\n`.
+    let mut after_cr = false;
     let mut state = State::Text {
         dec_start: 0,
         last_non_whitespace: 0,
@@ -651,6 +946,20 @@ pub fn parse_html(
     };
 
     for (i, c) in body.char_indices() {
+        let c = match c {
+            '\r' => {
+                after_cr = true;
+                '\n'
+            }
+            '\n' if after_cr => {
+                after_cr = false;
+                continue;
+            }
+            c => {
+                after_cr = false;
+                c
+            }
+        };
         state = match state {
             State::Text {
                 dec_start,
@@ -658,13 +967,16 @@ pub fn parse_html(
                 collapse_ws,
             } => {
                 if c == '<' {
-                    drop_entity(&mut in_entity, errors);
-                    nodes.push(HtmlNode::Text {
-                        start: dec_start,
-                        end: decoded.len(),
-                        all_ws: dec_start == last_non_whitespace,
-                    });
-                    tag_node_start = nodes.len();
+                    end_entity(
+                        &mut in_entity,
+                        &mut decoded,
+                        &mut last_non_whitespace,
+                        collapse_ws,
+                        errors,
+                    );
+                    b.text(dec_start, decoded.len(), last_non_whitespace <= dec_start);
+                    lnw_before_tag = last_non_whitespace;
+                    b.begin_tag();
                     State::TagOpen(i + 1)
                 } else {
                     process_entity(
@@ -674,6 +986,7 @@ pub fn parse_html(
                         &mut decoded,
                         &mut last_non_whitespace,
                         collapse_ws,
+                        errors,
                     );
                     State::Text {
                         dec_start,
@@ -700,15 +1013,12 @@ pub fn parse_html(
                     let dec_start = decoded.len();
                     decoded.push('<');
                     let mut last_non_whitespace = decoded.len();
-                    let collapse_ws = preserve.collapses();
+                    let collapse_ws = b.collapses();
                     if c == '<' {
                         // `<<b>`: the second `<` may still open a tag.
-                        nodes.push(HtmlNode::Text {
-                            start: dec_start,
-                            end: decoded.len(),
-                            all_ws: false,
-                        });
-                        tag_node_start = nodes.len();
+                        b.text(dec_start, decoded.len(), false);
+                        lnw_before_tag = last_non_whitespace;
+                        b.begin_tag();
                         State::TagOpen(i + 1)
                     } else {
                         process_entity(
@@ -718,6 +1028,7 @@ pub fn parse_html(
                             &mut decoded,
                             &mut last_non_whitespace,
                             collapse_ws,
+                            errors,
                         );
                         State::Text {
                             dec_start,
@@ -729,14 +1040,15 @@ pub fn parse_html(
             }
             State::TagName(start) => {
                 if is_html_whitespace(c) {
-                    push_open_tag(&mut nodes, &mut preserve, &body[start..i], intern);
+                    b.open_tag(&body[start..i], intern);
                     State::BeforeAttributeName
                 } else if c == '/' {
-                    push_open_tag(&mut nodes, &mut preserve, &body[start..i], intern);
+                    b.open_tag(&body[start..i], intern);
                     State::SelfClosingStartTag
                 } else if c == '>' {
-                    push_open_tag(&mut nodes, &mut preserve, &body[start..i], intern);
-                    text_state(&decoded, &preserve)
+                    b.open_tag(&body[start..i], intern);
+                    b.end_open_tag();
+                    text_after_tag(&decoded, &b)
                 } else {
                     State::TagName(start)
                 }
@@ -747,7 +1059,7 @@ pub fn parse_html(
                 } else if c == '>' {
                     // `</>` has no name to close. Ignored, as a browser does.
                     report(errors, "Missing end tag name", i);
-                    text_state(&decoded, &preserve)
+                    text_after_nothing(&decoded, &b, lnw_before_tag)
                 } else {
                     // `</3`: a bogus comment running to the next `>`.
                     report(errors, "Invalid first character of end tag name", i);
@@ -756,31 +1068,31 @@ pub fn parse_html(
             }
             State::EndTagName(start) => {
                 if c == '>' {
-                    let (lc, nc) = attribute_ids(&body[start..i], intern);
-                    push_close_tag(&mut nodes, &mut preserve, lc, nc);
-                    text_state(&decoded, &preserve)
+                    b.close_tag(&body[start..i], intern);
+                    text_after_tag(&decoded, &b)
                 } else if is_html_whitespace(c) || c == '/' {
-                    let (lc, nc) = attribute_ids(&body[start..i], intern);
-                    push_close_tag(&mut nodes, &mut preserve, lc, nc);
-                    State::AfterEndTagName
+                    State::AfterEndTagName(start, i)
                 } else {
                     State::EndTagName(start)
                 }
             }
-            State::AfterEndTagName => {
+            State::AfterEndTagName(start, end) => {
                 if c == '>' {
-                    text_state(&decoded, &preserve)
+                    b.close_tag(&body[start..end], intern);
+                    text_after_tag(&decoded, &b)
                 } else if is_html_whitespace(c) || c == '/' {
-                    State::AfterEndTagName
+                    State::AfterEndTagName(start, end)
                 } else {
+                    // Attributes on an end tag are discarded — along with
+                    // the tag itself if `>` never comes.
                     report(errors, "Attributes on an end tag are ignored", i);
-                    State::BogusComment
+                    State::AfterEndTagName(start, end)
                 }
             }
             State::SelfClosingStartTag => {
                 if c == '>' {
-                    push_self_close(&mut nodes, &mut preserve, tag_node_start);
-                    text_state(&decoded, &preserve)
+                    b.self_close();
+                    text_after_tag(&decoded, &b)
                 } else {
                     // `<a/b>`: the slash was not a self-closing marker after
                     // all. Read on as `<a b>`.
@@ -800,7 +1112,8 @@ pub fn parse_html(
                 } else if c == '/' {
                     State::SelfClosingStartTag
                 } else if c == '>' {
-                    text_state(&decoded, &preserve)
+                    b.end_open_tag();
+                    text_after_tag(&decoded, &b)
                 } else {
                     State::AttributeName(i)
                 }
@@ -814,12 +1127,13 @@ pub fn parse_html(
                     State::BeforeAttributeValue(lc, nc)
                 } else if c == '/' {
                     let (lc, nc) = attribute_ids(&body[start..i], intern);
-                    push_attribute(&mut nodes, lc, nc, 0, 0);
+                    b.attribute(lc, nc, 0, 0);
                     State::SelfClosingStartTag
                 } else if c == '>' {
                     let (lc, nc) = attribute_ids(&body[start..i], intern);
-                    push_attribute(&mut nodes, lc, nc, 0, 0);
-                    text_state(&decoded, &preserve)
+                    b.attribute(lc, nc, 0, 0);
+                    b.end_open_tag();
+                    text_after_tag(&decoded, &b)
                 } else {
                     State::AttributeName(start)
                 }
@@ -830,13 +1144,14 @@ pub fn parse_html(
                 } else if c == '=' {
                     State::BeforeAttributeValue(lc, nc)
                 } else if c == '/' {
-                    push_attribute(&mut nodes, lc, nc, 0, 0);
+                    b.attribute(lc, nc, 0, 0);
                     State::SelfClosingStartTag
                 } else if c == '>' {
-                    push_attribute(&mut nodes, lc, nc, 0, 0);
-                    text_state(&decoded, &preserve)
+                    b.attribute(lc, nc, 0, 0);
+                    b.end_open_tag();
+                    text_after_tag(&decoded, &b)
                 } else {
-                    push_attribute(&mut nodes, lc, nc, 0, 0);
+                    b.attribute(lc, nc, 0, 0);
                     State::AttributeName(i)
                 }
             }
@@ -850,54 +1165,60 @@ pub fn parse_html(
                 } else if c == '>' {
                     // `<a href=>`: an empty value, and the tag ends here.
                     report(errors, "Missing attribute value", i);
-                    push_attribute(&mut nodes, lc, nc, 0, 0);
-                    text_state(&decoded, &preserve)
+                    b.attribute(lc, nc, 0, 0);
+                    b.end_open_tag();
+                    text_after_tag(&decoded, &b)
                 } else {
                     let start = decoded.len();
                     attr_lnw = start;
-                    process_entity(c, i, &mut in_entity, &mut decoded, &mut attr_lnw, false);
+                    process_entity(c, i, &mut in_entity, &mut decoded, &mut attr_lnw, false, errors);
                     State::AttributeValueUnquoted(lc, nc, start)
                 }
             }
             State::AttributeValueDq(lc, nc, start) => {
                 if c == '"' {
-                    drop_entity(&mut in_entity, errors);
-                    push_attribute(&mut nodes, lc, nc, start, decoded.len());
+                    end_entity(&mut in_entity, &mut decoded, &mut attr_lnw, false, errors);
+                    b.attribute(lc, nc, start, decoded.len());
                     State::BeforeAttributeName
                 } else {
-                    process_entity(c, i, &mut in_entity, &mut decoded, &mut attr_lnw, false);
+                    process_entity(c, i, &mut in_entity, &mut decoded, &mut attr_lnw, false, errors);
                     State::AttributeValueDq(lc, nc, start)
                 }
             }
             State::AttributeValueSq(lc, nc, start) => {
                 if c == '\'' {
-                    drop_entity(&mut in_entity, errors);
-                    push_attribute(&mut nodes, lc, nc, start, decoded.len());
+                    end_entity(&mut in_entity, &mut decoded, &mut attr_lnw, false, errors);
+                    b.attribute(lc, nc, start, decoded.len());
                     State::BeforeAttributeName
                 } else {
-                    process_entity(c, i, &mut in_entity, &mut decoded, &mut attr_lnw, false);
+                    process_entity(c, i, &mut in_entity, &mut decoded, &mut attr_lnw, false, errors);
                     State::AttributeValueSq(lc, nc, start)
                 }
             }
             State::AttributeValueUnquoted(lc, nc, start) => {
                 if is_html_whitespace(c) {
-                    drop_entity(&mut in_entity, errors);
-                    push_attribute(&mut nodes, lc, nc, start, decoded.len());
+                    end_entity(&mut in_entity, &mut decoded, &mut attr_lnw, false, errors);
+                    b.attribute(lc, nc, start, decoded.len());
                     State::BeforeAttributeName
                 } else if c == '>' {
-                    drop_entity(&mut in_entity, errors);
-                    push_attribute(&mut nodes, lc, nc, start, decoded.len());
-                    text_state(&decoded, &preserve)
+                    end_entity(&mut in_entity, &mut decoded, &mut attr_lnw, false, errors);
+                    b.attribute(lc, nc, start, decoded.len());
+                    b.end_open_tag();
+                    text_after_tag(&decoded, &b)
                 } else {
                     // Everything else, `/` included, is part of the value:
                     // `<a href=http://host/path>`.
-                    process_entity(c, i, &mut in_entity, &mut decoded, &mut attr_lnw, false);
+                    process_entity(c, i, &mut in_entity, &mut decoded, &mut attr_lnw, false, errors);
                     State::AttributeValueUnquoted(lc, nc, start)
                 }
             }
             State::MarkupDeclarationOpen => {
                 if c == '-' {
                     State::MarkupDeclarationDash
+                } else if c == '>' {
+                    // `<!>`: an empty bogus comment.
+                    report(errors, "Incorrectly opened comment", i);
+                    text_after_nothing(&decoded, &b, lnw_before_tag)
                 } else {
                     // `<!DOCTYPE ...>`, `<![CDATA[...]]>`, `<!x`: none of them
                     // produce a node, and all of them end at the next `>`.
@@ -907,8 +1228,12 @@ pub fn parse_html(
             State::MarkupDeclarationDash => {
                 if c == '-' {
                     State::CommentStart
+                } else if c == '>' {
+                    // `<!->` likewise.
+                    report(errors, "Incorrectly opened comment", i);
+                    text_after_nothing(&decoded, &b, lnw_before_tag)
                 } else {
-                    report(errors, "Expected `--` after `<!`", i);
+                    report(errors, "Incorrectly opened comment", i);
                     State::BogusComment
                 }
             }
@@ -918,7 +1243,7 @@ pub fn parse_html(
                 } else if c == '>' {
                     // `<!-->` is a complete, empty comment.
                     report(errors, "Abruptly closed empty comment", i);
-                    text_state(&decoded, &preserve)
+                    text_after_nothing(&decoded, &b, lnw_before_tag)
                 } else {
                     State::Comment
                 }
@@ -929,7 +1254,7 @@ pub fn parse_html(
                 } else if c == '>' {
                     // `<!--->` likewise.
                     report(errors, "Abruptly closed empty comment", i);
-                    text_state(&decoded, &preserve)
+                    text_after_nothing(&decoded, &b, lnw_before_tag)
                 } else {
                     State::Comment
                 }
@@ -950,7 +1275,7 @@ pub fn parse_html(
             }
             State::CommentEnd => {
                 if c == '>' {
-                    text_state(&decoded, &preserve)
+                    text_after_nothing(&decoded, &b, lnw_before_tag)
                 } else if c == '!' {
                     State::CommentEndBang
                 } else if c == '-' {
@@ -966,14 +1291,14 @@ pub fn parse_html(
                 } else if c == '>' {
                     // `--!>` closes a comment, with a complaint.
                     report(errors, "Incorrectly closed comment", i);
-                    text_state(&decoded, &preserve)
+                    text_after_nothing(&decoded, &b, lnw_before_tag)
                 } else {
                     State::Comment
                 }
             }
             State::BogusComment => {
                 if c == '>' {
-                    text_state(&decoded, &preserve)
+                    text_after_nothing(&decoded, &b, lnw_before_tag)
                 } else {
                     State::BogusComment
                 }
@@ -984,15 +1309,17 @@ pub fn parse_html(
     match state {
         State::Text {
             dec_start,
-            last_non_whitespace,
-            ..
+            mut last_non_whitespace,
+            collapse_ws,
         } => {
-            drop_entity(&mut in_entity, errors);
-            nodes.push(HtmlNode::Text {
-                start: dec_start,
-                end: decoded.len(),
-                all_ws: dec_start == last_non_whitespace,
-            });
+            end_entity(
+                &mut in_entity,
+                &mut decoded,
+                &mut last_non_whitespace,
+                collapse_ws,
+                errors,
+            );
+            b.text(dec_start, decoded.len(), last_non_whitespace <= dec_start);
         }
         // `a<` and `a</`: the `<` never became a tag, so it is text.
         State::TagOpen(_) | State::EndTagOpen(_) => {
@@ -1001,15 +1328,11 @@ pub fn parse_html(
             if matches!(state, State::EndTagOpen(_)) {
                 decoded.push('/');
             }
-            nodes.push(HtmlNode::Text {
-                start,
-                end: decoded.len(),
-                all_ws: false,
-            });
+            b.text(start, decoded.len(), false);
         }
         State::TagName(_)
         | State::EndTagName(_)
-        | State::AfterEndTagName
+        | State::AfterEndTagName(..)
         | State::SelfClosingStartTag
         | State::BeforeAttributeName
         | State::AttributeName(_)
@@ -1019,9 +1342,7 @@ pub fn parse_html(
         | State::AttributeValueSq(..)
         | State::AttributeValueUnquoted(..) => {
             report(errors, "Unexpected end of input inside a tag", body.len());
-            // A tag cut off by the end of input is dropped whole, as a
-            // browser drops it.
-            nodes.truncate(tag_node_start);
+            b.drop_tag();
         }
         State::MarkupDeclarationOpen
         | State::MarkupDeclarationDash
@@ -1036,59 +1357,7 @@ pub fn parse_html(
         }
     }
 
-    let closes = compute_closes(&nodes);
-    HtmlDoc {
-        nodes,
-        decoded,
-        closes,
-    }
-}
-
-/// For each node, the index of the close tag that ends the element opened
-/// there, or [`NO_CLOSE`] for every other node.
-///
-/// A close tag ends the innermost open element of its name. Anything opened
-/// inside that element and still open — a void element such as `<br>`, or an
-/// element the document never closed — ends there as well, without a close
-/// tag of its own. A close tag with no open element of its name is ignored.
-/// This is the recovery a browser applies, and it is what makes the walker's
-/// `jump_to_close` immune to void elements.
-fn compute_closes(nodes: &[HtmlNode]) -> Vec<usize> {
-    let mut closes = vec![NO_CLOSE; nodes.len()];
-    // Indices of the open tags currently unclosed, outermost first.
-    let mut open: Vec<usize> = Vec::new();
-    // How many elements of each name are open, so a stray close tag is
-    // rejected without walking the stack: a message can combine deep nesting
-    // with many stray close tags, and walking would be quadratic.
-    let mut counts: LiveIdMap<u32> = LiveIdMap::default();
-    let name_of = |i: usize| match &nodes[i] {
-        HtmlNode::OpenTag { lc, .. } => *lc,
-        _ => LiveId::empty(),
-    };
-    for (i, node) in nodes.iter().enumerate() {
-        match node {
-            HtmlNode::OpenTag { lc, .. } => {
-                open.push(i);
-                *counts.entry(*lc).or_insert(0) += 1;
-            }
-            HtmlNode::CloseTag { lc, .. } => {
-                if !counts.get(lc).is_some_and(|n| *n > 0) {
-                    continue;
-                }
-                if let Some(pos) = open.iter().rposition(|&j| name_of(j) == *lc) {
-                    closes[open[pos]] = i;
-                    for &j in &open[pos..] {
-                        if let Some(n) = counts.get_mut(&name_of(j)) {
-                            *n = n.saturating_sub(1);
-                        }
-                    }
-                    open.truncate(pos);
-                }
-            }
-            _ => {}
-        }
-    }
-    closes
+    b.finish(decoded)
 }
 
 pub fn match_entity(what: &str) -> Result<u32, String> {
@@ -2748,10 +3017,28 @@ mod tests {
             assert_eq!(text_of(body), "\u{fffd}", "{body:?}");
             assert_nodes_consistent(body);
         }
-        for body in ["&#-1;", "&#x-1;", "&#;", "&#x;", "&#12a;", "&#xZZ;"] {
+        for body in ["&#-1;", "&#x-1;", "&#;", "&#x;", "&#xZZ;"] {
             assert_eq!(text_of(body), body, "{body:?} should survive as literal text");
             assert_nodes_consistent(body);
         }
+        // a reference ends at the first non-digit whether or not `;` follows
+        assert_eq!(text_of("&#38 b"), "& b");
+        assert_eq!(text_of("&#38<b>x</b>"), "&x");
+        assert_eq!(text_of("&#x26z"), "&z");
+        assert_eq!(text_of("&#12a;"), " a;"); // U+000C, collapsed like any whitespace
+        assert_eq!(text_of("<pre>&#12a;</pre>"), "\u{c}a;");
+        assert_eq!(text_of("a&#38"), "a&");
+        assert_eq!(text_of("&#x26"), "&");
+        // an unquoted attribute value too
+        let doc = parse_html("<a href=x&#38y>t</a>", &mut None, InternLiveId::No);
+        let mut walker = doc.new_walker();
+        while !walker.done() && walker.open_tag_lc().is_none() {
+            walker.walk();
+        }
+        assert_eq!(walker.find_attr_lc(live_id!(href)), Some("x&y"));
+        // and there is no length limit: forty digits saturate to U+FFFD
+        assert_eq!(text_of("&#1111111111111111111111111111111111111111;"), "\u{fffd}");
+        assert_eq!(text_of("&#00000000000000000000000000000038;"), "&");
         // the C1 range is read as Windows-1252, which is what legacy content
         // means by it
         assert_eq!(text_of("&#151;"), "\u{2014}");
@@ -3005,9 +3292,14 @@ mod tests {
         let doc = parse_html("<img src=x/>", &mut None, InternLiveId::No);
         assert!(!doc.nodes.iter().any(|n| matches!(n, HtmlNode::CloseTag { .. })));
         assert_eq!(attr("<a href=x/ y=2>t</a>", live_id!(href)).as_deref(), Some("x/"));
-        // quoted values still self-close, which the SVG parser relies on
-        let doc = parse_html("<img src=\"x\"/>", &mut None, InternLiveId::No);
-        assert!(doc.nodes.iter().any(|n| matches!(n, HtmlNode::CloseTag { lc, .. } if *lc == live_id!(img))));
+        // a quoted value followed by `/>` still self-closes a non-void
+        // element, which the SVG parser relies on; a void element never has
+        // a close tag, so `<img src="x"/>` and `<img src="x">` are one node
+        let doc = parse_html("<path d=\"m\"/>", &mut None, InternLiveId::No);
+        assert!(doc.nodes.iter().any(|n| matches!(n, HtmlNode::CloseTag { lc, .. } if *lc == live_id!(path))));
+        let with_slash = parse_html("<img src=\"x\"/>", &mut None, InternLiveId::No);
+        let without = parse_html("<img src=\"x\">", &mut None, InternLiveId::No);
+        assert!(with_slash.nodes == without.nodes);
     }
 
     /// A `<` that cannot begin a tag is literal text, the way a browser
@@ -3052,7 +3344,8 @@ mod tests {
     fn end_tag_open_follows_the_tokenizer() {
         assert_eq!(text_of("a</>b"), "ab");
         assert_eq!(text_of("i </3 u"), "i ");
-        assert_eq!(text_of("i </3 u> x"), "i  x");
+        // and the bogus comment is not content, so the run collapses across it
+        assert_eq!(text_of("i </3 u> x"), "i x");
         assert_eq!(text_of("a</ b>c"), "ac");
         // but `</` at the very end of input is text
         assert_eq!(text_of("a</"), "a</");
@@ -3156,6 +3449,146 @@ mod tests {
         assert_eq!(text_of("<pre><code>a  b</pre>c  d"), "a  bc d");
         assert_eq!(text_of("<code>a  <pre>b  c</code>d  e</pre>"), "a  b  cd e");
         assert_eq!(text_of("</pre>a  b"), "a b");
+    }
+
+    /// Where each element ends is resolved by the parser: past its own close
+    /// tag, at the enclosing close tag that ended it, at the end of input,
+    /// or — for a void element — just past its attributes.
+    #[test]
+    fn end_index_resolves_every_element() {
+        fn ends(body: &str) -> Vec<(LiveId, Option<usize>, usize)> {
+            let doc = parse_html(body, &mut None, InternLiveId::No);
+            let mut out = Vec::new();
+            let mut w = doc.new_walker();
+            while !w.done() {
+                if let Some(lc) = w.open_tag_lc() {
+                    out.push((lc, w.close_index(), w.end_index().unwrap()));
+                }
+                w.walk();
+            }
+            out
+        }
+        fn close_of(body: &str, tag: LiveId) -> usize {
+            let doc = parse_html(body, &mut None, InternLiveId::No);
+            doc.nodes
+                .iter()
+                .position(|n| matches!(n, HtmlNode::CloseTag { lc, .. } if *lc == tag))
+                .unwrap()
+        }
+        fn open_of(body: &str, tag: LiveId) -> usize {
+            let doc = parse_html(body, &mut None, InternLiveId::No);
+            doc.nodes
+                .iter()
+                .position(|n| matches!(n, HtmlNode::OpenTag { lc, .. } if *lc == tag))
+                .unwrap()
+        }
+        fn len_of(body: &str) -> usize {
+            parse_html(body, &mut None, InternLiveId::No).nodes.len()
+        }
+
+        let body = "<p>hello<b>x</b></p>tail";
+        let (p_close, b_close) = (close_of(body, live_id!(p)), close_of(body, live_id!(b)));
+        assert_eq!(ends(body), vec![
+            (live_id!(p), Some(p_close), p_close + 1),
+            (live_id!(b), Some(b_close), b_close + 1),
+        ]);
+        // the tokenizer does not know `<li>` closes `<li>` (that is the
+        // widget's tree-builder rule), so both items end at `</ul>`
+        let body = "<ul><li>one<li>two</ul>";
+        let ul_close = close_of(body, live_id!(ul));
+        assert_eq!(ends(body), vec![
+            (live_id!(ul), Some(ul_close), ul_close + 1),
+            (live_id!(li), None, ul_close),
+            (live_id!(li), None, ul_close),
+        ]);
+        // a void element is whole at its open tag, however it is written
+        for body in ["<br>x", "<br/>x", "<br></br>x"] {
+            let br = open_of(body, live_id!(br));
+            assert_eq!(ends(body), vec![(live_id!(br), None, br + 1)], "{body:?}");
+        }
+        let body = "<img src=x alt=y>t";
+        let img = open_of(body, live_id!(img));
+        assert_eq!(ends(body), vec![(live_id!(img), None, img + 3)]);
+        // unclosed at end of input
+        assert_eq!(ends("<b>x"), vec![(live_id!(b), None, len_of("<b>x"))]);
+        // ended by an ancestor: the link ends at `</td>`
+        let body = "<td><a href=u>link</td>";
+        let td_close = close_of(body, live_id!(td));
+        assert_eq!(ends(body), vec![
+            (live_id!(td), Some(td_close), td_close + 1),
+            (live_id!(a), None, td_close),
+        ]);
+    }
+
+    /// `<pre>` is tracked on the same stack as every other element, so an
+    /// enclosing close tag that ends it also ends its whitespace preservation.
+    #[test]
+    fn pre_ended_by_an_ancestor_stops_preserving_whitespace() {
+        assert_eq!(text_of("<div><pre>a  b</div>c  d"), "a  bc d");
+        assert_eq!(text_of("<p><code>x</p>  y  z"), "x y z");
+        assert_eq!(text_of("<blockquote><pre>a  b</blockquote>c  d"), "a  bc d");
+    }
+
+    /// `<!>` and `<!->` are complete (empty) bogus comments, and a comment is
+    /// not content, so the text run continues across it with one space.
+    #[test]
+    fn empty_declarations_and_comments_do_not_split_the_text() {
+        assert_eq!(text_of("a<!>b"), "ab");
+        assert_eq!(text_of("a<!->b"), "ab");
+        assert_eq!(text_of("a<!>b>c"), "ab>c");
+        assert_eq!(text_of("a <!-- c --> b"), "a b");
+        assert_eq!(text_of("a </> b"), "a b");
+        assert_eq!(text_of("a <!DOCTYPE x> b"), "a b");
+        assert_eq!(text_of("<p> a <!-- c --> </p>"), " a ");
+        assert_nodes_consistent("a <!-- c --> b");
+        assert_nodes_consistent("<p> <!-- c --> </p>");
+    }
+
+    /// The input stream turns `\r\n` and a lone `\r` into `\n`.
+    #[test]
+    fn carriage_returns_are_normalized() {
+        assert_eq!(text_of("<pre>a\r\nb\rc</pre>"), "a\nb\nc");
+        let doc = parse_html("<a title=\"x\r\ny\">t</a>", &mut None, InternLiveId::No);
+        let mut w = doc.new_walker();
+        while !w.done() && w.open_tag_lc().is_none() {
+            w.walk();
+        }
+        assert_eq!(w.find_attr_lc(live_id!(title)), Some("x\ny"));
+        assert_eq!(text_of("a\r\nb"), "a b");
+    }
+
+    /// The tokenizer drops every attribute after the first with the same
+    /// name, so a consumer iterating attributes sees one `data-mx-color`.
+    #[test]
+    fn duplicate_attributes_are_dropped() {
+        let doc = parse_html("<a HREF=x Href=y b=1 b=2 c c>t</a>", &mut None, InternLiveId::No);
+        let attrs: Vec<_> = doc.nodes.iter().filter_map(|n| match n {
+            HtmlNode::Attribute { lc, start, end, .. } => Some((*lc, doc.decoded[*start..*end].to_string())),
+            _ => None,
+        }).collect();
+        assert_eq!(attrs, vec![
+            (live_id!(href), "x".into()), (live_id!(b), "1".into()), (live_id!(c), String::new()),
+        ]);
+    }
+
+    /// An end tag followed by junk and then end of input is dropped like any
+    /// other tag cut off by end of input.
+    #[test]
+    fn an_end_tag_cut_off_by_end_of_input_is_dropped() {
+        for body in ["<b>x</b/junk", "<a>t</a x", "<b>x</b "] {
+            let doc = parse_html(body, &mut None, InternLiveId::No);
+            assert!(!doc.nodes.iter().any(|n| matches!(n, HtmlNode::CloseTag { .. })), "{body:?}");
+        }
+        assert_eq!(text_of("<b>x</b/junk"), "x");
+    }
+
+    /// `find_tag_text` answers for the first matching element only.
+    #[test]
+    fn find_tag_text_does_not_fall_through_to_a_later_element() {
+        let doc = parse_html("<p><b>x</b>y</p><p>z</p>", &mut None, InternLiveId::No);
+        assert_eq!(doc.new_walker().find_tag_text(live_id!(p)), Some("x"));
+        let doc = parse_html("<p></p><p>z</p>", &mut None, InternLiveId::No);
+        assert_eq!(doc.new_walker().find_tag_text(live_id!(p)), None);
     }
 
     #[test]

--- a/libs/html/src/lib.rs
+++ b/libs/html/src/lib.rs
@@ -71,26 +71,37 @@ impl<'a> HtmlWalker<'a> {
         }
     }
 
+    /// Advances to the close tag matching the open tag the walker is on.
+    ///
+    /// Only tags with the *same* id affect nesting depth. Counting every
+    /// open tag would over-consume, because a void element written without a
+    /// slash (`<br>`, `<img src=x>`, `<hr>`) emits an `OpenTag` with no
+    /// matching `CloseTag`, so each one would leave the depth permanently
+    /// unbalanced and swallow the rest of the document.
+    ///
+    /// The walker does not move when the element has no close tag of its own
+    /// — it is void, or unclosed — so the caller's own `walk()` still visits
+    /// the following nodes and any enclosing close tag is still delivered.
     pub fn jump_to_close(&mut self) {
-        if self.index < self.nodes.len() {
-            let mut depth = 0;
-            for i in self.index + 1..self.nodes.len() {
-                match &self.nodes[i] {
-                    HtmlNode::OpenTag { .. } => {
-                        depth += 1;
-                    }
-                    HtmlNode::CloseTag { .. } => {
-                        if depth == 0 {
-                            self.index = i;
-                            return;
-                        }
-                        depth -= 1;
-                    }
-                    _ => (),
+        let Some(open_lc) = self.open_tag_lc() else {
+            return;
+        };
+        let mut depth = 0u32;
+        for i in self.index + 1..self.nodes.len() {
+            match &self.nodes[i] {
+                HtmlNode::OpenTag { lc, .. } if *lc == open_lc => {
+                    depth += 1;
                 }
+                HtmlNode::CloseTag { lc, .. } if *lc == open_lc => {
+                    if depth == 0 {
+                        self.index = i;
+                        return;
+                    }
+                    depth -= 1;
+                }
+                _ => (),
             }
         }
-        self.index = self.nodes.len();
     }
 
     pub fn done(&self) -> bool {
@@ -174,24 +185,44 @@ impl<'a> HtmlWalker<'a> {
         None
     }
 
+    /// Returns the first non-empty text at or after the current position,
+    /// stopping at the first close tag.
+    ///
+    /// The parser emits a zero-length `Text` node in front of every tag, so
+    /// those are skipped: otherwise `<a href="x"><b>label</b></a>` reports no
+    /// text at all rather than `label`.
     pub fn find_text(&self) -> Option<&'a str> {
         for i in self.index..self.nodes.len() {
             match &self.nodes[i] {
                 HtmlNode::CloseTag { .. } => return None,
-                HtmlNode::Text { start, end, .. } => return Some(&self.decoded[*start..*end]),
+                HtmlNode::Text { start, end, .. } if start != end => {
+                    return Some(&self.decoded[*start..*end]);
+                }
                 _ => (),
             }
         }
         None
     }
 
+    /// Returns the text directly inside the next `tag` open tag at or after
+    /// the current position. `tag` is matched against the lowercased tag id,
+    /// since HTML tag names are case-insensitive.
     pub fn find_tag_text(&self, tag: LiveId) -> Option<&'a str> {
         for i in self.index..self.nodes.len() {
             match &self.nodes[i] {
-                HtmlNode::OpenTag { nc, .. } if *nc == tag => {
-                    // the next one must be a text node
-                    if let Some(HtmlNode::Text { start, end, .. }) = self.nodes.get(i + 1) {
-                        return Some(&self.decoded[*start..*end]);
+                HtmlNode::OpenTag { lc, .. } if *lc == tag => {
+                    // Attributes sit between the open tag and its text, and
+                    // the parser emits a zero-length text node before any
+                    // nested markup; skip both to reach the real content.
+                    for candidate in &self.nodes[i + 1..] {
+                        match candidate {
+                            HtmlNode::Attribute { .. } => (),
+                            HtmlNode::Text { start, end, .. } if start == end => (),
+                            HtmlNode::Text { start, end, .. } => {
+                                return Some(&self.decoded[*start..*end]);
+                            }
+                            _ => break,
+                        }
                     }
                 }
                 _ => (),
@@ -271,6 +302,15 @@ impl HtmlDoc {
     }
 }
 
+/// The five characters HTML treats as whitespace.
+///
+/// `char::is_whitespace` follows Unicode, which also covers U+00A0 and
+/// U+3000. Using it here collapsed `&nbsp;` away and ate the full-width
+/// spaces in CJK text, neither of which HTML permits.
+fn is_html_whitespace(c: char) -> bool {
+    matches!(c, ' ' | '\t' | '\n' | '\r' | '\u{c}')
+}
+
 pub fn parse_html(
     body: &str,
     errors: &mut Option<Vec<HtmlError>>,
@@ -294,6 +334,7 @@ pub fn parse_html(
         AttribValueSq(LiveId, LiveId, usize),
         AttribValueDq(LiveId, LiveId, usize),
         AttribValueBare(LiveId, LiveId, usize),
+        AttribValueBareSlash(LiveId, LiveId, usize),
         CommentStartDash1,
         CommentStartDash2,
         CommentEndDash,
@@ -304,14 +345,34 @@ pub fn parse_html(
         CommentBody,
     }
 
+    /// The longest name in `match_entity` is `DownLeftRightVector`. A run of
+    /// characters longer than this cannot become a named entity, so scanning
+    /// stops there rather than buffering unbounded text.
+    const MAX_ENTITY_NAME: usize = "DownLeftRightVector".len();
+    /// Numeric references (`&#38;`, `&#x26;`) may be zero-padded, so they get
+    /// a longer budget than a name would.
+    const MAX_ENTITY_NUMERIC: usize = 32;
+
+    /// State for an entity currently being scanned.
+    #[derive(Copy, Clone)]
+    struct InEntity {
+        /// Index in `decoded` of the opening `&`.
+        start: usize,
+        /// `last_non_whitespace` as it was *before* the `&` was appended.
+        /// The entity's own characters are appended to `decoded` while it is
+        /// being scanned and then truncated away again on a match, so the
+        /// index has to be restored rather than recomputed.
+        saved_last_non_whitespace: usize,
+    }
+
     fn process_entity(
         c: char,
-        in_entity: &mut Option<usize>,
+        in_entity: &mut Option<InEntity>,
         decoded: &mut String,
         last_non_whitespace: &mut usize,
         collapse_ws: bool,
     ) {
-        if let Some(start) = *in_entity {
+        if let Some(InEntity { start, saved_last_non_whitespace }) = *in_entity {
             // scan entity
             if c == ';' {
                 // potential end of entity
@@ -321,47 +382,64 @@ pub fn parse_html(
                     }
                     Ok(entity) => {
                         *in_entity = None;
-                        decoded.truncate(start);
-                        let ch = std::char::from_u32(entity).unwrap();
-                        decoded.push(ch);
-                        // While the entity body was being scanned, each
-                        // character was appended to `decoded` and (if
-                        // non-whitespace) advanced `last_non_whitespace`.
-                        // After truncating, that index is now stale and
-                        // must be corrected — otherwise the next real
-                        // whitespace char collapses against a phantom
-                        // non-whitespace position past the buffer end, and
-                        // gets silently dropped.
-                        if ch.is_whitespace() {
-                            *last_non_whitespace = (*last_non_whitespace).min(start);
-                        } else {
-                            *last_non_whitespace = decoded.len();
+                        // `match_entity` only yields Unicode scalar values,
+                        // but fall back to leaving the text as-is rather than
+                        // panicking if that ever stops holding.
+                        if let Some(ch) = char::from_u32(entity) {
+                            decoded.truncate(start);
+                            decoded.push(ch);
+                            *last_non_whitespace = if is_html_whitespace(ch) {
+                                saved_last_non_whitespace
+                            } else {
+                                decoded.len()
+                            };
+                            return;
                         }
-                        return;
                     }
                 }
             }
             // definitely not an entity
-            else if c.is_whitespace() || decoded.len() - start > "DOWNLEFTRIGHTVECTOR".len() {
-                *in_entity = None;
+            else {
+                let scanned = decoded.len() - start;
+                let budget = if decoded.as_bytes().get(start + 1) == Some(&b'#') {
+                    MAX_ENTITY_NUMERIC
+                } else {
+                    MAX_ENTITY_NAME
+                };
+                if is_html_whitespace(c) || scanned > budget {
+                    *in_entity = None;
+                }
             }
         }
         if c == '&' {
-            *in_entity = Some(decoded.len());
+            *in_entity = Some(InEntity {
+                start: decoded.len(),
+                saved_last_non_whitespace: *last_non_whitespace,
+            });
         }
-        if collapse_ws && c.is_whitespace() {
+        if collapse_ws && is_html_whitespace(c) {
             if *last_non_whitespace == decoded.len() {
                 decoded.push(' ');
             }
         } else {
             decoded.push(c);
-            if !c.is_whitespace() {
+            if !is_html_whitespace(c) {
                 *last_non_whitespace = decoded.len();
             }
         }
     }
 
+    /// `<pre>` and `<code>` keep their whitespace verbatim.
+    fn preserves_whitespace(lc: LiveId) -> bool {
+        lc == live_id!(pre) || lc == live_id!(code)
+    }
+
     let mut nodes = Vec::new();
+    // How many whitespace-preserving elements are currently open. A single
+    // flag would be wrong: any tag nested inside `<pre>` used to reset
+    // collapsing for the rest of the element, so `<pre>a  <b>b  b</b>  c</pre>`
+    // lost every space after the first text run.
+    let mut pre_depth = 0usize;
     let mut state = State::Text {
         start: 0,
         dec_start: 0,
@@ -379,7 +457,7 @@ pub fn parse_html(
                         start: i + 1,
                         dec_start: decoded.len(),
                         last_non_whitespace: decoded.len(),
-                        collapse_ws: true,
+                        collapse_ws: pre_depth == 0,
                     }
                 } else {
                     State::DocType
@@ -398,7 +476,7 @@ pub fn parse_html(
                         start: i + 1,
                         dec_start: decoded.len(),
                         last_non_whitespace: decoded.len(),
-                        collapse_ws: true,
+                        collapse_ws: pre_depth == 0,
                     }
                 } else {
                     State::HeaderQuestion
@@ -411,7 +489,7 @@ pub fn parse_html(
                 collapse_ws,
             } => {
                 if c == '<' {
-                    if let Some(start) = in_entity {
+                    if let Some(InEntity { start, .. }) = in_entity {
                         if let Some(errors) = errors {
                             errors.push(HtmlError {
                                 message: "Unterminated entity".into(),
@@ -419,6 +497,10 @@ pub fn parse_html(
                             })
                         };
                     }
+                    // An entity cannot span this boundary. Dropping it here is
+                    // what keeps a later `;` from truncating `decoded` back
+                    // past text that has already been committed to a node.
+                    in_entity = None;
                     nodes.push(HtmlNode::Text {
                         start: dec_start,
                         end: decoded.len(),
@@ -447,44 +529,62 @@ pub fn parse_html(
                     State::ElementClose(i + 1)
                 } else if c == '!' && i == start {
                     State::CommentStartDash1
-                } else if c == '?' {
+                } else if c == '?' && i == start {
                     State::HeaderQuestion
-                } else if c.is_whitespace() {
-                    if start == i {
-                        if let Some(errors) = errors {
-                            errors.push(HtmlError {
-                                message: "Found whitespace at beginning of tag".into(),
-                                position: i,
-                            })
-                        };
-                        State::Text {
-                            start: i + 1,
-                            dec_start: decoded.len(),
-                            last_non_whitespace: decoded.len(),
-                            collapse_ws: true,
-                        }
-                    } else {
-                        nodes.push(HtmlNode::OpenTag {
-                            lc: LiveId::from_str_lc(&body[start..i]),
-                            nc: LiveId::from_str_with_intern(&body[start..i], intern),
-                        });
-                        State::ElementAttrs
+                } else if i == start && !c.is_ascii_alphabetic() {
+                    // A tag name has to start with an ASCII letter. Anything
+                    // else means the `<` was never markup — `5<10`, `a < b`,
+                    // `<>` — so put it back as literal text instead of
+                    // parsing a bogus element and losing the rest of the
+                    // line to it.
+                    let dec_start = decoded.len();
+                    decoded.push('<');
+                    let mut last_non_whitespace = decoded.len();
+                    process_entity(
+                        c,
+                        &mut in_entity,
+                        &mut decoded,
+                        &mut last_non_whitespace,
+                        pre_depth == 0,
+                    );
+                    State::Text {
+                        start,
+                        dec_start,
+                        last_non_whitespace,
+                        collapse_ws: pre_depth == 0,
                     }
-                } else if c == '/' {
+                } else if is_html_whitespace(c) {
+                    let lc = LiveId::from_str_lc(&body[start..i]);
+                    if preserves_whitespace(lc) {
+                        pre_depth += 1;
+                    }
                     nodes.push(HtmlNode::OpenTag {
-                        lc: LiveId::from_str_lc(&body[start..i]),
+                        lc,
+                        nc: LiveId::from_str_with_intern(&body[start..i], intern),
+                    });
+                    State::ElementAttrs
+                } else if c == '/' {
+                    let lc = LiveId::from_str_lc(&body[start..i]);
+                    if preserves_whitespace(lc) {
+                        pre_depth += 1;
+                    }
+                    nodes.push(HtmlNode::OpenTag {
+                        lc,
                         nc: LiveId::from_str_with_intern(&body[start..i], intern),
                     });
                     State::ElementSelfClose
                 } else if c == '>' {
                     let lc = LiveId::from_str_lc(&body[start..i]);
                     let nc = LiveId::from_str_with_intern(&body[start..i], intern);
+                    if preserves_whitespace(lc) {
+                        pre_depth += 1;
+                    }
                     nodes.push(HtmlNode::OpenTag { lc, nc });
                     State::Text {
                         start: i + 1,
                         dec_start: decoded.len(),
                         last_non_whitespace: decoded.len(),
-                        collapse_ws: lc != live_id!(pre) && lc != live_id!(code),
+                        collapse_ws: pre_depth == 0,
                     }
                 } else {
                     State::ElementName(start)
@@ -494,16 +594,23 @@ pub fn parse_html(
                 if c == '>' {
                     let lc = LiveId::from_str_lc(&body[start..i]);
                     let nc = LiveId::from_str_with_intern(&body[start..i], intern);
+                    if preserves_whitespace(lc) {
+                        pre_depth = pre_depth.saturating_sub(1);
+                    }
                     nodes.push(HtmlNode::CloseTag { lc, nc });
                     State::Text {
                         start: i + 1,
                         dec_start: decoded.len(),
                         last_non_whitespace: decoded.len(),
-                        collapse_ws: true,
+                        collapse_ws: pre_depth == 0,
                     }
-                } else if c.is_whitespace() {
+                } else if is_html_whitespace(c) {
+                    let lc = LiveId::from_str_lc(&body[start..i]);
+                    if preserves_whitespace(lc) {
+                        pre_depth = pre_depth.saturating_sub(1);
+                    }
                     nodes.push(HtmlNode::CloseTag {
-                        lc: LiveId::from_str_lc(&body[start..i]),
+                        lc,
                         nc: LiveId::from_str_with_intern(&body[start..i], intern),
                     });
                     State::ElementCloseScanSpaces
@@ -517,9 +624,9 @@ pub fn parse_html(
                         start: i + 1,
                         dec_start: decoded.len(),
                         last_non_whitespace: decoded.len(),
-                        collapse_ws: true,
+                        collapse_ws: pre_depth == 0,
                     }
-                } else if !c.is_whitespace() {
+                } else if !is_html_whitespace(c) {
                     if let Some(errors) = errors {
                         errors.push(HtmlError{message:"Unexpected character after whitespace whilst looking for closing tag >".into(), position:i})
                     };
@@ -527,7 +634,7 @@ pub fn parse_html(
                         start: i + 1,
                         dec_start: decoded.len(),
                         last_non_whitespace: decoded.len(),
-                        collapse_ws: true,
+                        collapse_ws: pre_depth == 0,
                     }
                 } else {
                     State::ElementCloseScanSpaces
@@ -543,26 +650,27 @@ pub fn parse_html(
                     };
                 }
                 // look backwards to the OpenTag
-                let begin = nodes
-                    .iter()
-                    .rev()
-                    .find_map(|v| {
-                        if let HtmlNode::OpenTag { lc, nc } = v {
-                            Some((lc, nc))
-                        } else {
-                            None
-                        }
-                    })
-                    .unwrap();
-                nodes.push(HtmlNode::CloseTag {
-                    lc: *begin.0,
-                    nc: *begin.1,
+                let begin = nodes.iter().rev().find_map(|v| {
+                    if let HtmlNode::OpenTag { lc, nc } = v {
+                        Some((*lc, *nc))
+                    } else {
+                        None
+                    }
                 });
+                // Always present in a well-formed transition into this state,
+                // but a parser fed arbitrary input should not carry an
+                // `unwrap` that a future edit could make reachable.
+                if let Some((lc, nc)) = begin {
+                    if preserves_whitespace(lc) {
+                        pre_depth = pre_depth.saturating_sub(1);
+                    }
+                    nodes.push(HtmlNode::CloseTag { lc, nc });
+                }
                 State::Text {
                     start: i + 1,
                     dec_start: decoded.len(),
                     last_non_whitespace: decoded.len(),
-                    collapse_ws: true,
+                    collapse_ws: pre_depth == 0,
                 }
             }
             State::ElementAttrs => {
@@ -570,32 +678,20 @@ pub fn parse_html(
                     //nodes.push(HtmlNode::BeginElement(HtmlId::new(&body, start, i)));
                     State::ElementSelfClose
                 } else if c == '>' {
-                    let begin = nodes.iter().rev().find_map(|v| {
-                        if let HtmlNode::OpenTag { lc, nc: _ } = v {
-                            Some(*lc)
-                        } else {
-                            None
-                        }
-                    });
-
                     State::Text {
                         start: i + 1,
                         dec_start: decoded.len(),
                         last_non_whitespace: decoded.len(),
-                        collapse_ws: if let Some(lc) = begin {
-                            lc != live_id!(pre) && lc != live_id!(code)
-                        } else {
-                            true
-                        },
+                        collapse_ws: pre_depth == 0,
                     }
-                } else if !c.is_whitespace() {
+                } else if !is_html_whitespace(c) {
                     State::AttribName(i)
                 } else {
                     State::ElementAttrs
                 }
             }
             State::AttribName(start) => {
-                if c.is_whitespace() {
+                if is_html_whitespace(c) {
                     State::AttribValueEq(
                         LiveId::from_str_lc(&body[start..i]),
                         LiveId::from_str_with_intern(&body[start..i], intern),
@@ -624,7 +720,7 @@ pub fn parse_html(
                         start: i + 1,
                         dec_start: decoded.len(),
                         last_non_whitespace: decoded.len(),
-                        collapse_ws: true,
+                        collapse_ws: pre_depth == 0,
                     }
                 } else {
                     State::AttribName(start)
@@ -650,11 +746,11 @@ pub fn parse_html(
                         start: i + 1,
                         dec_start: decoded.len(),
                         last_non_whitespace: decoded.len(),
-                        collapse_ws: true,
+                        collapse_ws: pre_depth == 0,
                     }
                 } else if c == '=' {
                     State::AttribValueStart(lc, nc)
-                } else if !c.is_whitespace() {
+                } else if !is_html_whitespace(c) {
                     nodes.push(HtmlNode::Attribute {
                         lc,
                         nc,
@@ -667,22 +763,40 @@ pub fn parse_html(
                 }
             }
             State::AttribValueStart(lc, nc) => {
-                if c == '\"' {
+                if c == '>' {
+                    // An empty unquoted value: the tag ends here.
+                    nodes.push(HtmlNode::Attribute {
+                        lc,
+                        nc,
+                        start: 0,
+                        end: 0,
+                    });
+                    State::Text {
+                        start: i + 1,
+                        dec_start: decoded.len(),
+                        last_non_whitespace: decoded.len(),
+                        collapse_ws: pre_depth == 0,
+                    }
+                } else if c == '\"' {
                     // double quoted attrib
                     State::AttribValueDq(lc, nc, decoded.len())
                 } else if c == '\'' {
                     // single quoted attrib
                     State::AttribValueSq(lc, nc, decoded.len())
-                } else if !c.is_whitespace() {
-                    decoded.push(c);
-                    State::AttribValueBare(lc, nc, decoded.len() - 1)
+                } else if !is_html_whitespace(c) {
+                    // Route the first character through `process_entity` too,
+                    // otherwise a value starting with `&` never begins an
+                    // entity scan and `&amp;x` decodes as literal `&amp;x`.
+                    let start = decoded.len();
+                    process_entity(c, &mut in_entity, &mut decoded, &mut 0, false);
+                    State::AttribValueBare(lc, nc, start)
                 } else {
                     State::AttribValueStart(lc, nc)
                 }
             }
             State::AttribValueSq(lc, nc, start) => {
                 if c == '\'' {
-                    if let Some(start) = in_entity {
+                    if let Some(InEntity { start, .. }) = in_entity {
                         if let Some(errors) = errors {
                             errors.push(HtmlError {
                                 message: "Unterminated entity".into(),
@@ -690,6 +804,10 @@ pub fn parse_html(
                             })
                         };
                     }
+                    // An entity cannot span this boundary. Dropping it here is
+                    // what keeps a later `;` from truncating `decoded` back
+                    // past text that has already been committed to a node.
+                    in_entity = None;
                     nodes.push(HtmlNode::Attribute {
                         lc,
                         nc,
@@ -704,7 +822,7 @@ pub fn parse_html(
             }
             State::AttribValueDq(lc, nc, start) => {
                 if c == '\"' {
-                    if let Some(start) = in_entity {
+                    if let Some(InEntity { start, .. }) = in_entity {
                         if let Some(errors) = errors {
                             errors.push(HtmlError {
                                 message: "Unterminated entity".into(),
@@ -712,6 +830,10 @@ pub fn parse_html(
                             })
                         };
                     }
+                    // An entity cannot span this boundary. Dropping it here is
+                    // what keeps a later `;` from truncating `decoded` back
+                    // past text that has already been committed to a node.
+                    in_entity = None;
                     nodes.push(HtmlNode::Attribute {
                         lc,
                         nc,
@@ -724,16 +846,60 @@ pub fn parse_html(
                     State::AttribValueDq(lc, nc, start)
                 }
             }
-            State::AttribValueBare(lc, nc, start) => {
-                if c == '/' {
+            State::AttribValueBareSlash(lc, nc, start) => {
+                if c == '>' {
+                    // The slash really was the self-closing marker.
+                    in_entity = None;
                     nodes.push(HtmlNode::Attribute {
                         lc,
                         nc,
                         start,
                         end: decoded.len(),
                     });
-                    State::ElementSelfClose
+                    let begin = nodes.iter().rev().find_map(|v| {
+                        if let HtmlNode::OpenTag { lc, nc } = v {
+                            Some((*lc, *nc))
+                        } else {
+                            None
+                        }
+                    });
+                    if let Some((lc, nc)) = begin {
+                        if preserves_whitespace(lc) {
+                            pre_depth = pre_depth.saturating_sub(1);
+                        }
+                        nodes.push(HtmlNode::CloseTag { lc, nc });
+                    }
+                    State::Text {
+                        start: i + 1,
+                        dec_start: decoded.len(),
+                        last_non_whitespace: decoded.len(),
+                        collapse_ws: pre_depth == 0,
+                    }
+                } else if is_html_whitespace(c) {
+                    // `<a href=x/ y=2>`: the slash belongs to the value.
+                    decoded.push('/');
+                    in_entity = None;
+                    nodes.push(HtmlNode::Attribute {
+                        lc,
+                        nc,
+                        start,
+                        end: decoded.len(),
+                    });
+                    State::ElementAttrs
+                } else {
+                    // `<a href=http://host/path>`: an ordinary value character.
+                    decoded.push('/');
+                    process_entity(c, &mut in_entity, &mut decoded, &mut 0, false);
+                    State::AttribValueBare(lc, nc, start)
+                }
+            }
+            State::AttribValueBare(lc, nc, start) => {
+                if c == '/' {
+                    // Only a slash immediately before `>` closes the tag, so
+                    // decide once the next character is known.
+                    State::AttribValueBareSlash(lc, nc, start)
                 } else if c == '>' {
+                    in_entity = None;
                     nodes.push(HtmlNode::Attribute {
                         lc,
                         nc,
@@ -744,9 +910,10 @@ pub fn parse_html(
                         start: i + 1,
                         dec_start: decoded.len(),
                         last_non_whitespace: decoded.len(),
-                        collapse_ws: true,
+                        collapse_ws: pre_depth == 0,
                     }
-                } else if c.is_whitespace() {
+                } else if is_html_whitespace(c) {
+                    in_entity = None;
                     nodes.push(HtmlNode::Attribute {
                         lc,
                         nc,
@@ -755,7 +922,7 @@ pub fn parse_html(
                     });
                     State::ElementAttrs
                 } else {
-                    decoded.push(c);
+                    process_entity(c, &mut in_entity, &mut decoded, &mut 0, false);
                     State::AttribValueBare(lc, nc, start)
                 }
             }
@@ -776,8 +943,11 @@ pub fn parse_html(
                             position: i,
                         })
                     };
+                    State::CommentBody
+                } else {
+                    // `<!--` is complete: a `>` now closes an empty comment.
+                    State::CommentEnd
                 }
-                State::CommentBody
             }
             State::CommentBody => {
                 if c == '-' {
@@ -794,12 +964,15 @@ pub fn parse_html(
                 }
             }
             State::CommentEnd => {
-                if c == '>' {
+                if c == '-' {
+                    // A run of dashes keeps `>` able to close the comment.
+                    State::CommentEnd
+                } else if c == '>' {
                     State::Text {
                         start: i + 1,
                         dec_start: decoded.len(),
                         last_non_whitespace: decoded.len(),
-                        collapse_ws: true,
+                        collapse_ws: pre_depth == 0,
                     }
                 } else {
                     State::CommentBody
@@ -852,7 +1025,7 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "commat" => 64,
         "COMMAT" => 64,
         "Copf" => 8450,
-        "copf" => 8450,
+        "copf" => 120148,
         "COPF" => 8450,
         "incare" => 8453,
         "INCARE" => 8453,
@@ -861,27 +1034,27 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "hamilt" => 8459,
         "HAMILT" => 8459,
         "Hfr" => 8460,
-        "hfr" => 8460,
+        "hfr" => 120101,
         "HFR" => 8460,
         "Hopf" => 8461,
-        "hopf" => 8461,
+        "hopf" => 120153,
         "HOPF" => 8461,
         "planckh" => 8462,
         "PLANCKH" => 8462,
         "planck" => 8463,
         "PLANCK" => 8463,
         "Iscr" => 8464,
-        "iscr" => 8464,
+        "iscr" => 119998,
         "ISCR" => 8464,
         "image" => 8465,
         "IMAGE" => 8465,
         "Lscr" => 8466,
-        "lscr" => 8466,
+        "lscr" => 120001,
         "LSCR" => 8466,
         "ell" => 8467,
         "ELL" => 8467,
         "Nopf" => 8469,
-        "nopf" => 8469,
+        "nopf" => 120159,
         "NOPF" => 8469,
         "numero" => 8470,
         "NUMERO" => 8470,
@@ -890,44 +1063,44 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "weierp" => 8472,
         "WEIERP" => 8472,
         "Popf" => 8473,
-        "popf" => 8473,
+        "popf" => 120161,
         "POPF" => 8473,
         "Qopf" => 8474,
-        "qopf" => 8474,
+        "qopf" => 120162,
         "QOPF" => 8474,
         "Rscr" => 8475,
-        "rscr" => 8475,
+        "rscr" => 120007,
         "RSCR" => 8475,
         "real" => 8476,
         "REAL" => 8476,
         "Ropf" => 8477,
-        "ropf" => 8477,
+        "ropf" => 120163,
         "ROPF" => 8477,
         "rx" => 8478,
         "RX" => 8478,
         "Zopf" => 8484,
-        "zopf" => 8484,
+        "zopf" => 120171,
         "ZOPF" => 8484,
         "mho" => 8487,
         "MHO" => 8487,
         "Zfr" => 8488,
-        "zfr" => 8488,
+        "zfr" => 120119,
         "ZFR" => 8488,
         "iiota" => 8489,
         "IIOTA" => 8489,
         "bernou" => 8492,
         "BERNOU" => 8492,
         "Cfr" => 8493,
-        "cfr" => 8493,
+        "cfr" => 120096,
         "CFR" => 8493,
         "escr" => 8495,
         "ESCR" => 8495,
         "Escr" => 8496,
         "Fscr" => 8497,
-        "fscr" => 8497,
+        "fscr" => 119995,
         "FSCR" => 8497,
         "Mscr" => 8499,
-        "mscr" => 8499,
+        "mscr" => 120002,
         "MSCR" => 8499,
         "oscr" => 8500,
         "OSCR" => 8500,
@@ -940,7 +1113,7 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "daleth" => 8504,
         "DALETH" => 8504,
         "DD" => 8517,
-        "dd" => 8517,
+        "dd" => 8518,
         "ee" => 8519,
         "EE" => 8519,
         "ii" => 8520,
@@ -1033,8 +1206,8 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "VERT" => 124,
         "rbrace" => 125,
         "RBRACE" => 125,
-        "tilde" => 126,
-        "TILDE" => 126,
+        "tilde" => 732,
+        "TILDE" => 732,
         "circ" => 710,
         "CIRC" => 710,
         "nbsp" => 160,
@@ -1107,7 +1280,6 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "NLDR" => 8229,
         "hellip" => 8230,
         "HELLIP" => 8230,
-        "" => 8240,
         "pertenk" => 8241,
         "PERTENK" => 8241,
         "prime" => 8242,
@@ -1205,8 +1377,8 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "DEG" => 176,
         "fnof" => 402,
         "FNOF" => 402,
-        "permil" => 137,
-        "PERMIL" => 137,
+        "permil" => 8240,
+        "PERMIL" => 8240,
         "forall" => 8704,
         "FORALL" => 8704,
         "comp" => 8705,
@@ -1349,7 +1521,7 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "esdot" => 8784,
         "ESDOT" => 8784,
         "eDot" => 8785,
-        "edot" => 8785,
+        "edot" => 279,
         "EDOT" => 8785,
         "efDot" => 8786,
         "efdot" => 8786,
@@ -1384,10 +1556,10 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "lE" => 8806,
         "gE" => 8807,
         "lnE" => 8808,
-        "lne" => 8808,
+        "lne" => 10887,
         "LNE" => 8808,
         "gnE" => 8809,
-        "gne" => 8809,
+        "gne" => 10888,
         "GNE" => 8809,
         "Lt" => 8810,
         "Gt" => 8811,
@@ -1589,10 +1761,10 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "gtdot" => 8919,
         "GTDOT" => 8919,
         "Ll" => 8920,
-        "ll" => 8920,
+        "ll" => 8810,
         "LL" => 8920,
         "Gg" => 8921,
-        "gg" => 8921,
+        "gg" => 8811,
         "GG" => 8921,
         "leg" => 8922,
         "LEG" => 8922,
@@ -1667,81 +1839,81 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "LFLOOR" => 8970,
         "rfloor" => 8971,
         "RFLOOR" => 8971,
-        "lang" => 9001,
-        "LANG" => 9001,
-        "rang" => 9002,
-        "RANG" => 9002,
+        "lang" => 10216,
+        "LANG" => 10216,
+        "rang" => 10217,
+        "RANG" => 10217,
         "Alpha" => 913,
-        "alpha" => 913,
+        "alpha" => 945,
         "ALPHA" => 913,
         "Beta" => 914,
-        "beta" => 914,
+        "beta" => 946,
         "BETA" => 914,
         "Gamma" => 915,
-        "gamma" => 915,
+        "gamma" => 947,
         "GAMMA" => 915,
         "Delta" => 916,
-        "delta" => 916,
+        "delta" => 948,
         "DELTA" => 916,
         "Epsilon" => 917,
-        "epsilon" => 917,
+        "epsilon" => 949,
         "EPSILON" => 917,
         "Zeta" => 918,
-        "zeta" => 918,
+        "zeta" => 950,
         "ZETA" => 918,
         "Eta" => 919,
-        "eta" => 919,
+        "eta" => 951,
         "ETA" => 919,
         "Theta" => 920,
-        "theta" => 920,
+        "theta" => 952,
         "THETA" => 920,
         "Iota" => 921,
-        "iota" => 921,
+        "iota" => 953,
         "IOTA" => 921,
         "Kappa" => 922,
-        "kappa" => 922,
+        "kappa" => 954,
         "KAPPA" => 922,
         "Lambda" => 923,
-        "lambda" => 923,
+        "lambda" => 955,
         "LAMBDA" => 923,
         "Mu" => 924,
-        "mu" => 924,
+        "mu" => 956,
         "MU" => 924,
         "Nu" => 925,
-        "nu" => 925,
+        "nu" => 957,
         "NU" => 925,
         "Xi" => 926,
-        "xi" => 926,
+        "xi" => 958,
         "XI" => 926,
         "Omicron" => 927,
-        "omicron" => 927,
+        "omicron" => 959,
         "OMICRON" => 927,
         "Pi" => 928,
-        "pi" => 928,
+        "pi" => 960,
         "PI" => 928,
         "Rho" => 929,
-        "rho" => 929,
+        "rho" => 961,
         "RHO" => 929,
         "Sigma" => 931,
-        "sigma" => 931,
+        "sigma" => 963,
         "SIGMA" => 931,
         "Tau" => 932,
-        "tau" => 932,
+        "tau" => 964,
         "TAU" => 932,
         "Upsilon" => 933,
-        "upsilon" => 933,
+        "upsilon" => 965,
         "UPSILON" => 933,
         "Phi" => 934,
-        "phi" => 934,
+        "phi" => 966,
         "PHI" => 934,
         "Chi" => 935,
-        "chi" => 935,
+        "chi" => 967,
         "CHI" => 935,
         "Psi" => 936,
-        "psi" => 936,
+        "psi" => 968,
         "PSI" => 936,
         "Omega" => 937,
-        "omega" => 937,
+        "omega" => 969,
         "OMEGA" => 937,
         "sigmaf" => 962,
         "SIGMAF" => 962,
@@ -1752,93 +1924,88 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "piv" => 982,
         "PIV" => 982,
         "Agrave" => 192,
-        "agrave" => 192,
+        "agrave" => 224,
         "AGRAVE" => 192,
         "Aacute" => 193,
-        "aacute" => 193,
+        "aacute" => 225,
         "AACUTE" => 193,
         "Acirc" => 194,
-        "acirc" => 194,
+        "acirc" => 226,
         "ACIRC" => 194,
         "Atilde" => 195,
-        "atilde" => 195,
+        "atilde" => 227,
         "ATILDE" => 195,
         "Auml" => 196,
-        "auml" => 196,
+        "auml" => 228,
         "AUML" => 196,
         "Aring" => 197,
-        "aring" => 197,
+        "aring" => 229,
         "ARING" => 197,
         "AElig" => 198,
-        "aelig" => 198,
+        "aelig" => 230,
         "AELIG" => 198,
         "Ccedil" => 199,
-        "ccedil" => 199,
+        "ccedil" => 231,
         "CCEDIL" => 199,
         "Egrave" => 200,
-        "egrave" => 200,
+        "egrave" => 232,
         "EGRAVE" => 200,
         "Eacute" => 201,
-        "eacute" => 201,
+        "eacute" => 233,
         "EACUTE" => 201,
         "Ecirc" => 202,
-        "ecirc" => 202,
+        "ecirc" => 234,
         "ECIRC" => 202,
         "Euml" => 203,
-        "euml" => 203,
+        "euml" => 235,
         "EUML" => 203,
-        "Lgrave" => 204,
-        "lgrave" => 204,
-        "LGRAVE" => 204,
+        "Igrave" => 204,
+        "Iacute" => 205,
         "Lacute" => 313,
-        "lacute" => 313,
+        "lacute" => 314,
         "LACUTE" => 313,
-        "Lcirc" => 206,
-        "lcirc" => 206,
-        "LCIRC" => 206,
-        "Luml" => 207,
-        "luml" => 207,
-        "LUML" => 207,
+        "Icirc" => 206,
+        "Iuml" => 207,
         "ETH" => 208,
-        "eth" => 208,
+        "eth" => 240,
         "Ntilde" => 209,
-        "ntilde" => 209,
+        "ntilde" => 241,
         "NTILDE" => 209,
         "Ograve" => 210,
-        "ograve" => 210,
+        "ograve" => 242,
         "OGRAVE" => 210,
         "Oacute" => 211,
-        "oacute" => 211,
+        "oacute" => 243,
         "OACUTE" => 211,
         "Ocirc" => 212,
-        "ocirc" => 212,
+        "ocirc" => 244,
         "OCIRC" => 212,
         "Otilde" => 213,
-        "otilde" => 213,
+        "otilde" => 245,
         "OTILDE" => 213,
         "Ouml" => 214,
-        "ouml" => 214,
+        "ouml" => 246,
         "OUML" => 214,
         "Oslash" => 216,
-        "oslash" => 216,
+        "oslash" => 248,
         "OSLASH" => 216,
         "Ugrave" => 217,
-        "ugrave" => 217,
+        "ugrave" => 249,
         "UGRAVE" => 217,
         "Uacute" => 218,
-        "uacute" => 218,
+        "uacute" => 250,
         "UACUTE" => 218,
         "Ucirc" => 219,
-        "ucirc" => 219,
+        "ucirc" => 251,
         "UCIRC" => 219,
         "Uuml" => 220,
-        "uuml" => 220,
+        "uuml" => 252,
         "UUML" => 220,
         "Yacute" => 221,
-        "yacute" => 221,
+        "yacute" => 253,
         "YACUTE" => 221,
         "THORN" => 222,
-        "thorn" => 222,
+        "thorn" => 254,
         "szlig" => 223,
         "SZLIG" => 223,
         "igrave" => 236,
@@ -1852,68 +2019,68 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "yuml" => 255,
         "YUML" => 255,
         "Amacr" => 256,
-        "amacr" => 256,
+        "amacr" => 257,
         "AMACR" => 256,
         "Abreve" => 258,
-        "abreve" => 258,
+        "abreve" => 259,
         "ABREVE" => 258,
         "Aogon" => 260,
-        "aogon" => 260,
+        "aogon" => 261,
         "AOGON" => 260,
         "Cacute" => 262,
-        "cacute" => 262,
+        "cacute" => 263,
         "CACUTE" => 262,
         "Ccirc" => 264,
-        "ccirc" => 264,
+        "ccirc" => 265,
         "CCIRC" => 264,
         "Cdot" => 266,
-        "cdot" => 266,
+        "cdot" => 267,
         "CDOT" => 266,
         "Ccaron" => 268,
-        "ccaron" => 268,
+        "ccaron" => 269,
         "CCARON" => 268,
         "Dcaron" => 270,
-        "dcaron" => 270,
+        "dcaron" => 271,
         "DCARON" => 270,
         "Dstrok" => 272,
-        "dstrok" => 272,
+        "dstrok" => 273,
         "DSTROK" => 272,
         "Emacr" => 274,
-        "emacr" => 274,
+        "emacr" => 275,
         "EMACR" => 274,
         "Edot" => 278,
         "Eogon" => 280,
-        "eogon" => 280,
+        "eogon" => 281,
         "EOGON" => 280,
         "Ecaron" => 282,
-        "ecaron" => 282,
+        "ecaron" => 283,
         "ECARON" => 282,
         "Gcirc" => 284,
-        "gcirc" => 284,
+        "gcirc" => 285,
         "GCIRC" => 284,
         "Gbreve" => 286,
-        "gbreve" => 286,
+        "gbreve" => 287,
         "GBREVE" => 286,
         "Gdot" => 288,
-        "gdot" => 288,
+        "gdot" => 289,
         "GDOT" => 288,
         "Gcedil" => 290,
         "gcedil" => 290,
         "GCEDIL" => 290,
         "Hcirc" => 292,
-        "hcirc" => 292,
+        "hcirc" => 293,
         "HCIRC" => 292,
         "Hstrok" => 294,
-        "hstrok" => 294,
+        "hstrok" => 295,
         "HSTROK" => 294,
         "Itilde" => 296,
-        "itilde" => 296,
+        "itilde" => 297,
         "ITILDE" => 296,
         "Imacr" => 298,
-        "imacr" => 298,
+        "imacr" => 299,
         "IMACR" => 298,
         "Iogon" => 302,
-        "iogon" => 302,
+        "iogon" => 303,
         "IOGON" => 302,
         "Idot" => 304,
         "idot" => 304,
@@ -1921,113 +2088,113 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "imath" => 305,
         "IMATH" => 305,
         "IJlig" => 306,
-        "ijlig" => 306,
+        "ijlig" => 307,
         "IJLIG" => 306,
         "Jcirc" => 308,
-        "jcirc" => 308,
+        "jcirc" => 309,
         "JCIRC" => 308,
         "Kcedil" => 310,
-        "kcedil" => 310,
+        "kcedil" => 311,
         "KCEDIL" => 310,
         "kgreen" => 312,
         "KGREEN" => 312,
         "Lcedil" => 315,
-        "lcedil" => 315,
+        "lcedil" => 316,
         "LCEDIL" => 315,
         "Lcaron" => 317,
-        "lcaron" => 317,
+        "lcaron" => 318,
         "LCARON" => 317,
         "Lmidot" => 319,
-        "lmidot" => 319,
+        "lmidot" => 320,
         "LMIDOT" => 319,
         "Lstrok" => 321,
-        "lstrok" => 321,
+        "lstrok" => 322,
         "LSTROK" => 321,
         "Nacute" => 323,
-        "nacute" => 323,
+        "nacute" => 324,
         "NACUTE" => 323,
         "Ncedil" => 325,
-        "ncedil" => 325,
+        "ncedil" => 326,
         "NCEDIL" => 325,
         "Ncaron" => 327,
-        "ncaron" => 327,
+        "ncaron" => 328,
         "NCARON" => 327,
         "napos" => 329,
         "NAPOS" => 329,
         "ENG" => 330,
-        "eng" => 330,
+        "eng" => 331,
         "Omacr" => 332,
-        "omacr" => 332,
+        "omacr" => 333,
         "OMACR" => 332,
         "Odblac" => 336,
-        "odblac" => 336,
+        "odblac" => 337,
         "ODBLAC" => 336,
         "OElig" => 338,
-        "oelig" => 338,
+        "oelig" => 339,
         "OELIG" => 338,
         "Racute" => 340,
-        "racute" => 340,
+        "racute" => 341,
         "RACUTE" => 340,
         "Rcedil" => 342,
-        "rcedil" => 342,
+        "rcedil" => 343,
         "RCEDIL" => 342,
         "Rcaron" => 344,
-        "rcaron" => 344,
+        "rcaron" => 345,
         "RCARON" => 344,
         "Sacute" => 346,
-        "sacute" => 346,
+        "sacute" => 347,
         "SACUTE" => 346,
         "Scirc" => 348,
-        "scirc" => 348,
+        "scirc" => 349,
         "SCIRC" => 348,
         "Scedil" => 350,
-        "scedil" => 350,
+        "scedil" => 351,
         "SCEDIL" => 350,
         "Scaron" => 352,
-        "scaron" => 352,
+        "scaron" => 353,
         "SCARON" => 352,
         "Tcedil" => 354,
-        "tcedil" => 354,
+        "tcedil" => 355,
         "TCEDIL" => 354,
         "Tcaron" => 356,
-        "tcaron" => 356,
+        "tcaron" => 357,
         "TCARON" => 356,
         "Tstrok" => 358,
-        "tstrok" => 358,
+        "tstrok" => 359,
         "TSTROK" => 358,
         "Utilde" => 360,
-        "utilde" => 360,
+        "utilde" => 361,
         "UTILDE" => 360,
         "Umacr" => 362,
-        "umacr" => 362,
+        "umacr" => 363,
         "UMACR" => 362,
         "Ubreve" => 364,
-        "ubreve" => 364,
+        "ubreve" => 365,
         "UBREVE" => 364,
         "Uring" => 366,
-        "uring" => 366,
+        "uring" => 367,
         "URING" => 366,
         "Udblac" => 368,
-        "udblac" => 368,
+        "udblac" => 369,
         "UDBLAC" => 368,
         "Uogon" => 370,
-        "uogon" => 370,
+        "uogon" => 371,
         "UOGON" => 370,
         "Wcirc" => 372,
-        "wcirc" => 372,
+        "wcirc" => 373,
         "WCIRC" => 372,
         "Ycirc" => 374,
-        "ycirc" => 374,
+        "ycirc" => 375,
         "YCIRC" => 374,
         "Yuml" => 376,
         "Zacute" => 377,
-        "zacute" => 377,
+        "zacute" => 378,
         "ZACUTE" => 377,
         "Zdot" => 379,
-        "zdot" => 379,
+        "zdot" => 380,
         "ZDOT" => 379,
         "Zcaron" => 381,
-        "zcaron" => 381,
+        "zcaron" => 382,
         "ZCARON" => 381,
         "DownBreve" => 785,
         "downbreve" => 785,
@@ -2071,43 +2238,43 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "rlhar" => 8652,
         "RLHAR" => 8652,
         "nlArr" => 8653,
-        "nlarr" => 8653,
+        "nlarr" => 8602,
         "NLARR" => 8653,
         "nhArr" => 8654,
-        "nharr" => 8654,
+        "nharr" => 8622,
         "NHARR" => 8654,
         "nrArr" => 8655,
-        "nrarr" => 8655,
+        "nrarr" => 8603,
         "NRARR" => 8655,
         "lArr" => 8656,
-        "larr" => 8656,
+        "larr" => 8592,
         "LARR" => 8656,
         "uArr" => 8657,
-        "uarr" => 8657,
+        "uarr" => 8593,
         "UARR" => 8657,
         "rArr" => 8658,
-        "rarr" => 8658,
+        "rarr" => 8594,
         "RARR" => 8658,
         "dArr" => 8659,
-        "darr" => 8659,
+        "darr" => 8595,
         "DARR" => 8659,
         "hArr" => 8660,
-        "harr" => 8660,
+        "harr" => 8596,
         "HARR" => 8660,
         "vArr" => 8661,
-        "varr" => 8661,
+        "varr" => 8597,
         "VARR" => 8661,
         "nwArr" => 8662,
-        "nwarr" => 8662,
+        "nwarr" => 8598,
         "NWARR" => 8662,
         "neArr" => 8663,
-        "nearr" => 8663,
+        "nearr" => 8599,
         "NEARR" => 8663,
         "seArr" => 8664,
-        "searr" => 8664,
+        "searr" => 8600,
         "SEARR" => 8664,
         "swArr" => 8665,
-        "swarr" => 8665,
+        "swarr" => 8601,
         "SWARR" => 8665,
         "lAarr" => 8666,
         "laarr" => 8666,
@@ -2154,7 +2321,7 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "nvharr" => 10500,
         "NVHARR" => 10500,
         "Map" => 10501,
-        "map" => 10501,
+        "map" => 8614,
         "MAP" => 10501,
         "lbarr" => 10508,
         "LBARR" => 10508,
@@ -2173,7 +2340,7 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "downarrowbar" => 10515,
         "DOWNARROWBAR" => 10515,
         "Rarrtl" => 10518,
-        "rarrtl" => 10518,
+        "rarrtl" => 8611,
         "RARRTL" => 10518,
         "latail" => 10521,
         "LATAIL" => 10521,
@@ -2349,34 +2516,441 @@ pub fn match_entity(what: &str) -> Result<u32, String> {
         "dfisht" => 10623,
         "DFISHT" => 10623,
         x => {
-            // check if we are a bare unicode number
-            let x = x.as_bytes();
-            if x[0] == b'#' {
-                if x.len() > 1 && x[1] == b'x' {
-                    // hex
-                    if let Ok(utf8) = std::str::from_utf8(&x[2..]) {
-                        if let Ok(num) = i64::from_str_radix(utf8, 16) {
-                            num as u32
-                        } else {
-                            return Err("Cannot parse hex html entity".into());
-                        }
-                    } else {
-                        return Err("Cannot parse hex html entity".into());
-                    }
-                } else {
-                    if let Ok(utf8) = std::str::from_utf8(&x[1..]) {
-                        if let Ok(num) = utf8.parse::<i64>() {
-                            num as u32
-                        } else {
-                            return Err("Cannot parse digit html entity".into());
-                        }
-                    } else {
-                        return Err("Cannot parse digit html entity".into());
-                    }
-                }
-            } else {
+            // Not a named entity: it may be a numeric character reference.
+            // Everything here is validated rather than cast, because the
+            // caller turns the result into a `char`: an out-of-range value,
+            // a surrogate, or a negative number would otherwise panic.
+            let Some(digits) = x.strip_prefix('#') else {
                 return Err("unknown html entity".into());
+            };
+            // `&#x..;` / `&#X..;` are hex, anything else is decimal. Parsing
+            // as `u32` (not `i64`) rejects a leading `-` or `+` outright.
+            let num = match digits.strip_prefix(['x', 'X']) {
+                Some(hex) => u32::from_str_radix(hex, 16)
+                    .map_err(|_| String::from("Cannot parse hex html entity"))?,
+                None => digits
+                    .parse::<u32>()
+                    .map_err(|_| String::from("Cannot parse digit html entity"))?,
+            };
+            // Reject anything that is not a Unicode scalar value: beyond
+            // U+10FFFF, or a UTF-16 surrogate half.
+            if char::from_u32(num).is_none() {
+                return Err("Html entity is not a valid unicode scalar".into());
             }
+            num
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Concatenated text of every text node, in document order.
+    fn text_of(body: &str) -> String {
+        let doc = parse_html(body, &mut None, InternLiveId::No);
+        let mut walker = doc.new_walker();
+        let mut out = String::new();
+        while !walker.done() {
+            if let Some(text) = walker.text() {
+                out.push_str(text);
+            }
+            walker.walk();
+        }
+        out
+    }
+
+    /// Every node's byte range must be in bounds, ordered, and on a char
+    /// boundary of `decoded`, and `all_ws` must match the text it describes.
+    fn assert_nodes_consistent(body: &str) {
+        let doc = parse_html(body, &mut None, InternLiveId::No);
+        let mut highest_text_end = 0;
+        for (i, node) in doc.nodes.iter().enumerate() {
+            let (start, end) = match node {
+                HtmlNode::Text { start, end, .. } | HtmlNode::Attribute { start, end, .. } => {
+                    (*start, *end)
+                }
+                _ => continue,
+            };
+            assert!(start <= end, "{body:?}: node {i} has start {start} > end {end}");
+            assert!(
+                end <= doc.decoded.len(),
+                "{body:?}: node {i} ends at {end}, past decoded len {}",
+                doc.decoded.len()
+            );
+            assert!(
+                doc.decoded.is_char_boundary(start) && doc.decoded.is_char_boundary(end),
+                "{body:?}: node {i} range {start}..{end} splits a character"
+            );
+            if let HtmlNode::Text { all_ws, .. } = node {
+                let really_all_ws = doc.decoded[start..end].chars().all(is_html_whitespace);
+                assert_eq!(
+                    *all_ws, really_all_ws,
+                    "{body:?}: node {i} all_ws={all_ws} but text is {:?}",
+                    &doc.decoded[start..end]
+                );
+                assert!(
+                    start >= highest_text_end,
+                    "{body:?}: node {i} overlaps an earlier text node"
+                );
+                highest_text_end = end;
+            }
+        }
+    }
+
+    /// Numeric character references that do not name a Unicode scalar value
+    /// used to reach `char::from_u32(..).unwrap()` and abort the process. Any
+    /// of these is reachable from a hostile chat message.
+    #[test]
+    fn out_of_range_numeric_entities_are_left_as_text() {
+        for body in [
+            "&#xD800;",           // high surrogate
+            "&#xDFFF;",           // low surrogate
+            "&#55296;",           // the same, in decimal
+            "&#x110000;",         // one past the last scalar value
+            "&#-1;",              // negative
+            "&#x-1;",
+            "&#99999999999999;",  // overflows every integer width
+            "&#;",
+            "&#x;",
+        ] {
+            assert_eq!(text_of(body), body, "{body:?} should survive as literal text");
+            assert_nodes_consistent(body);
+        }
+    }
+
+    /// A `&` that never terminates must not stay pending across a tag or a
+    /// closing quote: a later `;` would truncate `decoded` and retroactively
+    /// invalidate the byte ranges of nodes already emitted.
+    #[test]
+    fn an_unterminated_entity_does_not_span_a_tag_boundary() {
+        for body in [
+            "<p>&am<b>p;</b></p>",
+            "<p>&am</p><b>p;</b>",
+            "&<>;",
+            "&#<>1;",
+            "<a href='&am'>p;</a>",
+            "<a href=\"&am\">p;</a>",
+            "<a href=&am>p;</a>",
+        ] {
+            assert_nodes_consistent(body);
+        }
+        assert_eq!(text_of("<p>&am<b>p;</b></p>"), "&amp;");
+    }
+
+    /// `&;` is not an entity. It decoded to `‰` because the table carried an
+    /// empty-string key where `permil` belonged.
+    #[test]
+    fn an_empty_entity_name_is_not_an_entity() {
+        assert_eq!(text_of("&;"), "&;");
+        assert_eq!(match_entity("").is_err(), true);
+        assert_eq!(text_of("&permil;"), "\u{2030}");
+    }
+
+    /// The table was generated by folding names case-insensitively, so every
+    /// entity whose name differs from another only by case took the other's
+    /// code point: `&eacute;` rendered `É`, `&alpha;` rendered `Α`.
+    #[test]
+    fn case_distinct_entities_keep_their_own_code_points() {
+        for (body, expected) in [
+            ("&aacute;", "\u{e1}"),
+            ("&Aacute;", "\u{c1}"),
+            ("&eacute;", "\u{e9}"),
+            ("&Eacute;", "\u{c9}"),
+            ("&alpha;", "\u{3b1}"),
+            ("&Alpha;", "\u{391}"),
+            ("&omega;", "\u{3c9}"),
+            ("&Omega;", "\u{3a9}"),
+            ("&larr;", "\u{2190}"),
+            ("&lArr;", "\u{21d0}"),
+            ("&rarr;", "\u{2192}"),
+            ("&rArr;", "\u{21d2}"),
+            ("&copf;", "\u{1d554}"),
+            ("&Copf;", "\u{2102}"),
+        ] {
+            assert_eq!(text_of(body), expected, "{body:?}");
+        }
+    }
+
+    /// `Igrave`/`Icirc`/`Iuml` had been transcribed as `Lgrave`/`Lcirc`/`Luml`,
+    /// and `Iacute` was missing outright.
+    #[test]
+    fn capital_i_accents_are_reachable() {
+        assert_eq!(text_of("&Igrave;"), "\u{cc}");
+        assert_eq!(text_of("&Iacute;"), "\u{cd}");
+        assert_eq!(text_of("&Icirc;"), "\u{ce}");
+        assert_eq!(text_of("&Iuml;"), "\u{cf}");
+        // the invented l-accent spellings are not entities
+        assert_eq!(text_of("&Lgrave;"), "&Lgrave;");
+        assert_eq!(text_of("&lcirc;"), "&lcirc;");
+    }
+
+    /// Entities that already worked must keep working.
+    #[test]
+    fn common_entities_are_unchanged() {
+        for (body, expected) in [
+            ("&amp;", "&"),
+            ("&lt;", "<"),
+            ("&gt;", ">"),
+            ("&quot;", "\""),
+            ("&apos;", "'"),
+            ("&nbsp;", "\u{a0}"),
+            ("&mdash;", "\u{2014}"),
+            ("&hellip;", "\u{2026}"),
+            ("&#38;", "&"),
+            ("&#x26;", "&"),
+            ("&#X26;", "&"),
+            ("&amp;lt;", "&lt;"),
+            ("&notanentity;", "&notanentity;"),
+            ("&DownLeftRightVector;", "\u{2950}"),
+        ] {
+            assert_eq!(text_of(body), expected, "{body:?}");
+        }
+    }
+
+    /// `<pre>` and `<code>` keep their whitespace. A single flag meant any
+    /// nested tag cancelled that for the rest of the element, so a
+    /// syntax-highlighted code block lost its indentation.
+    #[test]
+    fn whitespace_is_preserved_for_the_whole_pre_element() {
+        assert_eq!(text_of("<pre>a    b</pre>"), "a    b");
+        assert_eq!(
+            text_of("<pre>a    <b>b    b</b>    c</pre>"),
+            "a    b    b    c"
+        );
+        assert_eq!(
+            text_of("<pre><code><span>fn</span>  main()</code></pre>"),
+            "fn  main()"
+        );
+        assert_eq!(text_of("<pre><code>x\n    y</code></pre>"), "x\n    y");
+        // and collapsing resumes once the element closes
+        assert_eq!(text_of("<pre>a  b</pre>c    d"), "a  bc d");
+        assert_eq!(text_of("<p>a    b</p>"), "a b");
+    }
+
+    /// A void element written without a slash emits an open tag and no close
+    /// tag. Counting every open tag as a nesting level therefore left the
+    /// depth permanently unbalanced and swallowed the rest of the document.
+    #[test]
+    fn jump_to_close_steps_over_void_elements() {
+        fn tail_after_first_element(body: &str) -> String {
+            let doc = parse_html(body, &mut None, InternLiveId::No);
+            let mut walker = doc.new_walker();
+            while !walker.done() && walker.open_tag_lc().is_none() {
+                walker.walk();
+            }
+            walker.jump_to_close();
+            let mut out = String::new();
+            while !walker.done() {
+                if let Some(text) = walker.text() {
+                    out.push_str(text);
+                }
+                walker.walk();
+            }
+            out
+        }
+        assert_eq!(tail_after_first_element("<div><b>x</b></div>AFTER"), "AFTER");
+        assert_eq!(tail_after_first_element("<div><br>x</div>AFTER"), "AFTER");
+        assert_eq!(tail_after_first_element("<div><br/>x</div>AFTER"), "AFTER");
+        assert_eq!(
+            tail_after_first_element("<a href='u'><img src='i'>caption</a>AFTER"),
+            "AFTER"
+        );
+        assert_eq!(tail_after_first_element("<b>x<b>y</b>z</b>AFTER"), "AFTER");
+        // an element with no close tag of its own leaves the walker where it
+        // is, so the caller still sees everything that follows
+        assert_eq!(tail_after_first_element("<img src='i'>AFTER"), "AFTER");
+        assert_eq!(tail_after_first_element("<p>unclosed"), "unclosed");
+    }
+
+    /// Unquoted attribute values were the only value form that never decoded
+    /// entities, and a value beginning with a multi-byte character recorded a
+    /// byte range that split that character.
+    #[test]
+    fn unquoted_attribute_values_are_decoded_and_stay_on_char_boundaries() {
+        fn href(body: &str) -> Option<String> {
+            let doc = parse_html(body, &mut None, InternLiveId::No);
+            let mut walker = doc.new_walker();
+            while !walker.done() && walker.open_tag_lc().is_none() {
+                walker.walk();
+            }
+            walker.find_attr_lc(live_id!(href)).map(str::to_string)
+        }
+        assert_eq!(href("<a href=a&amp;b>t</a>").as_deref(), Some("a&b"));
+        assert_eq!(href("<a href=&amp;x>t</a>").as_deref(), Some("&x"));
+        assert_eq!(href("<a href=\"a&amp;b\">t</a>").as_deref(), Some("a&b"));
+        assert_eq!(href("<a href='a&amp;b'>t</a>").as_deref(), Some("a&b"));
+        assert_eq!(href("<a href=émile>t</a>").as_deref(), Some("émile"));
+        assert_nodes_consistent("<a href=émile>t</a>");
+        assert_nodes_consistent("<a href=漢字 title=🙂>t</a>");
+    }
+
+    /// `<a href=>` took `>` as the first character of the value, so the tag
+    /// never closed and its content leaked out as literal text.
+    #[test]
+    fn an_empty_unquoted_attribute_value_still_closes_the_tag() {
+        assert_eq!(text_of("<a href=>hello</a><p>after</p>"), "helloafter");
+        let doc = parse_html("<a href=>hello</a>", &mut None, InternLiveId::No);
+        let mut walker = doc.new_walker();
+        while !walker.done() && walker.open_tag_lc().is_none() {
+            walker.walk();
+        }
+        assert_eq!(walker.find_attr_lc(live_id!(href)), Some(""));
+    }
+
+    /// The parser emits a zero-length text node in front of every tag, so
+    /// `find_text` reported no text for any element whose content starts with
+    /// markup, and `find_tag_text` missed any tag carrying an attribute.
+    #[test]
+    fn text_lookups_skip_parser_artifacts() {
+        let doc = parse_html("<a href='x'><b>label</b></a>", &mut None, InternLiveId::No);
+        let mut walker = doc.new_walker();
+        while !walker.done() && walker.open_tag_lc() != Some(live_id!(a)) {
+            walker.walk();
+        }
+        assert_eq!(walker.find_text(), Some("label"));
+
+        let doc = parse_html("<p class='x'>Hello</p>", &mut None, InternLiveId::No);
+        assert_eq!(doc.new_walker().find_tag_text(live_id!(p)), Some("Hello"));
+        // tag names are case-insensitive
+        let doc = parse_html("<P>Hello</P>", &mut None, InternLiveId::No);
+        assert_eq!(doc.new_walker().find_tag_text(live_id!(p)), Some("Hello"));
+    }
+
+    /// Whitespace introduced by an entity has to leave `all_ws` describing the
+    /// text that is actually there.
+    /// HTML's whitespace set is the five ASCII characters, not Unicode's.
+    /// Treating U+00A0 and U+3000 as collapsible ate `&nbsp;` runs and the
+    /// full-width spaces in CJK text.
+    #[test]
+    fn only_ascii_whitespace_collapses() {
+        assert_eq!(text_of("<p>a&nbsp; b</p>"), "a\u{a0} b");
+        assert_eq!(text_of("<p>&nbsp;&nbsp;</p>"), "\u{a0}\u{a0}");
+        assert_eq!(text_of("<p>\u{3000}x\u{3000}</p>"), "\u{3000}x\u{3000}");
+        assert_eq!(text_of("<p>a    b</p>"), "a b");
+        assert_eq!(text_of("<p>a\t\n\r b</p>"), "a b");
+        // a cell holding only &nbsp; is content, not collapsible whitespace
+        let doc = parse_html("<td>&nbsp;</td>", &mut None, InternLiveId::No);
+        let all_ws: Vec<bool> = doc.nodes.iter().filter_map(|n| match n {
+            HtmlNode::Text { all_ws, start, end } if start != end => Some(*all_ws),
+            _ => None,
+        }).collect();
+        assert_eq!(all_ws, vec![false]);
+    }
+
+    /// A `/` only closes the tag when `>` follows it, so unquoted URLs keep
+    /// their path.
+    #[test]
+    fn an_unquoted_value_keeps_slashes_that_are_not_the_self_closing_marker() {
+        fn attr(body: &str, key: LiveId) -> Option<String> {
+            let doc = parse_html(body, &mut None, InternLiveId::No);
+            let mut walker = doc.new_walker();
+            while !walker.done() && walker.open_tag_lc().is_none() {
+                walker.walk();
+            }
+            walker.find_attr_lc(key).map(str::to_string)
+        }
+        assert_eq!(
+            attr("<a href=http://example.com/page>x</a>", live_id!(href)).as_deref(),
+            Some("http://example.com/page")
+        );
+        assert_eq!(text_of("<a href=http://example.com/page>x</a> rest"), "x rest");
+        assert_eq!(attr("<img src=/media/pic.png>", live_id!(src)).as_deref(), Some("/media/pic.png"));
+        // and the self-closing form still self-closes
+        assert_eq!(attr("<img src=x/>", live_id!(src)).as_deref(), Some("x"));
+        let doc = parse_html("<img src=x/>", &mut None, InternLiveId::No);
+        assert!(doc.nodes.iter().any(|n| matches!(n, HtmlNode::CloseTag { lc, .. } if *lc == live_id!(img))));
+        assert_eq!(attr("<a href=x/ y=2>t</a>", live_id!(href)).as_deref(), Some("x/"));
+    }
+
+    /// A `<` that cannot begin a tag is literal text, the way a browser
+    /// treats it. Parsing it as an element used to consume the rest of the
+    /// line as a tag name and attributes, and drop it.
+    #[test]
+    fn a_less_than_that_is_not_a_tag_stays_text() {
+        assert_eq!(text_of("5<10 and 6<12"), "5<10 and 6<12");
+        assert_eq!(text_of("a < b"), "a < b");
+        assert_eq!(text_of("<>"), "<>");
+        assert_eq!(text_of("<1a>x"), "<1a>x");
+        assert_eq!(text_of("i <3 you"), "i <3 you");
+        assert_eq!(text_of("<é>text"), "<é>text");
+        // real tags still parse
+        assert_eq!(text_of("<p>x</p>"), "x");
+        assert_eq!(text_of("<P>x</P>"), "x");
+        for body in ["5<10 and 6<12", "a < b", "<>", "<1a>x", "i <3 you", "<é>t"] {
+            assert_nodes_consistent(body);
+        }
+    }
+
+    /// `<!-->` is a complete comment rather than the start of an
+    /// unterminated one that eats the rest of the document.
+    #[test]
+    fn declarations_and_comments_do_not_swallow_the_document() {
+        assert_eq!(text_of("5<10? yes"), "5<10? yes");
+        assert_eq!(text_of("a<!-->b"), "ab");
+        assert_eq!(text_of("a<!--->b"), "ab");
+        assert_eq!(text_of("a<!----->b"), "ab");
+        assert_eq!(text_of("a<!--c-->b"), "ab");
+        assert_eq!(text_of("a<!--c--->b"), "ab");
+        assert_eq!(text_of("a<?xml version='1'?>b"), "ab");
+    }
+
+    #[test]
+    fn all_ws_matches_the_decoded_text() {
+        for body in [
+            " &#11;",
+            "&nbsp;",
+            "&nbsp;&nbsp;",
+            " &nbsp;",
+            "&#32;",
+            "&#32;x",
+            "<td>&nbsp;</td>",
+            "<td>&nbsp;&nbsp;</td>",
+        ] {
+            assert_nodes_consistent(body);
+        }
+    }
+
+    /// Malformed input must still produce a walkable document rather than a
+    /// panic or a corrupted node range.
+    #[test]
+    fn malformed_input_stays_walkable() {
+        for body in [
+            "", "<", ">", "</", "/>", "<>", "</>", "<//>", "< />", "<a", "<a ",
+            "<a href", "<a href=", "<a href='", "<a href=\"", "<!--", "<!---",
+            "<!-->", "<!--->", "<!", "<!DOCTYPE html>", "<?xml version='1'?>",
+            "<?", "<a?b>", "&", "&#", "&#x", "&amp", "<p>&", "</p></p></p>",
+            "<b><i></b></i>", "<a href=x/ y=2>t</a>", "<a//b>", "\u{feff}<p>x</p>",
+            "<é>text</é>", "<p>🙂<br>👨‍👩‍👧</p>", "<p>\r\n\tx</p>",
+        ] {
+            assert_nodes_consistent(body);
+            // walking the whole document must not panic
+            let doc = parse_html(body, &mut None, InternLiveId::No);
+            let mut walker = doc.new_walker();
+            while !walker.done() {
+                let _ = walker.text();
+                let _ = walker.open_tag();
+                let _ = walker.close_tag();
+                let _ = walker.find_attr_lc(live_id!(href));
+                let _ = walker.find_text();
+                let _ = walker.text_is_all_ws();
+                let before = walker.index();
+                let mut probe = doc.new_walker_with_index(before);
+                probe.jump_to_close();
+                assert!(probe.index() >= before, "{body:?}: jump_to_close moved backwards");
+                walker.walk();
+            }
+        }
+    }
+
+    /// Interning changes how names are stored, never the shape of the document.
+    #[test]
+    fn interning_does_not_change_the_document() {
+        for body in ["<p class='a'>x</p>", "<a href=y>&amp;</a>", "<pre>a  b</pre>"] {
+            let plain = parse_html(body, &mut None, InternLiveId::No);
+            let interned = parse_html(body, &mut None, InternLiveId::Yes);
+            assert_eq!(plain.decoded, interned.decoded, "{body:?}");
+            assert_eq!(plain.nodes.len(), interned.nodes.len(), "{body:?}");
+        }
+    }
 }

--- a/platform/script/src/mod_html.rs
+++ b/platform/script/src/mod_html.rs
@@ -163,12 +163,23 @@ fn parse_query(sel: &str) -> ParsedQuery {
 
 // ---- Query execution (zero-copy, operates on backing) ----
 
+/// Index of the close tag matching the open tag at `open_idx`, or `open_idx`
+/// itself when the element has none.
+///
+/// Only tags with the same id affect depth. Counting every open tag would
+/// over-consume, because a void element written without a slash (`<br>`,
+/// `<img src=x>`) emits an `OpenTag` and no `CloseTag`, leaving the depth
+/// permanently unbalanced and running every element's range to end of input.
 fn find_close_tag(nodes: &[HtmlNode], open_idx: usize) -> usize {
+    let open_lc = match nodes.get(open_idx) {
+        Some(HtmlNode::OpenTag { lc, .. }) => *lc,
+        _ => return open_idx,
+    };
     let mut depth = 0u32;
     for i in (open_idx + 1)..nodes.len() {
         match &nodes[i] {
-            HtmlNode::OpenTag { .. } => depth += 1,
-            HtmlNode::CloseTag { .. } => {
+            HtmlNode::OpenTag { lc, .. } if *lc == open_lc => depth += 1,
+            HtmlNode::CloseTag { lc, .. } if *lc == open_lc => {
                 if depth == 0 {
                     return i;
                 }
@@ -177,7 +188,7 @@ fn find_close_tag(nodes: &[HtmlNode], open_idx: usize) -> usize {
             _ => {}
         }
     }
-    nodes.len().saturating_sub(1)
+    open_idx
 }
 
 fn element_matches(decoded: &str, nodes: &[HtmlNode], idx: usize, step: &QueryStep) -> bool {
@@ -385,24 +396,10 @@ fn get_attr<'a>(
     None
 }
 
+/// Counted from the same ranges the callers walk, so a void element can't
+/// make the two disagree.
 fn count_top_level_elements(nodes: &[HtmlNode]) -> usize {
-    let mut count = 0;
-    let mut depth = 0u32;
-    for node in nodes {
-        match node {
-            HtmlNode::OpenTag { .. } => {
-                if depth == 0 {
-                    count += 1;
-                }
-                depth += 1;
-            }
-            HtmlNode::CloseTag { .. } => {
-                depth = depth.saturating_sub(1);
-            }
-            _ => {}
-        }
-    }
-    count
+    top_level_ranges(nodes).len()
 }
 
 fn top_level_ranges(nodes: &[HtmlNode]) -> Vec<(u32, u32)> {
@@ -412,7 +409,8 @@ fn top_level_ranges(nodes: &[HtmlNode]) -> Vec<(u32, u32)> {
         if let HtmlNode::OpenTag { .. } = &nodes[i] {
             let close = find_close_tag(nodes, i);
             out.push((i as u32, close as u32));
-            i = close + 1;
+            // A void element reports itself as its own close tag.
+            i = close.max(i) + 1;
         } else {
             i += 1;
         }

--- a/platform/script/src/mod_html.rs
+++ b/platform/script/src/mod_html.rs
@@ -4,19 +4,15 @@ use crate::makepad_live_id::live_id::*;
 use crate::native::*;
 use crate::value::*;
 use crate::*;
-use makepad_html::{parse_html, HtmlNode};
+use makepad_html::{parse_html, HtmlDoc, HtmlNode};
 use makepad_live_id::live_id::InternLiveId;
+use std::fmt::Write as _;
 use std::rc::Rc;
 
-// Shared backing store — the parsed HTML data is Rc'd so query results
-// just reference ranges into it without copying strings or nodes.
-struct HtmlBacking {
-    decoded: String,
-    nodes: Vec<HtmlNode>,
-}
-
 pub struct ScriptHtmlDoc {
-    backing: Rc<HtmlBacking>,
+    // The parsed document is `Rc`'d so query results just reference ranges
+    // into it without copying strings or nodes.
+    backing: Rc<HtmlDoc>,
     // Element ranges as (open_tag_index, close_tag_index) into backing.nodes.
     ranges: Vec<(u32, u32)>,
     // true = root document (empty ranges means whole doc), false = query result (empty = no matches)
@@ -163,32 +159,13 @@ fn parse_query(sel: &str) -> ParsedQuery {
 
 // ---- Query execution (zero-copy, operates on backing) ----
 
-/// Index of the close tag matching the open tag at `open_idx`, or `open_idx`
-/// itself when the element has none.
-///
-/// Only tags with the same id affect depth. Counting every open tag would
-/// over-consume, because a void element written without a slash (`<br>`,
-/// `<img src=x>`) emits an `OpenTag` and no `CloseTag`, leaving the depth
-/// permanently unbalanced and running every element's range to end of input.
-fn find_close_tag(nodes: &[HtmlNode], open_idx: usize) -> usize {
-    let open_lc = match nodes.get(open_idx) {
-        Some(HtmlNode::OpenTag { lc, .. }) => *lc,
-        _ => return open_idx,
-    };
-    let mut depth = 0u32;
-    for i in (open_idx + 1)..nodes.len() {
-        match &nodes[i] {
-            HtmlNode::OpenTag { lc, .. } if *lc == open_lc => depth += 1,
-            HtmlNode::CloseTag { lc, .. } if *lc == open_lc => {
-                if depth == 0 {
-                    return i;
-                }
-                depth -= 1;
-            }
-            _ => {}
-        }
-    }
-    open_idx
+/// Index of the close tag ending the element opened at `open_idx`, or
+/// `open_idx` itself when the element has none — a void element, or one the
+/// document never closed. The parser resolves these, so this is a lookup.
+fn find_close_tag(doc: &HtmlDoc, open_idx: usize) -> usize {
+    doc.new_walker_with_index(open_idx)
+        .close_index()
+        .unwrap_or(open_idx)
 }
 
 fn element_matches(decoded: &str, nodes: &[HtmlNode], idx: usize, step: &QueryStep) -> bool {
@@ -232,43 +209,36 @@ fn element_matches(decoded: &str, nodes: &[HtmlNode], idx: usize, step: &QuerySt
 }
 
 fn find_elements(
-    decoded: &str,
-    nodes: &[HtmlNode],
+    doc: &HtmlDoc,
     step: &QueryStep,
     range_start: usize,
     range_end: usize,
     recurse: bool,
     out: &mut Vec<(u32, u32)>,
 ) {
+    let nodes = &doc.nodes;
     let mut i = range_start;
-    let mut depth = 0u32;
-    while i < range_end {
-        match &nodes[i] {
-            HtmlNode::OpenTag { .. } => {
-                if (recurse || depth == 0) && element_matches(decoded, nodes, i, step) {
-                    let close = find_close_tag(nodes, i);
-                    out.push((i as u32, close as u32));
-                    if !recurse {
-                        i = close + 1;
-                        continue;
-                    }
-                }
-                depth += 1;
+    while i < range_end.min(nodes.len()) {
+        if let HtmlNode::OpenTag { .. } = &nodes[i] {
+            let close = find_close_tag(doc, i);
+            if element_matches(&doc.decoded, nodes, i, step) {
+                out.push((i as u32, close as u32));
             }
-            HtmlNode::CloseTag { .. } => {
-                if depth > 0 {
-                    depth -= 1;
-                }
+            // A child combinator sees only direct children, so step over
+            // each element's whole subtree; a descendant combinator looks
+            // inside. Using the resolved close index rather than counting
+            // tags keeps void elements from unbalancing the depth.
+            if !recurse {
+                i = close.max(i) + 1;
+                continue;
             }
-            _ => {}
         }
         i += 1;
     }
 }
 
 fn execute_query(
-    decoded: &str,
-    nodes: &[HtmlNode],
+    doc: &HtmlDoc,
     ranges: &[(u32, u32)],
     steps: &[QueryStep],
 ) -> Vec<(u32, u32)> {
@@ -281,19 +251,17 @@ fn execute_query(
     if ranges.is_empty() {
         // Whole document
         find_elements(
-            decoded,
-            nodes,
+            doc,
             &steps[0],
             0,
-            nodes.len(),
+            doc.nodes.len(),
             true,
             &mut matches,
         );
     } else {
         for &(s, e) in ranges {
             find_elements(
-                decoded,
-                nodes,
+                doc,
                 &steps[0],
                 s as usize,
                 e as usize,
@@ -311,8 +279,7 @@ fn execute_query(
             let child_start = s as usize + 1;
             if child_start < e as usize {
                 find_elements(
-                    decoded,
-                    nodes,
+                    doc,
                     step,
                     child_start,
                     e as usize,
@@ -398,16 +365,17 @@ fn get_attr<'a>(
 
 /// Counted from the same ranges the callers walk, so a void element can't
 /// make the two disagree.
-fn count_top_level_elements(nodes: &[HtmlNode]) -> usize {
-    top_level_ranges(nodes).len()
+fn count_top_level_elements(doc: &HtmlDoc) -> usize {
+    top_level_ranges(doc).len()
 }
 
-fn top_level_ranges(nodes: &[HtmlNode]) -> Vec<(u32, u32)> {
+fn top_level_ranges(doc: &HtmlDoc) -> Vec<(u32, u32)> {
+    let nodes = &doc.nodes;
     let mut out = Vec::new();
     let mut i = 0;
     while i < nodes.len() {
         if let HtmlNode::OpenTag { .. } = &nodes[i] {
-            let close = find_close_tag(nodes, i);
+            let close = find_close_tag(doc, i);
             out.push((i as u32, close as u32));
             // A void element reports itself as its own close tag.
             i = close.max(i) + 1;
@@ -431,7 +399,9 @@ pub fn define_html_module(heap: &mut ScriptHeap, native: &mut ScriptNative) {
             let sself = script_value!(vm, args.self);
             let doc =
                 if let Some(d) = vm.bx.heap.string_mut_self_with(sself, |_heap, s| {
-                    parse_html(s, &mut None, InternLiveId::No)
+                    // Interned, so `.html` can print tag and attribute names
+                    // back out; an un-interned `LiveId` only prints as hex.
+                    parse_html(s, &mut None, InternLiveId::Yes)
                 }) {
                     d
                 } else {
@@ -440,10 +410,7 @@ pub fn define_html_module(heap: &mut ScriptHeap, native: &mut ScriptNative) {
                         "parse_html called on non-string value"
                     );
                 };
-            let backing = Rc::new(HtmlBacking {
-                decoded: doc.decoded,
-                nodes: doc.nodes,
-            });
+            let backing = Rc::new(doc);
             let html_doc = ScriptHtmlDoc {
                 backing,
                 ranges: Vec::new(),
@@ -500,7 +467,7 @@ pub fn define_html_module(heap: &mut ScriptHeap, native: &mut ScriptNative) {
                 return vm.bx.heap.new_handle(html_type, Box::new(sub)).into();
             }
 
-            let matches = execute_query(&backing.decoded, &backing.nodes, &ranges, &parsed.steps);
+            let matches = execute_query(&backing, &ranges, &parsed.steps);
 
             match parsed.terminal {
                 Terminal::Attr(attr_id) => {
@@ -658,7 +625,7 @@ pub fn define_html_module(heap: &mut ScriptHeap, native: &mut ScriptNative) {
             let (backing, ranges) =
                 if let Some(doc) = vm.bx.heap.handle_ref::<ScriptHtmlDoc>(handle) {
                     let r = if doc.is_root && doc.ranges.is_empty() {
-                        top_level_ranges(doc.nodes())
+                        top_level_ranges(&doc.backing)
                     } else if !doc.ranges.is_empty() {
                         doc.ranges.clone()
                     } else {
@@ -698,7 +665,7 @@ pub fn define_html_module(heap: &mut ScriptHeap, native: &mut ScriptNative) {
                 if !doc.is_root || !doc.ranges.is_empty() {
                     return ScriptValue::from_f64(doc.ranges.len() as f64);
                 }
-                return ScriptValue::from_f64(count_top_level_elements(doc.nodes()) as f64);
+                return ScriptValue::from_f64(count_top_level_elements(&doc.backing) as f64);
             }
             return NIL;
         }
@@ -758,6 +725,22 @@ pub fn define_html_module(heap: &mut ScriptHeap, native: &mut ScriptNative) {
     });
 }
 
+/// Appends `s` with the characters that would read back as markup escaped,
+/// so the `.html` of a document parses to the same document again. The
+/// decoded text has had its entities resolved, so emitting it verbatim used
+/// to turn a literal `<` in a text node into a tag.
+fn push_escaped(out: &mut String, s: &str, in_attribute: bool) {
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' if in_attribute => out.push_str("&quot;"),
+            c => out.push(c),
+        }
+    }
+}
+
 fn reconstruct_html(decoded: &str, nodes: &[HtmlNode], start: usize, end: usize) -> String {
     let mut out = String::new();
     reconstruct_html_into(&mut out, decoded, nodes, start, end);
@@ -776,16 +759,16 @@ fn reconstruct_html_into(
         match &nodes[i] {
             HtmlNode::OpenTag { nc, .. } => {
                 out.push('<');
-                out.push_str(&format!("{}", nc));
+                let _ = write!(out, "{}", nc);
                 let mut j = i + 1;
                 while j < end && j < nodes.len() {
                     if let HtmlNode::Attribute { nc, start, end, .. } = &nodes[j] {
                         out.push(' ');
-                        out.push_str(&format!("{}", nc));
+                        let _ = write!(out, "{}", nc);
                         let val = &decoded[*start..*end];
                         if !val.is_empty() {
                             out.push_str("=\"");
-                            out.push_str(val);
+                            push_escaped(out, val, true);
                             out.push('"');
                         }
                         j += 1;
@@ -797,11 +780,11 @@ fn reconstruct_html_into(
             }
             HtmlNode::CloseTag { nc, .. } => {
                 out.push_str("</");
-                out.push_str(&format!("{}", nc));
+                let _ = write!(out, "{}", nc);
                 out.push('>');
             }
             HtmlNode::Text { start, end, .. } => {
-                out.push_str(&decoded[*start..*end]);
+                push_escaped(out, &decoded[*start..*end], false);
             }
             HtmlNode::Attribute { .. } => {}
         }

--- a/platform/script/src/mod_html.rs
+++ b/platform/script/src/mod_html.rs
@@ -13,7 +13,9 @@ pub struct ScriptHtmlDoc {
     // The parsed document is `Rc`'d so query results just reference ranges
     // into it without copying strings or nodes.
     backing: Rc<HtmlDoc>,
-    // Element ranges as (open_tag_index, close_tag_index) into backing.nodes.
+    // Element ranges as (open_tag_index, end_index) into backing.nodes: the
+    // end is exclusive, one past the element's own close tag, or the index
+    // of the enclosing close tag that ended it.
     ranges: Vec<(u32, u32)>,
     // true = root document (empty ranges means whole doc), false = query result (empty = no matches)
     is_root: bool,
@@ -109,7 +111,9 @@ fn parse_query(sel: &str) -> ParsedQuery {
 
         // [N] index terminal
         if let Some(b) = tag_part.find('[') {
-            if let Some(e) = tag_part.find(']') {
+            // Only a `]` after the `[` closes it; `a]b[` used to slice
+            // backwards and panic.
+            if let Some(e) = tag_part[b..].find(']').map(|e| b + e) {
                 if let Ok(idx) = tag_part[b + 1..e].parse::<usize>() {
                     terminal = Terminal::Index(idx);
                 }
@@ -159,13 +163,17 @@ fn parse_query(sel: &str) -> ParsedQuery {
 
 // ---- Query execution (zero-copy, operates on backing) ----
 
-/// Index of the close tag ending the element opened at `open_idx`, or
-/// `open_idx` itself when the element has none — a void element, or one the
-/// document never closed. The parser resolves these, so this is a lookup.
-fn find_close_tag(doc: &HtmlDoc, open_idx: usize) -> usize {
+/// One past the last node of the element opened at `open_idx`: past its own
+/// close tag, or at the close tag of the enclosing element that ended it, or
+/// the end of the document; for a void element, just past its attributes.
+/// The parser resolves these, so this is a lookup. Mapping an element
+/// without a close tag to itself, as this used to, gave every `<li>a<li>b`
+/// item an empty range: no `.text`, no `.html`, and children promoted to
+/// siblings.
+fn element_end(doc: &HtmlDoc, open_idx: usize) -> usize {
     doc.new_walker_with_index(open_idx)
-        .close_index()
-        .unwrap_or(open_idx)
+        .end_index()
+        .unwrap_or(open_idx + 1)
 }
 
 fn element_matches(decoded: &str, nodes: &[HtmlNode], idx: usize, step: &QueryStep) -> bool {
@@ -220,16 +228,16 @@ fn find_elements(
     let mut i = range_start;
     while i < range_end.min(nodes.len()) {
         if let HtmlNode::OpenTag { .. } = &nodes[i] {
-            let close = find_close_tag(doc, i);
+            let end = element_end(doc, i);
             if element_matches(&doc.decoded, nodes, i, step) {
-                out.push((i as u32, close as u32));
+                out.push((i as u32, end as u32));
             }
             // A child combinator sees only direct children, so step over
             // each element's whole subtree; a descendant combinator looks
-            // inside. Using the resolved close index rather than counting
-            // tags keeps void elements from unbalancing the depth.
+            // inside. Using the resolved end rather than counting tags keeps
+            // void elements from unbalancing the depth.
             if !recurse {
-                i = close.max(i) + 1;
+                i = end;
                 continue;
             }
         }
@@ -301,7 +309,7 @@ fn collect_text<'a>(decoded: &'a str, nodes: &[HtmlNode], start: usize, end: usi
     // Fast path: if there's exactly one text node, return a slice (no alloc)
     let mut first_text: Option<(usize, usize)> = None;
     let mut count = 0;
-    for i in start..=end.min(nodes.len().saturating_sub(1)) {
+    for i in start..end.min(nodes.len()) {
         if let HtmlNode::Text {
             start: s,
             end: e,
@@ -327,7 +335,7 @@ fn collect_text<'a>(decoded: &'a str, nodes: &[HtmlNode], start: usize, end: usi
 
 fn collect_text_owned(decoded: &str, nodes: &[HtmlNode], start: usize, end: usize) -> String {
     let mut text = String::new();
-    for i in start..=end.min(nodes.len().saturating_sub(1)) {
+    for i in start..end.min(nodes.len()) {
         if let HtmlNode::Text {
             start: s,
             end: e,
@@ -375,10 +383,9 @@ fn top_level_ranges(doc: &HtmlDoc) -> Vec<(u32, u32)> {
     let mut i = 0;
     while i < nodes.len() {
         if let HtmlNode::OpenTag { .. } = &nodes[i] {
-            let close = find_close_tag(doc, i);
-            out.push((i as u32, close as u32));
-            // A void element reports itself as its own close tag.
-            i = close.max(i) + 1;
+            let end = element_end(doc, i);
+            out.push((i as u32, end as u32));
+            i = end;
         } else {
             i += 1;
         }
@@ -675,12 +682,7 @@ pub fn define_html_module(heap: &mut ScriptHeap, native: &mut ScriptNative) {
             if field == id!(text) {
                 let mut text = String::new();
                 if doc.is_root && doc.ranges.is_empty() {
-                    text = collect_text_owned(
-                        doc.decoded(),
-                        doc.nodes(),
-                        0,
-                        doc.nodes().len().saturating_sub(1),
-                    );
+                    text = collect_text_owned(doc.decoded(), doc.nodes(), 0, doc.nodes().len());
                 } else {
                     for &(s, e) in &doc.ranges {
                         let t =
@@ -705,7 +707,7 @@ pub fn define_html_module(heap: &mut ScriptHeap, native: &mut ScriptNative) {
                             doc.decoded(),
                             doc.nodes(),
                             s as usize,
-                            e as usize + 1,
+                            e as usize,
                         );
                     }
                     out

--- a/platform/script/src/mod_html.rs
+++ b/platform/script/src/mod_html.rs
@@ -65,6 +65,12 @@ struct ParsedQuery {
     terminal: Terminal,
 }
 
+/// Parses a selector. Each whitespace-separated token (or `>`-separated for
+/// the child combinator) is `[tag|*][.class|.text][#id]` followed by at most
+/// one terminal, `[N]` or `@attr`, in that order: `@attr` takes the rest of
+/// the token, `[N]` overrides `@attr` when both appear, and a suffix written
+/// out of order is folded into the name before it (`a.foo.text` is class
+/// `foo.text`). Only the last token's terminal applies.
 fn parse_query(sel: &str) -> ParsedQuery {
     let sel = sel.trim();
     let mut steps = Vec::new();
@@ -267,11 +273,13 @@ fn execute_query(
             &mut matches,
         );
     } else {
+        // Inside the selection: `querySelectorAll` on an element never
+        // returns the element itself.
         for &(s, e) in ranges {
             find_elements(
                 doc,
                 &steps[0],
-                s as usize,
+                s as usize + 1,
                 e as usize,
                 true,
                 &mut matches,
@@ -283,7 +291,15 @@ fn execute_query(
     for step in &steps[1..] {
         let prev = std::mem::take(&mut matches);
         let is_child = matches!(step.combinator, Combinator::Child);
+        // For a descendant step, a match nested inside a match already
+        // scanned has already had its subtree searched; rescanning it made
+        // `b b` on deeply nested `<b>` quadratic. `prev` is sorted.
+        let mut scanned_end = 0usize;
         for &(s, e) in &prev {
+            if !is_child && (s as usize) < scanned_end {
+                continue;
+            }
+            scanned_end = scanned_end.max(e as usize);
             let child_start = s as usize + 1;
             if child_start < e as usize {
                 find_elements(
@@ -310,13 +326,8 @@ fn collect_text<'a>(decoded: &'a str, nodes: &[HtmlNode], start: usize, end: usi
     let mut first_text: Option<(usize, usize)> = None;
     let mut count = 0;
     for i in start..end.min(nodes.len()) {
-        if let HtmlNode::Text {
-            start: s,
-            end: e,
-            all_ws,
-        } = &nodes[i]
-        {
-            if !all_ws {
+        if let HtmlNode::Text { start: s, end: e, .. } = &nodes[i] {
+            if s != e {
                 count += 1;
                 if count == 1 {
                     first_text = Some((*s, *e));
@@ -333,21 +344,15 @@ fn collect_text<'a>(decoded: &'a str, nodes: &[HtmlNode], start: usize, end: usi
     ""
 }
 
+/// The element's text content: its text nodes concatenated as decoded.
+/// Inserting a space between nodes, as this used to, put one inside a word
+/// split by a comment or an inline tag (`a<!-- -->b`, `a<b>b</b>`) and made
+/// `.text` disagree with `.html`.
 fn collect_text_owned(decoded: &str, nodes: &[HtmlNode], start: usize, end: usize) -> String {
     let mut text = String::new();
     for i in start..end.min(nodes.len()) {
-        if let HtmlNode::Text {
-            start: s,
-            end: e,
-            all_ws,
-        } = &nodes[i]
-        {
-            if !all_ws || (text.is_empty() && *all_ws) {
-                if !text.is_empty() {
-                    text.push(' ');
-                }
-                text.push_str(&decoded[*s..*e]);
-            }
+        if let HtmlNode::Text { start: s, end: e, .. } = &nodes[i] {
+            text.push_str(&decoded[*s..*e]);
         }
     }
     text
@@ -759,26 +764,41 @@ fn reconstruct_html_into(
     let mut i = start;
     while i < end && i < nodes.len() {
         match &nodes[i] {
-            HtmlNode::OpenTag { nc, .. } => {
+            HtmlNode::OpenTag { lc, nc } => {
                 out.push('<');
                 let _ = write!(out, "{}", nc);
                 let mut j = i + 1;
+                // The serializer's rule for `<pre>`: a newline that starts
+                // its content is written twice, because the parser drops
+                // the first one. Otherwise `.html` loses a line each time
+                // it is parsed.
+                let doubles_leading_newline =
+                    *lc == live_id!(pre) || *lc == live_id!(textarea) || *lc == live_id!(listing);
                 while j < end && j < nodes.len() {
                     if let HtmlNode::Attribute { nc, start, end, .. } = &nodes[j] {
                         out.push(' ');
                         let _ = write!(out, "{}", nc);
-                        let val = &decoded[*start..*end];
-                        if !val.is_empty() {
-                            out.push_str("=\"");
-                            push_escaped(out, val, true);
-                            out.push('"');
-                        }
+                        // Always `=""`, as the serializer specifies: a bare
+                        // name followed by an attribute whose name starts
+                        // with `=` would re-parse to a different document.
+                        out.push_str("=\"");
+                        push_escaped(out, &decoded[*start..*end], true);
+                        out.push('"');
                         j += 1;
                     } else {
                         break;
                     }
                 }
                 out.push('>');
+                if doubles_leading_newline {
+                    let first_text = nodes[j..end.min(nodes.len())].iter().find_map(|n| match n {
+                        HtmlNode::Text { start, end, .. } if start != end => Some(&decoded[*start..*end]),
+                        _ => None,
+                    });
+                    if first_text.is_some_and(|t| t.starts_with('\n')) {
+                        out.push('\n');
+                    }
+                }
             }
             HtmlNode::CloseTag { nc, .. } => {
                 out.push_str("</");

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -235,6 +235,12 @@ pub struct Html {
     #[rust]
     open_elements: Vec<LiveId>,
 
+    /// How many of each tag `open_elements` holds, so an unmatched close tag
+    /// is rejected without scanning the stack. A message can carry both deep
+    /// nesting and many stray close tags.
+    #[rust]
+    open_element_counts: HashMap<LiveId, u32>,
+
     /// How many `<summary>` elements are open. `</summary>` pops a tracker
     /// that `<summary>` pushed, so a message containing only the close tag
     /// used to pop an empty stack.
@@ -573,6 +579,16 @@ impl Html {
         (None, trim_whitespace_in_text)
     }
 
+    /// Drops one occurrence of `lc` from the open-element tally.
+    fn release_open_element(counts: &mut HashMap<LiveId, u32>, lc: LiveId) {
+        if let Some(n) = counts.get_mut(&lc) {
+            *n = n.saturating_sub(1);
+            if *n == 0 {
+                counts.remove(&lc);
+            }
+        }
+    }
+
     /// Tags whose close handler changes `TextFlow` state, so their open tag
     /// has to be remembered and their close tag ignored when unmatched.
     fn element_is_tracked(lc: LiveId) -> bool {
@@ -797,6 +813,7 @@ impl Widget for Html {
         // inside an unclosed element must not bleed into this one.
         self.list_stack.clear();
         self.open_elements.clear();
+        self.open_element_counts.clear();
         self.open_summaries = 0;
         self.used_widget_ids.clear();
         self.table_columns_cache.clear();
@@ -1013,6 +1030,7 @@ impl Widget for Html {
                         break;
                     }
                     self.open_elements.pop();
+                    Self::release_open_element(&mut self.open_element_counts, top);
                     let _ = Self::handle_close_tag(
                         cx,
                         &mut self.text_flow,
@@ -1050,6 +1068,7 @@ impl Widget for Html {
                     if let Some(lc) = open_lc {
                         if Self::element_is_tracked(lc) {
                             self.open_elements.push(lc);
+                            *self.open_element_counts.entry(lc).or_insert(0) += 1;
                         }
                     }
                 }
@@ -1058,9 +1077,15 @@ impl Widget for Html {
             // Run a close handler only for an element this draw actually
             // opened, unwinding anything left open inside it.
             if let Some(close_lc) = node.close_tag_lc() {
-                if let Some(depth) = self.open_elements.iter().rposition(|t| *t == close_lc) {
+                if self.open_element_counts.get(&close_lc).is_some_and(|n| *n > 0) {
+                    let depth = self
+                        .open_elements
+                        .iter()
+                        .rposition(|t| *t == close_lc)
+                        .unwrap_or(0);
                     while self.open_elements.len() > depth {
                         let lc = self.open_elements.pop().unwrap_or(close_lc);
+                        Self::release_open_element(&mut self.open_element_counts, lc);
                         let _ = Self::handle_close_tag(
                             cx,
                             &mut self.text_flow,
@@ -1076,6 +1101,7 @@ impl Widget for Html {
         // Close anything the document left open, so `<ul><li>item` hands a
         // balanced turtle stack back to `TextFlow::end`.
         while let Some(lc) = self.open_elements.pop() {
+            Self::release_open_element(&mut self.open_element_counts, lc);
             let _ = Self::handle_close_tag(cx, &mut self.text_flow, lc, &mut self.list_stack);
         }
         self.text_flow.end(cx);
@@ -1620,11 +1646,18 @@ fn cell_align_x(node: &HtmlWalker) -> f64 {
 }
 
 fn align_keyword_to_x(keyword: &str) -> Option<f64> {
-    match keyword.trim().to_ascii_lowercase().as_str() {
-        "left" | "start" | "justify" => Some(0.0),
-        "center" => Some(0.5),
-        "right" | "end" => Some(1.0),
-        _ => None,
+    // Compared in place rather than lowercased into a fresh String, which ran
+    // once per aligned cell on every draw.
+    let keyword = keyword.trim();
+    let eq = |s: &str| keyword.eq_ignore_ascii_case(s);
+    if eq("left") || eq("start") || eq("justify") {
+        Some(0.0)
+    } else if eq("center") {
+        Some(0.5)
+    } else if eq("right") || eq("end") {
+        Some(1.0)
+    } else {
+        None
     }
 }
 

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -213,20 +213,15 @@ pub struct Html {
     #[rust]
     list_stack: Vec<ListLevel>,
 
-    /// The elements this widget has actually opened, innermost last, for the
-    /// draw currently in progress.
-    ///
-    /// A close tag only runs its handler when a matching open tag is on this
-    /// stack. Without that, a stray `</td>` or `</li>` in a message reaches
-    /// `cx.end_turtle()` with nothing to end and unbalances the frame.
+    /// The elements this widget has opened and not yet closed, innermost
+    /// last, for the draw in progress. Each carries the node index at which
+    /// the parser resolved it to end, and its close handler runs when the
+    /// walk reaches that index — its own close tag, or the enclosing close
+    /// tag that ended it, or the start tag that implicitly closed it. So a
+    /// stray `</td>` closes nothing, `<li>a<li>b` closes the first item
+    /// where a browser would, and nothing reaches `cx.end_turtle()` twice.
     #[rust]
-    open_elements: Vec<LiveId>,
-
-    /// How many of each tag `open_elements` holds, so an unmatched close tag
-    /// is rejected without scanning the stack. A message can carry both deep
-    /// nesting and many stray close tags.
-    #[rust]
-    open_element_counts: HashMap<LiveId, u32>,
+    open_elements: Vec<OpenElement>,
 
     /// The `<summary>` elements currently open, innermost last. `</summary>`
     /// pops a tracker that `<summary>` pushed, so a message containing only
@@ -389,11 +384,10 @@ impl Html {
     /// Ends the innermost open `<details>`: anything still open inside it —
     /// elements, and a `<summary>` that never closed — ends first.
     fn pop_details_level(&mut self, cx: &mut Cx2d) {
-        let Some(level) = self.details_stack.last() else {
+        if self.details_stack.is_empty() {
             return;
-        };
-        let (depth, index) = (level.open_depth, self.details_stack.len() - 1);
-        self.unwind_open_elements(cx, depth);
+        }
+        let index = self.details_stack.len() - 1;
         while self.open_summaries.last().is_some_and(|s| s.owner == Some(index)) {
             let summary = self.open_summaries.pop();
             self.close_summary(cx, summary.and_then(|s| s.owner));
@@ -406,16 +400,12 @@ impl Html {
 
     /// After a collapsed `<details>`'s summary closes: the index to resume at
     /// so its body is not drawn. That is its own `</details>` when it has
-    /// one, so that handler still runs; otherwise the element was ended by
-    /// an enclosing element, its level is closed here, and drawing resumes
-    /// at that enclosing close tag.
-    fn skip_collapsed_body(&mut self, cx: &mut Cx2d, node: &HtmlWalker) -> Option<usize> {
+    /// one, so that handler pops the level; otherwise the enclosing close tag
+    /// that ended it, where the level's `open_elements` entry pops it.
+    fn skip_collapsed_body(&self, node: &HtmlWalker) -> Option<usize> {
         let open_index = self.details_stack.last()?.open_index;
         let mut probe = node.at(open_index);
         Self::skip_details_body(&mut probe, open_index);
-        if node.at(open_index).close_index().is_none() {
-            self.pop_details_level(cx);
-        }
         Some(probe.index)
     }
 
@@ -443,7 +433,6 @@ impl Html {
             .or(node.end_index())
             .unwrap_or(node.nodes.len());
         let mut count = 0;
-        let mut in_row = false;
         let mut i = node.index + 1;
         while i < end {
             match &node.nodes[i] {
@@ -454,19 +443,19 @@ impl Html {
                         continue;
                     }
                     if *lc == live_id!(tr) {
-                        if in_row {
+                        // A row that contributed no cells does not size the
+                        // table; keep looking for one that does.
+                        if count > 0 {
                             break;
                         }
-                        in_row = true;
                     } else if *lc == live_id!(td) || *lc == live_id!(th) {
-                        in_row = true;
                         count += 1;
                         i = at.end_index().unwrap_or(i + 1);
                         continue;
                     }
                 }
                 HtmlNode::CloseTag { lc, .. } => {
-                    if in_row
+                    if count > 0
                         && (*lc == live_id!(tr) || *lc == live_id!(thead) || *lc == live_id!(tbody))
                     {
                         break;
@@ -646,16 +635,6 @@ impl Html {
         None
     }
 
-    /// Drops one occurrence of `lc` from the open-element tally.
-    fn release_open_element(counts: &mut HashMap<LiveId, u32>, lc: LiveId) {
-        if let Some(n) = counts.get_mut(&lc) {
-            *n = n.saturating_sub(1);
-            if *n == 0 {
-                counts.remove(&lc);
-            }
-        }
-    }
-
     /// Tags whose close handler changes `TextFlow` state, so their open tag
     /// has to be remembered and their close tag ignored when unmatched.
     fn element_is_tracked(lc: LiveId) -> bool {
@@ -675,83 +654,26 @@ impl Html {
         TRACKED.contains(&lc)
     }
 
-    /// Runs the close handler for everything above `depth` on the open stack,
-    /// innermost first, and drops it.
-    fn unwind_open_elements(&mut self, cx: &mut Cx2d, depth: usize) {
-        while self.open_elements.len() > depth {
-            let Some(lc) = self.open_elements.pop() else {
+    /// Runs the close handler of every open element the parser resolved to
+    /// end at or before node `index`, innermost first. Called before each
+    /// node is handled, and with `usize::MAX` once the walk is over.
+    fn close_elements_ending_by(&mut self, cx: &mut Cx2d, index: usize) {
+        while let Some(top) = self.open_elements.last() {
+            if top.until > index {
+                break;
+            }
+            let Some(element) = self.open_elements.pop() else {
                 break;
             };
-            Self::release_open_element(&mut self.open_element_counts, lc);
-            let _ = Self::handle_close_tag(cx, &mut self.text_flow, lc, &mut self.list_stack);
-        }
-    }
-
-    /// Closes the outermost open element in `targets` found before reaching
-    /// one in `scope`, and everything above it. With `top_only`, only the
-    /// innermost open element is considered.
-    fn close_implicitly(
-        &mut self,
-        cx: &mut Cx2d,
-        targets: &[LiveId],
-        scope: &[LiveId],
-        top_only: bool,
-    ) {
-        let mut close_to = None;
-        for (depth, open) in self.open_elements.iter().enumerate().rev() {
-            if targets.contains(open) {
-                close_to = Some(depth);
-            } else if scope.contains(open) {
-                break;
+            if element.lc == live_id!(details) {
+                self.pop_details_level(cx);
+            } else if element.lc == live_id!(summary) {
+                if let Some(summary) = self.open_summaries.pop() {
+                    self.close_summary(cx, summary.owner);
+                }
+            } else {
+                let _ = Self::handle_close_tag(cx, &mut self.text_flow, element.lc, &mut self.list_stack);
             }
-            if top_only {
-                break;
-            }
-        }
-        if let Some(depth) = close_to {
-            self.unwind_open_elements(cx, depth);
-        }
-    }
-
-    /// What opening `tag` implicitly closes, following the tree builder's
-    /// rules: a heading closes a heading it directly follows, `<li>` closes
-    /// an open item up to the enclosing list, a cell closes an open cell up
-    /// to its row, a row closes an open row and its cells, and any block
-    /// element closes an open `<p>`. This is what makes the shorthand real
-    /// documents use — `<li>a<li>b`, `<td>a<td>b`, `<p>a<p>b` — nest the
-    /// way a browser reads it.
-    fn apply_implicit_closes(&mut self, cx: &mut Cx2d, tag: LiveId) {
-        const HEADINGS: &[LiveId] = &[
-            live_id!(h1), live_id!(h2), live_id!(h3),
-            live_id!(h4), live_id!(h5), live_id!(h6),
-        ];
-        const ITEM: &[LiveId] = &[live_id!(li)];
-        const LISTS: &[LiveId] = &[live_id!(ul), live_id!(ol)];
-        const CELLS: &[LiveId] = &[live_id!(td), live_id!(th)];
-        const ROW_SCOPE: &[LiveId] = &[live_id!(tr), live_id!(table)];
-        const ROW_AND_CELLS: &[LiveId] = &[live_id!(tr), live_id!(td), live_id!(th)];
-        const TABLE_SCOPE: &[LiveId] = &[live_id!(table), live_id!(thead), live_id!(tbody)];
-        const PARAGRAPH: &[LiveId] = &[live_id!(p)];
-        const BUTTON_SCOPE: &[LiveId] = &[live_id!(table), live_id!(td), live_id!(th)];
-        const CLOSES_PARAGRAPH: &[LiveId] = &[
-            live_id!(h1), live_id!(h2), live_id!(h3), live_id!(h4), live_id!(h5), live_id!(h6),
-            live_id!(p), live_id!(blockquote), live_id!(pre),
-            live_id!(ul), live_id!(ol), live_id!(li), live_id!(table),
-        ];
-        // The tree builder closes a `<p>` in button scope first, and only
-        // then pops a heading that is the current node.
-        if CLOSES_PARAGRAPH.contains(&tag) {
-            self.close_implicitly(cx, PARAGRAPH, BUTTON_SCOPE, false);
-        }
-        if HEADINGS.contains(&tag) {
-            self.close_implicitly(cx, HEADINGS, &[], true);
-        }
-        if tag == live_id!(li) {
-            self.close_implicitly(cx, ITEM, LISTS, false);
-        } else if CELLS.contains(&tag) {
-            self.close_implicitly(cx, CELLS, ROW_SCOPE, false);
-        } else if tag == live_id!(tr) {
-            self.close_implicitly(cx, ROW_AND_CELLS, TABLE_SCOPE, false);
         }
     }
 
@@ -932,10 +854,14 @@ impl Widget for Html {
         // inside an unclosed element must not bleed into this one.
         self.list_stack.clear();
         self.open_elements.clear();
-        self.open_element_counts.clear();
         self.open_summaries.clear();
         self.table_columns_cache.clear();
         while !node.done() {
+            // Every element the parser resolved to end here ends now, before
+            // this node is handled: inside a `</summary>`, at the next `<li>`,
+            // at an enclosing close tag, or after a jump past its end.
+            self.close_elements_ending_by(cx, node.index);
+
             // Intercept <details> / <summary> open tags before the generic
             // handler, so <details> never falls through to handle_custom_widget
             // (which would jump_to_close and hide all content).
@@ -954,8 +880,17 @@ impl Widget for Html {
                         id: details_id,
                         is_open: initial_open,
                         open_index: node.index,
-                        open_depth: self.open_elements.len(),
                     });
+                    // Its `</details>` pops the level. Without one — ended by
+                    // an enclosing close tag, or never — it has to be popped
+                    // where the parser resolved it to end, like any element;
+                    // a level left behind would claim the next `<summary>`.
+                    if node.close_index().is_none() {
+                        self.open_elements.push(OpenElement {
+                            lc: live_id!(details),
+                            until: node.end_index().unwrap_or(usize::MAX),
+                        });
+                    }
                     // Small top margin so a `<details>` doesn't butt up
                     // against the preceding content. Scaled by the current
                     // font size so it tracks headings, sub/superscript, etc.
@@ -1045,8 +980,14 @@ impl Widget for Html {
                     self.text_flow.bold.push();
                     self.open_summaries.push(OpenSummary {
                         owner: self.details_stack.len().checked_sub(1),
-                        depth: self.open_elements.len(),
                     });
+                    // Likewise a `<summary>` with no `</summary>` of its own.
+                    if node.close_index().is_none() {
+                        self.open_elements.push(OpenElement {
+                            lc: live_id!(summary),
+                            until: node.end_index().unwrap_or(usize::MAX),
+                        });
+                    }
                     node.walk();
                     continue;
                 }
@@ -1060,18 +1001,20 @@ impl Widget for Html {
                         node.walk();
                         continue;
                     };
-                    // Anything opened inside the summary ends with it — an
-                    // `<li>` or a table cell, and any `<details>` nested in it.
-                    self.unwind_open_elements(cx, summary.depth);
+                    // A `<details>` nested inside the summary ends with it.
                     if let Some(owner) = summary.owner {
                         while self.details_stack.len() > owner + 1 {
                             self.pop_details_level(cx);
                         }
                     }
                     if self.close_summary(cx, summary.owner) {
-                        if let Some(resume) = self.skip_collapsed_body(cx, &node) {
-                            node.index = resume;
-                            continue;
+                        // The body lies ahead of the walker; a resume behind
+                        // it would redraw what was already drawn.
+                        if let Some(resume) = self.skip_collapsed_body(&node) {
+                            if resume > node.index {
+                                node.index = resume;
+                                continue;
+                            }
                         }
                     }
                     node.walk();
@@ -1089,10 +1032,6 @@ impl Widget for Html {
 
             // Regular tag/text handling for everything else.
             let open_lc = node.open_tag_lc();
-            if let Some(open_lc) = open_lc {
-                self.apply_implicit_closes(cx, open_lc);
-            }
-
             let tf = &mut self.text_flow;
             match Self::handle_open_tag(
                 cx,
@@ -1111,23 +1050,13 @@ impl Widget for Html {
                 None => {
                     if let Some(lc) = open_lc {
                         if Self::element_is_tracked(lc) {
-                            self.open_elements.push(lc);
-                            *self.open_element_counts.entry(lc).or_insert(0) += 1;
+                            let until = node
+                                .close_index()
+                                .or(node.end_index())
+                                .unwrap_or(usize::MAX);
+                            self.open_elements.push(OpenElement { lc, until });
                         }
                     }
-                }
-            }
-
-            // Run a close handler only for an element this draw actually
-            // opened, unwinding anything left open inside it.
-            if let Some(close_lc) = node.close_tag_lc() {
-                if self.open_element_counts.get(&close_lc).is_some_and(|n| *n > 0) {
-                    let depth = self
-                        .open_elements
-                        .iter()
-                        .rposition(|t| *t == close_lc)
-                        .unwrap_or(0);
-                    self.unwind_open_elements(cx, depth);
                 }
             }
             Self::handle_text_node(cx, &mut self.text_flow, &mut node);
@@ -1136,7 +1065,7 @@ impl Widget for Html {
         // Close anything the document left open, so `<ul><li>item` hands a
         // balanced turtle stack back to `TextFlow::end`, and a `<summary>`
         // that never closed doesn't leave its bold run and tracker behind.
-        self.unwind_open_elements(cx, 0);
+        self.close_elements_ending_by(cx, usize::MAX);
         while let Some(summary) = self.open_summaries.pop() {
             self.close_summary(cx, summary.owner);
         }
@@ -1527,17 +1456,20 @@ struct DetailsLevel {
     /// Node index of the `<details>` open tag, so a collapsed body can be
     /// skipped to the element's resolved end.
     open_index: usize,
-    /// `open_elements.len()` when the element opened; `</details>` unwinds
-    /// back to it, ending anything left open in the body.
-    open_depth: usize,
 }
 
 /// A `<summary>` that has been opened and not yet closed.
 struct OpenSummary {
     /// Index into `details_stack` of the `<details>` it belongs to, if any.
     owner: Option<usize>,
-    /// `open_elements.len()` when it opened; `</summary>` unwinds back to it.
-    depth: usize,
+}
+
+/// An element the widget opened, and the node index at which it ends.
+struct OpenElement {
+    lc: LiveId,
+    /// Its own close tag's index, or, when it has none, the index the
+    /// parser resolved as its end.
+    until: usize,
 }
 
 /// The format and metadata of a list at a given nesting level.

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -526,7 +526,7 @@ impl Html {
                                 .unwrap_or_else(|| "#".into())
                         }
                     };
-                    ll.li_count += 1;
+                    ll.li_count = ll.li_count.saturating_add(1);
                     (marker, ll.padding)
                 });
                 let (marker, pad) = marker_and_pad
@@ -799,6 +799,7 @@ impl Widget for Html {
         self.open_elements.clear();
         self.open_summaries = 0;
         self.used_widget_ids.clear();
+        self.table_columns_cache.clear();
         while !node.done() {
             // Intercept <details> / <summary> open tags before the generic
             // handler, so <details> never falls through to handle_custom_widget
@@ -1147,10 +1148,21 @@ fn handle_custom_widget(
     };
 
     let template = node.open_tag_nc().unwrap();
-    let mut scope_with_attrs = Scope::with_props_index(doc, node.index);
+    let open_index = node.index;
+    let mut scope_with_attrs = Scope::with_props_index(doc, open_index);
+
+    // Find the element's extent first. One with no close tag of its own is
+    // void, so it has no text: reading ahead would pick up the *following*
+    // sibling's text, which the main loop then draws again.
+    node.jump_to_close();
+    let text = if node.index() == open_index {
+        ""
+    } else {
+        doc.new_walker_with_index(open_index).find_text().unwrap_or("")
+    };
 
     if let Some(item) = tf.item_with_scope(cx, &mut scope_with_attrs, id, template) {
-        item.set_text(cx, node.find_text().unwrap_or(""));
+        item.set_text(cx, text);
         // A widget is walked atomically, so on the last allowed line it has to
         // be kept there rather than relocated onto a row the budget cannot pay
         // for; when it overruns that line it is cut at the edge with an
@@ -1161,8 +1173,6 @@ fn handle_custom_widget(
         item.draw_all(cx, &mut draw_scope);
         tf.end_inline_content(cx, hold);
     }
-
-    node.jump_to_close();
 }
 
 #[derive(Clone, Debug, Default)]
@@ -1485,8 +1495,9 @@ impl OrderedListType {
     /// Returns the marker for the given count and separator character.
     ///
     /// ## Notes on behavior
+    /// ## Notes on behavior
     /// * A negative or zero `count` will always return an integer number marker.
-    /// * Currently, for `UpperApha` and `LowerAlpha`, a `count` higher than 25 will result in a wrong character.
+    /// * `UpperAlpha` and `LowerAlpha` continue past `z` as `aa`, `ab`, ...
     /// * Roman numerals >= 4000 will return an integer number marker.
     pub fn marker(&self, count: i32, separator: &str) -> String {
         let to_number = || format!("{count}{separator}");

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -226,6 +226,32 @@ pub struct Html {
     #[rust]
     list_stack: Vec<ListLevel>,
 
+    /// The elements this widget has actually opened, innermost last, for the
+    /// draw currently in progress.
+    ///
+    /// A close tag only runs its handler when a matching open tag is on this
+    /// stack. Without that, a stray `</td>` or `</li>` in a message reaches
+    /// `cx.end_turtle()` with nothing to end and unbalances the frame.
+    #[rust]
+    open_elements: Vec<LiveId>,
+
+    /// How many `<summary>` elements are open. `</summary>` pops a tracker
+    /// that `<summary>` pushed, so a message containing only the close tag
+    /// used to pop an empty stack.
+    #[rust]
+    open_summaries: usize,
+
+    /// Widget ids already claimed during this draw, so a repeated `id`
+    /// attribute cannot bind two elements to the same cached sub-widget.
+    #[rust]
+    used_widget_ids: HashSet<LiveId>,
+
+    /// Column counts already computed for a `<table>` at a given node index.
+    /// Counting scans forward to the first row, so a document that is
+    /// thousands of unclosed `<table>` tags would otherwise be quadratic.
+    #[rust]
+    table_columns_cache: HashMap<usize, usize>,
+
     /// The stack of currently-open `<details>` tags while traversing the
     /// document. Rebuilt on each draw.
     #[rust]
@@ -366,6 +392,7 @@ impl Html {
         ul_markers: &Vec<String>,
         ol_markers: &Vec<OrderedListType>,
         ol_separator: &str,
+        table_columns_cache: &mut HashMap<usize, usize>,
     ) -> (Option<LiveId>, TrimWhitespaceInText) {
         let mut trim_whitespace_in_text = TrimWhitespaceInText::default();
 
@@ -512,7 +539,9 @@ impl Html {
             }
             some_id!(table) => {
                 tf.new_line_collapsed(cx);
-                let col_count = Self::count_table_columns(node.nodes, node.index);
+                let col_count = *table_columns_cache
+                    .entry(node.index)
+                    .or_insert_with(|| Self::count_table_columns(node.nodes, node.index));
                 tf.begin_table(cx, col_count);
                 trim_whitespace_in_text = TrimWhitespaceInText::Trim;
             }
@@ -544,13 +573,51 @@ impl Html {
         (None, trim_whitespace_in_text)
     }
 
+    /// Tags whose close handler changes `TextFlow` state, so their open tag
+    /// has to be remembered and their close tag ignored when unmatched.
+    fn element_is_tracked(lc: LiveId) -> bool {
+        // Every tag `handle_close_tag` has an arm for, minus the void ones
+        // (`<br>`, `<hr>`, `<sep>`), which never carry a close tag.
+        const TRACKED: &[LiveId] = &[
+            live_id!(h1), live_id!(h2), live_id!(h3),
+            live_id!(h4), live_id!(h5), live_id!(h6),
+            live_id!(b), live_id!(strong), live_id!(i), live_id!(em),
+            live_id!(p), live_id!(blockquote), live_id!(code), live_id!(pre),
+            live_id!(sub), live_id!(sup),
+            live_id!(ul), live_id!(ol), live_id!(li),
+            live_id!(u), live_id!(del), live_id!(s), live_id!(strike),
+            live_id!(table), live_id!(thead), live_id!(tbody),
+            live_id!(tr), live_id!(th), live_id!(td),
+        ];
+        TRACKED.contains(&lc)
+    }
+
+    /// The elements a newly-opened `tag` implicitly closes when they are still
+    /// open, so that the shorthand real documents use — `<li>a<li>b`,
+    /// `<td>a<td>b`, `<p>a<p>b` — nests the way a browser reads it.
+    fn implicitly_closed_by(tag: LiveId, top: LiveId) -> bool {
+        if tag == live_id!(li) {
+            top == live_id!(li)
+        } else if tag == live_id!(p) {
+            top == live_id!(p)
+        } else if tag == live_id!(td) || tag == live_id!(th) {
+            top == live_id!(td) || top == live_id!(th)
+        } else if tag == live_id!(tr) {
+            top == live_id!(td) || top == live_id!(th) || top == live_id!(tr)
+        } else {
+            false
+        }
+    }
+
     fn handle_close_tag(
         cx: &mut Cx2d,
         tf: &mut TextFlow,
-        node: &mut HtmlWalker,
+        close_lc: LiveId,
         list_stack: &mut Vec<ListLevel>,
     ) -> Option<LiveId> {
-        match node.close_tag_lc() {
+        // Takes the id rather than reading it off the walker, so the caller can
+        // also drive it for elements a document left open.
+        match Some(close_lc) {
             some_id!(h1)
             | some_id!(h2)
             | some_id!(h3)
@@ -726,14 +793,27 @@ impl Widget for Html {
         let mut node = self.doc.new_walker();
         self.details_stack.clear();
         self.summary_click_areas.clear();
+        // These describe the draw in progress; a previous draw that ended
+        // inside an unclosed element must not bleed into this one.
+        self.list_stack.clear();
+        self.open_elements.clear();
+        self.open_summaries = 0;
+        self.used_widget_ids.clear();
         while !node.done() {
             // Intercept <details> / <summary> open tags before the generic
             // handler, so <details> never falls through to handle_custom_widget
             // (which would jump_to_close and hide all content).
             if let Some(tag) = node.open_tag_lc() {
                 if tag == live_id!(details) {
-                    let details_id = if let Some(id_str) = node.find_attr_lc(live_id!(id)) {
-                        LiveId::from_str(id_str)
+                    let details_id = if let Some(id) = node
+                        .find_attr_lc(live_id!(id))
+                        .map(LiveId::from_str)
+                        .filter(|id| self.used_widget_ids.insert(*id))
+                    {
+                        // As for custom widgets: the first element to claim an
+                        // `id` keeps it, so two `<details>` sharing one id
+                        // don't share a single fold state.
+                        id
                     } else {
                         // Key by the node's stable doc index (a visit-order counter
                         // would renumber when a collapsed <details> hides nodes).
@@ -832,6 +912,7 @@ impl Widget for Html {
                     // click target in handle_event.
                     self.text_flow.areas_tracker.push_tracker();
                     self.text_flow.bold.push();
+                    self.open_summaries += 1;
                     node.walk();
                     continue;
                 }
@@ -840,6 +921,12 @@ impl Widget for Html {
             // Intercept </summary> and </details> close tags.
             if let Some(close_tag) = node.close_tag_lc() {
                 if close_tag == live_id!(summary) {
+                    // A `</summary>` with no `<summary>` has no tracker to pop.
+                    if self.open_summaries == 0 {
+                        node.walk();
+                        continue;
+                    }
+                    self.open_summaries -= 1;
                     self.text_flow.bold.pop();
                     let (start, end) = self.text_flow.areas_tracker.pop_tracker();
                     if let Some(dl) = self.details_stack.last() {
@@ -904,16 +991,37 @@ impl Widget for Html {
                     continue;
                 }
                 if close_tag == live_id!(details) {
-                    self.details_stack.pop();
-                    // Matching bottom margin (see `<details>` open handler).
-                    self.text_flow
-                        .new_line_collapsed_with_spacing(cx, self.details_margin_em());
+                    // Likewise, only balance a `<details>` this draw opened.
+                    if self.details_stack.pop().is_some() {
+                        // Matching bottom margin (see `<details>` open handler).
+                        self.text_flow
+                            .new_line_collapsed_with_spacing(cx, self.details_margin_em());
+                    }
                     node.walk();
                     continue;
                 }
             }
 
             // Regular tag/text handling for everything else.
+            // An open tag that a browser would treat as implicitly closing the
+            // element above it — `<li>a<li>b`, `<td>a<td>b` — closes it here
+            // too, so the turtles nest the way the document reads.
+            if let Some(open_lc) = node.open_tag_lc() {
+                while let Some(&top) = self.open_elements.last() {
+                    if !Self::implicitly_closed_by(open_lc, top) {
+                        break;
+                    }
+                    self.open_elements.pop();
+                    let _ = Self::handle_close_tag(
+                        cx,
+                        &mut self.text_flow,
+                        top,
+                        &mut self.list_stack,
+                    );
+                }
+            }
+
+            let open_lc = node.open_tag_lc();
             let tf = &mut self.text_flow;
             let mut trim = TrimWhitespaceInText::default();
             match Self::handle_open_tag(
@@ -924,17 +1032,50 @@ impl Widget for Html {
                 &self.ul_markers,
                 &self.ol_markers,
                 &self.ol_separator,
+                &mut self.table_columns_cache,
             ) {
                 (Some(_), _tws) => {
-                    handle_custom_widget(cx, scope, tf, &self.doc, &mut node);
+                    handle_custom_widget(
+                        cx,
+                        scope,
+                        tf,
+                        &self.doc,
+                        &mut node,
+                        &mut self.used_widget_ids,
+                    );
                 }
                 (None, tws) => {
                     trim = tws;
+                    if let Some(lc) = open_lc {
+                        if Self::element_is_tracked(lc) {
+                            self.open_elements.push(lc);
+                        }
+                    }
                 }
             }
-            let _ = Self::handle_close_tag(cx, tf, &mut node, &mut self.list_stack);
-            Self::handle_text_node(cx, tf, &mut node, trim);
+
+            // Run a close handler only for an element this draw actually
+            // opened, unwinding anything left open inside it.
+            if let Some(close_lc) = node.close_tag_lc() {
+                if let Some(depth) = self.open_elements.iter().rposition(|t| *t == close_lc) {
+                    while self.open_elements.len() > depth {
+                        let lc = self.open_elements.pop().unwrap_or(close_lc);
+                        let _ = Self::handle_close_tag(
+                            cx,
+                            &mut self.text_flow,
+                            lc,
+                            &mut self.list_stack,
+                        );
+                    }
+                }
+            }
+            Self::handle_text_node(cx, &mut self.text_flow, &mut node, trim);
             node.walk();
+        }
+        // Close anything the document left open, so `<ul><li>item` hands a
+        // balanced turtle stack back to `TextFlow::end`.
+        while let Some(lc) = self.open_elements.pop() {
+            let _ = Self::handle_close_tag(cx, &mut self.text_flow, lc, &mut self.list_stack);
         }
         self.text_flow.end(cx);
         DrawStep::done()
@@ -977,6 +1118,7 @@ fn handle_custom_widget(
     tf: &mut TextFlow,
     doc: &HtmlDoc,
     node: &mut HtmlWalker,
+    used_widget_ids: &mut HashSet<LiveId>,
 ) {
     // A custom widget draws straight into the turtle rather than through
     // `TextFlow::draw_text`, so it has to honour the line budget itself.
@@ -987,8 +1129,15 @@ fn handle_custom_widget(
         return;
     }
 
-    let id = if let Some(id) = node.find_attr_lc(live_id!(id)) {
-        LiveId::from_str(id)
+    let id = if let Some(id) = node.find_attr_lc(live_id!(id))
+        .map(LiveId::from_str)
+        .filter(|id| used_widget_ids.insert(*id))
+    {
+        // The `id` attribute keys the cached sub-widget, but a document may
+        // repeat it. The first element to claim an id keeps it; a later
+        // duplicate falls back to its node index, so two links can't end up
+        // sharing one widget — and with it one `href`.
+        id
     } else {
         // Key by the node's stable index in the parsed doc rather than a
         // visit-order counter: skip mode (a collapsed <details>) doesn't visit
@@ -1348,10 +1497,10 @@ impl OrderedListType {
         match self {
             OrderedListType::Numbers => to_number(),
             OrderedListType::UpperAlpha => {
-                format!("{}{separator}", ('A' as u8 + count as u8 - 1) as char)
+                format!("{}{separator}", alphabetic_marker(count, b'A'))
             }
             OrderedListType::LowerAlpha => {
-                format!("{}{separator}", ('a' as u8 + count as u8 - 1) as char)
+                format!("{}{separator}", alphabetic_marker(count, b'a'))
             }
             OrderedListType::UpperRoman => to_roman_numeral(count)
                 .map(|m| format!("{}{separator}", m))
@@ -1382,6 +1531,22 @@ impl OrderedListType {
 /// Returns `None` if the input is not between 1 and 3999 inclusive.
 ///
 /// This code was adapted from the [`roman` crate](https://crates.io/crates/roman).
+/// Numbers an alphabetic list item the way `list-style-type: lower-alpha`
+/// does: `a`..`z`, then `aa`, `ab`, and so on.
+///
+/// `count` comes from the `start` and `value` attributes, so it is
+/// attacker-controlled and must not be truncated into a byte.
+fn alphabetic_marker(count: i32, base: u8) -> String {
+    let mut remaining = count as i64;
+    let mut letters = Vec::new();
+    while remaining > 0 {
+        let digit = ((remaining - 1) % 26) as u8;
+        letters.push((base + digit) as char);
+        remaining = (remaining - 1) / 26;
+    }
+    letters.iter().rev().collect()
+}
+
 pub fn to_roman_numeral(mut count: i32) -> Option<String> {
     const MAX: i32 = 3999;
     static NUMERALS: &[(i32, &str)] = &[

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
 use crate::{
@@ -186,20 +187,6 @@ script_mod! {
     }
 }
 
-/// Whether to trim leading and trailing whitespace in the text body of an HTML tag.
-///
-/// Currently, *all* Unicode whitespace characters are trimmed, not just ASCII whitespace.
-///
-/// The default is to keep all whitespace.
-#[derive(Copy, Clone, PartialEq, Default)]
-pub enum TrimWhitespaceInText {
-    /// Leading and trailing whitespace will be preserved in the text.
-    #[default]
-    Keep,
-    /// Leading and trailing whitespace will be trimmed from the text.
-    Trim,
-}
-
 #[derive(Script, Widget)]
 pub struct Html {
     #[source]
@@ -246,11 +233,6 @@ pub struct Html {
     /// used to pop an empty stack.
     #[rust]
     open_summaries: usize,
-
-    /// Widget ids already claimed during this draw, so a repeated `id`
-    /// attribute cannot bind two elements to the same cached sub-widget.
-    #[rust]
-    used_widget_ids: HashSet<LiveId>,
 
     /// Column counts already computed for a `<table>` at a given node index.
     /// Counting scans forward to the first row, so a document that is
@@ -341,6 +323,74 @@ impl Html {
         }
     }
 
+    /// Ends the innermost open `<summary>`: pops the bold run and the glyph
+    /// tracker `<summary>` pushed, and lays the invisible click target over
+    /// the summary line. Returns whether the enclosing `<details>` is
+    /// collapsed, in which case the caller skips its body.
+    ///
+    /// Called for `</summary>`, and also for `</details>` and the end of the
+    /// document when the `<summary>` was never closed — otherwise its bold
+    /// and its tracker would leak into everything drawn after it.
+    fn close_summary(&mut self, cx: &mut Cx2d) -> bool {
+        self.open_summaries = self.open_summaries.saturating_sub(1);
+        if let Some(level) = self.details_stack.last_mut() {
+            level.summary_open = false;
+        }
+        self.text_flow.bold.pop();
+        let (start, end) = self.text_flow.areas_tracker.pop_tracker();
+        if let Some(dl) = self.details_stack.last() {
+            // Compute the bounding rect from the laid-out glyph
+            // rects so we know where to put the invisible hit
+            // target quad. We use `Area::rect` (raw) not
+            // `clipped_rect`, because the draw_clip on rect-areas
+            // isn't populated inside a nested turtle.
+            let mut bounds: Option<Rect> = None;
+            for a in &self.text_flow.areas_tracker.areas[start..end] {
+                let r = a.rect(cx);
+                if r.size.x > 0.0 && r.size.y > 0.0 {
+                    bounds = Some(match bounds {
+                        None => r,
+                        Some(b) => {
+                            let x0 = b.pos.x.min(r.pos.x);
+                            let y0 = b.pos.y.min(r.pos.y);
+                            let x1 = (b.pos.x + b.size.x).max(r.pos.x + r.size.x);
+                            let y1 = (b.pos.y + b.size.y).max(r.pos.y + r.size.y);
+                            Rect {
+                                pos: dvec2(x0, y0),
+                                size: dvec2(x1 - x0, y1 - y0),
+                            }
+                        }
+                    });
+                }
+            }
+            if let Some(b) = bounds {
+                // Emit an invisible DrawQuad covering the summary
+                // line. Its `Area::Instance` has valid rect_pos
+                // and rect_size in the shader instance data, so
+                // `event.hits` can hit-test it correctly — unlike
+                // the glyph-run rect-areas, which need the outer
+                // pass turtle to close before their draw_clip is
+                // populated.
+                //
+                // Seeding `draw_vars.area` from the cache lets
+                // `update_area_refs` (called inside `draw_abs`)
+                // carry hover/capture state from the previous
+                // frame to the fresh instance.
+                let prev_area = self
+                    .summary_area_cache
+                    .get(&dl.id)
+                    .copied()
+                    .unwrap_or(Area::Empty);
+                self.draw_summary_hit.draw_vars.area = prev_area;
+                self.draw_summary_hit.draw_abs(cx, b);
+                let new_area = self.draw_summary_hit.draw_vars.area;
+                self.summary_area_cache.insert(dl.id, new_area);
+                self.summary_click_areas.push((dl.id, new_area));
+            }
+        }
+        matches!(self.details_stack.last(), Some(dl) if !dl.is_open)
+    }
+
     /// Vertical spacing inserted before a `<details>` opens and after it
     /// closes, in pixels, scaled by the current font size. Keeps the block
     /// from butting up against surrounding content. A single helper so the
@@ -399,16 +449,8 @@ impl Html {
         ol_markers: &Vec<OrderedListType>,
         ol_separator: &str,
         table_columns_cache: &mut HashMap<usize, usize>,
-    ) -> (Option<LiveId>, TrimWhitespaceInText) {
-        let mut trim_whitespace_in_text = TrimWhitespaceInText::default();
-
-        fn open_header_tag(
-            cx: &mut Cx2d,
-            tf: &mut TextFlow,
-            scale: f64,
-            trim: &mut TrimWhitespaceInText,
-        ) {
-            *trim = TrimWhitespaceInText::Trim;
+    ) -> Option<LiveId> {
+        fn open_header_tag(cx: &mut Cx2d, tf: &mut TextFlow, scale: f64) {
             tf.bold.push();
             tf.push_size_abs_scale(scale);
             let fs = *tf.font_sizes.last().unwrap_or(&tf.font_size) as f64;
@@ -416,47 +458,38 @@ impl Html {
         }
 
         match node.open_tag_lc() {
-            some_id!(h1) => open_header_tag(cx, tf, 2.0, &mut trim_whitespace_in_text),
-            some_id!(h2) => open_header_tag(cx, tf, 1.5, &mut trim_whitespace_in_text),
-            some_id!(h3) => open_header_tag(cx, tf, 1.17, &mut trim_whitespace_in_text),
-            some_id!(h4) => open_header_tag(cx, tf, 1.0, &mut trim_whitespace_in_text),
-            some_id!(h5) => open_header_tag(cx, tf, 0.83, &mut trim_whitespace_in_text),
-            some_id!(h6) => open_header_tag(cx, tf, 0.67, &mut trim_whitespace_in_text),
+            some_id!(h1) => open_header_tag(cx, tf, 2.0),
+            some_id!(h2) => open_header_tag(cx, tf, 1.5),
+            some_id!(h3) => open_header_tag(cx, tf, 1.17),
+            some_id!(h4) => open_header_tag(cx, tf, 1.0),
+            some_id!(h5) => open_header_tag(cx, tf, 0.83),
+            some_id!(h6) => open_header_tag(cx, tf, 0.67),
 
             some_id!(p) => {
                 let fs = *tf.font_sizes.last().unwrap_or(&tf.font_size) as f64;
                 tf.new_line_collapsed_with_spacing(cx, fs * tf.paragraph_margin.top);
-                trim_whitespace_in_text = TrimWhitespaceInText::Trim;
             }
             some_id!(code) => {
                 tf.push_size_rel_scale(tf.fixed_font_size_scale);
-                tf.combine_spaces.push(false);
                 tf.fixed.push();
                 tf.inline_code.push();
             }
             some_id!(pre) => {
                 tf.new_line_collapsed(cx);
                 tf.fixed.push();
-                tf.ignore_newlines.push(false);
-                tf.combine_spaces.push(false);
                 tf.begin_code(cx);
             }
             some_id!(blockquote) => {
                 tf.new_line_collapsed(cx);
-                tf.ignore_newlines.push(false);
-                tf.combine_spaces.push(false);
                 tf.begin_quote(cx);
-                trim_whitespace_in_text = TrimWhitespaceInText::Trim;
             }
             some_id!(br) => {
                 tf.new_line_with_wrap_spacing(cx);
-                trim_whitespace_in_text = TrimWhitespaceInText::Trim;
             }
             some_id!(hr) | some_id!(sep) => {
                 tf.new_line_collapsed(cx);
                 tf.sep(cx);
                 tf.new_line_collapsed(cx);
-                trim_whitespace_in_text = TrimWhitespaceInText::Trim;
             }
             some_id!(u) => tf.underline.push(),
             some_id!(del) | some_id!(s) | some_id!(strike) => tf.strikethrough.push(),
@@ -481,7 +514,6 @@ impl Html {
                 tf.y_shift_scales.push(-0.2);
             }
             some_id!(ul) => {
-                trim_whitespace_in_text = TrimWhitespaceInText::Trim;
                 list_stack.push(ListLevel {
                     list_kind: ListKind::Unordered,
                     numbering_type: None,
@@ -490,7 +522,6 @@ impl Html {
                 });
             }
             some_id!(ol) => {
-                trim_whitespace_in_text = TrimWhitespaceInText::Trim;
                 let start_attr = node.find_attr_lc(live_id!(start));
                 let start: i32 = start_attr.and_then(|s| s.parse().ok()).unwrap_or(1);
 
@@ -505,15 +536,16 @@ impl Html {
                 });
             }
             some_id!(li) => {
-                trim_whitespace_in_text = TrimWhitespaceInText::Trim;
                 let indent_level = list_stack.len();
                 let index = indent_level.saturating_sub(1);
                 let marker_and_pad = list_stack.last_mut().map(|ll| {
-                    let marker = match ll.list_kind {
+                    // Borrowed for the common case: a fresh String per item
+                    // per draw was most of a list's draw cost.
+                    let marker: Cow<'_, str> = match ll.list_kind {
                         ListKind::Unordered => ul_markers
                             .get(index)
-                            .cloned()
-                            .unwrap_or_else(|| BULLET.into()),
+                            .map(|m| Cow::Borrowed(m.as_str()))
+                            .unwrap_or(Cow::Borrowed(BULLET)),
                         ListKind::Ordered => {
                             let value_attr = node.find_attr_lc(live_id!(value));
                             let value: i32 = value_attr
@@ -528,8 +560,8 @@ impl Html {
                                 .as_ref()
                                 .or_else(|| ll.numbering_type.as_ref())
                                 .or_else(|| ol_markers.get(index))
-                                .map(|ol_type| ol_type.marker(value, ol_separator))
-                                .unwrap_or_else(|| "#".into())
+                                .map(|ol_type| Cow::Owned(ol_type.marker(value, ol_separator)))
+                                .unwrap_or(Cow::Borrowed("#"))
                         }
                     };
                     ll.li_count = ll.li_count.saturating_add(1);
@@ -537,7 +569,7 @@ impl Html {
                 });
                 let (marker, pad) = marker_and_pad
                     .as_ref()
-                    .map(|(m, p)| (m.as_str(), *p))
+                    .map(|(m, p)| (m.as_ref(), *p))
                     .unwrap_or((BULLET, 2.5));
 
                 tf.new_line_collapsed(cx);
@@ -549,7 +581,6 @@ impl Html {
                     .entry(node.index)
                     .or_insert_with(|| Self::count_table_columns(node.nodes, node.index));
                 tf.begin_table(cx, col_count);
-                trim_whitespace_in_text = TrimWhitespaceInText::Trim;
             }
             some_id!(thead) => {
                 tf.in_table_header = true;
@@ -561,22 +592,19 @@ impl Html {
                 } else {
                     tf.begin_table_row(cx);
                 }
-                trim_whitespace_in_text = TrimWhitespaceInText::Trim;
             }
             some_id!(th) => {
                 tf.table_row_is_header = true;
                 tf.begin_table_cell(cx, cell_align_x(node));
                 tf.bold.push();
-                trim_whitespace_in_text = TrimWhitespaceInText::Trim;
             }
             some_id!(td) => {
                 tf.begin_table_cell(cx, cell_align_x(node));
-                trim_whitespace_in_text = TrimWhitespaceInText::Trim;
             }
-            Some(x) => return (Some(x), trim_whitespace_in_text),
+            Some(x) => return Some(x),
             _ => (),
         }
-        (None, trim_whitespace_in_text)
+        None
     }
 
     /// Drops one occurrence of `lc` from the open-element tally.
@@ -608,20 +636,81 @@ impl Html {
         TRACKED.contains(&lc)
     }
 
-    /// The elements a newly-opened `tag` implicitly closes when they are still
-    /// open, so that the shorthand real documents use — `<li>a<li>b`,
-    /// `<td>a<td>b`, `<p>a<p>b` — nests the way a browser reads it.
-    fn implicitly_closed_by(tag: LiveId, top: LiveId) -> bool {
+    /// Runs the close handler for everything above `depth` on the open stack,
+    /// innermost first, and drops it.
+    fn unwind_open_elements(&mut self, cx: &mut Cx2d, depth: usize) {
+        while self.open_elements.len() > depth {
+            let Some(lc) = self.open_elements.pop() else {
+                break;
+            };
+            Self::release_open_element(&mut self.open_element_counts, lc);
+            let _ = Self::handle_close_tag(cx, &mut self.text_flow, lc, &mut self.list_stack);
+        }
+    }
+
+    /// Closes the outermost open element in `targets` found before reaching
+    /// one in `scope`, and everything above it. With `top_only`, only the
+    /// innermost open element is considered.
+    fn close_implicitly(
+        &mut self,
+        cx: &mut Cx2d,
+        targets: &[LiveId],
+        scope: &[LiveId],
+        top_only: bool,
+    ) {
+        let mut close_to = None;
+        for (depth, open) in self.open_elements.iter().enumerate().rev() {
+            if targets.contains(open) {
+                close_to = Some(depth);
+            } else if scope.contains(open) {
+                break;
+            }
+            if top_only {
+                break;
+            }
+        }
+        if let Some(depth) = close_to {
+            self.unwind_open_elements(cx, depth);
+        }
+    }
+
+    /// What opening `tag` implicitly closes, following the tree builder's
+    /// rules: a heading closes a heading it directly follows, `<li>` closes
+    /// an open item up to the enclosing list, a cell closes an open cell up
+    /// to its row, a row closes an open row and its cells, and any block
+    /// element closes an open `<p>`. This is what makes the shorthand real
+    /// documents use — `<li>a<li>b`, `<td>a<td>b`, `<p>a<p>b` — nest the
+    /// way a browser reads it.
+    fn apply_implicit_closes(&mut self, cx: &mut Cx2d, tag: LiveId) {
+        const HEADINGS: &[LiveId] = &[
+            live_id!(h1), live_id!(h2), live_id!(h3),
+            live_id!(h4), live_id!(h5), live_id!(h6),
+        ];
+        const ITEM: &[LiveId] = &[live_id!(li)];
+        const LISTS: &[LiveId] = &[live_id!(ul), live_id!(ol)];
+        const CELLS: &[LiveId] = &[live_id!(td), live_id!(th)];
+        const ROW_SCOPE: &[LiveId] = &[live_id!(tr), live_id!(table)];
+        const ROW_AND_CELLS: &[LiveId] = &[live_id!(tr), live_id!(td), live_id!(th)];
+        const TABLE_SCOPE: &[LiveId] = &[live_id!(table), live_id!(thead), live_id!(tbody)];
+        const PARAGRAPH: &[LiveId] = &[live_id!(p)];
+        const BUTTON_SCOPE: &[LiveId] = &[live_id!(table), live_id!(td), live_id!(th)];
+        const CLOSES_PARAGRAPH: &[LiveId] = &[
+            live_id!(h1), live_id!(h2), live_id!(h3), live_id!(h4), live_id!(h5), live_id!(h6),
+            live_id!(p), live_id!(blockquote), live_id!(pre),
+            live_id!(ul), live_id!(ol), live_id!(li), live_id!(table),
+        ];
+        if HEADINGS.contains(&tag) {
+            self.close_implicitly(cx, HEADINGS, &[], true);
+        }
         if tag == live_id!(li) {
-            top == live_id!(li)
-        } else if tag == live_id!(p) {
-            top == live_id!(p)
-        } else if tag == live_id!(td) || tag == live_id!(th) {
-            top == live_id!(td) || top == live_id!(th)
+            self.close_implicitly(cx, ITEM, LISTS, false);
+        } else if CELLS.contains(&tag) {
+            self.close_implicitly(cx, CELLS, ROW_SCOPE, false);
         } else if tag == live_id!(tr) {
-            top == live_id!(td) || top == live_id!(th) || top == live_id!(tr)
-        } else {
-            false
+            self.close_implicitly(cx, ROW_AND_CELLS, TABLE_SCOPE, false);
+        }
+        if CLOSES_PARAGRAPH.contains(&tag) {
+            self.close_implicitly(cx, PARAGRAPH, BUTTON_SCOPE, false);
         }
     }
 
@@ -654,20 +743,15 @@ impl Html {
                 tf.new_line_collapsed_with_spacing(cx, fs * tf.paragraph_margin.bottom);
             }
             some_id!(blockquote) => {
-                tf.ignore_newlines.pop();
-                tf.combine_spaces.pop();
                 tf.end_quote(cx);
             }
             some_id!(code) => {
                 tf.inline_code.pop();
                 tf.font_sizes.pop();
-                tf.combine_spaces.pop();
                 tf.fixed.pop();
             }
             some_id!(pre) => {
                 tf.fixed.pop();
-                tf.ignore_newlines.pop();
-                tf.combine_spaces.pop();
                 tf.end_code(cx);
             }
             some_id!(sub) => {
@@ -702,18 +786,8 @@ impl Html {
         None
     }
 
-    pub fn handle_text_node(
-        cx: &mut Cx2d,
-        tf: &mut TextFlow,
-        node: &mut HtmlWalker,
-        trim: TrimWhitespaceInText,
-    ) -> bool {
+    pub fn handle_text_node(cx: &mut Cx2d, tf: &mut TextFlow, node: &mut HtmlWalker) -> bool {
         if let Some(text) = node.text() {
-            let text = if trim == TrimWhitespaceInText::Trim {
-                text.trim_matches(char::is_whitespace)
-            } else {
-                text
-            };
             if tf.table_num_columns > 0 && node.text_is_all_ws() {
                 return false;
             }
@@ -806,7 +880,11 @@ impl Widget for Html {
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         self.text_flow.begin(cx, walk);
-        let mut node = self.doc.new_walker();
+        // The walker borrows the document for the whole draw and the handlers
+        // below need `&mut self`, so the document lives in a local for the
+        // duration and goes back at the end.
+        let doc = std::mem::take(&mut self.doc);
+        let mut node = doc.new_walker();
         self.details_stack.clear();
         self.summary_click_areas.clear();
         // These describe the draw in progress; a previous draw that ended
@@ -815,7 +893,6 @@ impl Widget for Html {
         self.open_elements.clear();
         self.open_element_counts.clear();
         self.open_summaries = 0;
-        self.used_widget_ids.clear();
         self.table_columns_cache.clear();
         while !node.done() {
             // Intercept <details> / <summary> open tags before the generic
@@ -823,26 +900,19 @@ impl Widget for Html {
             // (which would jump_to_close and hide all content).
             if let Some(tag) = node.open_tag_lc() {
                 if tag == live_id!(details) {
-                    let details_id = if let Some(id) = node
-                        .find_attr_lc(live_id!(id))
-                        .map(LiveId::from_str)
-                        .filter(|id| self.used_widget_ids.insert(*id))
-                    {
-                        // As for custom widgets: the first element to claim an
-                        // `id` keeps it, so two `<details>` sharing one id
-                        // don't share a single fold state.
-                        id
-                    } else {
-                        // Key by the node's stable doc index (a visit-order counter
-                        // would renumber when a collapsed <details> hides nodes).
-                        // Offset into the high bits to avoid colliding with the
-                        // custom-widget ids (small ints) in the items map.
-                        LiveId(0xd37a_115_0000_0000u64.wrapping_add(node.index as u64))
-                    };
+                    // Key by the node's stable doc index (a visit-order counter
+                    // would renumber when a collapsed <details> hides nodes).
+                    // Offset into the high bits to avoid colliding with the
+                    // custom-widget ids (small ints) in the items map. The
+                    // `id` attribute is deliberately not used: a document that
+                    // repeats one would make two `<details>` share a fold state.
+                    let details_id =
+                        LiveId(0xd37a_115_0000_0000u64.wrapping_add(node.index as u64));
                     let initial_open = node.find_attr_lc(live_id!(open)).is_some();
                     self.details_stack.push(DetailsLevel {
                         id: details_id,
                         is_open: initial_open,
+                        summary_open: false,
                     });
                     // Small top margin so a `<details>` doesn't butt up
                     // against the preceding content. Scaled by the current
@@ -857,6 +927,7 @@ impl Widget for Html {
                     if let Some(&DetailsLevel {
                         id: details_id,
                         is_open: initial_open,
+                        ..
                     }) = self.details_stack.last()
                     {
                         let fb_ref = self.text_flow.item_with_scope(
@@ -931,6 +1002,9 @@ impl Widget for Html {
                     self.text_flow.areas_tracker.push_tracker();
                     self.text_flow.bold.push();
                     self.open_summaries += 1;
+                    if let Some(level) = self.details_stack.last_mut() {
+                        level.summary_open = true;
+                    }
                     node.walk();
                     continue;
                 }
@@ -944,64 +1018,7 @@ impl Widget for Html {
                         node.walk();
                         continue;
                     }
-                    self.open_summaries -= 1;
-                    self.text_flow.bold.pop();
-                    let (start, end) = self.text_flow.areas_tracker.pop_tracker();
-                    if let Some(dl) = self.details_stack.last() {
-                        // Compute the bounding rect from the laid-out glyph
-                        // rects so we know where to put the invisible hit
-                        // target quad. We use `Area::rect` (raw) not
-                        // `clipped_rect`, because the draw_clip on rect-areas
-                        // isn't populated inside a nested turtle.
-                        let mut bounds: Option<Rect> = None;
-                        for a in &self.text_flow.areas_tracker.areas[start..end] {
-                            let r = a.rect(cx);
-                            if r.size.x > 0.0 && r.size.y > 0.0 {
-                                bounds = Some(match bounds {
-                                    None => r,
-                                    Some(b) => {
-                                        let x0 = b.pos.x.min(r.pos.x);
-                                        let y0 = b.pos.y.min(r.pos.y);
-                                        let x1 = (b.pos.x + b.size.x).max(r.pos.x + r.size.x);
-                                        let y1 = (b.pos.y + b.size.y).max(r.pos.y + r.size.y);
-                                        Rect {
-                                            pos: dvec2(x0, y0),
-                                            size: dvec2(x1 - x0, y1 - y0),
-                                        }
-                                    }
-                                });
-                            }
-                        }
-                        if let Some(b) = bounds {
-                            // Emit an invisible DrawQuad covering the summary
-                            // line. Its `Area::Instance` has valid rect_pos
-                            // and rect_size in the shader instance data, so
-                            // `event.hits` can hit-test it correctly — unlike
-                            // the glyph-run rect-areas, which need the outer
-                            // pass turtle to close before their draw_clip is
-                            // populated.
-                            //
-                            // Seeding `draw_vars.area` from the cache lets
-                            // `update_area_refs` (called inside `draw_abs`)
-                            // carry hover/capture state from the previous
-                            // frame to the fresh instance.
-                            let prev_area = self
-                                .summary_area_cache
-                                .get(&dl.id)
-                                .copied()
-                                .unwrap_or(Area::Empty);
-                            self.draw_summary_hit.draw_vars.area = prev_area;
-                            self.draw_summary_hit.draw_abs(cx, b);
-                            let new_area = self.draw_summary_hit.draw_vars.area;
-                            self.summary_area_cache.insert(dl.id, new_area);
-                            self.summary_click_areas.push((dl.id, new_area));
-                        }
-                    }
-                    // Only skip the body when there is an enclosing
-                    // `<details>` that is collapsed. A stray `<summary>` with
-                    // no parent `<details>` must not skip to the end of the
-                    // document, which is what `map_or(true, ...)` would do.
-                    if matches!(self.details_stack.last(), Some(dl) if !dl.is_open) {
+                    if self.close_summary(cx) {
                         Self::skip_details_body(&mut node);
                         continue;
                     }
@@ -1009,6 +1026,10 @@ impl Widget for Html {
                     continue;
                 }
                 if close_tag == live_id!(details) {
+                    // A `<summary>` still open inside this element ends here.
+                    if matches!(self.details_stack.last(), Some(level) if level.summary_open) {
+                        self.close_summary(cx);
+                    }
                     // Likewise, only balance a `<details>` this draw opened.
                     if self.details_stack.pop().is_some() {
                         // Matching bottom margin (see `<details>` open handler).
@@ -1021,28 +1042,12 @@ impl Widget for Html {
             }
 
             // Regular tag/text handling for everything else.
-            // An open tag that a browser would treat as implicitly closing the
-            // element above it — `<li>a<li>b`, `<td>a<td>b` — closes it here
-            // too, so the turtles nest the way the document reads.
-            if let Some(open_lc) = node.open_tag_lc() {
-                while let Some(&top) = self.open_elements.last() {
-                    if !Self::implicitly_closed_by(open_lc, top) {
-                        break;
-                    }
-                    self.open_elements.pop();
-                    Self::release_open_element(&mut self.open_element_counts, top);
-                    let _ = Self::handle_close_tag(
-                        cx,
-                        &mut self.text_flow,
-                        top,
-                        &mut self.list_stack,
-                    );
-                }
+            let open_lc = node.open_tag_lc();
+            if let Some(open_lc) = open_lc {
+                self.apply_implicit_closes(cx, open_lc);
             }
 
-            let open_lc = node.open_tag_lc();
             let tf = &mut self.text_flow;
-            let mut trim = TrimWhitespaceInText::default();
             match Self::handle_open_tag(
                 cx,
                 tf,
@@ -1053,18 +1058,10 @@ impl Widget for Html {
                 &self.ol_separator,
                 &mut self.table_columns_cache,
             ) {
-                (Some(_), _tws) => {
-                    handle_custom_widget(
-                        cx,
-                        scope,
-                        tf,
-                        &self.doc,
-                        &mut node,
-                        &mut self.used_widget_ids,
-                    );
+                Some(_) => {
+                    handle_custom_widget(cx, scope, tf, &doc, &mut node);
                 }
-                (None, tws) => {
-                    trim = tws;
+                None => {
                     if let Some(lc) = open_lc {
                         if Self::element_is_tracked(lc) {
                             self.open_elements.push(lc);
@@ -1083,28 +1080,21 @@ impl Widget for Html {
                         .iter()
                         .rposition(|t| *t == close_lc)
                         .unwrap_or(0);
-                    while self.open_elements.len() > depth {
-                        let lc = self.open_elements.pop().unwrap_or(close_lc);
-                        Self::release_open_element(&mut self.open_element_counts, lc);
-                        let _ = Self::handle_close_tag(
-                            cx,
-                            &mut self.text_flow,
-                            lc,
-                            &mut self.list_stack,
-                        );
-                    }
+                    self.unwind_open_elements(cx, depth);
                 }
             }
-            Self::handle_text_node(cx, &mut self.text_flow, &mut node, trim);
+            Self::handle_text_node(cx, &mut self.text_flow, &mut node);
             node.walk();
         }
         // Close anything the document left open, so `<ul><li>item` hands a
-        // balanced turtle stack back to `TextFlow::end`.
-        while let Some(lc) = self.open_elements.pop() {
-            Self::release_open_element(&mut self.open_element_counts, lc);
-            let _ = Self::handle_close_tag(cx, &mut self.text_flow, lc, &mut self.list_stack);
+        // balanced turtle stack back to `TextFlow::end`, and a `<summary>`
+        // that never closed doesn't leave its bold run and tracker behind.
+        self.unwind_open_elements(cx, 0);
+        while self.open_summaries > 0 {
+            self.close_summary(cx);
         }
         self.text_flow.end(cx);
+        self.doc = doc;
         DrawStep::done()
     }
 
@@ -1145,7 +1135,6 @@ fn handle_custom_widget(
     tf: &mut TextFlow,
     doc: &HtmlDoc,
     node: &mut HtmlWalker,
-    used_widget_ids: &mut HashSet<LiveId>,
 ) {
     // A custom widget draws straight into the turtle rather than through
     // `TextFlow::draw_text`, so it has to honour the line budget itself.
@@ -1155,40 +1144,31 @@ fn handle_custom_widget(
         node.jump_to_close();
         return;
     }
-
-    let id = if let Some(id) = node.find_attr_lc(live_id!(id))
-        .map(LiveId::from_str)
-        .filter(|id| used_widget_ids.insert(*id))
-    {
-        // The `id` attribute keys the cached sub-widget, but a document may
-        // repeat it. The first element to claim an id keeps it; a later
-        // duplicate falls back to its node index, so two links can't end up
-        // sharing one widget — and with it one `href`.
-        id
-    } else {
-        // Key by the node's stable index in the parsed doc rather than a
-        // visit-order counter: skip mode (a collapsed <details>) doesn't visit
-        // hidden nodes, so a counter would renumber every widget after the
-        // details on toggle, rebinding links and spans to the wrong nodes.
-        LiveId(node.index as u64)
+    let Some(template) = node.open_tag_nc() else {
+        return;
     };
 
-    let template = node.open_tag_nc().unwrap();
+    // Key by the node's stable index in the parsed doc rather than a
+    // visit-order counter: skip mode (a collapsed <details>) doesn't visit
+    // hidden nodes, so a counter would renumber every widget after the
+    // details on toggle, rebinding links and spans to the wrong nodes. The
+    // `id` attribute is deliberately not used: a document that repeats one
+    // would bind two elements to a single cached widget — and one `href`.
     let open_index = node.index;
+    let id = LiveId(open_index as u64);
     let mut scope_with_attrs = Scope::with_props_index(doc, open_index);
 
-    // Find the element's extent first. One with no close tag of its own is
-    // void, so it has no text: reading ahead would pick up the *following*
-    // sibling's text, which the main loop then draws again.
-    node.jump_to_close();
-    let text = if node.index() == open_index {
-        ""
-    } else {
-        doc.new_walker_with_index(open_index).find_text().unwrap_or("")
+    // The label is every text run inside the element. One with no close tag
+    // of its own is void and has none: reading ahead would pick up the
+    // *following* sibling's text, which the main loop then draws again.
+    let label = match node.close_index() {
+        Some(close) => element_text(doc, open_index, close),
+        None => Cow::Borrowed(""),
     };
+    node.jump_to_close();
 
     if let Some(item) = tf.item_with_scope(cx, &mut scope_with_attrs, id, template) {
-        item.set_text(cx, text);
+        item.set_text(cx, &label);
         // A widget is walked atomically, so on the last allowed line it has to
         // be kept there rather than relocated onto a row the budget cannot pay
         // for; when it overruns that line it is cut at the edge with an
@@ -1199,6 +1179,28 @@ fn handle_custom_widget(
         item.draw_all(cx, &mut draw_scope);
         tf.end_inline_content(cx, hold);
     }
+}
+
+/// The text between the open tag at `open` and its close tag at `close`:
+/// borrowed when it is a single run, joined otherwise, so
+/// `<a href="x"><b>Click</b> me</a>` labels its link "Click me" rather than
+/// stopping at the first child.
+fn element_text(doc: &HtmlDoc, open: usize, close: usize) -> Cow<'_, str> {
+    let mut runs = doc.nodes[open..close].iter().filter_map(|n| match n {
+        HtmlNode::Text { start, end, .. } if start != end => Some(&doc.decoded[*start..*end]),
+        _ => None,
+    });
+    let Some(first) = runs.next() else {
+        return Cow::Borrowed("");
+    };
+    let Some(second) = runs.next() else {
+        return Cow::Borrowed(first);
+    };
+    let mut joined = String::with_capacity(first.len() + second.len());
+    joined.push_str(first);
+    joined.push_str(second);
+    joined.extend(runs);
+    Cow::Owned(joined)
 }
 
 #[derive(Clone, Debug, Default)]
@@ -1299,7 +1301,8 @@ impl Widget for HtmlLink {
 
         self.widget_match_event(cx, event, scope);
 
-        for area in self.drawn_areas.clone().into_iter() {
+        for i in 0..self.drawn_areas.len() {
+            let area = self.drawn_areas[i];
             match event.hits(cx, area) {
                 Hit::FingerDown(fe) => {
                     if fe.is_primary_hit() {
@@ -1470,6 +1473,9 @@ struct DetailsLevel {
     /// Controls whether the body content between `</summary>` and
     /// `</details>` is drawn or skipped.
     is_open: bool,
+    /// Whether a `<summary>` opened inside this element is still open, so
+    /// `</details>` (or the end of the document) can close it.
+    summary_open: bool,
 }
 
 /// The format and metadata of a list at a given nesting level.

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -237,12 +237,6 @@ pub struct Html {
     #[rust]
     seen_details: HashSet<LiveId>,
 
-    /// When `Some`, the draw walk is skipping nodes because the enclosing
-    /// `<details>` is collapsed. The inner counter tracks the nested open-tag
-    /// depth while skipping, so the matching `</details>` can be recognized.
-    #[rust]
-    skip_details_depth: Option<i32>,
-
     /// Transparent DrawQuad emitted over each `<summary>` so the whole summary
     /// line is clickable, not just the fold triangle. The quad's default
     /// shader produces `#0000`, so it's invisible but its instance area
@@ -296,6 +290,25 @@ impl ScriptHook for Html {
 }
 
 impl Html {
+    /// Advance from `</summary>` to the enclosing `</details>`, leaving the
+    /// close tag for the normal handler. Only nested details affect depth:
+    /// void elements such as `<br>` have no matching close tag.
+    fn skip_details_body(node: &mut HtmlWalker<'_>) {
+        let mut depth = 0;
+        node.walk();
+        while !node.done() {
+            if node.open_tag_lc() == Some(live_id!(details)) {
+                depth += 1;
+            } else if node.close_tag_lc() == Some(live_id!(details)) {
+                if depth == 0 {
+                    return;
+                }
+                depth -= 1;
+            }
+            node.walk();
+        }
+    }
+
     /// Vertical spacing inserted before a `<details>` opens and after it
     /// closes, in pixels, scaled by the current font size. Keeps the block
     /// from butting up against surrounding content. A single helper so the
@@ -712,34 +725,8 @@ impl Widget for Html {
         self.text_flow.begin(cx, walk);
         let mut node = self.doc.new_walker();
         self.details_stack.clear();
-        self.skip_details_depth = None;
         self.summary_click_areas.clear();
         while !node.done() {
-            // If the enclosing <details> is collapsed, fast-skip nodes until
-            // the matching </details> close tag at depth 0.
-            if let Some(depth) = self.skip_details_depth.as_mut() {
-                if node.open_tag_lc().is_some() {
-                    *depth += 1;
-                    node.walk();
-                    continue;
-                } else if let Some(close_tag) = node.close_tag_lc() {
-                    if *depth == 0 && close_tag == live_id!(details) {
-                        // Reached the matching </details>; leave skip mode and
-                        // fall through so the close handler runs normally.
-                        self.skip_details_depth = None;
-                    } else {
-                        if *depth > 0 {
-                            *depth -= 1;
-                        }
-                        node.walk();
-                        continue;
-                    }
-                } else {
-                    node.walk();
-                    continue;
-                }
-            }
-
             // Intercept <details> / <summary> open tags before the generic
             // handler, so <details> never falls through to handle_custom_widget
             // (which would jump_to_close and hide all content).
@@ -905,12 +892,13 @@ impl Widget for Html {
                             self.summary_click_areas.push((dl.id, new_area));
                         }
                     }
-                    // Only enter skip mode when there is an enclosing
+                    // Only skip the body when there is an enclosing
                     // `<details>` that is collapsed. A stray `<summary>` with
                     // no parent `<details>` must not skip to the end of the
                     // document, which is what `map_or(true, ...)` would do.
                     if matches!(self.details_stack.last(), Some(dl) if !dl.is_open) {
-                        self.skip_details_depth = Some(0);
+                        Self::skip_details_body(&mut node);
+                        continue;
                     }
                     node.walk();
                     continue;
@@ -1461,5 +1449,85 @@ fn align_keyword_to_x(keyword: &str) -> Option<f64> {
         "center" => Some(0.5),
         "right" | "end" => Some(1.0),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary_close(doc: &HtmlDoc) -> HtmlWalker<'_> {
+        let mut node = doc.new_walker();
+        while !node.done() && node.close_tag_lc() != Some(live_id!(summary)) {
+            node.walk();
+        }
+        assert!(!node.done(), "fixture must contain a closing summary tag");
+        node
+    }
+
+    #[test]
+    fn collapsed_details_with_breaks_preserves_table_closures() {
+        let doc = parse_html(
+            "<table><tr><td><details><summary>View Bio</summary>\
+             <br>Hidden biography<br><br><a href='profile'>Profile</a></details>\
+             </td><td>Next cell</td></tr><tr><td>Next row</td></tr></table>\
+             <p>After table</p>",
+            &mut None,
+            InternLiveId::No,
+        );
+        let mut node = summary_close(&doc);
+        Html::skip_details_body(&mut node);
+        assert_eq!(node.close_tag_lc(), Some(live_id!(details)));
+
+        let remaining_closures: Vec<_> = node.nodes[node.index..].iter().filter_map(|node| {
+            match node {
+                HtmlNode::CloseTag { lc, .. } => Some(*lc),
+                _ => None,
+            }
+        }).collect();
+        assert_eq!(remaining_closures, vec![
+            live_id!(details), live_id!(td), live_id!(td), live_id!(tr),
+            live_id!(td), live_id!(tr), live_id!(table), live_id!(p),
+        ]);
+        let mut remaining_text = String::new();
+        while !node.done() {
+            if let Some(text) = node.text() {
+                remaining_text.push_str(text);
+            }
+            node.walk();
+        }
+        assert_eq!(remaining_text, "Next cellNext rowAfter table");
+    }
+
+    #[test]
+    fn collapsed_details_skips_nested_details_and_void_elements() {
+        let doc = parse_html(
+            "<details><summary>Outer</summary><br>\
+             <details open><summary>Inner</summary><BR class='space'>\
+             <b>Hidden</b></details>\
+             <DETAILS><summary>Second</summary><img src='picture'><br /></DETAILS>\
+             <hr>Outer hidden</details><p>After details</p>",
+            &mut None,
+            InternLiveId::No,
+        );
+        let outer_close = doc.nodes.iter().rposition(|node| {
+            matches!(node, HtmlNode::CloseTag { lc, .. } if *lc == live_id!(details))
+        }).unwrap();
+        let mut node = summary_close(&doc);
+        Html::skip_details_body(&mut node);
+        assert_eq!(node.index, outer_close);
+        assert_eq!(node.find_tag_text(live_id!(p)), Some("After details"));
+    }
+
+    #[test]
+    fn collapsed_details_without_close_stops_at_document_end() {
+        let doc = parse_html(
+            "<details><summary>Outer</summary><br>Hidden<details>Inner</details>",
+            &mut None,
+            InternLiveId::No,
+        );
+        let mut node = summary_close(&doc);
+        Html::skip_details_body(&mut node);
+        assert!(node.done());
     }
 }

--- a/widgets/src/html.rs
+++ b/widgets/src/html.rs
@@ -228,11 +228,13 @@ pub struct Html {
     #[rust]
     open_element_counts: HashMap<LiveId, u32>,
 
-    /// How many `<summary>` elements are open. `</summary>` pops a tracker
-    /// that `<summary>` pushed, so a message containing only the close tag
-    /// used to pop an empty stack.
+    /// The `<summary>` elements currently open, innermost last. `</summary>`
+    /// pops a tracker that `<summary>` pushed, so a message containing only
+    /// the close tag used to pop an empty stack; and each is tied to the
+    /// `<details>` that owns it, so a `<details>` opened inside a summary
+    /// cannot be mistaken for the owner.
     #[rust]
-    open_summaries: usize,
+    open_summaries: Vec<OpenSummary>,
 
     /// Column counts already computed for a `<table>` at a given node index.
     /// Counting scans forward to the first row, so a document that is
@@ -304,23 +306,18 @@ impl ScriptHook for Html {
 }
 
 impl Html {
-    /// Advance from `</summary>` to the enclosing `</details>`, leaving the
-    /// close tag for the normal handler. Only nested details affect depth:
-    /// void elements such as `<br>` have no matching close tag.
-    fn skip_details_body(node: &mut HtmlWalker<'_>) {
-        let mut depth = 0;
-        node.walk();
-        while !node.done() {
-            if node.open_tag_lc() == Some(live_id!(details)) {
-                depth += 1;
-            } else if node.close_tag_lc() == Some(live_id!(details)) {
-                if depth == 0 {
-                    return;
-                }
-                depth -= 1;
-            }
-            node.walk();
-        }
+    /// Moves from inside a collapsed `<details>` to where its body ends: its
+    /// own `</details>` when it has one, otherwise the close tag of the
+    /// enclosing element that ended it, or the end of the document. The
+    /// parser resolved that end, so no scan is needed — a scan that counted
+    /// every tag got void elements wrong, and one that matched only
+    /// `details` got a `<details>` ended by an ancestor wrong.
+    fn skip_details_body(node: &mut HtmlWalker<'_>, details_open: usize) {
+        let at = node.at(details_open);
+        node.index = at
+            .close_index()
+            .or(at.end_index())
+            .unwrap_or(node.nodes.len());
     }
 
     /// Ends the innermost open `<summary>`: pops the bold run and the glyph
@@ -331,14 +328,10 @@ impl Html {
     /// Called for `</summary>`, and also for `</details>` and the end of the
     /// document when the `<summary>` was never closed — otherwise its bold
     /// and its tracker would leak into everything drawn after it.
-    fn close_summary(&mut self, cx: &mut Cx2d) -> bool {
-        self.open_summaries = self.open_summaries.saturating_sub(1);
-        if let Some(level) = self.details_stack.last_mut() {
-            level.summary_open = false;
-        }
+    fn close_summary(&mut self, cx: &mut Cx2d, owner: Option<usize>) -> bool {
         self.text_flow.bold.pop();
         let (start, end) = self.text_flow.areas_tracker.pop_tracker();
-        if let Some(dl) = self.details_stack.last() {
+        if let Some(dl) = owner.and_then(|i| self.details_stack.get(i)) {
             // Compute the bounding rect from the laid-out glyph
             // rects so we know where to put the invisible hit
             // target quad. We use `Area::rect` (raw) not
@@ -388,7 +381,42 @@ impl Html {
                 self.summary_click_areas.push((dl.id, new_area));
             }
         }
-        matches!(self.details_stack.last(), Some(dl) if !dl.is_open)
+        owner
+            .and_then(|i| self.details_stack.get(i))
+            .is_some_and(|dl| !dl.is_open)
+    }
+
+    /// Ends the innermost open `<details>`: anything still open inside it —
+    /// elements, and a `<summary>` that never closed — ends first.
+    fn pop_details_level(&mut self, cx: &mut Cx2d) {
+        let Some(level) = self.details_stack.last() else {
+            return;
+        };
+        let (depth, index) = (level.open_depth, self.details_stack.len() - 1);
+        self.unwind_open_elements(cx, depth);
+        while self.open_summaries.last().is_some_and(|s| s.owner == Some(index)) {
+            let summary = self.open_summaries.pop();
+            self.close_summary(cx, summary.and_then(|s| s.owner));
+        }
+        self.details_stack.pop();
+        // Matching bottom margin (see `<details>` open handler).
+        self.text_flow
+            .new_line_collapsed_with_spacing(cx, self.details_margin_em());
+    }
+
+    /// After a collapsed `<details>`'s summary closes: the index to resume at
+    /// so its body is not drawn. That is its own `</details>` when it has
+    /// one, so that handler still runs; otherwise the element was ended by
+    /// an enclosing element, its level is closed here, and drawing resumes
+    /// at that enclosing close tag.
+    fn skip_collapsed_body(&mut self, cx: &mut Cx2d, node: &HtmlWalker) -> Option<usize> {
+        let open_index = self.details_stack.last()?.open_index;
+        let mut probe = node.at(open_index);
+        Self::skip_details_body(&mut probe, open_index);
+        if node.at(open_index).close_index().is_none() {
+            self.pop_details_level(cx);
+        }
+        Some(probe.index)
     }
 
     /// Vertical spacing inserted before a `<details>` opens and after it
@@ -404,38 +432,49 @@ impl Html {
         fs * 0.22
     }
 
-    fn count_table_columns(nodes: &[HtmlNode], start_index: usize) -> usize {
+    /// Number of cells in a table's first row, which sizes its columns. The
+    /// first row ends at `</tr>`, at the next `<tr>`, or where the table
+    /// ends — a row written without `</tr>` used to have the second row's
+    /// cells counted too, halving every column. A nested table, and each
+    /// cell's own content, is stepped over whole.
+    fn count_table_columns(node: &HtmlWalker) -> usize {
+        let end = node
+            .close_index()
+            .or(node.end_index())
+            .unwrap_or(node.nodes.len());
         let mut count = 0;
-        let mut in_first_row = false;
-        let mut depth = 0;
-        for node in &nodes[start_index + 1..] {
-            match node {
+        let mut in_row = false;
+        let mut i = node.index + 1;
+        while i < end {
+            match &node.nodes[i] {
                 HtmlNode::OpenTag { lc, .. } => {
+                    let at = node.at(i);
                     if *lc == live_id!(table) {
-                        depth += 1;
-                    } else if depth == 0 && *lc == live_id!(tr) && !in_first_row {
-                        in_first_row = true;
-                    } else if depth == 0
-                        && in_first_row
-                        && (*lc == live_id!(td) || *lc == live_id!(th))
-                    {
+                        i = at.end_index().unwrap_or(i + 1);
+                        continue;
+                    }
+                    if *lc == live_id!(tr) {
+                        if in_row {
+                            break;
+                        }
+                        in_row = true;
+                    } else if *lc == live_id!(td) || *lc == live_id!(th) {
+                        in_row = true;
                         count += 1;
+                        i = at.end_index().unwrap_or(i + 1);
+                        continue;
                     }
                 }
                 HtmlNode::CloseTag { lc, .. } => {
-                    if *lc == live_id!(table) {
-                        if depth > 0 {
-                            depth -= 1;
-                        } else {
-                            return count;
-                        }
-                    }
-                    if depth == 0 && *lc == live_id!(tr) && in_first_row {
-                        return count;
+                    if in_row
+                        && (*lc == live_id!(tr) || *lc == live_id!(thead) || *lc == live_id!(tbody))
+                    {
+                        break;
                     }
                 }
                 _ => {}
             }
+            i += 1;
         }
         count
     }
@@ -579,7 +618,7 @@ impl Html {
                 tf.new_line_collapsed(cx);
                 let col_count = *table_columns_cache
                     .entry(node.index)
-                    .or_insert_with(|| Self::count_table_columns(node.nodes, node.index));
+                    .or_insert_with(|| Self::count_table_columns(node));
                 tf.begin_table(cx, col_count);
             }
             some_id!(thead) => {
@@ -699,6 +738,11 @@ impl Html {
             live_id!(p), live_id!(blockquote), live_id!(pre),
             live_id!(ul), live_id!(ol), live_id!(li), live_id!(table),
         ];
+        // The tree builder closes a `<p>` in button scope first, and only
+        // then pops a heading that is the current node.
+        if CLOSES_PARAGRAPH.contains(&tag) {
+            self.close_implicitly(cx, PARAGRAPH, BUTTON_SCOPE, false);
+        }
         if HEADINGS.contains(&tag) {
             self.close_implicitly(cx, HEADINGS, &[], true);
         }
@@ -708,9 +752,6 @@ impl Html {
             self.close_implicitly(cx, CELLS, ROW_SCOPE, false);
         } else if tag == live_id!(tr) {
             self.close_implicitly(cx, ROW_AND_CELLS, TABLE_SCOPE, false);
-        }
-        if CLOSES_PARAGRAPH.contains(&tag) {
-            self.close_implicitly(cx, PARAGRAPH, BUTTON_SCOPE, false);
         }
     }
 
@@ -892,7 +933,7 @@ impl Widget for Html {
         self.list_stack.clear();
         self.open_elements.clear();
         self.open_element_counts.clear();
-        self.open_summaries = 0;
+        self.open_summaries.clear();
         self.table_columns_cache.clear();
         while !node.done() {
             // Intercept <details> / <summary> open tags before the generic
@@ -912,7 +953,8 @@ impl Widget for Html {
                     self.details_stack.push(DetailsLevel {
                         id: details_id,
                         is_open: initial_open,
-                        summary_open: false,
+                        open_index: node.index,
+                        open_depth: self.open_elements.len(),
                     });
                     // Small top margin so a `<details>` doesn't butt up
                     // against the preceding content. Scaled by the current
@@ -1001,10 +1043,10 @@ impl Widget for Html {
                     // click target in handle_event.
                     self.text_flow.areas_tracker.push_tracker();
                     self.text_flow.bold.push();
-                    self.open_summaries += 1;
-                    if let Some(level) = self.details_stack.last_mut() {
-                        level.summary_open = true;
-                    }
+                    self.open_summaries.push(OpenSummary {
+                        owner: self.details_stack.len().checked_sub(1),
+                        depth: self.open_elements.len(),
+                    });
                     node.walk();
                     continue;
                 }
@@ -1014,27 +1056,31 @@ impl Widget for Html {
             if let Some(close_tag) = node.close_tag_lc() {
                 if close_tag == live_id!(summary) {
                     // A `</summary>` with no `<summary>` has no tracker to pop.
-                    if self.open_summaries == 0 {
+                    let Some(summary) = self.open_summaries.pop() else {
                         node.walk();
                         continue;
+                    };
+                    // Anything opened inside the summary ends with it — an
+                    // `<li>` or a table cell, and any `<details>` nested in it.
+                    self.unwind_open_elements(cx, summary.depth);
+                    if let Some(owner) = summary.owner {
+                        while self.details_stack.len() > owner + 1 {
+                            self.pop_details_level(cx);
+                        }
                     }
-                    if self.close_summary(cx) {
-                        Self::skip_details_body(&mut node);
-                        continue;
+                    if self.close_summary(cx, summary.owner) {
+                        if let Some(resume) = self.skip_collapsed_body(cx, &node) {
+                            node.index = resume;
+                            continue;
+                        }
                     }
                     node.walk();
                     continue;
                 }
                 if close_tag == live_id!(details) {
-                    // A `<summary>` still open inside this element ends here.
-                    if matches!(self.details_stack.last(), Some(level) if level.summary_open) {
-                        self.close_summary(cx);
-                    }
-                    // Likewise, only balance a `<details>` this draw opened.
-                    if self.details_stack.pop().is_some() {
-                        // Matching bottom margin (see `<details>` open handler).
-                        self.text_flow
-                            .new_line_collapsed_with_spacing(cx, self.details_margin_em());
+                    // Only balance a `<details>` this draw opened.
+                    if !self.details_stack.is_empty() {
+                        self.pop_details_level(cx);
                     }
                     node.walk();
                     continue;
@@ -1059,7 +1105,8 @@ impl Widget for Html {
                 &mut self.table_columns_cache,
             ) {
                 Some(_) => {
-                    handle_custom_widget(cx, scope, tf, &doc, &mut node);
+                    node.index = handle_custom_widget(cx, scope, tf, &doc, &mut node);
+                    continue;
                 }
                 None => {
                     if let Some(lc) = open_lc {
@@ -1090,9 +1137,10 @@ impl Widget for Html {
         // balanced turtle stack back to `TextFlow::end`, and a `<summary>`
         // that never closed doesn't leave its bold run and tracker behind.
         self.unwind_open_elements(cx, 0);
-        while self.open_summaries > 0 {
-            self.close_summary(cx);
+        while let Some(summary) = self.open_summaries.pop() {
+            self.close_summary(cx, summary.owner);
         }
+        self.details_stack.clear();
         self.text_flow.end(cx);
         self.doc = doc;
         DrawStep::done()
@@ -1129,23 +1177,30 @@ impl Widget for Html {
     }
 }
 
+/// Draws the sub-widget for the custom element the walker is on, and returns
+/// the node index at which the caller should resume: past the element's own
+/// close tag, or at the enclosing close tag that ended it, or past a void
+/// element's attributes. The element's content is the widget's, so the
+/// caller must not walk into it.
 fn handle_custom_widget(
     cx: &mut Cx2d,
     _scope: &mut Scope,
     tf: &mut TextFlow,
     doc: &HtmlDoc,
     node: &mut HtmlWalker,
-) {
+) -> usize {
+    let open_index = node.index;
+    let resume = node.end_index().unwrap_or(open_index + 1);
+    let content_end = node.close_index().unwrap_or(resume);
+
     // A custom widget draws straight into the turtle rather than through
-    // `TextFlow::draw_text`, so it has to honour the line budget itself.
-    // `jump_to_close` keeps the parser from spilling the widget's inner text
-    // into the flow as loose text once the widget itself is skipped.
+    // `TextFlow::draw_text`, so it has to honour the line budget itself; once
+    // the widget is skipped, its inner text must not spill into the flow.
     if tf.is_content_truncated() {
-        node.jump_to_close();
-        return;
+        return resume;
     }
     let Some(template) = node.open_tag_nc() else {
-        return;
+        return resume;
     };
 
     // Key by the node's stable index in the parsed doc rather than a
@@ -1154,18 +1209,13 @@ fn handle_custom_widget(
     // details on toggle, rebinding links and spans to the wrong nodes. The
     // `id` attribute is deliberately not used: a document that repeats one
     // would bind two elements to a single cached widget — and one `href`.
-    let open_index = node.index;
     let id = LiveId(open_index as u64);
     let mut scope_with_attrs = Scope::with_props_index(doc, open_index);
 
-    // The label is every text run inside the element. One with no close tag
-    // of its own is void and has none: reading ahead would pick up the
-    // *following* sibling's text, which the main loop then draws again.
-    let label = match node.close_index() {
-        Some(close) => element_text(doc, open_index, close),
-        None => Cow::Borrowed(""),
-    };
-    node.jump_to_close();
+    // The label is every text run inside the element, up to wherever the
+    // parser resolved its end — so `<li><a href=u>link</li>` keeps its
+    // label, and a void element, which has no content, gets none.
+    let label = element_text(doc, open_index, content_end);
 
     if let Some(item) = tf.item_with_scope(cx, &mut scope_with_attrs, id, template) {
         item.set_text(cx, &label);
@@ -1179,6 +1229,7 @@ fn handle_custom_widget(
         item.draw_all(cx, &mut draw_scope);
         tf.end_inline_content(cx, hold);
     }
+    resume
 }
 
 /// The text between the open tag at `open` and its close tag at `close`:
@@ -1473,9 +1524,20 @@ struct DetailsLevel {
     /// Controls whether the body content between `</summary>` and
     /// `</details>` is drawn or skipped.
     is_open: bool,
-    /// Whether a `<summary>` opened inside this element is still open, so
-    /// `</details>` (or the end of the document) can close it.
-    summary_open: bool,
+    /// Node index of the `<details>` open tag, so a collapsed body can be
+    /// skipped to the element's resolved end.
+    open_index: usize,
+    /// `open_elements.len()` when the element opened; `</details>` unwinds
+    /// back to it, ending anything left open in the body.
+    open_depth: usize,
+}
+
+/// A `<summary>` that has been opened and not yet closed.
+struct OpenSummary {
+    /// Index into `details_stack` of the `<details>` it belongs to, if any.
+    owner: Option<usize>,
+    /// `open_elements.len()` when it opened; `</summary>` unwinds back to it.
+    depth: usize,
 }
 
 /// The format and metadata of a list at a given nesting level.
@@ -1671,6 +1733,13 @@ fn align_keyword_to_x(keyword: &str) -> Option<f64> {
 mod tests {
     use super::*;
 
+    fn first_details(doc: &HtmlDoc) -> usize {
+        doc.nodes
+            .iter()
+            .position(|node| matches!(node, HtmlNode::OpenTag { lc, .. } if *lc == live_id!(details)))
+            .expect("fixture must contain a <details> tag")
+    }
+
     fn summary_close(doc: &HtmlDoc) -> HtmlWalker<'_> {
         let mut node = doc.new_walker();
         while !node.done() && node.close_tag_lc() != Some(live_id!(summary)) {
@@ -1691,7 +1760,7 @@ mod tests {
             InternLiveId::No,
         );
         let mut node = summary_close(&doc);
-        Html::skip_details_body(&mut node);
+        Html::skip_details_body(&mut node, first_details(&doc));
         assert_eq!(node.close_tag_lc(), Some(live_id!(details)));
 
         let remaining_closures: Vec<_> = node.nodes[node.index..].iter().filter_map(|node| {
@@ -1729,7 +1798,7 @@ mod tests {
             matches!(node, HtmlNode::CloseTag { lc, .. } if *lc == live_id!(details))
         }).unwrap();
         let mut node = summary_close(&doc);
-        Html::skip_details_body(&mut node);
+        Html::skip_details_body(&mut node, first_details(&doc));
         assert_eq!(node.index, outer_close);
         assert_eq!(node.find_tag_text(live_id!(p)), Some("After details"));
     }
@@ -1742,7 +1811,7 @@ mod tests {
             InternLiveId::No,
         );
         let mut node = summary_close(&doc);
-        Html::skip_details_body(&mut node);
+        Html::skip_details_body(&mut node, first_details(&doc));
         assert!(node.done());
     }
 }

--- a/widgets/src/markdown.rs
+++ b/widgets/src/markdown.rs
@@ -406,7 +406,6 @@ impl Markdown {
                         self.code_block_string.clear();
                     } else {
                         tf.push_size_rel_scale(tf.fixed_font_size_scale);
-                        tf.combine_spaces.push(false);
                         tf.fixed.push();
                         tf.begin_code(cx);
                     }
@@ -445,7 +444,6 @@ impl Markdown {
                     } else {
                         tf.font_sizes.pop();
                         tf.fixed.pop();
-                        tf.combine_spaces.pop();
                         tf.end_code(cx);
                     }
                 }

--- a/widgets/src/text_flow.rs
+++ b/widgets/src/text_flow.rs
@@ -653,10 +653,6 @@ pub struct TextFlow {
     #[rust]
     pub font_colors: SmallVec<[Vec4f; 8]>,
     #[rust]
-    pub combine_spaces: SmallVec<[bool; 4]>,
-    #[rust]
-    pub ignore_newlines: SmallVec<[bool; 4]>,
-    #[rust]
     pub bold: StackCounter,
     #[rust]
     pub italic: StackCounter,
@@ -1335,8 +1331,6 @@ impl TextFlow {
         self.y_shift_scales.clear();
         self.font_colors.clear();
         self.area_stack.clear();
-        self.combine_spaces.clear();
-        self.ignore_newlines.clear();
         self.first_thing_on_a_line = true;
         self.table_num_columns = 0;
         self.in_table_header = false;
@@ -2564,7 +2558,8 @@ impl Widget for TextFlowLink {
             }
         }
 
-        for area in self.drawn_areas.clone().into_iter() {
+        for i in 0..self.drawn_areas.len() {
+            let area = self.drawn_areas[i];
             match event.hits(cx, area) {
                 Hit::FingerDown(fe) if fe.is_primary_hit() => {
                     if self.grab_key_focus {


### PR DESCRIPTION
Collapsed `<details>` content containing ordinary `<br>` tags can swallow the rest of an HTML table and leave its layout stack unbalanced. This showed up in Robrix with a Markdown speaker table whose biography cells use `<details><summary>…</summary><br>…<br><br>…</details>`: only the first speaker remained visible, and following content disappeared.

Skip from `</summary>` to the matching `</details>` by counting only nested details elements. Void tags no longer affect nesting, and the normal closing handler still runs before the enclosing table cell, row, and table close. The change is confined to `widgets/src/html.rs`.

Validation:
- Three regression tests pass with `cargo test --release -p makepad-widgets --lib html::tests`, covering table continuation, nested details with void elements, and missing closing tags.
- A standalone release rendering of the reported message now displays all 18 speakers and trailing content; expanding and collapsing the first biography works.
- A 650-pixel-wide `PortalList` reproducer preserves the parent layout turtle after drawing the message; scrolling shows the remaining speakers, trailing content, and following messages. The unpatched build changes the parent turtle and loses that content.
- `git diff --check` passes. No formatters were run.

The layout corruption was reproduced; the originally reported Robrix crash itself was not reproduced in the standalone harness.
