### PR TITLE
TextInput: run the scroll bar down the input's edge, not over its text

### DIFF
--- a/widgets/src/scroll_bar.rs
+++ b/widgets/src/scroll_bar.rs
@@ -1203,18 +1203,32 @@ impl ScrollBar {
         view_rect: Rect,
         view_total: Vec2d,
     ) -> f64 {
+        let track = Rect { pos: Vec2d::default(), size: view_rect.size };
+        self.draw_scroll_bar_along(cx, axis, track, view_rect.size, view_total)
+    }
+
+    /// Like [`Self::draw_scroll_bar`], but runs the bar along the far edge of `track`
+    /// (relative to the turtle's origin) instead of the edge of the visible area.
+    pub fn draw_scroll_bar_along(
+        &mut self,
+        cx: &mut Cx2d,
+        axis: ScrollAxis,
+        track: Rect,
+        view_visible: Vec2d,
+        view_total: Vec2d,
+    ) -> f64 {
         self.axis = axis;
 
         match self.axis {
             ScrollAxis::Horizontal => {
-                self.visible = view_total.x > view_rect.size.x + 0.1;
-                self.scroll_size = if view_total.y > view_rect.size.y + 0.1 {
-                    view_rect.size.x - self.bar_size
+                self.visible = view_total.x > view_visible.x + 0.1;
+                self.scroll_size = if view_total.y > view_visible.y + 0.1 {
+                    track.size.x - self.bar_size
                 } else {
-                    view_rect.size.x
+                    track.size.x
                 } - self.bar_side_margin * 2.;
                 self.view_total = view_total.x;
-                self.view_visible = view_rect.size.x;
+                self.view_visible = view_visible.x;
                 self.scroll_pos = self
                     .scroll_pos
                     .min(self.view_total - self.view_visible)
@@ -1229,7 +1243,8 @@ impl ScrollBar {
                     self.draw_bg.draw_rel(
                         cx,
                         Rect {
-                            pos: dvec2(self.bar_side_margin, view_rect.size.y - self.bar_size)
+                            pos: track.pos
+                                + dvec2(self.bar_side_margin, track.size.y - self.bar_size)
                                 + scroll,
                             size: dvec2(self.scroll_size, self.bar_size),
                         },
@@ -1238,14 +1253,14 @@ impl ScrollBar {
             }
             ScrollAxis::Vertical => {
                 // compute if we need a horizontal one
-                self.visible = view_total.y > view_rect.size.y + 0.1;
-                self.scroll_size = if view_total.x > view_rect.size.x + 0.1 {
-                    view_rect.size.y - self.bar_size
+                self.visible = view_total.y > view_visible.y + 0.1;
+                self.scroll_size = if view_total.x > view_visible.x + 0.1 {
+                    track.size.y - self.bar_size
                 } else {
-                    view_rect.size.y
+                    track.size.y
                 } - self.bar_side_margin * 2.;
                 self.view_total = view_total.y;
-                self.view_visible = view_rect.size.y;
+                self.view_visible = view_visible.y;
                 self.scroll_pos = self
                     .scroll_pos
                     .min(self.view_total - self.view_visible)
@@ -1260,7 +1275,8 @@ impl ScrollBar {
                     self.draw_bg.draw_rel(
                         cx,
                         Rect {
-                            pos: dvec2(view_rect.size.x - self.bar_size, self.bar_side_margin)
+                            pos: track.pos
+                                + dvec2(track.size.x - self.bar_size, self.bar_side_margin)
                                 + scroll,
                             size: dvec2(self.bar_size, self.scroll_size),
                         },

--- a/widgets/src/text_input.rs
+++ b/widgets/src/text_input.rs
@@ -588,6 +588,10 @@ pub struct TextInput {
     submit_on_enter: bool,
     #[live]
     scroll_bar: ScrollBar,
+    /// Space between the vertical scroll bar and the input's top, right and bottom edges,
+    /// e.g. to keep it clear of a button overlaid in a corner.
+    #[live]
+    scroll_bar_inset: Inset,
     #[live]
     scroll_y: f64,
     /// Horizontal scroll offset for single-line mode (in logical pixels).
@@ -1408,10 +1412,19 @@ impl TextInput {
         };
         let view_rect = cx.turtle().inner_rect();
         let view_total = dvec2(view_rect.size.x, laidout_text.size_in_lpxs.height as f64);
-        // Sync scroll_y (which scroll_to_cursor may have updated) into the scrollbar.
+        // The bar runs down the input's right edge, in its padding rather than over the text.
+        let size = cx.turtle().rect().size;
+        let inset = self.scroll_bar_inset;
+        let track = Rect {
+            pos: dvec2(0.0, inset.top),
+            size: dvec2(size.x - inset.right, size.y - inset.top - inset.bottom),
+        };
+        // Sync scroll_y (which scroll_to_cursor may have updated) into the scrollbar,
+        // after the new text height, so a scroll into newly added text isn't clamped away.
+        self.scroll_bar.set_scroll_view_total(cx, view_total.y);
         self.scroll_bar.set_scroll_pos_no_action(cx, self.scroll_y);
         self.scroll_bar
-            .draw_scroll_bar(cx, ScrollAxis::Vertical, view_rect, view_total);
+            .draw_scroll_bar_along(cx, ScrollAxis::Vertical, track, view_rect.size, view_total);
     }
 
     /// Moves the cursor one column to the left.


### PR DESCRIPTION
## The bug

`TextInput::draw_scroll_bar` hands `ScrollBar` the *inner* rect:

```rust
let view_rect = cx.turtle().inner_rect();
self.scroll_bar.draw_scroll_bar(cx, ScrollAxis::Vertical, view_rect, view_total);
```

`ScrollBar` then draws at `view_rect.size.x - bar_size`, relative to the turtle's origin, which is the *outer* origin. So the bar lands a full right padding short of the edge, on top of the text, and covers the last several pixels of every wrapped line. The wider the right padding, the further into the text it sits.

## The fix

The bar now runs down the input's right edge, inside its padding, where it covers nothing.

Since a text input's visible area is not the area the bar runs along, `ScrollBar` gains an entry point that takes the two separately:

```rust
pub fn draw_scroll_bar_along(&mut self, cx, axis, track: Rect, view_visible: Vec2d, view_total: Vec2d) -> f64
```

`draw_scroll_bar` is now a one-line call into it, passing `track = { pos: 0, size: view_rect.size }` and `view_visible = view_rect.size`, so every existing caller (`ScrollBars`, `PortalList`, `DataGrid`, `ComboBox`) keeps its exact behavior.

`TextInput` also gains `scroll_bar_inset: Inset`, which keeps the bar clear of whatever an app overlays on the input. Robrix puts a microphone button in the bottom-right corner of its message composer for dictation, and sets the inset's bottom so the bar stops just above it.

## Also here: the handle lagged a frame behind

`draw_scroll_bar` synced `scroll_y` into the bar *before* the bar learned the new content height, so the position was clamped against the previous height. After the text grew and scrolled (typing at the end, or dictation appending words), the handle stayed where it was until something else redrew the input. It now sets the view total first.

## Risk

Low. The only behavior change for other widgets is none: they go through the unchanged `draw_scroll_bar` signature, whose delegation reproduces the old geometry exactly. Inputs whose right padding is narrower than the bar will see the bar sit against the border instead of over the text.

`cargo test -p makepad-widgets --lib text_input` passes its 8 tests.

Verified in Robrix: the composer's scrollbar used to sit ~40px inside the text, over every wrapped line; it now runs down the right edge, stops above the microphone button, and the handle tracks the text as it grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
