### PR TITLE
Turtle: compute max_height from the height axis, not the width

### DIFF
--- a/draw/src/turtle.rs
+++ b/draw/src/turtle.rs
@@ -2925,7 +2925,7 @@ impl Turtle {
         if walk.height.is_fit() {
             return None;
         }
-        Some(self.next_walk_width(walk.height, walk.margin))
+        Some(self.next_walk_height(walk.height, walk.margin))
     }
 }
 


### PR DESCRIPTION
## The bug

`Turtle::max_height` resolves the walk's height against the *horizontal* axis:

```rust
pub fn max_height(&self, walk: Walk) -> Option<f64> {
    if walk.height.is_fit() {
        return None;
    }
    Some(self.next_walk_width(walk.height, walk.margin))
}
```

`next_walk_width` is the width routine. For `Size::Fill` it picks the available space
by the width flow rules (`unused_inner_width` / `unused_inner_width_for_current_row` /
`effective_inner_width`) and then subtracts `margin.width()` — the left and right
margins — rather than `margin.height()`.

So a `Fill` height comes back as the turtle's available *width*, minus the wrong pair
of margins.

## Why this has gone unseen

Only `Size::Fill` diverges. `Size::Fixed(v)` returns `v.max(0.0)` from both routines,
and `Size::Fit` never reaches the call because of the early `return None`. Every
current caller happens to stay on those two paths:

- `DrawText::max_layout_width_for_walk` only calls `max_width`.
- `DrawText::draw_walk_laidout` calls both, but text is generally laid out with a
  `Fit` height, which returns `None` and falls back to the laid-out size.

`draw_walk_laidout` is where it would surface: it builds `max_size_in_lpxs` from
`max_width(walk)` and `max_height(walk)` and hands both to `walk_turtle` as
`Size::Fixed`, so text drawn with `height: Fill` would take its height from the
available width.

## The fix

Call the height routine:

```rust
Some(self.next_walk_height(walk.height, walk.margin))
```

`next_walk_height` has the identical `(Size, Inset) -> f64` signature, so this is a
type-preserving one-token change. Every other `next_walk_*` call site in `turtle.rs`
already pairs correctly (1029/1030, 2152, 2178, 2350/2351, 2921); 2928 was the only
mismatched one.

## Risk

Low. Behaviour is unchanged for `Fixed` and `Fit` heights, which is every caller
reachable today; it only corrects the `Fill` case, which was returning a width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
