### PR TITLE
apple: silence too many verbose log lines

### DIFF
--- a/platform/src/os/apple/audio_unit.rs
+++ b/platform/src/os/apple/audio_unit.rs
@@ -1107,11 +1107,11 @@ impl AudioUnitAccess {
                                     if channel_count > 0 {
                                         input_channels = channel_count as usize;
                                     }
-                                    crate::log!(
-                                        "voice input: native format {}Hz {}ch",
-                                        stream_desc.mSampleRate,
-                                        input_channels
-                                    );
+                                    // crate::log!(
+                                    //     "voice input: native format {}Hz {}ch",
+                                    //     stream_desc.mSampleRate,
+                                    //     input_channels
+                                    // );
                                 }
                             }
                         }
@@ -1176,9 +1176,9 @@ impl AudioUnitAccess {
                                     std::mem::size_of::<DuckingConfig>() as u32,
                                 );
                                 if status == 0 {
-                                    crate::log!(
-                                        "voice input: other-audio ducking level {level} advanced {advanced}"
-                                    );
+                                    // crate::log!(
+                                    //     "voice input: other-audio ducking level {level} advanced {advanced}"
+                                    // );
                                 } else {
                                     crate::log!(
                                         "voice input: ducking config not applied (OSStatus {status})"

--- a/platform/src/os/apple/macos/macos_app.rs
+++ b/platform/src/os/apple/macos/macos_app.rs
@@ -1240,11 +1240,11 @@ impl MacosApp {
                 self.pin_restore = None;
                 return;
             }
-            crate::log!(
-                "PIN stats: ns_moves={} sum_dx={:.1}",
-                self.pin_ns_moves,
-                self.pin_sum_dx
-            );
+            // crate::log!(
+            //     "PIN stats: ns_moves={} sum_dx={:.1}",
+            //     self.pin_ns_moves,
+            //     self.pin_sum_dx
+            // );
             self.mouse_pointer_lock = false;
             self.pointer_lock_applied = false;
             self.pointer_pin_mode = false;
@@ -1339,7 +1339,7 @@ impl MacosApp {
                 }
                 // Runtime availability is the contract here: referring to the
                 // class by name keeps the binary loadable before macOS 14.
-                let mut is_metal_link = false;
+                let mut _is_metal_link = false;
                 let mut link = nil;
                 // Opt-in until it paces at the display's rate: measured 11 fps
                 // visible on 2026-08-25 against 62 fps on the CVDisplayLink path.
@@ -1384,7 +1384,7 @@ impl MacosApp {
                                     requested_fps,
                                 );
                             }
-                            is_metal_link = true;
+                            _is_metal_link = true;
                         }
                     }
                 }
@@ -1422,10 +1422,10 @@ impl MacosApp {
                                 preferred: fps,
                             };
                             let () = msg_send![link, setPreferredFrameRateRange: range];
-                            crate::log!(
-                                "macos: display link pinned to {}fps (panel maximum)",
-                                maximum_fps
-                            );
+                            // crate::log!(
+                            //     "macos: display link pinned to {}fps (panel maximum)",
+                            //     maximum_fps
+                            // );
                         } else {
                             crate::log!("macos: display link has no rate-range API");
                         }
@@ -1441,11 +1441,11 @@ impl MacosApp {
                     let () = msg_send![link, setPaused: YES];
                 }
                 self.display_links.push((window, link));
-                crate::log!(
-                    "macos: paint pacing on {} (frame-flip clock), window {}",
-                    if is_metal_link { "CAMetalDisplayLink" } else { "CADisplayLink" },
-                    self.display_links.len()
-                );
+                // crate::log!(
+                //     "macos: paint pacing on {} (frame-flip clock), window {}",
+                //     if _is_metal_link { "CAMetalDisplayLink" } else { "CADisplayLink" },
+                //     self.display_links.len()
+                // );
             }
             if self.display_links_paused {
                 for (_w, link) in &self.display_links {

--- a/platform/src/os/apple/macos/macos_window.rs
+++ b/platform/src/os/apple/macos/macos_window.rs
@@ -202,7 +202,7 @@ impl MacosWindow {
             return;
         }
         object_setClass(container, subclass as ObjcId);
-        crate::log!("defang: titlebar container swapped — WindowDragQuery decides drags");
+        // crate::log!("defang: titlebar container swapped — WindowDragQuery decides drags");
     }
 
     pub fn set_window_level(&mut self, level: MacosWindowLevel) {


### PR DESCRIPTION
## Why

Makepad's `log!` is its own printer rather than `tracing`, so an application can't filter it — anything logged this way is printed unconditionally, and an app developer reading their own output has to scroll past it. A number of recent calls sit on always-taken success paths and report internal decisions in Makepad's own vocabulary, which tells the app developer nothing they can act on.

## What

Six calls are commented out rather than deleted, so each is one uncomment away for anyone debugging that area:

| File | Log | Fires |
|---|---|---|
| `macos/macos_window.rs` | `defang: titlebar container swapped — WindowDragQuery decides drags` | once per window |
| `macos/macos_app.rs` | `macos: display link pinned to {}fps (panel maximum)` | once per window |
| `macos/macos_app.rs` | `macos: paint pacing on {} (frame-flip clock), window {}` | once per window |
| `macos/macos_app.rs` | `PIN stats: ns_moves={} sum_dx={:.1}` | every pointer-lock release |
| `audio_unit.rs` | `voice input: native format {}Hz {}ch` | every microphone open |
| `audio_unit.rs` | `voice input: other-audio ducking level {level} advanced {advanced}` | every microphone open |

The last three are the noisiest: an app that pins the pointer for drags prints on every release, and one that dictates prints two lines each time it opens the microphone. `is_metal_link` lost its only reader, so it's `_is_metal_link` now; `cargo check -p makepad-platform` is warning-free.

## Deliberately left alone

Error and warning paths beside these are untouched, as is anything already gated behind an env var, a cargo feature, or a once-per-process flag (for example the Metal zero-copy video log, which is behind a `LOGGED.swap(true, …)`). If you'd rather keep any of these, `crate::startup_trace()` behind `MAKEPAD_STARTUP_TRACE` would be a natural home for the three per-window ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
