### PR TITLE
macOS: preserve IME commands and consume composition key releases

### DIFF
--- a/platform/src/os/apple/macos/macos_app.rs
+++ b/platform/src/os/apple/macos/macos_app.rs
@@ -644,6 +644,24 @@ impl MacosApp {
     unsafe fn process_ns_event(ns_event: ObjcId) {
         let ev_type: NSEventType = msg_send![ns_event, type];
 
+        // Snapshot the IME composition state *before* AppKit dispatches this event.
+        // `sendEvent:` routes a key press through the view's `keyDown:` into
+        // `NSTextInputContext`, and while an IME has marked (composition) text it
+        // consumes the key itself: Return/Space commit the candidate, digits pick
+        // one, arrows navigate, Escape discards, Backspace edits the preedit.
+        // A committing key clears the marked text during that dispatch, so the
+        // state has to be observed up front.
+        let ime_consumed_key = matches!(ev_type, NSEventType::NSKeyDown)
+            && with_macos_app(|app| {
+                for (_, view) in &app.cocoa_windows {
+                    let marked: bool = unsafe { msg_send![*view, hasMarkedText] };
+                    if marked {
+                        return true;
+                    }
+                }
+                false
+            });
+
         let ns_app: ObjcId = msg_send![class!(NSApplication), sharedApplication];
         // Clear the menu-consumed marker so we can tell after `sendEvent:`
         // whether the main menu took this NSEvent as a key equivalent.
@@ -675,6 +693,14 @@ impl MacosApp {
             }
             NSEventType::NSKeyDown => {
                 if with_macos_app(|app| app.menu_command_fired) {
+                    return;
+                }
+                if ime_consumed_key {
+                    // The IME handled this key as part of a composition (see the
+                    // snapshot above). Don't also deliver it as a KeyDown: a Return
+                    // that merely committed a candidate would otherwise be taken as
+                    // a submit, and a Backspace that deleted the last preedit
+                    // character would also delete committed text.
                     return;
                 }
                 if let Some(key_code) = get_event_keycode(ns_event) {
@@ -737,21 +763,6 @@ impl MacosApp {
                         _ => {}
                     }
                     let time = with_macos_app(|app: &mut MacosApp| app.time_now());
-                    // lets check if we have marked text
-                    if KeyCode::Backspace == key_code {
-                        // we have to check if we dont have any marked text in our windows
-                        if with_macos_app(|app| {
-                            for (_, view) in &app.cocoa_windows {
-                                let marked = unsafe { msg_send![*view, hasMarkedText] };
-                                if marked {
-                                    return true;
-                                }
-                            }
-                            false
-                        }) {
-                            return;
-                        }
-                    }
                     MacosApp::do_callback(MacosEvent::KeyDown(KeyEvent {
                         key_code: key_code,
                         is_repeat: is_repeat,

--- a/platform/src/os/apple/macos/macos_app.rs
+++ b/platform/src/os/apple/macos/macos_app.rs
@@ -24,7 +24,7 @@ use {
                 str_to_nsstring,
             },
             cx_native::EventFlow,
-            macos::{macos_delegates::*, macos_event::*, macos_window::MacosWindow},
+            macos::{macos_delegates::*, macos_event::*, macos_ime::MacosImeKeyboard, macos_window::MacosWindow},
         },
         window::WindowId,
     },
@@ -368,6 +368,7 @@ pub struct MacosApp {
     /// Set by `send_command_event()` to avoid sending keyboard events
     /// for keyboard shortcuts that trigger a macOS menu command.
     pub(crate) menu_command_fired: bool,
+    pub(crate) ime_keyboard: MacosImeKeyboard,
 }
 
 impl MacosApp {
@@ -395,6 +396,7 @@ impl MacosApp {
                 cocoa_windows: Vec::new(),
                 cocoa_window_ids: Vec::new(),
                 retired_cocoa_windows: Vec::new(),
+                ime_keyboard: MacosImeKeyboard::default(),
                 event_flow: EventFlow::Poll,
                 last_key_mod: KeyModifiers {
                     ..Default::default()
@@ -644,23 +646,11 @@ impl MacosApp {
     unsafe fn process_ns_event(ns_event: ObjcId) {
         let ev_type: NSEventType = msg_send![ns_event, type];
 
-        // Snapshot the IME composition state *before* AppKit dispatches this event.
-        // `sendEvent:` routes a key press through the view's `keyDown:` into
-        // `NSTextInputContext`, and while an IME has marked (composition) text it
-        // consumes the key itself: Return/Space commit the candidate, digits pick
-        // one, arrows navigate, Escape discards, Backspace edits the preedit.
-        // A committing key clears the marked text during that dispatch, so the
-        // state has to be observed up front.
-        let ime_consumed_key = matches!(ev_type, NSEventType::NSKeyDown)
-            && with_macos_app(|app| {
-                for (_, view) in &app.cocoa_windows {
-                    let marked: bool = unsafe { msg_send![*view, hasMarkedText] };
-                    if marked {
-                        return true;
-                    }
-                }
-                false
-            });
+        // The receiving view records how its input context handled this event.
+        // Marked text in another view (or an inactive IME) must not consume it.
+        if matches!(ev_type, NSEventType::NSKeyDown) {
+            with_macos_app(|app| app.ime_keyboard.begin_key_down());
+        }
 
         let ns_app: ObjcId = msg_send![class!(NSApplication), sharedApplication];
         // Clear the menu-consumed marker so we can tell after `sendEvent:`
@@ -677,6 +667,10 @@ impl MacosApp {
             NSEventType::NSApplicationDefined => { // event loop unblocker
             }
             NSEventType::NSKeyUp => {
+                let native_key: u16 = msg_send![ns_event, keyCode];
+                if !with_macos_app(|app| app.ime_keyboard.key_up(native_key)) {
+                    return;
+                }
                 if let Some(key_code) = get_event_keycode(ns_event) {
                     let modifiers = get_event_key_modifier(ns_event);
                     //let key_char = get_event_char(ns_event);
@@ -692,21 +686,22 @@ impl MacosApp {
                 }
             }
             NSEventType::NSKeyDown => {
+                let native_key: u16 = msg_send![ns_event, keyCode];
+                let is_repeat: bool = msg_send![ns_event, isARepeat];
+                let forward_key = with_macos_app(|app| {
+                    app.ime_keyboard.end_key_down(native_key, is_repeat)
+                });
                 if with_macos_app(|app| app.menu_command_fired) {
                     return;
                 }
-                if ime_consumed_key {
-                    // The IME handled this key as part of a composition (see the
-                    // snapshot above). Don't also deliver it as a KeyDown: a Return
-                    // that merely committed a candidate would otherwise be taken as
-                    // a submit, and a Backspace that deleted the last preedit
-                    // character would also delete committed text.
+                if !forward_key {
+                    // Suppress both halves of an IME-owned press, including Escape
+                    // release, which would otherwise dismiss a containing modal.
                     return;
                 }
                 if let Some(key_code) = get_event_keycode(ns_event) {
                     let modifiers = get_event_key_modifier(ns_event);
                     //let key_char = get_event_char(ns_event);
-                    let is_repeat: bool = msg_send![ns_event, isARepeat];
                     //let is_return = if let KeyCode::Return = key_code{true} else{false};
 
                     #[cfg(target_os = "macos")]

--- a/platform/src/os/apple/macos/macos_delegates.rs
+++ b/platform/src/os/apple/macos/macos_delegates.rs
@@ -18,7 +18,7 @@ use {
             macos::{
                 macos_app::{try_with_macos_app, with_macos_app, MacosApp},
                 macos_event::MacosEvent,
-                macos_window::get_cocoa_window,
+                macos_window::{clear_marked_text_ivar, get_cocoa_window},
             },
         },
     },
@@ -782,6 +782,9 @@ pub fn define_cocoa_view_class() -> *const Class {
         _replacement_range: NSRange,
     ) {
         unsafe {
+            with_macos_app(|app| {
+                app.ime_keyboard.composition_changed(this as *const Object as usize);
+            });
             let marked_text_ref: &mut ObjcId = this.get_mut_ivar("markedText");
             let _: () = msg_send![(*marked_text_ref), release];
             let marked_text = NSMutableAttributedString::alloc(nil);
@@ -809,28 +812,24 @@ pub fn define_cocoa_view_class() -> *const Class {
         }
     }
 
-    // Clears the stored marked-text ivar and tells the input context the
-    // composition is finished. Does NOT notify the TextInput widget, so callers
-    // that have already updated/committed the widget can use it directly without
-    // emitting a second (and possibly destructive) text-input event.
-    unsafe fn clear_marked_text_ivar(this: &Object) {
-        let marked_text: ObjcId = *this.get_ivar("markedText");
-        let mutable_string = marked_text.mutable_string();
-        let _: () = msg_send![mutable_string, setString: get_apple_class_global().const_empty_string.as_id()];
-        let input_context: ObjcId = msg_send![this, inputContext];
-        let _: () = msg_send![input_context, discardMarkedText];
-    }
-
     extern "C" fn unmark_text(this: &Object, _sel: Sel) {
         unsafe {
+            // Native cleanup clears the ivar before discardMarkedText, which may
+            // call us again. Do not edit the newly focused widget on that path.
+            if has_marked_text(this, _sel) == NO {
+                return;
+            }
+            with_macos_app(|app| {
+                app.ime_keyboard.composition_changed(this as *const Object as usize);
+            });
             // AppKit asks us to discard the in-progress composition (e.g. the user
             // pressed Escape or the input session was interrupted). Remove the
-            // inline preview from the focused TextInput, then clear our state.
+            // inline preview from the focused TextInput after clearing our state.
             // (After a commit, `insert_text` clears the ivar directly instead of
             // routing through here, so this only fires for genuine discards and is
             // a no-op when the widget has no active composition.)
-            get_cocoa_window(this).send_text_input(String::new(), true);
             clear_marked_text_ivar(this);
+            get_cocoa_window(this).send_text_input(String::new(), true);
         }
     }
 
@@ -900,8 +899,12 @@ pub fn define_cocoa_view_class() -> *const Class {
         string: ObjcId,
         replacement_range: NSRange,
     ) {
-        let cw = get_cocoa_window(this);
         unsafe {
+            if has_marked_text(this, _sel) != NO {
+                with_macos_app(|app| {
+                    app.ime_keyboard.composition_changed(this as *const Object as usize);
+                });
+            }
             let has_attr = msg_send![string, isKindOfClass: class!(NSAttributedString)];
             let characters = if has_attr {
                 msg_send![string, string]
@@ -909,29 +912,40 @@ pub fn define_cocoa_view_class() -> *const Class {
                 string
             };
             let string = nsstring_to_string(characters);
-            cw.send_text_input(string, replacement_range.length != 0);
+            // Finish native composition before application callbacks can move
+            // focus or start another one. The widget receives the commit below.
+            clear_marked_text_ivar(this);
+            get_cocoa_window(this).send_text_input(string, replacement_range.length != 0);
             let input_context: ObjcId = msg_send![this, inputContext];
             let () = msg_send![input_context, invalidateCharacterCoordinates];
-            let () = msg_send![cw.view, setNeedsDisplay: YES];
-            // The commit above already replaced any composition preview in the
-            // widget; just clear our marked-text state (don't route through
-            // `unmark_text`, which would emit a second text-input event).
-            clear_marked_text_ivar(this);
+            let () = msg_send![this, setNeedsDisplay: YES];
         }
     }
 
-    extern "C" fn do_command_by_selector(this: &Object, _sel: Sel, _command: Sel) {
-        let _cw = get_cocoa_window(this);
+    extern "C" fn do_command_by_selector(this: &Object, _sel: Sel, command: Sel) {
+        let cancel = command == sel!(cancelOperation:);
+        with_macos_app(|app| {
+            app.ime_keyboard.command(this as *const Object as usize, cancel);
+        });
+        if cancel {
+            unmark_text(this, _sel);
+        }
     }
 
     extern "C" fn key_down(this: &Object, _sel: Sel, event: ObjcId) {
-        let cw = get_cocoa_window(this);
         // Only forward to NSTextInputContext when IME is active (a text field has focus).
         // Otherwise, typing outside the TextInput still trigger the system IME.
-        if cw.ime_active {
+        if get_cocoa_window(this).ime_active {
             unsafe {
+                let view = this as *const Object as usize;
+                let marked = has_marked_text(this, _sel) != NO;
+                with_macos_app(|app| app.ime_keyboard.begin_input_context(view, marked));
                 let input_context: ObjcId = msg_send![this, inputContext];
-                let () = msg_send![input_context, handleEvent: event];
+                let handled: BOOL = msg_send![input_context, handleEvent: event];
+                let marked = has_marked_text(this, _sel) != NO;
+                with_macos_app(|app| {
+                    app.ime_keyboard.end_input_context(view, handled != NO, marked);
+                });
             }
         }
     }

--- a/platform/src/os/apple/macos/macos_ime.rs
+++ b/platform/src/os/apple/macos/macos_ime.rs
@@ -1,0 +1,294 @@
+use std::collections::HashMap;
+
+#[derive(Default)]
+struct ImeKeyEvent {
+    view: Option<usize>,
+    composition: bool,
+    handled: bool,
+    command: bool,
+    cancel: bool,
+}
+
+impl ImeKeyEvent {
+    fn consumed(&self) -> bool {
+        self.composition
+            && (self.handled || self.cancel)
+            && (!self.command || self.cancel)
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct MacosImeKeyboard {
+    // AppKit can dispatch another event synchronously from an input callback.
+    events: Vec<ImeKeyEvent>,
+    // Whether the initial physical press reached Makepad. Keep its release paired
+    // even if composition starts or ends during key repeat.
+    presses: HashMap<u16, bool>,
+}
+
+impl MacosImeKeyboard {
+    pub(crate) fn begin_key_down(&mut self) {
+        self.events.push(ImeKeyEvent::default());
+    }
+
+    pub(crate) fn begin_input_context(&mut self, view: usize, marked: bool) {
+        if let Some(event) = self.events.last_mut() {
+            *event = ImeKeyEvent {
+                view: Some(view),
+                composition: marked,
+                ..Default::default()
+            };
+        }
+    }
+
+    fn event_for_view(&mut self, view: usize) -> Option<&mut ImeKeyEvent> {
+        self.events.last_mut().filter(|event| event.view == Some(view))
+    }
+
+    pub(crate) fn composition_changed(&mut self, view: usize) {
+        if let Some(event) = self.event_for_view(view) {
+            event.composition = true;
+        }
+    }
+
+    pub(crate) fn command(&mut self, view: usize, cancel: bool) {
+        if let Some(event) = self.event_for_view(view) {
+            event.command = true;
+            event.cancel |= cancel;
+        }
+    }
+
+    pub(crate) fn end_input_context(&mut self, view: usize, handled: bool, marked: bool) {
+        if let Some(event) = self.event_for_view(view) {
+            event.handled = handled;
+            event.composition |= marked;
+        }
+    }
+
+    pub(crate) fn end_key_down(&mut self, key: u16, repeat: bool) -> bool {
+        let consumed = self.events.pop().unwrap_or_default().consumed();
+        let forwarded = if repeat {
+            *self.presses.entry(key).or_insert(!consumed)
+        } else {
+            self.presses.insert(key, !consumed);
+            !consumed
+        };
+        forwarded && !consumed
+    }
+
+    pub(crate) fn key_up(&mut self, key: u16) -> bool {
+        self.presses.remove(&key).unwrap_or(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MacosImeKeyboard;
+
+    const VIEW: usize = 1;
+    const RETURN: u16 = 36;
+    const ESCAPE: u16 = 53;
+    const BACKSPACE: u16 = 51;
+
+    fn begin(ime: &mut MacosImeKeyboard, marked: bool) {
+        ime.begin_key_down();
+        ime.begin_input_context(VIEW, marked);
+    }
+
+    #[test]
+    fn inactive_or_other_views_do_not_consume_keys() {
+        let mut ime = MacosImeKeyboard::default();
+        ime.begin_key_down();
+        ime.composition_changed(VIEW);
+        assert!(ime.end_key_down(RETURN, false));
+        assert!(ime.key_up(RETURN));
+
+        begin(&mut ime, false);
+        ime.composition_changed(VIEW + 1);
+        ime.end_input_context(VIEW, true, false);
+        assert!(ime.end_key_down(RETURN, false));
+    }
+
+    #[test]
+    fn ordinary_text_and_unhandled_shortcuts_are_forwarded() {
+        let mut ime = MacosImeKeyboard::default();
+        begin(&mut ime, false);
+        ime.end_input_context(VIEW, true, false);
+        assert!(ime.end_key_down(0, false));
+        assert!(ime.key_up(0));
+
+        begin(&mut ime, true);
+        ime.end_input_context(VIEW, false, true);
+        assert!(ime.end_key_down(9, false));
+        assert!(ime.key_up(9));
+    }
+
+    #[test]
+    fn unhandled_shortcut_can_commit_pending_composition() {
+        let mut ime = MacosImeKeyboard::default();
+        begin(&mut ime, true);
+        ime.composition_changed(VIEW);
+        ime.end_input_context(VIEW, false, false);
+        assert!(ime.end_key_down(9, false));
+        assert!(ime.key_up(9));
+    }
+
+    #[test]
+    fn candidate_commit_consumes_return_but_next_press_submits() {
+        let mut ime = MacosImeKeyboard::default();
+        begin(&mut ime, true);
+        ime.composition_changed(VIEW);
+        ime.end_input_context(VIEW, true, false);
+        assert!(!ime.end_key_down(RETURN, false));
+        assert!(!ime.key_up(RETURN));
+
+        begin(&mut ime, false);
+        ime.command(VIEW, false);
+        ime.end_input_context(VIEW, true, false);
+        assert!(ime.end_key_down(RETURN, false));
+        assert!(ime.key_up(RETURN));
+    }
+
+    #[test]
+    fn deleting_last_preedit_character_does_not_delete_committed_text() {
+        let mut ime = MacosImeKeyboard::default();
+        begin(&mut ime, true);
+        ime.composition_changed(VIEW);
+        ime.end_input_context(VIEW, true, false);
+        assert!(!ime.end_key_down(BACKSPACE, false));
+        assert!(!ime.key_up(BACKSPACE));
+
+        begin(&mut ime, false);
+        ime.command(VIEW, false);
+        ime.end_input_context(VIEW, true, false);
+        assert!(ime.end_key_down(BACKSPACE, false));
+    }
+
+    #[test]
+    fn composition_begin_update_and_same_event_end_are_consumed() {
+        for (before, after) in [(false, true), (true, true), (false, false)] {
+            let mut ime = MacosImeKeyboard::default();
+            begin(&mut ime, before);
+            ime.composition_changed(VIEW);
+            ime.end_input_context(VIEW, true, after);
+            assert!(!ime.end_key_down(0, false));
+            assert!(!ime.key_up(0));
+        }
+    }
+
+    #[test]
+    fn korean_commit_still_forwards_requested_editing_command() {
+        let mut ime = MacosImeKeyboard::default();
+        begin(&mut ime, true);
+        ime.composition_changed(VIEW);
+        ime.command(VIEW, false);
+        ime.end_input_context(VIEW, true, false);
+        assert!(ime.end_key_down(RETURN, false));
+        assert!(ime.key_up(RETURN));
+    }
+
+    #[test]
+    fn commands_during_composition_reach_application_handlers() {
+        let mut ime = MacosImeKeyboard::default();
+        begin(&mut ime, true);
+        ime.command(VIEW, false);
+        ime.end_input_context(VIEW, true, true);
+        assert!(ime.end_key_down(9, false));
+        assert!(ime.key_up(9));
+    }
+
+    #[test]
+    fn escape_cancels_composition_without_dismissing_modal() {
+        for command in [false, true] {
+            let mut ime = MacosImeKeyboard::default();
+            begin(&mut ime, true);
+            if command {
+                ime.command(VIEW, true);
+            }
+            ime.composition_changed(VIEW);
+            ime.end_input_context(VIEW, true, false);
+            assert!(!ime.end_key_down(ESCAPE, false));
+            assert!(!ime.key_up(ESCAPE));
+
+            begin(&mut ime, false);
+            ime.command(VIEW, true);
+            ime.end_input_context(VIEW, true, false);
+            assert!(ime.end_key_down(ESCAPE, false));
+            assert!(ime.key_up(ESCAPE));
+        }
+    }
+
+    #[test]
+    fn cancellation_handled_by_the_view_consumes_the_key() {
+        let mut ime = MacosImeKeyboard::default();
+        begin(&mut ime, true);
+        ime.command(VIEW, true);
+        ime.composition_changed(VIEW);
+        ime.end_input_context(VIEW, false, false);
+        assert!(!ime.end_key_down(ESCAPE, false));
+        assert!(!ime.key_up(ESCAPE));
+    }
+
+    #[test]
+    fn holding_commit_or_escape_does_not_leak_repeats_or_release() {
+        for key in [RETURN, ESCAPE] {
+            let mut ime = MacosImeKeyboard::default();
+            begin(&mut ime, true);
+            ime.composition_changed(VIEW);
+            ime.end_input_context(VIEW, true, false);
+            assert!(!ime.end_key_down(key, false));
+
+            begin(&mut ime, false);
+            ime.command(VIEW, key == ESCAPE);
+            ime.end_input_context(VIEW, true, false);
+            assert!(!ime.end_key_down(key, true));
+            assert!(!ime.key_up(key));
+        }
+    }
+
+    #[test]
+    fn forwarded_press_keeps_release_when_repeat_enters_composition() {
+        let mut ime = MacosImeKeyboard::default();
+        begin(&mut ime, false);
+        ime.end_input_context(VIEW, true, false);
+        assert!(ime.end_key_down(0, false));
+
+        begin(&mut ime, false);
+        ime.composition_changed(VIEW);
+        ime.end_input_context(VIEW, true, true);
+        assert!(!ime.end_key_down(0, true));
+        assert!(ime.key_up(0));
+    }
+
+    #[test]
+    fn nested_events_keep_their_own_composition_and_key_release() {
+        let mut ime = MacosImeKeyboard::default();
+        begin(&mut ime, true);
+        ime.composition_changed(VIEW);
+
+        ime.begin_key_down();
+        ime.begin_input_context(VIEW + 1, false);
+        ime.command(VIEW + 1, false);
+        ime.end_input_context(VIEW + 1, true, false);
+        assert!(ime.end_key_down(RETURN, false));
+
+        ime.end_input_context(VIEW, true, false);
+        assert!(!ime.end_key_down(ESCAPE, false));
+        assert!(ime.key_up(RETURN));
+        assert!(!ime.key_up(ESCAPE));
+    }
+
+    #[test]
+    fn fresh_press_replaces_suppression_if_release_was_not_received() {
+        let mut ime = MacosImeKeyboard::default();
+        begin(&mut ime, true);
+        ime.end_input_context(VIEW, true, true);
+        assert!(!ime.end_key_down(ESCAPE, false));
+
+        begin(&mut ime, false);
+        ime.end_input_context(VIEW, false, false);
+        assert!(ime.end_key_down(ESCAPE, false));
+        assert!(ime.key_up(ESCAPE));
+        assert!(ime.key_up(RETURN));
+    }
+}

--- a/platform/src/os/apple/macos/macos_window.rs
+++ b/platform/src/os/apple/macos/macos_window.rs
@@ -9,6 +9,7 @@ use {
         makepad_math::{dvec2, Rect, Vec2d},
         os::{
             apple::apple_sys::*,
+            apple_classes::get_apple_class_global,
             apple::apple_util::str_to_nsstring,
             macos::{
                 macos_app::{
@@ -1103,6 +1104,16 @@ impl MacosWindow {
 
     pub fn set_ime_active(&mut self, active: bool) {
         self.ime_active = active;
+        if !active {
+            unsafe {
+                let has_marked_text: BOOL = msg_send![self.view, hasMarkedText];
+                if has_marked_text != NO {
+                    // The widget keeps its preview as text on blur. Clear only
+                    // AppKit's state so the next focused widget is not edited.
+                    clear_marked_text_ivar(&*self.view);
+                }
+            }
+        }
     }
 
     /// Starts a Finder-compatible file drag from this exact native window.
@@ -1226,6 +1237,16 @@ impl MacosWindow {
             session != nil
         }
     }
+}
+
+// Do not send TextInput here: callers have already committed the composition or
+// moved focus. Clear our state first so a reentrant unmarkText is a no-op.
+pub(crate) unsafe fn clear_marked_text_ivar(this: &Object) {
+    let marked_text: ObjcId = *this.get_ivar("markedText");
+    let mutable_string = marked_text.mutable_string();
+    let _: () = msg_send![mutable_string, setString: get_apple_class_global().const_empty_string.as_id()];
+    let input_context: ObjcId = msg_send![this, inputContext];
+    let _: () = msg_send![input_context, discardMarkedText];
 }
 
 pub fn get_cocoa_window(this: &Object) -> &mut MacosWindow {

--- a/platform/src/os/apple/macos/mod.rs
+++ b/platform/src/os/apple/macos/mod.rs
@@ -3,6 +3,7 @@ pub mod macos;
 pub mod macos_app;
 pub mod macos_delegates;
 pub mod macos_event;
+mod macos_ime;
 pub mod macos_stdin;
 pub mod macos_window;
 pub use self::macos::*;


### PR DESCRIPTION
~~Please merge #1223 first, this builds on it.~~ merged already

When Pinyin consumes Return to commit a candidate, Makepad must not submit the surrounding text field. However, treating marked text in any window as proof that every key was consumed also blocks keyboard input after focus loss and drops editing commands returned by other IMEs. Escape additionally reaches modal dismissal through `KeyUp`.

This follow-up:

- Tracks composition and command callbacks for the receiving view's active input context, honors `handleEvent:` declining a key, and preserves application handling of commands such as Korean IME's `insertNewline:` after commit.
- Clears native marked text when IME is disabled and before delivering a commit to application callbacks. Reentrant cleanup cannot remove text from the newly focused widget.
- Suppresses the matching key release and raw repeats for an initially IME-consumed physical press. Escape cancels composition without also closing a containing modal; a fresh Escape press still reaches the application.

All changes are confined to the macOS backend. The native menu and clipboard paths remain available for keys the input context passes back.

## Validation

- `cargo test --release -p makepad-platform --lib`: 107 passed, including 14 new routing regression tests.
- `git diff --check`: passed.
- Regression cases cover composition start/update/commit/cancellation, final-preedit Backspace, Korean command forwarding, declined shortcuts, inactive/other views, Escape down/up, held keys, missing releases, and nested key dispatch.
- Live Pinyin/Japanese/Korean/dead-key and modal UI validation remains outstanding. Studio was not running (`127.0.0.1:8001` refused the bridge connection); these are backend policy tests, not a real IME session.

For the native command distinction, see [Firefox's Korean IME handling](https://github.com/mozilla-firefox/firefox/blob/main/widget/cocoa/TextInputHandler.mm#L2972-L2976).
