### PR TITLE
macOS: don't deliver IME-consumed keys as KeyDown

### DIFF
--- a/platform/src/os/apple/macos/macos_app.rs
+++ b/platform/src/os/apple/macos/macos_app.rs
@@ -644,6 +644,24 @@ impl MacosApp {
     unsafe fn process_ns_event(ns_event: ObjcId) {
         let ev_type: NSEventType = msg_send![ns_event, type];
 
+        // Snapshot the IME composition state *before* AppKit dispatches this event.
+        // `sendEvent:` routes a key press through the view's `keyDown:` into
+        // `NSTextInputContext`, and while an IME has marked (composition) text it
+        // consumes the key itself: Return/Space commit the candidate, digits pick
+        // one, arrows navigate, Escape discards, Backspace edits the preedit.
+        // A committing key clears the marked text during that dispatch, so the
+        // state has to be observed up front.
+        let ime_consumed_key = matches!(ev_type, NSEventType::NSKeyDown)
+            && with_macos_app(|app| {
+                for (_, view) in &app.cocoa_windows {
+                    let marked: bool = unsafe { msg_send![*view, hasMarkedText] };
+                    if marked {
+                        return true;
+                    }
+                }
+                false
+            });
+
         let ns_app: ObjcId = msg_send![class!(NSApplication), sharedApplication];
         // Clear the menu-consumed marker so we can tell after `sendEvent:`
         // whether the main menu took this NSEvent as a key equivalent.
@@ -675,6 +693,14 @@ impl MacosApp {
             }
             NSEventType::NSKeyDown => {
                 if with_macos_app(|app| app.menu_command_fired) {
+                    return;
+                }
+                if ime_consumed_key {
+                    // The IME handled this key as part of a composition (see the
+                    // snapshot above). Don't also deliver it as a KeyDown: a Return
+                    // that merely committed a candidate would otherwise be taken as
+                    // a submit, and a Backspace that deleted the last preedit
+                    // character would also delete committed text.
                     return;
                 }
                 if let Some(key_code) = get_event_keycode(ns_event) {
@@ -737,21 +763,6 @@ impl MacosApp {
                         _ => {}
                     }
                     let time = with_macos_app(|app: &mut MacosApp| app.time_now());
-                    // lets check if we have marked text
-                    if KeyCode::Backspace == key_code {
-                        // we have to check if we dont have any marked text in our windows
-                        if with_macos_app(|app| {
-                            for (_, view) in &app.cocoa_windows {
-                                let marked = unsafe { msg_send![*view, hasMarkedText] };
-                                if marked {
-                                    return true;
-                                }
-                            }
-                            false
-                        }) {
-                            return;
-                        }
-                    }
                     MacosApp::do_callback(MacosEvent::KeyDown(KeyEvent {
                         key_code: key_code,
                         is_repeat: is_repeat,


### PR DESCRIPTION
## Problem

On macOS, a key that the IME consumed as part of a composition is still delivered to widgets as a `KeyDown`.

`MacosApp::process_ns_event` hands every NSEvent to AppKit via `sendEvent:` before emitting Makepad's own key event. That dispatch runs the view's `keyDown:` → `NSTextInputContext handleEvent:`, and while an IME has marked (composition) text it consumes the key itself: Return/Space commit the candidate, digits pick one, arrows navigate, Escape discards, Backspace edits the preedit. A committing key clears the marked text *during* that dispatch, so the existing post-dispatch `hasMarkedText` check (which only covered Backspace) cannot see it.

The visible symptom: with the Pinyin IME, pressing Return to commit a candidate into a multiline `TextInput` that has `submit_on_enter` set commits the text **and** emits `TextInputAction::Returned`, so a chat app sends the message mid-sentence. The same path leaks Escape out of a composition (dismissing whatever the app binds Escape to), and a Backspace that deletes the last preedit character falls through and deletes committed text as well.

Windows is unaffected: IME-consumed keys arrive as `VK_PROCESSKEY`, which maps to `KeyCode::Unknown`.

## Fix

Snapshot `hasMarkedText` across the app's views *before* `sendEvent:` for `NSKeyDown`, and skip the `KeyDown` callback when the IME was composing. This subsumes the old Backspace-only check, so that block is removed.

A side effect worth noting: Cmd+C/V/X pressed while a composition is active are now left to the IME rather than reaching Makepad's clipboard handling, which matches how native text views behave.

## Verification

- `cargo check -p makepad-platform` on macOS (dev HEAD 14fe611e).
- Reproduced by reading the dispatch order; a Robrix build against this branch is being exercised locally with the macOS Pinyin IME in the send-on-enter flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HLgZDz8vuuqqMya1nCWKf
