### PR TITLE
WidgetTree: warn when a live parent loses its child to another

### DIFF
--- a/widgets/src/cached_widget.rs
+++ b/widgets/src/cached_widget.rs
@@ -29,18 +29,23 @@ script_mod! {
 /// Subsequent uses of this `CachedWidget` with the same child id (`my_widget`) will reuse the cached instance.
 /// Note that only one child is supported per `CachedWidget`.
 ///
-/// CachedWidget supports Makepad's widget finding mechanism, allowing child widgets to be located as expected.
+/// # Caveat: only one use site may be live at a time
+///
+/// A widget has a single parent in the widget tree, so the last `CachedWidget` to
+/// apply takes the shared child for its own. Use sites that are live at the same time
+/// therefore do *not* all find it: `widget()` and the typed accessors built on it search
+/// a subtree, and from every other use site the child is no longer in that subtree, so
+/// they return an empty ref with no error. Use sites that are mutually exclusive — the
+/// variants of an `AdaptiveView`, say — are fine, and are what this widget is for.
+///
+/// To reach a child currently owned by another live use site, use the `_flood` lookups
+/// (`WidgetRef::widget_flood()`), which search outward past the subtree.
 ///
 /// # Implementation Details
 ///
 /// - Uses a global `WidgetWrapperCache` to store cached widgets
 /// - Handles widget creation and caching in the `on_after_apply` hook
 /// - Delegates most widget operations (like event handling and drawing) to the cached child widget
-///
-/// # Note
-///
-/// While `CachedWidget` can significantly improve performance for complex, frequently used widgets,
-/// it should be used judiciously. Overuse of caching can lead to unexpected behavior if not managed properly.
 #[derive(Script, WidgetRef, WidgetRegister)]
 pub struct CachedWidget {
     #[uid]

--- a/widgets/src/widget_tree.rs
+++ b/widgets/src/widget_tree.rs
@@ -97,6 +97,9 @@ fn widget_screen_rect(area: &Area, cx: &Cx) -> Option<Rect> {
 // WidgetTree: persistent graph + dense query index
 // ============================================================================
 
+/// How many distinct re-parenting conflicts to report before going quiet.
+const REPARENT_WARN_LIMIT: usize = 64;
+
 pub struct WidgetTree {
     inner: RefCell<WidgetTreeInner>,
 }
@@ -127,6 +130,9 @@ struct WidgetTreeInner {
     // Only set when tree topology changes (nodes added/removed, parent changes).
     // Property-only changes (name, widget ref, skip_search) are patched in-place.
     structure_dirty: bool,
+    /// One entry per (child, old parent, new parent) already reported by
+    /// `insert_child`, so a conflict that repeats every apply is said once.
+    reparent_warned: HashSet<(WidgetUid, WidgetUid, WidgetUid)>,
 }
 
 struct WidgetTreeNode {
@@ -595,6 +601,34 @@ impl WidgetTree {
                         prev_parent.children.remove(pos);
                         inner.structure_dirty = true;
                     }
+                }
+            }
+        }
+
+        // A widget has a single parent, so taking one away from a parent that is
+        // still alive silently breaks that parent's lookups: they search a subtree
+        // the child has just left. Say so once per pairing, since the applies that
+        // cause this repeat every frame.
+        if parent_changed {
+            if let Some(prev_parent_uid) = old_parent {
+                let prev_is_live = inner.graph.get(&prev_parent_uid).map_or(false, |prev| {
+                    !prev.placeholder && prev.widget.upgrade().is_some()
+                });
+                let within_limit = inner.reparent_warned.len() < REPARENT_WARN_LIMIT;
+                if prev_is_live
+                    && within_limit
+                    && inner
+                        .reparent_warned
+                        .insert((child_uid, prev_parent_uid, parent_uid))
+                {
+                    warning!(
+                        "Widget {} moved from parent {} to parent {}, but {} is still alive, so \
+                         its lookups for that child now find nothing. This usually means one \
+                         CachedWidget id is used by two places that are live at the same time: \
+                         give them separate ids, or look the child up with the `_flood` lookups, \
+                         which search past the subtree.",
+                        child_uid.0, prev_parent_uid.0, parent_uid.0, prev_parent_uid.0,
+                    );
                 }
             }
         }
@@ -3127,6 +3161,42 @@ mod tests {
     // ------------------------------------------------------------------
     // Basic tree construction and lookup
     // ------------------------------------------------------------------
+
+    #[test]
+    fn a_live_parent_losing_its_child_is_reported_once_per_pairing() {
+        // Two parents naming one child, as two CachedWidgets sharing an id do.
+        let tree = WidgetTree::default();
+        let first_uid = WidgetUid::new();
+        let second_uid = WidgetUid::new();
+        let child_uid = WidgetUid::new();
+        let child = make_widget(child_uid, vec![]);
+        // Kept in locals: the graph holds only weak refs, and a parent that has been
+        // dropped is not one whose lookups this is meant to warn about.
+        let first = make_widget(first_uid, vec![]);
+        let second = make_widget(second_uid, vec![]);
+        tree.observe_node(first_uid, name("first"), first.clone(), None);
+        tree.observe_node(second_uid, name("second"), second.clone(), None);
+
+        // The first claim is not a conflict: the child had no parent to lose.
+        tree.insert_child(first_uid, name("shared"), child.clone());
+        assert_eq!(tree.parent_of(child_uid), Some(first_uid));
+        assert_eq!(tree.inner.borrow().reparent_warned.len(), 0);
+
+        // The second use site takes it away from the first, which is still alive,
+        // unlinking it from the first's children so lookups rooted there cannot reach it.
+        tree.insert_child(second_uid, name("shared"), child.clone());
+        assert_eq!(tree.parent_of(child_uid), Some(second_uid));
+        assert!(!tree.inner.borrow().graph[&first_uid].children.contains(&child_uid));
+        assert!(tree.inner.borrow().graph[&second_uid].children.contains(&child_uid));
+        assert_eq!(tree.inner.borrow().reparent_warned.len(), 1);
+
+        // Taking it back is a new pairing, but repeating either is not.
+        tree.insert_child(first_uid, name("shared"), child.clone());
+        assert_eq!(tree.inner.borrow().reparent_warned.len(), 2);
+        tree.insert_child(second_uid, name("shared"), child.clone());
+        tree.insert_child(first_uid, name("shared"), child.clone());
+        assert_eq!(tree.inner.borrow().reparent_warned.len(), 2);
+    }
 
     #[test]
     fn test_observe_and_find_single_node() {


### PR DESCRIPTION
## The problem

`CachedWidget` exists to share ONE child instance across several use sites naming the same child id. But a widget has a single parent in the widget tree, so when two use sites are live at once the last one to apply takes the child — and `insert_child` does not merely repoint the parent edge, it also unlinks the child from the old parent's `children` vec:

```rust
if node.parent != Some(parent_uid) {
    node.parent = Some(parent_uid);
    parent_changed = true;
}
…
if old_parent != Some(parent_uid) {
    if let Some(prev_parent) = inner.graph.get_mut(&prev_parent_uid) {
        if let Some(pos) = prev_parent.children.iter().position(|e| *e == child_uid) {
            prev_parent.children.remove(pos);
```

Downward walks read that cached vec, so from every other live use site the child is simply gone: `widget()` and the typed accessors built on it search a subtree the child has left, and return an empty ref. No panic, no log, no error — the calling code just quietly stops working, and a typed accessor that returns `WidgetRef::empty()` makes every subsequent call a no-op.

Worse, the docs promised the opposite:

> CachedWidget supports Makepad's widget finding mechanism, allowing child widgets to be located as expected.

That line is false precisely when the widget is used the way it is meant to be used.

This is not theoretical. It cost a day of debugging in Robrix, where a filter input shared by two `CachedWidget` sites silently stopped driving its list on a fresh desktop start, and started working again after toggling the layout — because the toggle re-applied the wrappers in the other order.

## What this adds

**A warning, always on.** In `insert_child`, hung off the `parent_changed` flag it already computes, firing only when the OLD parent is still a live, non-placeholder widget:

```
Widget 42 moved from parent 7 to parent 9, but 7 is still alive, so its lookups for
that child now find nothing. This usually means one CachedWidget id is used by two
places that are live at the same time: give them separate ids, or look the child up
with the `_flood` lookups, which search past the subtree.
```

**Corrected docs** on `CachedWidget`: the false sentence is gone, replaced by a caveat saying that only one use site may be live at a time, that mutually exclusive sites (an `AdaptiveView`'s variants) are the intended use, and that `_flood` lookups reach a child owned by another live site.

## Why this is quiet in practice

The condition is deliberately narrow, because legitimate re-parenting is common:

- **`PortalList` / `DataGrid` / `FlatList` row recycling** re-inserts rows under the list's own uid, so `parent_changed` is false and this is one never-taken branch.
- **An `AdaptiveView` switching variants** drops the outgoing variant, so the old parent is dead and fails the liveness test.
- **Repeats.** Applies recur every frame, so one conflicting pairing would otherwise log forever. Each `(child, old parent, new parent)` triple is reported once, capped at 64 distinct pairings.

One residual false positive is known and accepted: `AdaptiveView { retain_unused_variants: true }` keeps the outgoing variant alive (`adaptive_view.rs:311-313`) and re-inserts it on restore, so that pairing warns once. I consider it a true positive wearing a disguise — the retained wrapper really will steal the child back, and lookups rooted in the other really do fail — and the flag is currently set nowhere in this repo or in Robrix.

## Why in `widget_tree.rs` rather than `cached_widget.rs`

The defect is not `CachedWidget`-specific: anything calling `widget_tree_insert_child_deep` with a shared child hits it. `insert_child` is where `old_parent`, `parent_changed` and the unlink already are, so the check costs one branch on a path that already decided a re-parent happened, and covers every caller rather than one widget.

## Risk

Low. No signature, type or behaviour changes — the only additions are a `HashSet` field on the private `WidgetTreeInner` (which derives `Default`) and a branch that can only run when `parent_changed` is already true. Nothing is silenced; the resolution logic is untouched. Worst case is the one `retain_unused_variants` pairing logging a single line.

Note that `CachedWidget` has no usages in this repo's own examples or tests — the multi-site case it exists for is entirely unexercised upstream, which is likely why this went unnoticed.

Covered by a unit test alongside the existing `widget_tree` tests: the first claim is not a conflict (there was no parent to lose), the steal is reported once and the child is unlinked from the still-live parent's `children`, taking the child back is a new pairing, and repeating either does not grow the set.

Note for whoever runs the suite: `cargo test -p makepad-widgets --lib widget_tree` on current `dev` already fails `test_observe_and_find_single_node` and `test_property_patch_no_structural_rebuild`, both on `find_within` returning empty where a hit is expected. Those two are unrelated to this change — they fail identically with it stashed — but they are worth a look on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
